### PR TITLE
Trimming TrimCommandPool, SetPrivateData, and replay DeviceGroupDeviceCreateInfo

### DIFF
--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -377,6 +377,11 @@ Optional arguments:
                         returned by vkEnumeratePhysicalDevices.  Replay may fail
                         if the specified device is not compatible with the
                         original capture devices.
+  --gpu-group <index>   Use the specified device group for replay, where index
+                        is the zero-based index to the array of physical device group
+                        returned by vkEnumeratePhysicalDeviceGroups.  Replay may fail
+                        if the specified device group is not compatible with the
+                        original capture device group.
   --pause-frame <N>     Pause after replaying frame number N.
   --paused              Pause after replaying the first frame (same
                         as --pause-frame 1).

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -258,6 +258,8 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     graphics::VulkanDevicePropertyFeatureInfo property_feature_info;
 
     std::unordered_map<uint32_t, VkDeviceQueueCreateFlags> queue_family_creation_flags;
+
+    std::vector<VkPhysicalDevice> replay_device_group;
 };
 
 struct QueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -945,11 +945,31 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     // capture and replay physical device properties or GPU override settings.
     void SelectPhysicalDevice(PhysicalDeviceInfo* physical_device_info);
 
+    void SelectPhysicalDeviceGroup(PhysicalDeviceInfo*                  physical_device_info,
+                                   VkDeviceGroupDeviceCreateInfo&       device_group_create_info,
+                                   const std::vector<format::HandleId>& capture_device_group,
+                                   std::vector<VkPhysicalDevice>&       replay_device_group);
+
     bool GetOverrideDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info);
+
+    bool GetOverrideDeviceGroup(InstanceInfo*                  instance_info,
+                                PhysicalDeviceInfo*            physical_device_info,
+                                VkDeviceGroupDeviceCreateInfo& device_group_create_info,
+                                std::vector<VkPhysicalDevice>& replay_device_group);
 
     void GetMatchingDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info);
 
+    void GetMatchingDeviceGroup(InstanceInfo*                        instance_info,
+                                PhysicalDeviceInfo*                  physical_device_info,
+                                VkDeviceGroupDeviceCreateInfo&       device_group_create_info,
+                                const std::vector<format::HandleId>& capture_device_group,
+                                std::vector<VkPhysicalDevice>&       replay_device_group);
+
     void CheckPhysicalDeviceCompatibility(PhysicalDeviceInfo* physical_device_info);
+
+    void CheckPhysicalDeviceGroupCompatibility(InstanceInfo*                        instance_info,
+                                               const std::vector<format::HandleId>& capture_device_group,
+                                               const std::vector<VkPhysicalDevice>& replay_device_group);
 
     bool CheckTrimDeviceExtensions(VkPhysicalDevice physical_device, std::vector<std::string>* extensions);
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -946,7 +946,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void SelectPhysicalDevice(PhysicalDeviceInfo* physical_device_info);
 
     void SelectPhysicalDeviceGroup(PhysicalDeviceInfo*                  physical_device_info,
-                                   VkDeviceGroupDeviceCreateInfo&       device_group_create_info,
                                    const std::vector<format::HandleId>& capture_device_group,
                                    std::vector<VkPhysicalDevice>&       replay_device_group);
 
@@ -954,14 +953,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     bool GetOverrideDeviceGroup(InstanceInfo*                  instance_info,
                                 PhysicalDeviceInfo*            physical_device_info,
-                                VkDeviceGroupDeviceCreateInfo& device_group_create_info,
                                 std::vector<VkPhysicalDevice>& replay_device_group);
 
     void GetMatchingDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info);
 
     void GetMatchingDeviceGroup(InstanceInfo*                        instance_info,
                                 PhysicalDeviceInfo*                  physical_device_info,
-                                VkDeviceGroupDeviceCreateInfo&       device_group_create_info,
                                 const std::vector<format::HandleId>& capture_device_group,
                                 std::vector<VkPhysicalDevice>&       replay_device_group);
 

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -49,6 +49,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         remove_unsupported_features{ false };
     bool                         enable_use_captured_swapchain_indices{ false };
     int32_t                      override_gpu_index{ -1 };
