### PR TITLE
Toascii - Rearranged Cases in ToString (Decoded_VkWriteDescriptorSet&)

### DIFF
--- a/framework/decode/custom_vulkan_struct_decoders_to_string.cpp
+++ b/framework/decode/custom_vulkan_struct_decoders_to_string.cpp
@@ -268,6 +268,8 @@ std::string ToString<decode::Decoded_VkWriteDescriptorSet>(const decode::Decoded
             case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
             case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
             case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            case VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM:
+            case VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM:
             {
                 FieldToString(strStrm, false, "pImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(decoded_obj.pImageInfo, toStringFlags, tabCount, tabSize));
             } break;
@@ -283,9 +285,24 @@ std::string ToString<decode::Decoded_VkWriteDescriptorSet>(const decode::Decoded
             {
                 FieldToString(strStrm, false, "pTexelBufferView", toStringFlags, tabCount, tabSize, ArrayToString(decoded_obj.pTexelBufferView.GetLength(), decoded_obj.pTexelBufferView.GetPointer(), toStringFlags, tabCount, tabSize));
             } break;
+            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+            case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            {
+                // NOP, The data was output in the pNext chain above.
+            } break;
+            /// @todo This should be fine as the data was output in the pNext chain above
+            //  via generated code but needs checking on RADV.
+            case VK_DESCRIPTOR_TYPE_MUTABLE_VALVE:
+            /// @todo This should also be fine, as the code to output the related data via
+            /// the pNext chain above is all generated but needs checking with a trace using
+            /// the old NV RT extension:
+            case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            {
+                GFXRECON_LOG_WARNING_ONCE("Untested descriptorType in VkWriteDescriptorSet: %s.", ToString(obj.descriptorType, 0, 0, 0).c_str());
+            } break;
             default: 
             {
-                GFXRECON_LOG_ERROR("Unknown descriptorType in VkWriteDescriptorSet.");
+                GFXRECON_LOG_ERROR("Unknown descriptorType in VkWriteDescriptorSet: %s.", ToString(obj.descriptorType, 0, 0, 0).c_str());
             }
             break;
             }


### PR DESCRIPTION
Fixes #794

This did pass CI with toascii enabled, that commit since backed-out.

They now reflect current known support.
Refined Logging for untested and unknown descriptor types.
Added comments to explain what work remains.

Everything turned out to be fine just by moving up some IHV-extension image types to be dealt with on standard image path, with a couple of non-P1 types not yet tested but expected to work based on generated code looking correct. Logging adjusted in light of that.

Verification of non-P1 types deferred to a new issue: https://github.com/LunarG/gfxreconstruct/issues/823