### PR TITLE
Toascii - Header Line with source, version, commit.

### DIFF
--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -43,6 +43,7 @@ void VulkanAsciiConsumerBase::Initialize(FILE* file)
 
 void VulkanAsciiConsumerBase::Destroy()
 {
+    // The file is owned elsewhere and was passed to Initialize() so don't close:
     file_ = nullptr;
     strStrm_.str(std::string{});
 }

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2022 Valve Corporation
+** Copyright (c) 2018-2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -20,6 +20,7 @@
 ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ** DEALINGS IN THE SOFTWARE.
 */
+/// @file A consumer of capture decode which converts the calls into JSON Lines.
 
 #include "decode/vulkan_ascii_consumer_base.h"
 #include "decode/custom_vulkan_ascii_consumer.h"
@@ -28,6 +29,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+/// The version of the JSON file format which will be produced.
+/// Inc the minor number when anything is added.
+#define GFXRECON_CONVERT_JSON_VERSION "0.8.0"
+
 VulkanAsciiConsumerBase::VulkanAsciiConsumerBase() : file_(nullptr) {}
 
 VulkanAsciiConsumerBase::~VulkanAsciiConsumerBase()
@@ -35,10 +40,24 @@ VulkanAsciiConsumerBase::~VulkanAsciiConsumerBase()
     Destroy();
 }
 
-void VulkanAsciiConsumerBase::Initialize(FILE* file)
+void VulkanAsciiConsumerBase::Initialize(FILE*      file,
+                                         const char gfxrVersion[],
+                                         const char vulkanVersion[],
+                                         const char inputFilepath[])
 {
     assert(file);
     file_ = file;
+    if (file != nullptr)
+    {
+        // Emit the header object as the first line of the file:
+        fprintf(file_,
+                "{\"header\":{\"source-path\":\"%s\",\"json-version\":"
+                "\"" GFXRECON_CONVERT_JSON_VERSION "\",\"gfxrecon-version\":\"%s\",\"vulkan-version\":\"%s\"}}\n",
+                inputFilepath,
+                gfxrVersion,
+                vulkanVersion);
+        fflush(file_);
+    }
 }
 
 void VulkanAsciiConsumerBase::Destroy()

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2022 Valve Corporation
+** Copyright (c) 2018-2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -46,7 +46,11 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
 
     /// @brief  Initialize the consumer for writing to the file passed in.
     /// @param file A file to output to. The caller retains ownership. Do not close this.
-    void Initialize(FILE* file);
+    /// @param gfxrVersion The version of the GFXReconstruct project the convert tool was built from,
+    /// including the branch and git commit in the case of a development build.
+    /// @param vulkanVersion The version of Vulkan Headers that is being built against.
+    /// @param inputFilepath The path to the source file as passed to the application.
+    void Initialize(FILE* file, const char gfxrVersion[], const char vulkanVersion[], const char inputFilepath[]);
 
     void Destroy();
 

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -154,6 +154,8 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
     }
 
   private:
+    /// File to write textual representation of capture out to.
+    /// @note This is passed to us in Initialize() and owned elsewhere.
     FILE* file_{ nullptr };
     /// Reusable string stream for formatting top-level objects like vkFuncs into.
     std::stringstream strStrm_;

--- a/tools/toascii/main.cpp
+++ b/tools/toascii/main.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2022 Valve Corporation
+** Copyright (c) 2018-2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,6 @@
 */
 
 #include "project_version.h"
-
 #include "tool_settings.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_ascii_consumer.h"
@@ -57,8 +56,10 @@ static void PrintUsage(const char* exe_name)
 #endif
 }
 
-static std::string GetOutputFileName(const gfxrecon::util::ArgumentParser& arg_parser,
-                                     const std::string&                    input_filename)
+namespace
+{
+
+std::string GetOutputFileName(const gfxrecon::util::ArgumentParser& arg_parser, const std::string& input_filename)
 {
     std::string output_filename;
     if (arg_parser.IsArgumentSet(kOutput))
@@ -77,6 +78,8 @@ static std::string GetOutputFileName(const gfxrecon::util::ArgumentParser& arg_p
     }
     return output_filename;
 }
+
+} // namespace
 
 int main(int argc, const char** argv)
 {
@@ -109,8 +112,8 @@ int main(int argc, const char** argv)
 #endif
 
     const auto& positional_arguments = arg_parser.GetPositionalArguments();
-    std::string input_filename       = positional_arguments[0];
-    std::string output_filename      = GetOutputFileName(arg_parser, input_filename);
+    const std::string input_filename       = positional_arguments[0];
+    const std::string output_filename      = GetOutputFileName(arg_parser, input_filename);
 
     gfxrecon::decode::FileProcessor file_processor;
     if (file_processor.Initialize(input_filename))
@@ -128,7 +131,13 @@ int main(int argc, const char** argv)
         if (output_file)
         {
             gfxrecon::decode::VulkanAsciiConsumer ascii_consumer;
-            ascii_consumer.Initialize(output_file);
+            ascii_consumer.Initialize(output_file,
+                                      GFXRECON_PROJECT_VERSION_STRING,
+                                      (std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE)) + "." +
+                                       std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE)) + "." +
+                                       std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE)))
+                                          .c_str(),
+                                      input_filename.c_str());
             gfxrecon::decode::VulkanDecoder decoder;
             decoder.AddConsumer(&ascii_consumer);
             file_processor.AddDecoder(&decoder);


### PR DESCRIPTION
Toascii - Header Line with source, version, commit.
    
Fixes #809

Toascii is disabled in the build, but this PR previously passed CI with it temporarily enabled. 

The headers look like:

```json
    {
      "header": {
        "source-path": "<long string>.gfxr",
        "json-version": "0.8.0",
        "gfxrecon-version": "0.9.15-dev (branch:c13c3fe*)",
        "vulkan-version": "1.3.224"
      }
    }
```