+    int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;
     ScreenshotFormat             screenshot_format{ ScreenshotFormat::kBmp };

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -581,6 +581,26 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdExecuteCommands>
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTrimCommandPool>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkTrimCommandPool(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTrimCommandPoolKHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkTrimCommandPool(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetCommandPool>
 {
     template <typename... Args>

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -1110,6 +1110,26 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindImageMemory2KHR>
     }
 };
 
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetPrivateDataEXT>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkSetPrivateData(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetPrivateData>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkSetPrivateData(result, args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2205,6 +2205,25 @@ void VulkanCaptureManager::PreProcess_vkGetAndroidHardwareBufferPropertiesANDROI
 #endif
 }
 
+void VulkanCaptureManager::PostProcess_vkSetPrivateData(VkResult          result,
+                                                        VkDevice          device,
+                                                        VkObjectType      objectType,
+                                                        uint64_t          objectHandle,
+                                                        VkPrivateDataSlot privateDataSlot,
+                                                        uint64_t          data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(privateDataSlot);
+
+    if (privateDataSlot != VK_NULL_HANDLE)
+    {
+        if (((GetCaptureMode() & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackSetPrivateData(device, objectType, objectHandle, privateDataSlot, data);
+        }
+    }
+}
+
 #if defined(__ANDROID__)
 void VulkanCaptureManager::OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t*         pPresentModeCount,
                                                                            VkPresentModeKHR* pPresentModes)

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -848,6 +848,15 @@ class VulkanCaptureManager : public CaptureManager
         }
     }
 
+    void PostProcess_vkTrimCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags)
+    {
+        if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackTrimCommandPool(device, commandPool);
+        }
+    }
+
     void PostProcess_vkResetCommandPool(VkResult result, VkDevice, VkCommandPool commandPool, VkCommandPoolResetFlags)
     {
         if (((GetCaptureMode() & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1151,6 +1151,13 @@ class VulkanCaptureManager : public CaptureManager
     void
     PreProcess_vkBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos);
 
+    void PostProcess_vkSetPrivateData(VkResult          result,
+                                      VkDevice          device,
+                                      VkObjectType      objectType,
+                                      uint64_t          objectHandle,
+                                      VkPrivateDataSlot privateDataSlot,
+                                      uint64_t          data);
+
 #if defined(__ANDROID__)
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
 #endif

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -369,6 +369,9 @@ struct CommandPoolWrapper : public HandleWrapper<VkCommandPool>
 
     // Members for trimming state tracking.
     uint32_t queue_family_index{ 0 };
+
+    DeviceWrapper* device{ nullptr };
+    bool           trim_command_pool{ false };
 };
 
 // For vkGetPhysicalDeviceSurfaceCapabilitiesKHR

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -78,7 +78,6 @@ struct DebugUtilsMessengerEXTWrapper        : public HandleWrapper<VkDebugUtilsM
 struct ValidationCacheEXTWrapper            : public HandleWrapper<VkValidationCacheEXT> {};
 struct IndirectCommandsLayoutNVWrapper      : public HandleWrapper<VkIndirectCommandsLayoutNV> {};
 struct PerformanceConfigurationINTELWrapper : public HandleWrapper<VkPerformanceConfigurationINTEL> {};
-struct PrivateDataSlotWrapper               : public HandleWrapper<VkPrivateDataSlot> {};
 
 // This handle type has a create function, but no destroy function. The handle wrapper will be owned by its parent VkDisplayKHR
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
@@ -453,6 +452,14 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
 struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStructureNV>
 {
     // TODO: Determine what additional state tracking is needed.
+};
+
+struct PrivateDataSlotWrapper : public HandleWrapper<VkPrivateDataSlot>
+{
+    DeviceWrapper* device{ nullptr };
+    VkObjectType   object_type{ VK_OBJECT_TYPE_UNKNOWN };
+    uint64_t       object_handle{ 0 };
+    uint64_t       data{ 0 };
 };
 
 // Handle alias types for extension handle types that have been promoted to core types.

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -65,6 +65,17 @@ void VulkanStateTracker::TrackCommandExecution(CommandBufferWrapper*           w
     }
 }
 
+void VulkanStateTracker::TrackTrimCommandPool(VkDevice device, VkCommandPool command_pool)
+{
+    assert(command_pool != VK_NULL_HANDLE);
+
+    auto wrapper               = reinterpret_cast<CommandPoolWrapper*>(command_pool);
+    wrapper->trim_command_pool = true;
+
+    auto device_wrapper = reinterpret_cast<DeviceWrapper*>(device);
+    wrapper->device     = device_wrapper;
+}
+
 void VulkanStateTracker::TrackResetCommandPool(VkCommandPool command_pool)
 {
     assert(command_pool != VK_NULL_HANDLE);

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1305,6 +1305,20 @@ void VulkanStateTracker::TrackReleaseFullScreenExclusiveMode(VkDevice device, Vk
     wrapper->release_full_screen_exclusive_mode = true;
 }
 
+void VulkanStateTracker::TrackSetPrivateData(
+    VkDevice device, VkObjectType objectType, uint64_t objectHandle, VkPrivateDataSlot privateDataSlot, uint64_t data)
+{
+    assert(privateDataSlot != VK_NULL_HANDLE);
+
+    auto wrapper        = reinterpret_cast<PrivateDataSlotWrapper*>(privateDataSlot);
+    auto device_wrapper = reinterpret_cast<DeviceWrapper*>(device);
+
+    wrapper->device        = device_wrapper;
+    wrapper->object_type   = objectType;
+    wrapper->object_handle = GetWrappedId(objectHandle, objectType);
+    wrapper->data          = data;
+}
+
 void VulkanStateTracker::DestroyState(InstanceWrapper* wrapper)
 {
     assert(wrapper != nullptr);

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -615,7 +615,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
                         {
                             auto* acc_struct = reinterpret_cast<VkWriteDescriptorSetAccelerationStructureKHR*>(
                                 const_cast<void*>(binding.write_pnext));
-                            binding.record_write_set_accel_structs.resize(acc_struct->accelerationStructureCount);
+                            binding.record_write_set_accel_structs.clear();
                             std::copy(acc_struct->pAccelerationStructures,
                                       acc_struct->pAccelerationStructures + acc_struct->accelerationStructureCount,
                                       std::back_inserter(binding.record_write_set_accel_structs));

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -248,6 +248,8 @@ class VulkanStateTracker
         }
     }
 
+    void TrackTrimCommandPool(VkDevice device, VkCommandPool command_pool);
+
     void TrackResetCommandPool(VkCommandPool command_pool);
 
     void TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice                        physical_device,

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -393,6 +393,12 @@ class VulkanStateTracker
 
     void TrackReleaseFullScreenExclusiveMode(VkDevice device, VkSwapchainKHR swapchain);
 
+    void TrackSetPrivateData(VkDevice          device,
+                             VkObjectType      objectType,
+                             uint64_t          objectHandle,
+                             VkPrivateDataSlot privateDataSlot,
+                             uint64_t          data);
+
   private:
     template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
     void AddGroupHandles(ParentHandle                  parent_handle,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -101,6 +101,8 @@ class VulkanStateWriter
 
     void WriteCommandBufferState(const VulkanStateTable& state_table);
 
+    void WriteTrimCommandPool(const VulkanStateTable& state_table);
+
     void WriteFenceState(const VulkanStateTable& state_table);
 
     void WriteEventState(const VulkanStateTable& state_table);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -103,6 +103,8 @@ class VulkanStateWriter
 
     void WriteTrimCommandPool(const VulkanStateTable& state_table);
 
+    void WritePrivateDataSlotState(const VulkanStateTable& state_table);
+
     void WriteFenceState(const VulkanStateTable& state_table);
 
     void WriteEventState(const VulkanStateTable& state_table);

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -30,9 +30,10 @@ const char kOptions[] =
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--dcp,--discard-cached-psos,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
     "range,--fmr|--flush-measurement-range,--use-captured-swapchain-indices";
-const char kArguments[] = "--log-level,--log-file,--gpu,--pause-frame,--wsi,--surface-index,-m|--memory-translation,--"
-                          "replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
-                          "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range";
+const char kArguments[] =
+    "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
+    "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
+    "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -46,7 +47,7 @@ static void PrintUsage(const char* exe_name)
 
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to replay GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s\t[-h | --help] [--version] [--gpu <index>]", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  %s\t[-h | --help] [--version] [--gpu <index>] [--gpu-group <index>]", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("\t\t\t[--pause-frame <N>] [--paused] [--sync] [--screenshot-all]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshots <N1(-N2),...>] [--screenshot-format <format>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]");
@@ -100,6 +101,11 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDevices.  Replay may fail");
     GFXRECON_WRITE_CONSOLE("          \t\tif the specified device is not compatible with the");
     GFXRECON_WRITE_CONSOLE("          \t\toriginal capture devices.");
+    GFXRECON_WRITE_CONSOLE("  --gpu-group <index>\t\tUse the specified device group for replay, where index");
+    GFXRECON_WRITE_CONSOLE("          \t\tis the zero-based index to the array of physical device group");
+    GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDeviceGroups.  Replay may fail");
+    GFXRECON_WRITE_CONSOLE("          \t\tif the specified device group is not compatible with the");
+    GFXRECON_WRITE_CONSOLE("          \t\toriginal capture device group.");
     GFXRECON_WRITE_CONSOLE("  --pause-frame <N>\tPause after replaying frame number N.");
     GFXRECON_WRITE_CONSOLE("  --paused\t\tPause after replaying the first frame (same");
     GFXRECON_WRITE_CONSOLE("          \t\tas --pause-frame 1).");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -59,6 +59,7 @@ const char kLogFileArgument[]                    = "--log-file";
 const char kLogDebugView[]                       = "--log-debugview";
 const char kNoDebugPopup[]                       = "--no-debug-popup";
 const char kOverrideGpuArgument[]                = "--gpu";
+const char kOverrideGpuGroupArgument[]           = "--gpu-group";
 const char kPausedOption[]                       = "--paused";
 const char kPauseFrameArgument[]                 = "--pause-frame";
 const char kSkipFailedAllocationShortOption[]    = "--sfa";
@@ -708,6 +709,12 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (!override_gpu.empty())
     {
         replay_options.override_gpu_index = std::stoi(override_gpu);
+    }
+
+    const auto& override_gpu_group = arg_parser.GetArgumentValue(kOverrideGpuGroupArgument);
+    if (!override_gpu_group.empty())
+    {
+        replay_options.override_gpu_group_index = std::stoi(override_gpu_group);
     }
 
     if (arg_parser.IsOptionSet(kRemoveUnsupportedOption))


### PR DESCRIPTION
Added a option `--gpu-group` to set device group when CreateDevice.

There're two requirements for device group setting.
https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDeviceGroupDeviceCreateInfo-pPhysicalDevices-00376
https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDeviceGroupDeviceCreateInfo-physicalDeviceCount-00377

There is an interesting thing. For Nvidia device, when the device group setting is wrong, it might crash sometimes. But for AMD device, it still plays normally for vkCube.