### PR TITLE
toascii - Minimal Change to Enable JSON Lines Output - Nested Body

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -136,6 +136,7 @@ target_sources(gfxrecon_decode
 
 if (MSVC)
     # These files may fail to compile with VS2017 and older, requiring the default section limit of 2^16 to be increased.
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_ascii_consumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_decoders_to_string.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/test/main.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     if (MSVC_VERSION LESS 1920)

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -80,7 +80,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
         FieldToString(strStrm, false, "[out]pCommandBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(commandBufferCount, pCommandBuffers, toStringFlags, tabCount, tabSize));
     };
     const auto return_val = '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"';
-    WriteApiCallToFile(call_info, "vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize, createString, return_val.c_str());
+    WriteApiCallToFile(call_info, "vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize, createString, return_val);
 }
 
 void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
@@ -107,7 +107,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
         FieldToString(strStrm, false, "[out]pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
     };
     const auto return_val = '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"';
-    WriteApiCallToFile(call_info, "vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize, createString, return_val.c_str());
+    WriteApiCallToFile(call_info, "vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize, createString, return_val);
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKHR(

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -43,10 +43,7 @@ void VulkanAsciiConsumerBase::Initialize(FILE* file)
 
 void VulkanAsciiConsumerBase::Destroy()
 {
-    if (file_ != nullptr)
-    {
-        file_ = nullptr;
-    }
+    file_ = nullptr;
     strStrm_.str(std::string{});
 }
 

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -39,14 +39,13 @@ void VulkanAsciiConsumerBase::Initialize(FILE* file)
 {
     assert(file);
     file_ = file;
-    fprintf(file_, "{");
 }
 
 void VulkanAsciiConsumerBase::Destroy()
 {
     if (file_ != nullptr)
     {
-        fprintf(file_, "\n}\n");
+        fprintf(file_, "\n");
         file_ = nullptr;
     }
 }

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -45,9 +45,9 @@ void VulkanAsciiConsumerBase::Destroy()
 {
     if (file_ != nullptr)
     {
-        fprintf(file_, "\n");
         file_ = nullptr;
     }
+    strStrm_.str(std::string{});
 }
 
 // clang-format off
@@ -71,8 +71,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
     uint32_t tabSize            = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
-        FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-        FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+        FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
         FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
 
         auto pDecodedAllocateInfo = pAllocateInfo ? pAllocateInfo->GetPointer() : nullptr;
@@ -80,8 +79,8 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
 
         FieldToString(strStrm, false, "[out]pCommandBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(commandBufferCount, pCommandBuffers, toStringFlags, tabCount, tabSize));
     };
-
-    WriteApiCallToFile(call_info, "vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize, createString);
+    const auto return_val = '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"';
+    WriteApiCallToFile(call_info, "vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize, createString, return_val.c_str());
 }
 
 void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
@@ -99,8 +98,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
     uint32_t tabSize            = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
-        FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-        FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+        FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
         FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
 
         auto pDecodedAllocateInfo = pAllocateInfo ? pAllocateInfo->GetPointer() : nullptr;
@@ -108,8 +106,8 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
 
         FieldToString(strStrm, false, "[out]pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
     };
-
-    WriteApiCallToFile(call_info, "vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize, createString);
+    const auto return_val = '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"';
+    WriteApiCallToFile(call_info, "vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize, createString, return_val.c_str());
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKHR(

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -79,7 +79,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
 
         FieldToString(strStrm, false, "[out]pCommandBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(commandBufferCount, pCommandBuffers, toStringFlags, tabCount, tabSize));
     };
-    const auto return_val = '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"';
+    const auto return_val = ToString(returnValue, toStringFlags, tabCount, tabSize);
     WriteApiCallToFile(call_info, "vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize, createString, return_val);
 }
 
@@ -106,7 +106,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
 
         FieldToString(strStrm, false, "[out]pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
     };
-    const auto return_val = '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"';
+    const auto return_val = ToString(returnValue, toStringFlags, tabCount, tabSize);
     WriteApiCallToFile(call_info, "vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize, createString, return_val);
 }
 

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -119,10 +119,10 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
                                    const uint32_t             tabSize,
                                    const ToStringFunctionType toStringFunction,
                                    /// The formatted return string value excluding trailing comma
-                                   const char* const return_val = nullptr)
+                                   const std::string& return_val = std::string())
     {
         // Output the start of a function call line, up to the arguments:
-        if (nullptr == return_val)
+        if (return_val.empty())
         {
             fprintf(file_,
                     "{\"index\":%llu,\"vkFunc\":{\"name\":\"%s\",\"args\":{",
@@ -135,7 +135,7 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
                     "{\"index\":%llu,\"vkFunc\":{\"name\":\"%s\",\"return\":%s,\"args\":{",
                     (long long unsigned int)call_info.index,
                     functionName.c_str(),
-                    return_val);
+                    return_val.c_str());
         }
 
         // Reset the per-call reusable stringstream and use it to capture the full tree of

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -132,7 +132,7 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
         else
         {
             fprintf(file_,
-                    "{\"index\":%llu,\"vkFunc\":{\"name\":\"%s\",\"return\":%s,\"args\":{",
+                    "{\"index\":%llu,\"vkFunc\":{\"name\":\"%s\",\"return\":\"%s\",\"args\":{",
                     (long long unsigned int)call_info.index,
                     functionName.c_str(),
                     return_val.c_str());

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -53,7 +53,7 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
             FieldToString(strStrm, true, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInstance", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pInstance));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -92,7 +92,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDevices", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pPhysicalDeviceCount, pPhysicalDevices, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -159,7 +159,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
             FieldToString(strStrm, false, "usage", toStringFlags, tabCount, tabSize, ToString(usage, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -238,7 +238,7 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDevice", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDevice));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -301,7 +301,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -318,7 +318,7 @@ void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -335,7 +335,7 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -358,7 +358,7 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
             FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemory", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMemory));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -405,7 +405,7 @@ void VulkanAsciiConsumer::Process_vkMapMemory(
             FieldToString(strStrm, false, "size", toStringFlags, tabCount, tabSize, ToString(size, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]ppData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(ppData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -444,7 +444,7 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -465,7 +465,7 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -508,7 +508,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory(
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -531,7 +531,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory(
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -646,7 +646,7 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfo", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -669,7 +669,7 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -710,7 +710,7 @@ void VulkanAsciiConsumer::Process_vkResetFences(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -729,7 +729,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceStatus(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -754,7 +754,7 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "waitAll", toStringFlags, tabCount, tabSize, ToString(waitAll, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -777,7 +777,7 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSemaphore", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSemaphore));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -820,7 +820,7 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pEvent", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pEvent));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -859,7 +859,7 @@ void VulkanAsciiConsumer::Process_vkGetEventStatus(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -878,7 +878,7 @@ void VulkanAsciiConsumer::Process_vkSetEvent(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -897,7 +897,7 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -920,7 +920,7 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueryPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pQueryPool));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -971,7 +971,7 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -994,7 +994,7 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pBuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1037,7 +1037,7 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1080,7 +1080,7 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImage", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pImage));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1145,7 +1145,7 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1188,7 +1188,7 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pShaderModule", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pShaderModule));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1231,7 +1231,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineCache));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1274,7 +1274,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1297,7 +1297,7 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1324,7 +1324,7 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1351,7 +1351,7 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1394,7 +1394,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineLayout));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1437,7 +1437,7 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSampler", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSampler));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1480,7 +1480,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSetLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSetLayout));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1523,7 +1523,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorPool));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1564,7 +1564,7 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1587,7 +1587,7 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "descriptorSetCount", toStringFlags, tabCount, tabSize, ToString(descriptorSetCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1634,7 +1634,7 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFramebuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFramebuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1677,7 +1677,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1740,7 +1740,7 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCommandPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCommandPool));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1781,7 +1781,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1822,7 +1822,7 @@ void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBeginInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1839,7 +1839,7 @@ void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -1858,7 +1858,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -2909,7 +2909,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -2930,7 +2930,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3021,7 +3021,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3160,7 +3160,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3283,7 +3283,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3326,7 +3326,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3505,7 +3505,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3606,7 +3606,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3627,7 +3627,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphores(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3646,7 +3646,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphore(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3665,7 +3665,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3684,7 +3684,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3703,7 +3703,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3724,7 +3724,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3747,7 +3747,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3792,7 +3792,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateData(
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -3941,7 +3941,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2(
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4480,7 +4480,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSupported", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSupported, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4501,7 +4501,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4524,7 +4524,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4547,7 +4547,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4570,7 +4570,7 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchain", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSwapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4613,7 +4613,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pSwapchainImageCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSwapchainImageCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchainImages", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pSwapchainImageCount, pSwapchainImages, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4640,7 +4640,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4659,7 +4659,7 @@ void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pPresentInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4678,7 +4678,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "[out]pDeviceGroupPresentCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceGroupPresentCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4699,7 +4699,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4722,7 +4722,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pRectCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRectCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRects", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRects, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4743,7 +4743,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4764,7 +4764,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4785,7 +4785,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4808,7 +4808,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplayCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplays", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pDisplayCount, pDisplays, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4831,7 +4831,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4856,7 +4856,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMode", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMode));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4879,7 +4879,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
             FieldToString(strStrm, false, "mode", toStringFlags, tabCount, tabSize, HandleIdToString(mode));
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4902,7 +4902,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4927,7 +4927,7 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchains", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(swapchainCount, pSwapchains, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4950,7 +4950,7 @@ void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4973,7 +4973,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "visualID", toStringFlags, tabCount, tabSize, ToString(visualID, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -4996,7 +4996,7 @@ void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5019,7 +5019,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connection", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(connection));
             FieldToString(strStrm, false, "visual_id", toStringFlags, tabCount, tabSize, ToString(visual_id, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5042,7 +5042,7 @@ void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5063,7 +5063,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5086,7 +5086,7 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5109,7 +5109,7 @@ void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5128,7 +5128,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5239,7 +5239,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5410,7 +5410,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5451,7 +5451,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5474,7 +5474,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "handle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(handle));
             FieldToString(strStrm, false, "[out]pMemoryWin32HandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryWin32HandleProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5495,7 +5495,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5518,7 +5518,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "fd", toStringFlags, tabCount, tabSize, ToString(fd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryFdProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryFdProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5557,7 +5557,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreWin32HandleInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5578,7 +5578,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5597,7 +5597,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreFdInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5618,7 +5618,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5667,7 +5667,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5710,7 +5710,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5787,7 +5787,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5826,7 +5826,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceWin32HandleInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5847,7 +5847,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5866,7 +5866,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceFdInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5887,7 +5887,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5912,7 +5912,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanc
             FieldToString(strStrm, false, "[out]pCounterCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounters", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounters, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounterDescriptions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounterDescriptions, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5951,7 +5951,7 @@ void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -5988,7 +5988,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6011,7 +6011,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6032,7 +6032,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6053,7 +6053,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6076,7 +6076,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6097,7 +6097,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pDisplayPlaneInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPlaneInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6182,7 +6182,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6223,7 +6223,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6244,7 +6244,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6341,7 +6341,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6362,7 +6362,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6381,7 +6381,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6402,7 +6402,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFragmentShadingRateCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFragmentShadingRateCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFragmentShadingRates", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pFragmentShadingRates, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6445,7 +6445,7 @@ void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "presentId", toStringFlags, tabCount, tabSize, ToString(presentId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6464,7 +6464,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6483,7 +6483,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6502,7 +6502,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6523,7 +6523,7 @@ void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDeferredOperation", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDeferredOperation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6562,7 +6562,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6581,7 +6581,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6600,7 +6600,7 @@ void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6623,7 +6623,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
             FieldToString(strStrm, false, "pPipelineInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPipelineInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExecutableCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6646,7 +6646,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatisticCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pStatisticCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatistics", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pStatistics, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6669,7 +6669,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInternalRepresentationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pInternalRepresentations, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -6794,7 +6794,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7049,7 +7049,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCallback", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCallback));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7118,7 +7118,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7137,7 +7137,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7356,7 +7356,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7377,7 +7377,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7460,7 +7460,7 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
             FieldToString(strStrm, false, "infoType", toStringFlags, tabCount, tabSize, '"' + ToString(infoType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pInfoSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfoSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInfo", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pInfo));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7483,7 +7483,7 @@ void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7514,7 +7514,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "externalHandleType", toStringFlags, tabCount, tabSize, ToString(externalHandleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7537,7 +7537,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, ToString(handleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7560,7 +7560,7 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7635,7 +7635,7 @@ void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7656,7 +7656,7 @@ void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7679,7 +7679,7 @@ void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "rrOutput", toStringFlags, tabCount, tabSize, ToString(rrOutput, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7700,7 +7700,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7721,7 +7721,7 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pDisplayPowerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPowerInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7744,7 +7744,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
             FieldToString(strStrm, false, "pDeviceEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7769,7 +7769,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
             FieldToString(strStrm, false, "pDisplayEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7792,7 +7792,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "counter", toStringFlags, tabCount, tabSize, '"' + ToString(counter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pCounterValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7813,7 +7813,7 @@ void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pDisplayTimingProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayTimingProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7836,7 +7836,7 @@ void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pPresentationTimingCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentationTimingCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentationTimings", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPresentationTimings, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7903,7 +7903,7 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7926,7 +7926,7 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7945,7 +7945,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -7964,7 +7964,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8091,7 +8091,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMessenger", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMessenger));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8154,7 +8154,7 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(buffer));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8175,7 +8175,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pBuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8234,7 +8234,7 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8257,7 +8257,7 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pValidationCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pValidationCache));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8300,7 +8300,7 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8323,7 +8323,7 @@ void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
             FieldToString(strStrm, false, "validationCache", toStringFlags, tabCount, tabSize, HandleIdToString(validationCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8410,7 +8410,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8471,7 +8471,7 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8596,7 +8596,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8623,7 +8623,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8650,7 +8650,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8673,7 +8673,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8720,7 +8720,7 @@ void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "shader", toStringFlags, tabCount, tabSize, ToString(shader, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8743,7 +8743,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pHostPointer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHostPointer));
             FieldToString(strStrm, false, "[out]pMemoryHostPointerProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryHostPointerProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8788,7 +8788,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pTimeDomainCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTimeDomainCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimeDomains", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pTimeDomainCount, pTimeDomains, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8813,7 +8813,7 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
             FieldToString(strStrm, false, "pTimestampInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pTimestampInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimestamps", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(timestampCount, pTimestamps, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMaxDeviation", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMaxDeviation, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8964,7 +8964,7 @@ void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInitializeInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInitializeInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -8999,7 +8999,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9018,7 +9018,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9037,7 +9037,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pOverrideInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pOverrideInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9058,7 +9058,7 @@ void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pConfiguration", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pConfiguration));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9077,7 +9077,7 @@ void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9096,7 +9096,7 @@ void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9117,7 +9117,7 @@ void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "parameter", toStringFlags, tabCount, tabSize, '"' + ToString(parameter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9160,7 +9160,7 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9183,7 +9183,7 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9202,7 +9202,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9223,7 +9223,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9244,7 +9244,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixProperties
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9265,7 +9265,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pCombinationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCombinationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCombinations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCombinations, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9288,7 +9288,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9307,7 +9307,7 @@ void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9326,7 +9326,7 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9347,7 +9347,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9370,7 +9370,7 @@ void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9753,7 +9753,7 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pIndirectCommandsLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pIndirectCommandsLayout));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9794,7 +9794,7 @@ void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9817,7 +9817,7 @@ void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connectorId", toStringFlags, tabCount, tabSize, ToString(connectorId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]display", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9840,7 +9840,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9885,7 +9885,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9970,7 +9970,7 @@ void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -9991,7 +9991,7 @@ void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "deviceRelativeId", toStringFlags, tabCount, tabSize, ToString(deviceRelativeId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10014,7 +10014,7 @@ void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10035,7 +10035,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupport
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dfb", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dfb));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10080,7 +10080,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10103,7 +10103,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "zirconHandle", toStringFlags, tabCount, tabSize, ToString(zirconHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryZirconHandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryZirconHandleProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10122,7 +10122,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreZirconHandleInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10143,7 +10143,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10184,7 +10184,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pMemoryGetRemoteAddressInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryGetRemoteAddressInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAddress", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pAddress));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10297,7 +10297,7 @@ void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10318,7 +10318,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQN
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "window", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(window));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10515,7 +10515,7 @@ void VulkanAsciiConsumer::Process_vkGetFramebufferTilePropertiesQCOM(
             FieldToString(strStrm, false, "framebuffer", toStringFlags, tabCount, tabSize, HandleIdToString(framebuffer));
             FieldToString(strStrm, false, "[out]pPropertiesCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertiesCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10536,7 +10536,7 @@ void VulkanAsciiConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10559,7 +10559,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10600,7 +10600,7 @@ void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10621,7 +10621,7 @@ void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10650,7 +10650,7 @@ void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10723,7 +10723,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10828,7 +10828,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10855,7 +10855,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandles
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 
@@ -10904,7 +10904,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "group", toStringFlags, tabCount, tabSize, ToString(group, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupShader", toStringFlags, tabCount, tabSize, '"' + ToString(groupShader, toStringFlags, tabCount, tabSize) + '"');
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
+        }, ToString(returnValue, toStringFlags, tabCount, tabSize)
     );
 }
 

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -50,11 +50,10 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
     WriteApiCallToFile(call_info, "vkCreateInstance", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
+            FieldToString(strStrm, true, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInstance", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pInstance));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -90,11 +89,10 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
     WriteApiCallToFile(call_info, "vkEnumeratePhysicalDevices", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDevices", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pPhysicalDeviceCount, pPhysicalDevices, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -154,15 +152,14 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "type", toStringFlags, tabCount, tabSize, '"' + ToString(type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "tiling", toStringFlags, tabCount, tabSize, '"' + ToString(tiling, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "usage", toStringFlags, tabCount, tabSize, ToString(usage, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -237,12 +234,11 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
     WriteApiCallToFile(call_info, "vkCreateDevice", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDevice", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDevice));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -301,12 +297,11 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
     WriteApiCallToFile(call_info, "vkQueueSubmit", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -322,9 +317,8 @@ void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
     WriteApiCallToFile(call_info, "vkQueueWaitIdle", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
-        }
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -340,9 +334,8 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
     WriteApiCallToFile(call_info, "vkDeviceWaitIdle", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
-        }
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -361,12 +354,11 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
     WriteApiCallToFile(call_info, "vkAllocateMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemory", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMemory));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -407,14 +399,13 @@ void VulkanAsciiConsumer::Process_vkMapMemory(
     WriteApiCallToFile(call_info, "vkMapMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "size", toStringFlags, tabCount, tabSize, ToString(size, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]ppData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(ppData));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -450,11 +441,10 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
     WriteApiCallToFile(call_info, "vkFlushMappedMemoryRanges", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -472,11 +462,10 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
     WriteApiCallToFile(call_info, "vkInvalidateMappedMemoryRanges", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -515,12 +504,11 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory(
     WriteApiCallToFile(call_info, "vkBindBufferMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -539,12 +527,11 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory(
     WriteApiCallToFile(call_info, "vkBindImageMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -655,12 +642,11 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
     WriteApiCallToFile(call_info, "vkQueueBindSparse", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfo", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -679,12 +665,11 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
     WriteApiCallToFile(call_info, "vkCreateFence", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -722,11 +707,10 @@ void VulkanAsciiConsumer::Process_vkResetFences(
     WriteApiCallToFile(call_info, "vkResetFences", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -743,10 +727,9 @@ void VulkanAsciiConsumer::Process_vkGetFenceStatus(
     WriteApiCallToFile(call_info, "vkGetFenceStatus", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -766,13 +749,12 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
     WriteApiCallToFile(call_info, "vkWaitForFences", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "waitAll", toStringFlags, tabCount, tabSize, ToString(waitAll, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -791,12 +773,11 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
     WriteApiCallToFile(call_info, "vkCreateSemaphore", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSemaphore", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSemaphore));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -835,12 +816,11 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
     WriteApiCallToFile(call_info, "vkCreateEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pEvent", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pEvent));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -877,10 +857,9 @@ void VulkanAsciiConsumer::Process_vkGetEventStatus(
     WriteApiCallToFile(call_info, "vkGetEventStatus", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -897,10 +876,9 @@ void VulkanAsciiConsumer::Process_vkSetEvent(
     WriteApiCallToFile(call_info, "vkSetEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -917,10 +895,9 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
     WriteApiCallToFile(call_info, "vkResetEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -939,12 +916,11 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
     WriteApiCallToFile(call_info, "vkCreateQueryPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueryPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pQueryPool));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -987,8 +963,7 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
     WriteApiCallToFile(call_info, "vkGetQueryPoolResults", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryCount", toStringFlags, tabCount, tabSize, ToString(queryCount, toStringFlags, tabCount, tabSize));
@@ -996,7 +971,7 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1015,12 +990,11 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
     WriteApiCallToFile(call_info, "vkCreateBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pBuffer));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1059,12 +1033,11 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
     WriteApiCallToFile(call_info, "vkCreateBufferView", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1103,12 +1076,11 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
     WriteApiCallToFile(call_info, "vkCreateImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImage", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pImage));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1169,12 +1141,11 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
     WriteApiCallToFile(call_info, "vkCreateImageView", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1213,12 +1184,11 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
     WriteApiCallToFile(call_info, "vkCreateShaderModule", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pShaderModule", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pShaderModule));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1257,12 +1227,11 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
     WriteApiCallToFile(call_info, "vkCreatePipelineCache", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineCache));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1301,12 +1270,11 @@ void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
     WriteApiCallToFile(call_info, "vkGetPipelineCacheData", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1325,12 +1293,11 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
     WriteApiCallToFile(call_info, "vkMergePipelineCaches", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1351,14 +1318,13 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
     WriteApiCallToFile(call_info, "vkCreateGraphicsPipelines", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1379,14 +1345,13 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
     WriteApiCallToFile(call_info, "vkCreateComputePipelines", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1425,12 +1390,11 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
     WriteApiCallToFile(call_info, "vkCreatePipelineLayout", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineLayout));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1469,12 +1433,11 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
     WriteApiCallToFile(call_info, "vkCreateSampler", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSampler", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSampler));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1513,12 +1476,11 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
     WriteApiCallToFile(call_info, "vkCreateDescriptorSetLayout", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSetLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSetLayout));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1557,12 +1519,11 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
     WriteApiCallToFile(call_info, "vkCreateDescriptorPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorPool));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1600,11 +1561,10 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
     WriteApiCallToFile(call_info, "vkResetDescriptorPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1623,12 +1583,11 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
     WriteApiCallToFile(call_info, "vkFreeDescriptorSets", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "descriptorSetCount", toStringFlags, tabCount, tabSize, ToString(descriptorSetCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1671,12 +1630,11 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
     WriteApiCallToFile(call_info, "vkCreateFramebuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFramebuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFramebuffer));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1715,12 +1673,11 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
     WriteApiCallToFile(call_info, "vkCreateRenderPass", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1779,12 +1736,11 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
     WriteApiCallToFile(call_info, "vkCreateCommandPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCommandPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCommandPool));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1822,11 +1778,10 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
     WriteApiCallToFile(call_info, "vkResetCommandPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1865,10 +1820,9 @@ void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
     WriteApiCallToFile(call_info, "vkBeginCommandBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBeginInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1884,9 +1838,8 @@ void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
     WriteApiCallToFile(call_info, "vkEndCommandBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
-        }
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -1903,10 +1856,9 @@ void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
     WriteApiCallToFile(call_info, "vkResetCommandBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -2954,11 +2906,10 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
     WriteApiCallToFile(call_info, "vkBindBufferMemory2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -2976,11 +2927,10 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
     WriteApiCallToFile(call_info, "vkBindImageMemory2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3068,11 +3018,10 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceGroups", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3208,11 +3157,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3331,12 +3279,11 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
     WriteApiCallToFile(call_info, "vkCreateSamplerYcbcrConversion", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3375,12 +3322,11 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
     WriteApiCallToFile(call_info, "vkCreateDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3555,12 +3501,11 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
     WriteApiCallToFile(call_info, "vkCreateRenderPass2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3658,11 +3603,10 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
     WriteApiCallToFile(call_info, "vkGetSemaphoreCounterValue", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3680,11 +3624,10 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphores(
     WriteApiCallToFile(call_info, "vkWaitSemaphores", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3701,10 +3644,9 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphore(
     WriteApiCallToFile(call_info, "vkSignalSemaphore", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3721,10 +3663,9 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
     WriteApiCallToFile(call_info, "vkGetBufferDeviceAddress", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3741,10 +3682,9 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
     WriteApiCallToFile(call_info, "vkGetBufferOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3761,10 +3701,9 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
     WriteApiCallToFile(call_info, "vkGetDeviceMemoryOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3782,11 +3721,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceToolProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3805,12 +3743,11 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
     WriteApiCallToFile(call_info, "vkCreatePrivateDataSlot", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -3850,13 +3787,12 @@ void VulkanAsciiConsumer::Process_vkSetPrivateData(
     WriteApiCallToFile(call_info, "vkSetPrivateData", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4001,12 +3937,11 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2(
     WriteApiCallToFile(call_info, "vkQueueSubmit2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4541,12 +4476,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSupported", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSupported, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4564,11 +4498,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4587,12 +4520,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceFormatsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4611,12 +4543,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4635,12 +4566,11 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
     WriteApiCallToFile(call_info, "vkCreateSwapchainKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchain", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSwapchain));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4679,12 +4609,11 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
     WriteApiCallToFile(call_info, "vkGetSwapchainImagesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pSwapchainImageCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSwapchainImageCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchainImages", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pSwapchainImageCount, pSwapchainImages, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4705,14 +4634,13 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
     WriteApiCallToFile(call_info, "vkAcquireNextImageKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4729,10 +4657,9 @@ void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
     WriteApiCallToFile(call_info, "vkQueuePresentKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pPresentInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4749,10 +4676,9 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
     WriteApiCallToFile(call_info, "vkGetDeviceGroupPresentCapabilitiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "[out]pDeviceGroupPresentCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceGroupPresentCapabilities, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4770,11 +4696,10 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
     WriteApiCallToFile(call_info, "vkGetDeviceGroupSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4793,12 +4718,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDevicePresentRectanglesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pRectCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRectCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRects", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRects, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4816,11 +4740,10 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
     WriteApiCallToFile(call_info, "vkAcquireNextImage2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4838,11 +4761,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4860,11 +4782,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4883,12 +4804,11 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     WriteApiCallToFile(call_info, "vkGetDisplayPlaneSupportedDisplaysKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplayCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplays", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pDisplayCount, pDisplays, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4907,12 +4827,11 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
     WriteApiCallToFile(call_info, "vkGetDisplayModePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4932,13 +4851,12 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
     WriteApiCallToFile(call_info, "vkCreateDisplayModeKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMode", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMode));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4957,12 +4875,11 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
     WriteApiCallToFile(call_info, "vkGetDisplayPlaneCapabilitiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "mode", toStringFlags, tabCount, tabSize, HandleIdToString(mode));
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -4981,12 +4898,11 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
     WriteApiCallToFile(call_info, "vkCreateDisplayPlaneSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5006,13 +4922,12 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
     WriteApiCallToFile(call_info, "vkCreateSharedSwapchainsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchainCount", toStringFlags, tabCount, tabSize, ToString(swapchainCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchains", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(swapchainCount, pSwapchains, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5031,12 +4946,11 @@ void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
     WriteApiCallToFile(call_info, "vkCreateXlibSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5055,12 +4969,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceXlibPresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "visualID", toStringFlags, tabCount, tabSize, ToString(visualID, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5079,12 +4992,11 @@ void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
     WriteApiCallToFile(call_info, "vkCreateXcbSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5103,12 +5015,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceXcbPresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connection", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(connection));
             FieldToString(strStrm, false, "visual_id", toStringFlags, tabCount, tabSize, ToString(visual_id, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5127,12 +5038,11 @@ void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
     WriteApiCallToFile(call_info, "vkCreateWaylandSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5150,11 +5060,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceWaylandPresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(display));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5173,12 +5082,11 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
     WriteApiCallToFile(call_info, "vkCreateAndroidSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5197,12 +5105,11 @@ void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
     WriteApiCallToFile(call_info, "vkCreateWin32SurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5219,10 +5126,9 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceWin32PresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5330,11 +5236,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5502,11 +5407,10 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceGroupsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5544,11 +5448,10 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
     WriteApiCallToFile(call_info, "vkGetMemoryWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5567,12 +5470,11 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
     WriteApiCallToFile(call_info, "vkGetMemoryWin32HandlePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "handle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(handle));
             FieldToString(strStrm, false, "[out]pMemoryWin32HandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryWin32HandleProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5590,11 +5492,10 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
     WriteApiCallToFile(call_info, "vkGetMemoryFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5613,12 +5514,11 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
     WriteApiCallToFile(call_info, "vkGetMemoryFdPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "fd", toStringFlags, tabCount, tabSize, ToString(fd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryFdProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryFdProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5655,10 +5555,9 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
     WriteApiCallToFile(call_info, "vkImportSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreWin32HandleInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5676,11 +5575,10 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
     WriteApiCallToFile(call_info, "vkGetSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5697,10 +5595,9 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
     WriteApiCallToFile(call_info, "vkImportSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreFdInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5718,11 +5615,10 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
     WriteApiCallToFile(call_info, "vkGetSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5767,12 +5663,11 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     WriteApiCallToFile(call_info, "vkCreateDescriptorUpdateTemplateKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5811,12 +5706,11 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
     WriteApiCallToFile(call_info, "vkCreateRenderPass2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5891,10 +5785,9 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
     WriteApiCallToFile(call_info, "vkGetSwapchainStatusKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5931,10 +5824,9 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
     WriteApiCallToFile(call_info, "vkImportFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceWin32HandleInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5952,11 +5844,10 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
     WriteApiCallToFile(call_info, "vkGetFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5973,10 +5864,9 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
     WriteApiCallToFile(call_info, "vkImportFenceFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceFdInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -5994,11 +5884,10 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
     WriteApiCallToFile(call_info, "vkGetFenceFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6018,13 +5907,12 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanc
     WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounterCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounters", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounters, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounterDescriptions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounterDescriptions, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6061,10 +5949,9 @@ void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
     WriteApiCallToFile(call_info, "vkAcquireProfilingLockKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6098,11 +5985,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilities2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6121,12 +6007,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceFormats2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6144,11 +6029,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6166,11 +6050,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPlaneProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6189,12 +6072,11 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
     WriteApiCallToFile(call_info, "vkGetDisplayModeProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6212,11 +6094,10 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
     WriteApiCallToFile(call_info, "vkGetDisplayPlaneCapabilities2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pDisplayPlaneInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPlaneInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6297,12 +6178,11 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     WriteApiCallToFile(call_info, "vkCreateSamplerYcbcrConversionKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6340,11 +6220,10 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
     WriteApiCallToFile(call_info, "vkBindBufferMemory2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6362,11 +6241,10 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
     WriteApiCallToFile(call_info, "vkBindImageMemory2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6460,11 +6338,10 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
     WriteApiCallToFile(call_info, "vkGetSemaphoreCounterValueKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6482,11 +6359,10 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
     WriteApiCallToFile(call_info, "vkWaitSemaphoresKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6503,10 +6379,9 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
     WriteApiCallToFile(call_info, "vkSignalSemaphoreKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6524,11 +6399,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFragmentShadingRatesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFragmentShadingRateCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFragmentShadingRateCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFragmentShadingRates", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pFragmentShadingRates, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6567,12 +6441,11 @@ void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
     WriteApiCallToFile(call_info, "vkWaitForPresentKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "presentId", toStringFlags, tabCount, tabSize, ToString(presentId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6589,10 +6462,9 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
     WriteApiCallToFile(call_info, "vkGetBufferDeviceAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6609,10 +6481,9 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
     WriteApiCallToFile(call_info, "vkGetBufferOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6629,10 +6500,9 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
     WriteApiCallToFile(call_info, "vkGetDeviceMemoryOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6650,11 +6520,10 @@ void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
     WriteApiCallToFile(call_info, "vkCreateDeferredOperationKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDeferredOperation", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDeferredOperation));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6691,10 +6560,9 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
     WriteApiCallToFile(call_info, "vkGetDeferredOperationMaxConcurrencyKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6711,10 +6579,9 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
     WriteApiCallToFile(call_info, "vkGetDeferredOperationResultKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6731,10 +6598,9 @@ void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
     WriteApiCallToFile(call_info, "vkDeferredOperationJoinKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6753,12 +6619,11 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     WriteApiCallToFile(call_info, "vkGetPipelineExecutablePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pPipelineInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPipelineInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExecutableCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6777,12 +6642,11 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     WriteApiCallToFile(call_info, "vkGetPipelineExecutableStatisticsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatisticCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pStatisticCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatistics", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pStatistics, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6801,12 +6665,11 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
     WriteApiCallToFile(call_info, "vkGetPipelineExecutableInternalRepresentationsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInternalRepresentationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pInternalRepresentations, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -6927,12 +6790,11 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
     WriteApiCallToFile(call_info, "vkQueueSubmit2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7183,12 +7045,11 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
     WriteApiCallToFile(call_info, "vkCreateDebugReportCallbackEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCallback", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCallback));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7255,10 +7116,9 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
     WriteApiCallToFile(call_info, "vkDebugMarkerSetObjectTagEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7275,10 +7135,9 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
     WriteApiCallToFile(call_info, "vkDebugMarkerSetObjectNameEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7495,10 +7354,9 @@ void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
     WriteApiCallToFile(call_info, "vkGetImageViewHandleNVX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7516,11 +7374,10 @@ void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
     WriteApiCallToFile(call_info, "vkGetImageViewAddressNVX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7597,14 +7454,13 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
     WriteApiCallToFile(call_info, "vkGetShaderInfoAMD", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "shaderStage", toStringFlags, tabCount, tabSize, '"' + ToString(shaderStage, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "infoType", toStringFlags, tabCount, tabSize, '"' + ToString(infoType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pInfoSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfoSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInfo", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pInfo));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7623,12 +7479,11 @@ void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     WriteApiCallToFile(call_info, "vkCreateStreamDescriptorSurfaceGGP", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7651,8 +7506,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "type", toStringFlags, tabCount, tabSize, '"' + ToString(type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "tiling", toStringFlags, tabCount, tabSize, '"' + ToString(tiling, toStringFlags, tabCount, tabSize) + '"');
@@ -7660,7 +7514,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "externalHandleType", toStringFlags, tabCount, tabSize, ToString(externalHandleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7679,12 +7533,11 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
     WriteApiCallToFile(call_info, "vkGetMemoryWin32HandleNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, ToString(handleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7703,12 +7556,11 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
     WriteApiCallToFile(call_info, "vkCreateViSurfaceNN", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7781,10 +7633,9 @@ void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
     WriteApiCallToFile(call_info, "vkReleaseDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7802,11 +7653,10 @@ void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
     WriteApiCallToFile(call_info, "vkAcquireXlibDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7825,12 +7675,11 @@ void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
     WriteApiCallToFile(call_info, "vkGetRandROutputDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "rrOutput", toStringFlags, tabCount, tabSize, ToString(rrOutput, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7848,11 +7697,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilities2EXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7870,11 +7718,10 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
     WriteApiCallToFile(call_info, "vkDisplayPowerControlEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pDisplayPowerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPowerInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7893,12 +7740,11 @@ void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
     WriteApiCallToFile(call_info, "vkRegisterDeviceEventEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pDeviceEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7918,13 +7764,12 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
     WriteApiCallToFile(call_info, "vkRegisterDisplayEventEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pDisplayEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7943,12 +7788,11 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
     WriteApiCallToFile(call_info, "vkGetSwapchainCounterEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "counter", toStringFlags, tabCount, tabSize, '"' + ToString(counter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pCounterValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterValue, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7966,11 +7810,10 @@ void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
     WriteApiCallToFile(call_info, "vkGetRefreshCycleDurationGOOGLE", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pDisplayTimingProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayTimingProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -7989,12 +7832,11 @@ void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
     WriteApiCallToFile(call_info, "vkGetPastPresentationTimingGOOGLE", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pPresentationTimingCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentationTimingCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentationTimings", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPresentationTimings, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8057,12 +7899,11 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
     WriteApiCallToFile(call_info, "vkCreateIOSSurfaceMVK", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8081,12 +7922,11 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
     WriteApiCallToFile(call_info, "vkCreateMacOSSurfaceMVK", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8103,10 +7943,9 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
     WriteApiCallToFile(call_info, "vkSetDebugUtilsObjectNameEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8123,10 +7962,9 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
     WriteApiCallToFile(call_info, "vkSetDebugUtilsObjectTagEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8249,12 +8087,11 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
     WriteApiCallToFile(call_info, "vkCreateDebugUtilsMessengerEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMessenger", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMessenger));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8314,11 +8151,10 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
     WriteApiCallToFile(call_info, "vkGetAndroidHardwareBufferPropertiesANDROID", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(buffer));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8336,11 +8172,10 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
     WriteApiCallToFile(call_info, "vkGetMemoryAndroidHardwareBufferANDROID", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pBuffer));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8396,11 +8231,10 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
     WriteApiCallToFile(call_info, "vkGetImageDrmFormatModifierPropertiesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8419,12 +8253,11 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
     WriteApiCallToFile(call_info, "vkCreateValidationCacheEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pValidationCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pValidationCache));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8463,12 +8296,11 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
     WriteApiCallToFile(call_info, "vkMergeValidationCachesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8487,12 +8319,11 @@ void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
     WriteApiCallToFile(call_info, "vkGetValidationCacheDataEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "validationCache", toStringFlags, tabCount, tabSize, HandleIdToString(validationCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8575,12 +8406,11 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
     WriteApiCallToFile(call_info, "vkCreateAccelerationStructureNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8638,11 +8468,10 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
     WriteApiCallToFile(call_info, "vkBindAccelerationStructureMemoryNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8761,14 +8590,13 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
     WriteApiCallToFile(call_info, "vkCreateRayTracingPipelinesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8789,14 +8617,13 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
     WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "firstGroup", toStringFlags, tabCount, tabSize, ToString(firstGroup, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8817,14 +8644,13 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
     WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupHandlesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "firstGroup", toStringFlags, tabCount, tabSize, ToString(firstGroup, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8843,12 +8669,11 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
     WriteApiCallToFile(call_info, "vkGetAccelerationStructureHandleNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8892,11 +8717,10 @@ void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
     WriteApiCallToFile(call_info, "vkCompileDeferredNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "shader", toStringFlags, tabCount, tabSize, ToString(shader, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8915,12 +8739,11 @@ void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
     WriteApiCallToFile(call_info, "vkGetMemoryHostPointerPropertiesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pHostPointer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHostPointer));
             FieldToString(strStrm, false, "[out]pMemoryHostPointerProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryHostPointerProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8962,11 +8785,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pTimeDomainCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTimeDomainCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimeDomains", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pTimeDomainCount, pTimeDomains, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -8986,13 +8808,12 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
     WriteApiCallToFile(call_info, "vkGetCalibratedTimestampsEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "timestampCount", toStringFlags, tabCount, tabSize, ToString(timestampCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pTimestampInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pTimestampInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimestamps", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(timestampCount, pTimestamps, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMaxDeviation", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMaxDeviation, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9141,10 +8962,9 @@ void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
     WriteApiCallToFile(call_info, "vkInitializePerformanceApiINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInitializeInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInitializeInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9177,10 +8997,9 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
     WriteApiCallToFile(call_info, "vkCmdSetPerformanceMarkerINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9197,10 +9016,9 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
     WriteApiCallToFile(call_info, "vkCmdSetPerformanceStreamMarkerINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9217,10 +9035,9 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
     WriteApiCallToFile(call_info, "vkCmdSetPerformanceOverrideINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pOverrideInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pOverrideInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9238,11 +9055,10 @@ void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     WriteApiCallToFile(call_info, "vkAcquirePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pConfiguration", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pConfiguration));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9259,10 +9075,9 @@ void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
     WriteApiCallToFile(call_info, "vkReleasePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9279,10 +9094,9 @@ void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
     WriteApiCallToFile(call_info, "vkQueueSetPerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9300,11 +9114,10 @@ void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
     WriteApiCallToFile(call_info, "vkGetPerformanceParameterINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "parameter", toStringFlags, tabCount, tabSize, '"' + ToString(parameter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9343,12 +9156,11 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     WriteApiCallToFile(call_info, "vkCreateImagePipeSurfaceFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9367,12 +9179,11 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
     WriteApiCallToFile(call_info, "vkCreateMetalSurfaceEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9389,10 +9200,9 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
     WriteApiCallToFile(call_info, "vkGetBufferDeviceAddressEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9410,11 +9220,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceToolPropertiesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9432,11 +9241,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixProperties
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9454,11 +9262,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pCombinationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCombinationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCombinations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCombinations, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9477,12 +9284,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9499,10 +9305,9 @@ void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
     WriteApiCallToFile(call_info, "vkAcquireFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9519,10 +9324,9 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
     WriteApiCallToFile(call_info, "vkReleaseFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9540,11 +9344,10 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
     WriteApiCallToFile(call_info, "vkGetDeviceGroupSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9563,12 +9366,11 @@ void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
     WriteApiCallToFile(call_info, "vkCreateHeadlessSurfaceEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9947,12 +9749,11 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
     WriteApiCallToFile(call_info, "vkCreateIndirectCommandsLayoutNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pIndirectCommandsLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pIndirectCommandsLayout));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -9990,11 +9791,10 @@ void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
     WriteApiCallToFile(call_info, "vkAcquireDrmDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10013,12 +9813,11 @@ void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
     WriteApiCallToFile(call_info, "vkGetDrmDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connectorId", toStringFlags, tabCount, tabSize, ToString(connectorId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]display", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(display));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10037,12 +9836,11 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
     WriteApiCallToFile(call_info, "vkCreatePrivateDataSlotEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10082,13 +9880,12 @@ void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
     WriteApiCallToFile(call_info, "vkSetPrivateDataEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10171,10 +9968,9 @@ void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
     WriteApiCallToFile(call_info, "vkAcquireWinrtDisplayNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10192,11 +9988,10 @@ void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
     WriteApiCallToFile(call_info, "vkGetWinrtDisplayNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "deviceRelativeId", toStringFlags, tabCount, tabSize, ToString(deviceRelativeId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10215,12 +10010,11 @@ void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
     WriteApiCallToFile(call_info, "vkCreateDirectFBSurfaceEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10238,11 +10032,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupport
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDirectFBPresentationSupportEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dfb", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dfb));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10284,11 +10077,10 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
     WriteApiCallToFile(call_info, "vkGetMemoryZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10307,12 +10099,11 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
     WriteApiCallToFile(call_info, "vkGetMemoryZirconHandlePropertiesFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "zirconHandle", toStringFlags, tabCount, tabSize, ToString(zirconHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryZirconHandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryZirconHandleProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10329,10 +10120,9 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
     WriteApiCallToFile(call_info, "vkImportSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreZirconHandleInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10350,11 +10140,10 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
     WriteApiCallToFile(call_info, "vkGetSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10392,11 +10181,10 @@ void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
     WriteApiCallToFile(call_info, "vkGetMemoryRemoteAddressNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pMemoryGetRemoteAddressInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryGetRemoteAddressInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAddress", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pAddress));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10505,12 +10293,11 @@ void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
     WriteApiCallToFile(call_info, "vkCreateScreenSurfaceQNX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10528,11 +10315,10 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQN
     WriteApiCallToFile(call_info, "vkGetPhysicalDeviceScreenPresentationSupportQNX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "window", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(window));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10725,12 +10511,11 @@ void VulkanAsciiConsumer::Process_vkGetFramebufferTilePropertiesQCOM(
     WriteApiCallToFile(call_info, "vkGetFramebufferTilePropertiesQCOM", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "framebuffer", toStringFlags, tabCount, tabSize, HandleIdToString(framebuffer));
             FieldToString(strStrm, false, "[out]pPropertiesCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertiesCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10748,11 +10533,10 @@ void VulkanAsciiConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
     WriteApiCallToFile(call_info, "vkGetDynamicRenderingTilePropertiesQCOM", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10771,12 +10555,11 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
     WriteApiCallToFile(call_info, "vkCreateAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10814,11 +10597,10 @@ void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
     WriteApiCallToFile(call_info, "vkCopyAccelerationStructureToMemoryKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10836,11 +10618,10 @@ void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
     WriteApiCallToFile(call_info, "vkCopyMemoryToAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10862,15 +10643,14 @@ void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
     WriteApiCallToFile(call_info, "vkWriteAccelerationStructuresPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructureCount", toStringFlags, tabCount, tabSize, ToString(accelerationStructureCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAccelerationStructures", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(accelerationStructureCount, pAccelerationStructures, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryType", toStringFlags, tabCount, tabSize, '"' + ToString(queryType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -10941,10 +10721,9 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
     WriteApiCallToFile(call_info, "vkGetAccelerationStructureDeviceAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -11042,15 +10821,14 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
     WriteApiCallToFile(call_info, "vkCreateRayTracingPipelinesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -11071,14 +10849,13 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandles
     WriteApiCallToFile(call_info, "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "firstGroup", toStringFlags, tabCount, tabSize, ToString(firstGroup, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 
@@ -11123,12 +10900,11 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
     WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupStackSizeKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "group", toStringFlags, tabCount, tabSize, ToString(group, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupShader", toStringFlags, tabCount, tabSize, '"' + ToString(groupShader, toStringFlags, tabCount, tabSize) + '"');
-        }
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
     );
 }
 

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -53,7 +53,7 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
             FieldToString(strStrm, true, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInstance", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pInstance));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -92,7 +92,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDevices", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pPhysicalDeviceCount, pPhysicalDevices, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -159,7 +159,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
             FieldToString(strStrm, false, "usage", toStringFlags, tabCount, tabSize, ToString(usage, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -238,7 +238,7 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDevice", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDevice));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -301,7 +301,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -318,7 +318,7 @@ void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -335,7 +335,7 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -358,7 +358,7 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
             FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemory", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMemory));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -405,7 +405,7 @@ void VulkanAsciiConsumer::Process_vkMapMemory(
             FieldToString(strStrm, false, "size", toStringFlags, tabCount, tabSize, ToString(size, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]ppData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(ppData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -444,7 +444,7 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -465,7 +465,7 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -508,7 +508,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory(
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -531,7 +531,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory(
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -646,7 +646,7 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfo", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -669,7 +669,7 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -710,7 +710,7 @@ void VulkanAsciiConsumer::Process_vkResetFences(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -729,7 +729,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceStatus(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -754,7 +754,7 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "waitAll", toStringFlags, tabCount, tabSize, ToString(waitAll, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -777,7 +777,7 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSemaphore", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSemaphore));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -820,7 +820,7 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pEvent", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pEvent));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -859,7 +859,7 @@ void VulkanAsciiConsumer::Process_vkGetEventStatus(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -878,7 +878,7 @@ void VulkanAsciiConsumer::Process_vkSetEvent(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -897,7 +897,7 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -920,7 +920,7 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueryPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pQueryPool));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -971,7 +971,7 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -994,7 +994,7 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pBuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1037,7 +1037,7 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1080,7 +1080,7 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImage", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pImage));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1145,7 +1145,7 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1188,7 +1188,7 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pShaderModule", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pShaderModule));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1231,7 +1231,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineCache));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1274,7 +1274,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1297,7 +1297,7 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1324,7 +1324,7 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1351,7 +1351,7 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1394,7 +1394,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineLayout));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1437,7 +1437,7 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSampler", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSampler));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1480,7 +1480,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSetLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSetLayout));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1523,7 +1523,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorPool));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1564,7 +1564,7 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1587,7 +1587,7 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "descriptorSetCount", toStringFlags, tabCount, tabSize, ToString(descriptorSetCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1634,7 +1634,7 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFramebuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFramebuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1677,7 +1677,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1740,7 +1740,7 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCommandPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCommandPool));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1781,7 +1781,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1822,7 +1822,7 @@ void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBeginInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1839,7 +1839,7 @@ void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -1858,7 +1858,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -2909,7 +2909,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -2930,7 +2930,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3021,7 +3021,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3160,7 +3160,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3283,7 +3283,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3326,7 +3326,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3505,7 +3505,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3606,7 +3606,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3627,7 +3627,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphores(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3646,7 +3646,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphore(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3665,7 +3665,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3684,7 +3684,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3703,7 +3703,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3724,7 +3724,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3747,7 +3747,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3792,7 +3792,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateData(
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -3941,7 +3941,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2(
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4480,7 +4480,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSupported", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSupported, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4501,7 +4501,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4524,7 +4524,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4547,7 +4547,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4570,7 +4570,7 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchain", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSwapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4613,7 +4613,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pSwapchainImageCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSwapchainImageCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchainImages", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pSwapchainImageCount, pSwapchainImages, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4640,7 +4640,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4659,7 +4659,7 @@ void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pPresentInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4678,7 +4678,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "[out]pDeviceGroupPresentCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceGroupPresentCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4699,7 +4699,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4722,7 +4722,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pRectCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRectCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRects", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRects, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4743,7 +4743,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4764,7 +4764,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4785,7 +4785,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4808,7 +4808,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplayCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplays", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pDisplayCount, pDisplays, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4831,7 +4831,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4856,7 +4856,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMode", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMode));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4879,7 +4879,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
             FieldToString(strStrm, false, "mode", toStringFlags, tabCount, tabSize, HandleIdToString(mode));
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4902,7 +4902,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4927,7 +4927,7 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchains", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(swapchainCount, pSwapchains, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4950,7 +4950,7 @@ void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4973,7 +4973,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "visualID", toStringFlags, tabCount, tabSize, ToString(visualID, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -4996,7 +4996,7 @@ void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5019,7 +5019,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connection", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(connection));
             FieldToString(strStrm, false, "visual_id", toStringFlags, tabCount, tabSize, ToString(visual_id, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5042,7 +5042,7 @@ void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5063,7 +5063,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5086,7 +5086,7 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5109,7 +5109,7 @@ void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5128,7 +5128,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5239,7 +5239,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5410,7 +5410,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5451,7 +5451,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5474,7 +5474,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "handle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(handle));
             FieldToString(strStrm, false, "[out]pMemoryWin32HandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryWin32HandleProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5495,7 +5495,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5518,7 +5518,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "fd", toStringFlags, tabCount, tabSize, ToString(fd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryFdProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryFdProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5557,7 +5557,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreWin32HandleInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5578,7 +5578,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5597,7 +5597,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreFdInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5618,7 +5618,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5667,7 +5667,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5710,7 +5710,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5787,7 +5787,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5826,7 +5826,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceWin32HandleInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5847,7 +5847,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5866,7 +5866,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceFdInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5887,7 +5887,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5912,7 +5912,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanc
             FieldToString(strStrm, false, "[out]pCounterCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounters", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounters, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounterDescriptions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounterDescriptions, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5951,7 +5951,7 @@ void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -5988,7 +5988,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6011,7 +6011,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6032,7 +6032,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6053,7 +6053,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6076,7 +6076,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6097,7 +6097,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pDisplayPlaneInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPlaneInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6182,7 +6182,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6223,7 +6223,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6244,7 +6244,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6341,7 +6341,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6362,7 +6362,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6381,7 +6381,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6402,7 +6402,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFragmentShadingRateCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFragmentShadingRateCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFragmentShadingRates", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pFragmentShadingRates, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6445,7 +6445,7 @@ void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "presentId", toStringFlags, tabCount, tabSize, ToString(presentId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6464,7 +6464,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6483,7 +6483,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6502,7 +6502,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6523,7 +6523,7 @@ void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDeferredOperation", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDeferredOperation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6562,7 +6562,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6581,7 +6581,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6600,7 +6600,7 @@ void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6623,7 +6623,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
             FieldToString(strStrm, false, "pPipelineInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPipelineInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExecutableCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6646,7 +6646,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatisticCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pStatisticCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatistics", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pStatistics, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6669,7 +6669,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInternalRepresentationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pInternalRepresentations, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -6794,7 +6794,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7049,7 +7049,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCallback", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCallback));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7118,7 +7118,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7137,7 +7137,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7356,7 +7356,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7377,7 +7377,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7460,7 +7460,7 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
             FieldToString(strStrm, false, "infoType", toStringFlags, tabCount, tabSize, '"' + ToString(infoType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pInfoSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfoSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInfo", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pInfo));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7483,7 +7483,7 @@ void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7514,7 +7514,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "externalHandleType", toStringFlags, tabCount, tabSize, ToString(externalHandleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalImageFormatProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7537,7 +7537,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, ToString(handleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7560,7 +7560,7 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7635,7 +7635,7 @@ void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7656,7 +7656,7 @@ void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7679,7 +7679,7 @@ void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "rrOutput", toStringFlags, tabCount, tabSize, ToString(rrOutput, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7700,7 +7700,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7721,7 +7721,7 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pDisplayPowerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPowerInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7744,7 +7744,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
             FieldToString(strStrm, false, "pDeviceEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7769,7 +7769,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
             FieldToString(strStrm, false, "pDisplayEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7792,7 +7792,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "counter", toStringFlags, tabCount, tabSize, '"' + ToString(counter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pCounterValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7813,7 +7813,7 @@ void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pDisplayTimingProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayTimingProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7836,7 +7836,7 @@ void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pPresentationTimingCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentationTimingCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentationTimings", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPresentationTimings, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7903,7 +7903,7 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7926,7 +7926,7 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7945,7 +7945,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -7964,7 +7964,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8091,7 +8091,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMessenger", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMessenger));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8154,7 +8154,7 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(buffer));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8175,7 +8175,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pBuffer));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8234,7 +8234,7 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8257,7 +8257,7 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pValidationCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pValidationCache));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8300,7 +8300,7 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8323,7 +8323,7 @@ void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
             FieldToString(strStrm, false, "validationCache", toStringFlags, tabCount, tabSize, HandleIdToString(validationCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8410,7 +8410,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8471,7 +8471,7 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8596,7 +8596,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8623,7 +8623,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8650,7 +8650,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8673,7 +8673,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8720,7 +8720,7 @@ void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "shader", toStringFlags, tabCount, tabSize, ToString(shader, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8743,7 +8743,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pHostPointer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHostPointer));
             FieldToString(strStrm, false, "[out]pMemoryHostPointerProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryHostPointerProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8788,7 +8788,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pTimeDomainCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTimeDomainCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimeDomains", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pTimeDomainCount, pTimeDomains, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8813,7 +8813,7 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
             FieldToString(strStrm, false, "pTimestampInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pTimestampInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimestamps", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(timestampCount, pTimestamps, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMaxDeviation", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMaxDeviation, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8964,7 +8964,7 @@ void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInitializeInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInitializeInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -8999,7 +8999,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9018,7 +9018,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9037,7 +9037,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pOverrideInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pOverrideInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9058,7 +9058,7 @@ void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pConfiguration", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pConfiguration));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9077,7 +9077,7 @@ void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9096,7 +9096,7 @@ void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9117,7 +9117,7 @@ void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "parameter", toStringFlags, tabCount, tabSize, '"' + ToString(parameter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9160,7 +9160,7 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9183,7 +9183,7 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9202,7 +9202,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9223,7 +9223,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9244,7 +9244,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixProperties
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9265,7 +9265,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pCombinationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCombinationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCombinations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCombinations, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9288,7 +9288,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9307,7 +9307,7 @@ void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9326,7 +9326,7 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9347,7 +9347,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9370,7 +9370,7 @@ void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9753,7 +9753,7 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pIndirectCommandsLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pIndirectCommandsLayout));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9794,7 +9794,7 @@ void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9817,7 +9817,7 @@ void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connectorId", toStringFlags, tabCount, tabSize, ToString(connectorId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]display", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9840,7 +9840,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9885,7 +9885,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9970,7 +9970,7 @@ void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -9991,7 +9991,7 @@ void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "deviceRelativeId", toStringFlags, tabCount, tabSize, ToString(deviceRelativeId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10014,7 +10014,7 @@ void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10035,7 +10035,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupport
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dfb", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dfb));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10080,7 +10080,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10103,7 +10103,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "zirconHandle", toStringFlags, tabCount, tabSize, ToString(zirconHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryZirconHandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryZirconHandleProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10122,7 +10122,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreZirconHandleInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10143,7 +10143,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10184,7 +10184,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pMemoryGetRemoteAddressInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryGetRemoteAddressInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAddress", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pAddress));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10297,7 +10297,7 @@ void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10318,7 +10318,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQN
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "window", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(window));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10515,7 +10515,7 @@ void VulkanAsciiConsumer::Process_vkGetFramebufferTilePropertiesQCOM(
             FieldToString(strStrm, false, "framebuffer", toStringFlags, tabCount, tabSize, HandleIdToString(framebuffer));
             FieldToString(strStrm, false, "[out]pPropertiesCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertiesCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10536,7 +10536,7 @@ void VulkanAsciiConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10559,7 +10559,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10600,7 +10600,7 @@ void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10621,7 +10621,7 @@ void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10650,7 +10650,7 @@ void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10723,7 +10723,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10828,7 +10828,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10855,7 +10855,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandles
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 
@@ -10904,7 +10904,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "group", toStringFlags, tabCount, tabSize, ToString(group, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupShader", toStringFlags, tabCount, tabSize, '"' + ToString(groupShader, toStringFlags, tabCount, tabSize) + '"');
-        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"').c_str()
+        }, ('"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"')
     );
 }
 

--- a/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
@@ -137,6 +137,9 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                 cmddef += self.make_consumer_func_decl(
                     return_type, 'VulkanAsciiConsumer::Process_' + cmd, values
                 ) + '\n'
+                return_val = ""
+                if not 'void' in return_type:
+                    return_val = ', (\'"\' + ToString(returnValue, toStringFlags, tabCount, tabSize) + \'"\').c_str()'
                 cmddef += inspect.cleandoc(
                     '''
                     {{
@@ -155,10 +158,10 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                 )
                 cmddef += inspect.cleandoc(
                     '''
-                            }
+                            }}{0}
                         );
-                    }
-                    '''
+                    }}
+                    '''.format(return_val)
                 )
                 write(cmddef, file=self.outFile)
                 first = False
@@ -167,10 +170,6 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
     def make_consumer_func_body(self, return_type, name, values):
         """Return VulkanAsciiConsumer class member function definition."""
         body = ''
-
-        # Handle function return value
-        if not 'void' in return_type:
-            body = '            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, \'"\' + ToString(returnValue, toStringFlags, tabCount, tabSize) + \'"\');\n'
 
         # Handle function arguments
         for value in values:

--- a/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
@@ -139,7 +139,7 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                 ) + '\n'
                 return_val = ""
                 if not 'void' in return_type:
-                    return_val = ', (\'"\' + ToString(returnValue, toStringFlags, tabCount, tabSize) + \'"\').c_str()'
+                    return_val = ', (\'"\' + ToString(returnValue, toStringFlags, tabCount, tabSize) + \'"\')'
                 cmddef += inspect.cleandoc(
                     '''
                     {{

--- a/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
@@ -139,7 +139,7 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                 ) + '\n'
                 return_val = ""
                 if not 'void' in return_type:
-                    return_val = ', (\'"\' + ToString(returnValue, toStringFlags, tabCount, tabSize) + \'"\')'
+                    return_val = ', ToString(returnValue, toStringFlags, tabCount, tabSize)'
                 cmddef += inspect.cleandoc(
                     '''
                     {{

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -100,12 +100,13 @@ inline std::string
 ObjectToString(ToStringFlags toStringFlags, uint32_t& tabCount, uint32_t tabSize, ToStringFunctionType toStringFunction)
 {
     std::stringstream strStrm;
+    const auto        nl = GetNewlineString(toStringFlags);
     strStrm << '{';
-    strStrm << GetNewlineString(toStringFlags);
+    strStrm << nl;
     ++tabCount;
     toStringFunction(strStrm);
     --tabCount;
-    strStrm << GetNewlineString(toStringFlags);
+    strStrm << nl;
     strStrm << GetTabString(toStringFlags, tabCount, tabSize);
     strStrm << '}';
     return strStrm.str();

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -36,7 +36,7 @@ enum ToStringFlagBits
 {
     kToString_Unformatted = 0,
     kToString_Formatted   = 1,
-    kToString_Default     = kToString_Formatted,
+    kToString_Default     = kToString_Unformatted,
 };
 
 typedef uint32_t ToStringFlags;


### PR DESCRIPTION
The point of this PR is to enable a minimal diff from our current format to let it work as JSONLines. Another change may follow later to address the requirements of users.

Fixes Issue #765.
Fixes Issue #783

This is an alternative to [toascii - Minimal Change to Enable JSON Lines Output](https://github.com/LunarG/gfxreconstruct/pull/807), using a different top-level structure, and implying a different per-line dispatch mechanism in processing scripts. **This PR811 is the currently preferred option over PR807**.

The output is like the following examples.
```json
{"index":1,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS","args":{"instance":1,"[out]pPhysicalDeviceCount":1,"[out]pPhysicalDevices":[2]}}}
{"index":2,"vkFunc":{"name":"vkGetPhysicalDeviceQueueFamilyProperties","args":{"physicalDevice":2,"[out]pQueueFamilyPropertyCount":3,"[out]pQueueFamilyProperties":[]}}}
{"index":3,"vkFunc":{"name":"vkGetPhysicalDeviceQueueFamilyProperties","args":{"physicalDevice":2,"[out]pQueueFamilyPropertyCount":3,"[out]pQueueFamilyProperties":[{"queueFlags":15,"queueCount":0,"timestampValidBits":0,"minImageTransferGranularity":{"width":0,"height":0,"depth":0}},{"queueFlags":0,"queueCount":0,"timestampValidBits":0,"minImageTransferGranularity":{"width":0,"height":0,"depth":0}},{"queueFlags":0,"queueCount":0,"timestampValidBits":0,"minImageTransferGranularity":{"width":0,"height":0,"depth":0}}]}}}
{"index":4,"vkFunc":{"name":"vkCreateDevice","return":"VK_SUCCESS","args":{"physicalDevice":2,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO","pNext":{"sType":"VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT","pNext":null,"memoryPriority":1},"flags":0,"queueCreateInfoCount":2,"pQueueCreateInfos":[{"sType":"VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO","pNext":null,"flags":0,"queueFamilyIndex":0,"queueCount":1,"pQueuePriorities":[1.000000]},{"sType":"VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO","pNext":null,"flags":0,"queueFamilyIndex":2,"queueCount":1,"pQueuePriorities":[1.000000]}],"enabledLayerCount":0,"ppEnabledLayerNames":[],"enabledExtensionCount":17,"ppEnabledExtensionNames":["VK_KHR_swapchain","VK_NV_dedicated_allocation","VK_KHR_descriptor_update_template","VK_KHR_image_format_list","VK_KHR_maintenance1","VK_KHR_maintenance2","VK_EXT_separate_stencil_usage","VK_KHR_swapchain_mutable_format","VK_EXT_memory_budget","VK_EXT_memory_priority","VK_KHR_ray_tracing","VK_KHR_get_memory_requirements2","VK_EXT_descriptor_indexing","VK_KHR_buffer_device_address","VK_KHR_deferred_host_operations","VK_KHR_pipeline_library","VK_KHR_maintenance3"],"pEnabledFeatures":{"robustBufferAccess":0,"fullDrawIndexUint32":1,"imageCubeArray":1,"independentBlend":1,"geometryShader":1,"tessellationShader":1,"sampleRateShading":1,"dualSrcBlend":1,"logicOp":1,"multiDrawIndirect":1,"drawIndirectFirstInstance":1,"depthClamp":1,"depthBiasClamp":1,"fillModeNonSolid":1,"depthBounds":1,"wideLines":1,"largePoints":1,"alphaToOne":1,"multiViewport":1,"samplerAnisotropy":1,"textureCompressionETC2":0,"textureCompressionASTC_LDR":0,"textureCompressionBC":1,"occlusionQueryPrecise":1,"pipelineStatisticsQuery":1,"vertexPipelineStoresAndAtomics":1,"fragmentStoresAndAtomics":1,"shaderTessellationAndGeometryPointSize":1,"shaderImageGatherExtended":1,"shaderStorageImageExtendedFormats":1,"shaderStorageImageMultisample":1,"shaderStorageImageReadWithoutFormat":1,"shaderStorageImageWriteWithoutFormat":1,"shaderUniformBufferArrayDynamicIndexing":1,"shaderSampledImageArrayDynamicIndexing":1,"shaderStorageBufferArrayDynamicIndexing":1,"shaderStorageImageArrayDynamicIndexing":1,"shaderClipDistance":1,"shaderCullDistance":1,"shaderFloat64":1,"shaderInt64":1,"shaderInt16":1,"shaderResourceResidency":1,"shaderResourceMinLod":1,"sparseBinding":1,"sparseResidencyBuffer":1,"sparseResidencyImage2D":1,"sparseResidencyImage3D":1,"sparseResidency2Samples":1,"sparseResidency4Samples":1,"sparseResidency8Samples":1,"sparseResidency16Samples":1,"sparseResidencyAliased":1,"variableMultisampleRate":1,"inheritedQueries":1}},"pAllocator":null,"[out]pDevice":3}}}
{"index":5,"vkFunc":{"name":"vkGetDeviceQueue","args":{"device":3,"queueFamilyIndex":0,"queueIndex":0,"[out]pQueue":15}}}
{"index":6,"vkFunc":{"name":"vkGetDeviceQueue","args":{"device":3,"queueFamilyIndex":2,"queueIndex":0,"[out]pQueue":16}}}
{"index":7,"vkFunc":{"name":"vkCreateFence","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_FENCE_CREATE_INFO","pNext":null,"flags":0},"pAllocator":null,"[out]pFence":88}}}

...

{"index":83,"vkFunc":{"name":"vkCreateBuffer","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO","pNext":null,"flags":0,"size":8388608,"usage":431,"sharingMode":"VK_SHARING_MODE_EXCLUSIVE","queueFamilyIndexCount":0,"pQueueFamilyIndices":[]},"pAllocator":null,"[out]pBuffer":39318}}}
{"index":84,"vkFunc":{"name":"vkGetSwapchainImagesKHR","return":"VK_SUCCESS","args":{"device":3,"swapchain":71,"[out]pSwapchainImageCount":4,"[out]pSwapchainImages":[76,77,78,79]}}}
{"index":85,"vkFunc":{"name":"vkCreateImage","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO","pNext":null,"flags":0,"imageType":"VK_IMAGE_TYPE_2D","format":"VK_FORMAT_B8G8R8A8_SRGB","extent":{"width":1920,"height":1080,"depth":1},"mipLevels":1,"arrayLayers":1,"samples":"VK_SAMPLE_COUNT_1_BIT","tiling":"VK_IMAGE_TILING_OPTIMAL","usage":3,"sharingMode":                  "VK_SHARING_MODE_EXCLUSIVE","queueFamilyIndexCount":0,"pQueueFamilyIndices":[],"initialLayout":"VK_IMAGE_LAYOUT_UNDEFINED"},"pAllocator":null,"[out]pImage":82}}}

...

{"index":2932,"vkFunc":{"name":"vkAllocateMemory","return":"VK_SUCCESS","args":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO","pNext":null,"allocationSize":8388608,"memoryTypeIndex":1},"pAllocator":null,"[out]pMemory":39324}}}
{"index":2933,"vkFunc":{"name":"vkGetBufferMemoryRequirements","args":{"device":3,"buffer":84,"[out]pMemoryRequirements":{"size":8294400,"alignment":256,"memoryTypeBits":31}}}}

...

{"index":7447,"vkFunc":{"name":"vkGetImageMemoryRequirements","args":{"device":3,"image":33186,"[out]pMemoryRequirements":{"size":177152,"alignment":1024,"memoryTypeBits":3}}}}
{"index":7448,"vkFunc":{"name":"vkBindImageMemory","return":"VK_SUCCESS","args":{"device":3,"image":33186,"memory":18651,"memoryOffset":4206592}}}


...

{"index":9999,"vkFunc":{"name":"vkCreateImageView","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO","pNext":null,"flags":0,"image":4231,"viewType":"VK_IMAGE_VIEW_TYPE_3D","format":"VK_FORMAT_R8G8B8A8_UNORM","components":{"r":"VK_COMPONENT_SWIZZLE_R","g":"VK_COMPONENT_SWIZZLE_G","b":"VK_COMPONENT_SWIZZLE_B","a":"VK_COMPONENT_SWIZZLE_A"},"subresourceRange":          {"aspectMask":1,"baseMipLevel":0,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},"pAllocator":null,"[out]pView":4233}}}

...

{"index":13867,"vkFunc":{"name":"vkCreateSampler","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO","pNext":null,"flags":0,"magFilter":"VK_FILTER_NEAREST","minFilter":"VK_FILTER_NEAREST","mipmapMode":"VK_SAMPLER_MIPMAP_MODE_NEAREST","addressModeU":"VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE","addressModeV":"VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE","addressModeW":             "VK_SAMPLER_ADDRESS_MODE_REPEAT","mipLodBias":0.000000,"anisotropyEnable":0,"maxAnisotropy":1.000000,"compareEnable":0,"compareOp":"VK_COMPARE_OP_LESS","minLod":0.000000,"maxLod":15.000000,"borderColor":"VK_BORDER_COLOR_INT_TRANSPARENT_BLACK","unnormalizedCoordinates":0},"pAllocator":null,"[out]pSampler":20859}}}
{"index":13868,"vkFunc":{"name":"vkCreateRenderPass","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO","pNext":null,"flags":0,"attachmentCount":1,"pAttachments":[{"flags":0,"format":"VK_FORMAT_R8G8B8A8_SRGB","samples":"VK_SAMPLE_COUNT_1_BIT","loadOp":"VK_ATTACHMENT_LOAD_OP_LOAD","storeOp":"VK_ATTACHMENT_STORE_OP_STORE","stencilLoadOp":                              "VK_ATTACHMENT_LOAD_OP_DONT_CARE","stencilStoreOp":"VK_ATTACHMENT_STORE_OP_DONT_CARE","initialLayout":"VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL","finalLayout":"VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL"}],"subpassCount":1,"pSubpasses":[{"flags":0,"pipelineBindPoint":"VK_PIPELINE_BIND_POINT_GRAPHICS","inputAttachmentCount":0,"pInputAttachments":[],"colorAttachmentCount":1,"pColorAttachments":[{"attachment":0,"layout":      "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL"}],"pResolveAttachments":[],"pDepthStencilAttachment":{"attachment":4294967295,"layout":"VK_IMAGE_LAYOUT_UNDEFINED"},"preserveAttachmentCount":0,"pPreserveAttachments":[]}],"dependencyCount":0,"pDependencies":[]},"pAllocator":null,"[out]pRenderPass":55}}}

...

{"index":13922,"vkFunc":{"name":"vkCreateFramebuffer","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO","pNext":null,"flags":0,"renderPass":72,"attachmentCount":1,"pAttachments":[80],"width":1920,"height":1080,"layers":1},"pAllocator":null,"[out]pFramebuffer":81}}}
{"index":13923,"vkFunc":{"name":"vkCreateFramebuffer","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO","pNext":null,"flags":0,"renderPass":72,"attachmentCount":1,"pAttachments":[89],"width":1920,"height":1080,"layers":1},"pAllocator":null,"[out]pFramebuffer":90}}}
{"index":13924,"vkFunc":{"name":"vkCreateFramebuffer","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO","pNext":null,"flags":0,"renderPass":72,"attachmentCount":1,"pAttachments":[98],"width":1920,"height":1080,"layers":1},"pAllocator":null,"[out]pFramebuffer":99}}}
{"index":13925,"vkFunc":{"name":"vkCreateFramebuffer","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO","pNext":null,"flags":0,"renderPass":72,"attachmentCount":1,"pAttachments":[107],"width":1920,"height":1080,"layers":1},"pAllocator":null,"[out]pFramebuffer":108}}}
{"index":13926,"vkFunc":{"name":"vkCreateFramebuffer","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO","pNext":null,"flags":0,"renderPass":6781,"attachmentCount":2,"pAttachments":[6575,6601],"width":1920,"height":1080,"layers":1},"pAllocator":null,"[out]pFramebuffer":6782}}}

...

{"index":13945,"vkFunc":{"name":"vkCreateShaderModule","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO","pNext":null,"flags":0,"codeSize":896,"pCode":"0x2106b218750"},"pAllocator":null,"[out]pShaderModule":4}}}
{"index":13946,"vkFunc":{"name":"vkCreateShaderModule","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO","pNext":null,"flags":0,"codeSize":724,"pCode":"0x2106a0a4960"},"pAllocator":null,"[out]pShaderModule":5}}}
{"index":13947,"vkFunc":{"name":"vkCreateShaderModule","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO","pNext":null,"flags":0,"codeSize":1876,"pCode":"0x2106b348480"},"pAllocator":null,"[out]pShaderModule":6}}}
{"index":13948,"vkFunc":{"name":"vkCreateShaderModule","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO","pNext":null,"flags":0,"codeSize":6704,"pCode":"0x2106b3d9ea0"},"pAllocator":null,"[out]pShaderModule":7}}}

...

{"index":17615,"vkFunc":{"name":"vkCreateDescriptorSetLayout","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO","pNext":null,"flags":0,"bindingCount":1,"pBindings":[{"binding":0,"descriptorType":"VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER","descriptorCount":1,"stageFlags":16,"pImmutableSamplers":[]}]},"pAllocator":null,"[out]pSetLayout":10}}}
{"index":17616,"vkFunc":{"name":"vkCreateDescriptorSetLayout","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO","pNext":null,"flags":0,"bindingCount":4,"pBindings":[{"binding":0,"descriptorType":"VK_DESCRIPTOR_TYPE_STORAGE_IMAGE","descriptorCount":1,"stageFlags":32,"pImmutableSamplers":[]},{"binding":1,"descriptorType":                                    "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC","descriptorCount":1,"stageFlags":32,"pImmutableSamplers":[]},{"binding":2,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE","descriptorCount":1,"stageFlags":32,"pImmutableSamplers":[]},{"binding":3,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLER","descriptorCount":1,"stageFlags":32,"pImmutableSamplers":[]}]},"pAllocator":null,"[out]pSetLayout":12}}}
{"index":17617,"vkFunc":{"name":"vkCreateDescriptorSetLayout","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO","pNext":null,"flags":0,"bindingCount":1,"pBindings":[{"binding":150,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE","descriptorCount":1,"stageFlags":16,"pImmutableSamplers":[]}]},"pAllocator":null,"[out]pSetLayout":56}}}
{"index":17618,"vkFunc":{"name":"vkCreateDescriptorSetLayout","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO","pNext":null,"flags":0,"bindingCount":0,"pBindings":[]},"pAllocator":null,"[out]pSetLayout":6565}}}
{"index":17619,"vkFunc":{"name":"vkCreateDescriptorSetLayout","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO","pNext":null,"flags":0,"bindingCount":4,"pBindings":[{"binding":86,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLER","descriptorCount":1,"stageFlags":1,"pImmutableSamplers":[]},{"binding":278,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE",     "descriptorCount":1,"stageFlags":1,"pImmutableSamplers":[]},{"binding":0,"descriptorType":"VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER","descriptorCount":1,"stageFlags":16,"pImmutableSamplers":[]},{"binding":14,"descriptorType":"VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER","descriptorCount":1,"stageFlags":1,"pImmutableSamplers":[]}]},"pAllocator":null,"[out]pSetLayout":6626}}}

...

{"index":17866,"vkFunc":{"name":"vkCreatePipelineLayout","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO","pNext":null,"flags":0,"setLayoutCount":1,"pSetLayouts":[7508],"pushConstantRangeCount":0,"pPushConstantRanges":[]},"pAllocator":null,"[out]pPipelineLayout":7509}}}
{"index":17867,"vkFunc":{"name":"vkCreatePipelineLayout","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO","pNext":null,"flags":0,"setLayoutCount":4,"pSetLayouts":[7578,7579,7580,7581],"pushConstantRangeCount":1,"pPushConstantRanges":[{"stageFlags":16,"offset":0,"size":112}]},"pAllocator":null,"[out]pPipelineLayout":7582}}}

...

{"index":18011,"vkFunc":{"name":"vkCreatePipelineCache","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO","pNext":null,"flags":0,"initialDataSize":0,"pInitialData":"0x0"},"pAllocator":null,"[out]pPipelineCache":49}}}
{"index":18012,"vkFunc":{"name":"vkCreateGraphicsPipelines","return":"VK_SUCCESS","args":{"device":3,"pipelineCache":49,"createInfoCount":1,"pCreateInfos":[{"sType":"VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO","pNext":null,"flags":0,"stageCount":2,"pStages":[{"sType":"VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO","pNext":null,"flags":0,"stage":"VK_SHADER_STAGE_FRAGMENT_BIT","module":54,"pName":"main",         "pSpecializationInfo":null},{"sType":"VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO","pNext":null,"flags":0,"stage":"VK_SHADER_STAGE_VERTEX_BIT","module":53,"pName":"main","pSpecializationInfo":null}],"pVertexInputState":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO","pNext":null,"flags":0,"vertexBindingDescriptionCount":2,"pVertexBindingDescriptions":[{"binding":0,"stride":36,"inputRate":     "VK_VERTEX_INPUT_RATE_VERTEX"},{"binding":1,"stride":0,"inputRate":"VK_VERTEX_INPUT_RATE_INSTANCE"}],"vertexAttributeDescriptionCount":2,"pVertexAttributeDescriptions":[{"location":0,"binding":0,"format":"VK_FORMAT_R32G32B32_SFLOAT","offset":0},{"location":1,"binding":0,"format":"VK_FORMAT_R32G32B32A32_SFLOAT","offset":12}]},"pInputAssemblyState":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO",     "pNext":null,"flags":0,"topology":"VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST","primitiveRestartEnable":0},"pTessellationState":null,"pViewportState":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO","pNext":null,"flags":0,"viewportCount":1,"pViewports":[],"scissorCount":1,"pScissors":[]},"pRasterizationState":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO","pNext":null,"flags":0,            "depthClampEnable":0,"rasterizerDiscardEnable":0,"polygonMode":"VK_POLYGON_MODE_FILL","cullMode":0,"frontFace":"VK_FRONT_FACE_COUNTER_CLOCKWISE","depthBiasEnable":1,"depthBiasConstantFactor":0.000000,"depthBiasClamp":0.000000,"depthBiasSlopeFactor":0.000000,"lineWidth":1.000000},"pMultisampleState":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO","pNext":null,"flags":0,"rasterizationSamples":           "VK_SAMPLE_COUNT_1_BIT","sampleShadingEnable":0,"minSampleShading":0.000000,"pSampleMask":[],"alphaToCoverageEnable":0,"alphaToOneEnable":0},"pDepthStencilState":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO","pNext":null,"flags":0,"depthTestEnable":0,"depthWriteEnable":0,"depthCompareOp":"VK_COMPARE_OP_ALWAYS","depthBoundsTestEnable":0,"stencilTestEnable":0,"front":{"failOp":"VK_STENCIL_OP_KEEP",  "passOp":"VK_STENCIL_OP_KEEP","depthFailOp":"VK_STENCIL_OP_KEEP","compareOp":"VK_COMPARE_OP_NEVER","compareMask":0,"writeMask":0,"reference":0},"back":{"failOp":"VK_STENCIL_OP_KEEP","passOp":"VK_STENCIL_OP_KEEP","depthFailOp":"VK_STENCIL_OP_KEEP","compareOp":"VK_COMPARE_OP_NEVER","compareMask":0,"writeMask":0,"reference":0},"minDepthBounds":0.000000,"maxDepthBounds":0.000000},"pColorBlendState":{"sType":                  "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO","pNext":null,"flags":0,"logicOpEnable":0,"logicOp":"VK_LOGIC_OP_COPY","attachmentCount":1,"pAttachments":[{"blendEnable":0,"srcColorBlendFactor":"VK_BLEND_FACTOR_ONE","dstColorBlendFactor":"VK_BLEND_FACTOR_ZERO","colorBlendOp":"VK_BLEND_OP_ADD","srcAlphaBlendFactor":"VK_BLEND_FACTOR_ONE","dstAlphaBlendFactor":"VK_BLEND_FACTOR_ZERO","alphaBlendOp":                 "VK_BLEND_OP_ADD","colorWriteMask":15}],"blendConstants":[0.000000,0.000000,0.000000,0.000000]},"pDynamicState":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO","pNext":null,"flags":0,"dynamicStateCount":7,"pDynamicStates":["VK_DYNAMIC_STATE_VIEWPORT","VK_DYNAMIC_STATE_SCISSOR","VK_DYNAMIC_STATE_DEPTH_BIAS","VK_DYNAMIC_STATE_BLEND_CONSTANTS","VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK",                          "VK_DYNAMIC_STATE_STENCIL_WRITE_MASK","VK_DYNAMIC_STATE_STENCIL_REFERENCE"]},"layout":57,"renderPass":55,"subpass":0,"basePipelineHandle":"VK_NULL_HANDLE","basePipelineIndex":0}],"pAllocator":null,"[out]pPipelines":[58]}}}

...

{"index":18938,"vkFunc":{"name":"vkCreateComputePipelines","return":"VK_SUCCESS","args":{"device":3,"pipelineCache":49,"createInfoCount":1,"pCreateInfos":[{"sType":"VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO","pNext":null,"flags":0,"stage":{"sType":"VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO","pNext":null,"flags":0,"stage":"VK_SHADER_STAGE_COMPUTE_BIT","module":7307,"pName":"main","pSpecializationInfo":null},"layout":7304,"basePipelineHandle":"VK_NULL_HANDLE","basePipelineIndex":0}],"pAllocator":null,"[out]pPipelines":[7308]}}}
{"index":18939,"vkFunc":{"name":"vkCreateDescriptorPool","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO","pNext":null,"flags":1,"maxSets":8192,"poolSizeCount":5,"pPoolSizes":[{"type":"VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER","descriptorCount":8192},{"type":"VK_DESCRIPTOR_TYPE_STORAGE_IMAGE","descriptorCount":8192},{"type":                                   "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC","descriptorCount":8192},{"type":"VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE","descriptorCount":8192},{"type":"VK_DESCRIPTOR_TYPE_SAMPLER","descriptorCount":8192}]},"pAllocator":null,"[out]pDescriptorPool":14}}}
{"index":18940,"vkFunc":{"name":"vkCreateDescriptorPool","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO","pNext":null,"flags":0,"maxSets":1024,"poolSizeCount":4,"pPoolSizes":[{"type":"VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER","descriptorCount":61440},{"type":"VK_DESCRIPTOR_TYPE_SAMPLER","descriptorCount":32768},{"type":"VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE",            "descriptorCount":131072},{"type":"VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC","descriptorCount":4096}]},"pAllocator":null,"[out]pDescriptorPool":6564}}}

...

{"index":19882,"vkFunc":{"name":"vkCreateDescriptorUpdateTemplateKHR","return":"VK_SUCCESS","args":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO","pNext":null,"flags":0,"descriptorUpdateEntryCount":7,"pDescriptorUpdateEntries":[{"dstBinding":70,"dstArrayElement":0,"descriptorCount":12,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLER","offset":0,"stride":24},{"dstBinding":86,     "dstArrayElement":0,"descriptorCount":1,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLER","offset":288,"stride":24},{"dstBinding":155,"dstArrayElement":0,"descriptorCount":18,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE","offset":312,"stride":24},{"dstBinding":289,"dstArrayElement":0,"descriptorCount":1,"descriptorType":"VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE","offset":744,"stride":24},{"dstBinding":0,"dstArrayElement":0,    "descriptorCount":8,"descriptorType":"VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER","offset":768,"stride":24},{"dstBinding":14,"dstArrayElement":0,"descriptorCount":2,"descriptorType":"VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER","offset":960,"stride":24},{"dstBinding":17,"dstArrayElement":0,"descriptorCount":1,"descriptorType":"VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER","offset":1008,"stride":24}],"templateType":                                     "VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET","descriptorSetLayout":8346,"pipelineBindPoint":"VK_PIPELINE_BIND_POINT_GRAPHICS","pipelineLayout":8347,"set":0},"pAllocator":null,"[out]pDescriptorUpdateTemplate":35845}}}

...

{"index":89710,"vkFunc":{"name":"vkQueuePresentKHR","return":"VK_SUCCESS","args":{"queue":15,"pPresentInfo":{"sType":"VK_STRUCTURE_TYPE_PRESENT_INFO_KHR","pNext":null,"waitSemaphoreCount":0,"pWaitSemaphores":[],"swapchainCount":1,"pSwapchains":[71],"pImageIndices":[2],"pResults":[]}}}}
{"index":89711,"vkFunc":{"name":"vkResetCommandBuffer","return":"VK_SUCCESS","args":{"commandBuffer":4813,"flags":0}}}
{"index":89712,"vkFunc":{"name":"vkResetCommandBuffer","return":"VK_SUCCESS","args":{"commandBuffer":4347,"flags":0}}}
{"index":89713,"vkFunc":{"name":"vkBeginCommandBuffer","return":"VK_SUCCESS","args":{"commandBuffer":4347,"pBeginInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO","pNext":null,"flags":1,"pInheritanceInfo":null}}}}
{"index":89714,"vkFunc":{"name":"vkBeginCommandBuffer","return":"VK_SUCCESS","args":{"commandBuffer":4813,"pBeginInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO","pNext":null,"flags":1,"pInheritanceInfo":null}}}}
{"index":89715,"vkFunc":{"name":"vkEndCommandBuffer","return":"VK_SUCCESS","args":{"commandBuffer":4813}}}
{"index":89716,"vkFunc":{"name":"vkQueueSubmit","return":"VK_SUCCESS","args":{"queue":15,"submitCount":1,"pSubmits":[{"sType":"VK_STRUCTURE_TYPE_SUBMIT_INFO","pNext":null,"waitSemaphoreCount":0,"pWaitSemaphores":[],"pWaitDstStageMask":[],"commandBufferCount":1,"pCommandBuffers":[4813],"signalSemaphoreCount":0,"pSignalSemaphores":[]}],"fence":6808}}}
{"index":89717,"vkFunc":{"name":"vkGetFenceStatus","return":"VK_NOT_READY","args":{"device":3,"fence":5148}}}
{"index":89718,"vkFunc":{"name":"vkGetFenceStatus","return":"VK_SUCCESS","args":{"device":3,"fence":3892}}}
{"index":89719,"vkFunc":{"name":"vkDestroySemaphore","args":{"device":3,"semaphore":39904,"pAllocator":null}}}
{"index":89720,"vkFunc":{"name":"vkCmdCopyBuffer","args":{"commandBuffer":4347,"srcBuffer":39907,"dstBuffer":39972,"regionCount":1,"pRegions":[{"srcOffset":3025920,"dstOffset":1728784,"size":183072}]}}}
{"index":89721,"vkFunc":{"name":"vkCmdPipelineBarrier","args":{"commandBuffer":4347,"srcStageMask":4096,"dstStageMask":4,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":1,"pBufferMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER","pNext":null,"srcAccessMask":4096,"dstAccessMask":4,"srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"buffer":39972,  "offset":1728784,"size":183072}],"imageMemoryBarrierCount":0,"pImageMemoryBarriers":[]}}}
{"index":89722,"vkFunc":{"name":"vkWaitForFences","return":"VK_SUCCESS","args":{"device":3,"fenceCount":1,"pFences":[6403],"waitAll":1,"timeout":18446744073709551615}}}
{"index":89723,"vkFunc":{"name":"vkResetFences","return":"VK_SUCCESS","args":{"device":3,"fenceCount":1,"pFences":[6403]}}}
{"index":89724,"vkFunc":{"name":"vkCmdCopyBuffer","args":{"commandBuffer":4347,"srcBuffer":39907,"dstBuffer":39974,"regionCount":1,"pRegions":[{"srcOffset":3208992,"dstOffset":139840,"size":41064}]}}}
{"index":89725,"vkFunc":{"name":"vkCmdPipelineBarrier","args":{"commandBuffer":4347,"srcStageMask":4096,"dstStageMask":4,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":1,"pBufferMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER","pNext":null,"srcAccessMask":4096,"dstAccessMask":2,"srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"buffer":39974,  "offset":139840,"size":41064}],"imageMemoryBarrierCount":0,"pImageMemoryBarriers":[]}}}
{"index":89726,"vkFunc":{"name":"vkEndCommandBuffer","return":"VK_SUCCESS","args":{"commandBuffer":4347}}}

...

```

Here is some output pretty-printed by piping through `jq`:
```json
{
  "index": 162,
  "vkFunc": {
    "name": "vkCreateImage",
    "return": "VK_SUCCESS",
    "args": {
      "device": 3,
      "pCreateInfo": {
        "sType": "VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO",
        "pNext": {
          "sType": "VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO",
          "pNext": null,
          "viewFormatCount": 2,
          "pViewFormats": [
            "VK_FORMAT_R8G8B8A8_SRGB",
            "VK_FORMAT_R8G8B8A8_UNORM"
          ]
        },
        "flags": 8,
        "imageType": "VK_IMAGE_TYPE_2D",
        "format": "VK_FORMAT_R8G8B8A8_SRGB",
        "extent": {
          "width": 1,
          "height": 1,
          "depth": 1
        },
        "mipLevels": 1,
        "arrayLayers": 1,
        "samples": "VK_SAMPLE_COUNT_1_BIT",
        "tiling": "VK_IMAGE_TILING_OPTIMAL",
        "usage": 7,
        "sharingMode": "VK_SHARING_MODE_EXCLUSIVE",
        "queueFamilyIndexCount": 0,
        "pQueueFamilyIndices": [],
        "initialLayout": "VK_IMAGE_LAYOUT_UNDEFINED"
      },
      "pAllocator": null,
      "[out]pImage": 487         //<----- "[out]" prefix is under review for a future PR.
    }
  }
}

...

{
  "index": 77273,
  "vkFunc": {
    "name": "vkQueueSubmit",
    "return": "VK_SUCCESS",
    "args": {
      "queue": 15,
      "submitCount": 1,
      "pSubmits": [
        {
          "sType": "VK_STRUCTURE_TYPE_SUBMIT_INFO",
          "pNext": null,
          "waitSemaphoreCount": 0,
          "pWaitSemaphores": [],
          "pWaitDstStageMask": [],
          "commandBufferCount": 1,
          "pCommandBuffers": [
            3019
          ],
          "signalSemaphoreCount": 0,
          "pSignalSemaphores": []
        }
      ],
      "fence": 6403
    }
  }
}

...

{
  "index": 86510,
  "vkFunc": {
    "name": "vkDestroyBuffer",
    "args": {
      "device": 3,
      "buffer": 39234,
      "pAllocator": null
    }
  }
}
{
  "index": 86511,
  "vkFunc": {
    "name": "vkFreeMemory",
    "args": {
      "device": 3,
      "memory": 39235,
      "pAllocator": null
    }
  }
}

...

{
  "index": 0,
  "vkFunc": {
    "name": "vkCreateInstance",
    "return": "VK_SUCCESS",
    "args": {
      "pCreateInfo": {
        "sType": "VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO",
        "pNext": null,
        "flags": 0,
        "pApplicationInfo": {
          "sType": "VK_STRUCTURE_TYPE_APPLICATION_INFO",
          "pNext": null,
          "pApplicationName": "quake 2 pathtracing",
          "applicationVersion": 4194304,
          "pEngineName": "vkpt",
          "engineVersion": 4194304,
          "apiVersion": 4198400
        },
        "enabledLayerCount": 0,
        "ppEnabledLayerNames": [],
        "enabledExtensionCount": 5,
        "ppEnabledExtensionNames": [
          "VK_KHR_surface",
          "VK_KHR_win32_surface",
          "VK_EXT_debug_utils",
          "VK_EXT_debug_report",
          "VK_KHR_device_group_creation"
        ]
      },
      "pAllocator": null,
      "[out]pInstance": 1
    }
  }
}

...

{
  "index": 2211,
  "vkFunc": {
    "name": "vkCreateRayTracingPipelinesNV",
    "return": "VK_SUCCESS",
    "args": {
      "device": 5,
      "pipelineCache": "VK_NULL_HANDLE",
      "createInfoCount": 1,
      "pCreateInfos": [
        {
          "sType": "VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV",
          "pNext": null,
          "flags": 0,
          "stageCount": 14,
          "pStages": [
            {
              "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
              "pNext": null,
              "flags": 0,
              "stage": "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
              "module": 40,
              "pName": "main",
              "pSpecializationInfo": null
            },
            {
              "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
              "pNext": null,
              "flags": 0,
              "stage": "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
              "module": 41,
              "pName": "main",
              "pSpecializationInfo": {
                "mapEntryCount": 1,
                "pMapEntries": [
                  {
                    "constantID": 0,
                    "offset": 0,
                    "size": 4
                  }
                ],
                "dataSize": 4,
                "pData": "0x436f8ff080"
              }
            },
            {
              "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
              "pNext": null,
              "flags": 0,
              "stage": "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
              "module": 41,
              "pName": "main",
              "pSpecializationInfo": {
                "mapEntryCount": 1,
                "pMapEntries": [
                  {
                    "constantID": 0,
                    "offset": 0,
                    "size": 4
                  }
                ],
                "dataSize": 4,
                "pData": "0x436f8ff084"
              }
            },
            {
              "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
              "pNext": null,
              "flags": 0,
              "stage": "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
              "module": 42,
              "pName": "main",
              "pSpecializationInfo": {
                "mapEntryCount": 1,
                "pMapEntries": [
                  {
                    "constantID": 0,
                    "offset": 0,
                    "size": 4
                  }
                ],
                "dataSize": 4,
                "pData": "0x436f8ff080"
              }
            },
            {
              "sType": "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
              "pNext": null,
              "flags": 0,
              "stage": "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
              "module": 42,
              "pName": "main",
              "pSpecializationInfo": {
                "mapEntryCount": 1,
                "pMapEntries": [
                  {
                    "constantID": 0,
                    "offset": 0,
                    "size": 4
                  }
                ],
                "dataSize": 4,
                "pData": "0x436f8ff084"
              }
            },
...

{
  "index": 2217,
  "vkFunc": {
    "name": "vkGetRayTracingShaderGroupHandlesNV",
    "return": "VK_SUCCESS",
    "args": {
      "device": 5,
      "pipeline": 343,
      "firstGroup": 0,
      "groupCount": 15,
      "dataSize": 480,
      "[out]pData": "0x1771d100000"
    }
  }
}
{
  "index": 2218,
  "vkFunc": {
    "name": "vkUnmapMemory",
    "args": {
      "device": 5,
      "memory": 345
    }
  }
}

...

{
  "index": 47437,
  "vkFunc": {
    "name": "vkCmdTraceRaysNV",
    "args": {
      "commandBuffer": 393,
      "raygenShaderBindingTableBuffer": 344,
      "raygenShaderBindingOffset": 32,
      "missShaderBindingTableBuffer": 344,
      "missShaderBindingOffset": 0,
      "missShaderBindingStride": 32,
      "hitShaderBindingTableBuffer": 344,
      "hitShaderBindingOffset": 0,
      "hitShaderBindingStride": 32,
      "callableShaderBindingTableBuffer": "VK_NULL_HANDLE",
      "callableShaderBindingOffset": 0,
      "callableShaderBindingStride": 0,
      "width": 960,
      "height": 1080,
      "depth": 2
    }
  }
}

...

{
  "index": 52233,
  "vkFunc": {
    "name": "vkGetAccelerationStructureMemoryRequirementsNV",
    "args": {
      "device": 5,
      "pInfo": {
        "sType": "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV",
        "pNext": null,
        "type": "VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV",
        "accelerationStructure": 2037
      },
      "[out]pMemoryRequirements": {
        "sType": "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2",
        "pNext": null,
        "memoryRequirements": {
          "size": 119040,
          "alignment": 0,
          "memoryTypeBits": 0
        }
      }
    }
  }
}
{
  "index": 52234,
  "vkFunc": {
    "name": "vkCmdBuildAccelerationStructureNV",
    "args": {
      "commandBuffer": 33,
      "pInfo": {
        "sType": "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV",
        "pNext": null,
        "type": "VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR",
        "flags": 8,
        "instanceCount": 0,
        "geometryCount": 1,
        "pGeometries": [
          {
            "sType": "VK_STRUCTURE_TYPE_GEOMETRY_NV",
            "pNext": null,
            "geometryType": "VK_GEOMETRY_TYPE_TRIANGLES_KHR",
            "geometry": {
              "triangles": {
                "sType": "VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV",
                "pNext": null,
                "vertexData": 76,
                "vertexOffset": 310378512,
                "vertexCount": 22254,
                "vertexStride": 12,
                "vertexFormat": "VK_FORMAT_R32G32B32_SFLOAT",
                "indexData": "VK_NULL_HANDLE",
                "indexOffset": 0,
                "indexCount": 22254,
                "indexType": "VK_INDEX_TYPE_NONE_KHR",
                "transformData": "VK_NULL_HANDLE",
                "transformOffset": 0
              },
              "aabbs": {
                "sType": "VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV",
                "pNext": null,
                "aabbData": "VK_NULL_HANDLE",
                "numAABBs": 0,
                "stride": 0,
                "offset": 0
              }
            },
            "flags": 0
          }
        ]
      },
      "instanceData": "VK_NULL_HANDLE",
      "instanceOffset": 0,
      "update": 0,
      "dst": 2037,
      "src": "VK_NULL_HANDLE",
      "scratch": 332,
      "scratchOffset": 0
    }
  }
}
```