### PR TITLE
Heading Level Corrected

### DIFF
--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -139,7 +139,7 @@ The following example demonstrates how to set the layer's log level to
 export GFXRECON_LOG_LEVEL=warning
 ```
 
-##### Supported Options
+#### Supported Options
 
 Options with the BOOL type accept the following values:
 


### PR DESCRIPTION
In USAGE_Desktop.md, Supported Options was a level 5 header, nesting it under the level 4 Linux Options header above. I don't think that is right since there are options marked "Windows only" in that section.