### PR TITLE
Check resource binding alignment when page guard is in use

### DIFF
--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -1030,6 +1030,66 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetAndroidHardwareBuffe
     }
 };
 
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindBufferMemory>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkBindBufferMemory(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindBufferMemory2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkBindBufferMemory2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindBufferMemory2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkBindBufferMemory2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindImageMemory>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkBindImageMemory(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindImageMemory2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkBindImageMemory2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindImageMemory2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkBindImageMemory2(args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2222,10 +2222,7 @@ bool VulkanCaptureManager::CheckBindAlignment(VkDeviceSize memoryOffset)
 {
     if ((GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kPageGuard) && !GetPageGuardAlignBufferSizes())
     {
-        util::PageGuardManager* manager = util::PageGuardManager::Get();
-        assert(manager != nullptr);
-
-        return (memoryOffset % manager->GetSystemPageSize()) == 0;
+        return (memoryOffset % util::platform::GetSystemPageSize()) == 0;
     }
 
     return true;

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1131,6 +1131,17 @@ class VulkanCaptureManager : public CaptureManager
                                                                 const struct AHardwareBuffer*             buffer,
                                                                 VkAndroidHardwareBufferPropertiesANDROID* pProperties);
 
+    void
+    PreProcess_vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
+
+    void
+    PreProcess_vkBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos);
+
+    void PreProcess_vkBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);
+
+    void
+    PreProcess_vkBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos);
+
 #if defined(__ANDROID__)
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
 #endif
@@ -1193,6 +1204,7 @@ class VulkanCaptureManager : public CaptureManager
     bool ProcessReferenceToAndroidHardwareBuffer(VkDevice device, AHardwareBuffer* hardware_buffer);
     void ProcessImportAndroidHardwareBuffer(VkDevice device, VkDeviceMemory memory, AHardwareBuffer* hardware_buffer);
     void ReleaseAndroidHardwareBuffer(AHardwareBuffer* hardware_buffer);
+    bool CheckBindAlignment(VkDeviceSize memoryOffset);
 
   private:
     void QueueSubmitWriteFillMemoryCmd();

--- a/framework/util/page_guard_manager.cpp
+++ b/framework/util/page_guard_manager.cpp
@@ -201,7 +201,7 @@ void PageGuardManager::InitializeSystemExceptionContext(void)
 }
 
 PageGuardManager::PageGuardManager() :
-    exception_handler_(nullptr), exception_handler_count_(0), system_page_size_(GetSystemPageSize()),
+    exception_handler_(nullptr), exception_handler_count_(0), system_page_size_(util::platform::GetSystemPageSize()),
     system_page_pot_shift_(GetSystemPagePotShift()), enable_copy_on_map_(kDefaultEnableCopyOnMap),
     enable_separate_read_(kDefaultEnableSeparateRead), unblock_sigsegv_(kDefaultUnblockSIGSEGV),
     enable_read_write_same_page_(kDefaultEnableReadWriteSamePage)
@@ -214,7 +214,7 @@ PageGuardManager::PageGuardManager(bool enable_copy_on_map,
                                    bool expect_read_write_same_page,
                                    bool unblock_SIGSEGV) :
     exception_handler_(nullptr),
-    exception_handler_count_(0), system_page_size_(GetSystemPageSize()),
+    exception_handler_count_(0), system_page_size_(util::platform::GetSystemPageSize()),
     system_page_pot_shift_(GetSystemPagePotShift()), enable_copy_on_map_(enable_copy_on_map),
     enable_separate_read_(enable_separate_read), unblock_sigsegv_(unblock_SIGSEGV),
     enable_read_write_same_page_(expect_read_write_same_page)
@@ -255,21 +255,10 @@ void PageGuardManager::Destroy()
     }
 }
 
-size_t PageGuardManager::GetSystemPageSize() const
-{
-#if defined(WIN32)
-    SYSTEM_INFO sSysInfo;
-    GetSystemInfo(&sSysInfo);
-    return sSysInfo.dwPageSize;
-#else
-    return getpagesize();
-#endif
-}
-
 size_t PageGuardManager::GetSystemPagePotShift() const
 {
     size_t pot_shift = 0;
-    size_t page_size = GetSystemPageSize();
+    size_t page_size = util::platform::GetSystemPageSize();
 
     if (page_size != 0)
     {

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -106,8 +106,6 @@ class PageGuardManager
 
     void FreePersistentShadowMemory(uintptr_t shadow_memory_handle);
 
-    size_t GetSystemPageSize() const;
-
   protected:
     PageGuardManager();
 

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -106,6 +106,8 @@ class PageGuardManager
 
     void FreePersistentShadowMemory(uintptr_t shadow_memory_handle);
 
+    size_t GetSystemPageSize() const;
+
   protected:
     PageGuardManager();
 
@@ -184,7 +186,6 @@ class PageGuardManager
     typedef std::unordered_map<uint64_t, MemoryInfo> MemoryInfoMap;
 
   private:
-    size_t GetSystemPageSize() const;
     size_t GetSystemPagePotShift() const;
     void   InitializeSystemExceptionContext();
 

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -211,6 +211,13 @@ inline int32_t MakeDirectory(const char* filename)
     return _mkdir(filename);
 }
 
+inline size_t GetSystemPageSize()
+{
+    SYSTEM_INFO sSysInfo;
+    GetSystemInfo(&sSysInfo);
+    return sSysInfo.dwPageSize;
+}
+
 #else // !defined(WIN32)
 
 // Error value indicating string was truncated
@@ -453,6 +460,11 @@ inline int32_t GMTime(tm* gm_time, const time_t* timer)
 inline int32_t MakeDirectory(const char* filename)
 {
     return mkdir(filename, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+}
+
+inline size_t GetSystemPageSize()
+{
+    return getpagesize();
 }
 
 #endif // WIN32


### PR DESCRIPTION
When page guard mechanism is in use, and the application performs cpu writes and gpu reads/copies to different buffers/images that are bound to the same page of mapped memory, data loss can occur which can lead to rendering artifacts. This can happen when resources are bound to device memory at offsets that are not multiples of the system page size. To work around this the "Page Guard Align Buffer Sizes" environment variable must be set to true (see usage for more information).

This commit will print a warning message when resources are bound at offsets that are not a multiples of the system's page size.