### PR TITLE
Renamed gfxrecon-toascii to gfxrecon-convert

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -50,7 +50,7 @@ organized with the following file structure:
 | | extract | Tool to extract SPIR-V binaries from GFXR capture files. |
 | | info | Tool to print information describing GFXR capture files. |
 | | replay | Tool to replay GFXR capture files. |
-| | toascii | Tool to convert GFXR capture files to an ASCII listing of API calls. |
+| | convert | Tool to convert GFXR capture files to a JSON Lines listing of API calls. |
 
 ## Repository Set-Up
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The GFXReconstruct components currently provided with this repository are:
     zlib, which are currently optional build dependencies.
 * The `gfxrecon-extract` tool to extract SPIR-V binaries from
   GFXReconstruct capture files.
-* The `gfxrecon-toascii` tool to convert GFXReconstruct capture files to
-  an ASCII listing of API calls.
+* The `gfxrecon-convert` tool to convert GFXReconstruct capture files to
+  a [JSON Lines](https://jsonlines.org/) listing of API calls.
 
 
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,8 +5,7 @@ add_subdirectory(extract)
 add_subdirectory(optimize)
 add_subdirectory(capture)
 add_subdirectory(gfxrecon)
-
-# TOASCII build is currently disabled pending resolution of some issues
-if(BUILD_TOASCII)
-add_subdirectory(toascii)
+# gfxrecon-convert build is currently disabled pending resolution of some issues
+if(GFXRECON_BUILD_CONVERT)
+add_subdirectory(convert)
 endif()

--- a/tools/convert/CMakeLists.txt
+++ b/tools/convert/CMakeLists.txt
@@ -26,18 +26,18 @@
 # Description: CMake script for framework util target
 ###############################################################################
 
-add_executable(gfxrecon-toascii "")
+add_executable(gfxrecon-convert "")
 
-target_sources(gfxrecon-toascii
+target_sources(gfxrecon-convert
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/main.cpp
               )
 
-target_include_directories(gfxrecon-toascii PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/..)
+target_include_directories(gfxrecon-convert PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/..)
 
-target_link_libraries(gfxrecon-toascii gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
+target_link_libraries(gfxrecon-convert gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
 
-common_build_directives(gfxrecon-toascii)
+common_build_directives(gfxrecon-convert)
 
-install(TARGETS gfxrecon-toascii RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS gfxrecon-convert RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/convert/README.md
+++ b/tools/convert/README.md
@@ -1,13 +1,13 @@
-### To ASCII
+### Convert
 
-The `gfxrecon-toascii.exe` converts GFXReconstruct capture files to text.
+The `gfxrecon-convert` tool converts GFXReconstruct capture files to lines of JSON text.
 The text output is formatted as JSON and written by default to a .txt file in the directory of the specified GFXReconstruct capture file. Use `--output` to override the default filename for the output.
 
 ```text
-gfxrecon-toascii.exe - A tool to convert GFXReconstruct capture files to text.
+gfxrecon-convert - A tool to convert GFXReconstruct capture files to text.
 
 Usage:
-  gfxrecon-toascii.exe [-h | --help] [--version] [--output filename] <file>
+  gfxrecon-convert.exe [-h | --help] [--version] [--output filename] <file>
 
 Required arguments:
   <file>                Path to the GFXReconstruct capture file to be converted

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -49,7 +49,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  -h\t\t\tPrint usage information and exit (same as --help).");
     GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
     GFXRECON_WRITE_CONSOLE("  --output file\t\t'stdout' or a path to a file to write JSON output");
-    GFXRECON_WRITE_CONSOLE("        \t\tto. Default is the input filepath with \"gfxr\" replaced by \"txt\".");
+    GFXRECON_WRITE_CONSOLE("        \t\tto. Default is the input filepath with \"gfxr\" replaced");
+    GFXRECON_WRITE_CONSOLE("        \t\tby \"txt\".");
 #if defined(WIN32) && defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
     GFXRECON_WRITE_CONSOLE("        \t\tdisplayed when abort() is called (Windows debug only).");
@@ -111,7 +112,7 @@ int main(int argc, const char** argv)
     }
 #endif
 
-    const auto& positional_arguments = arg_parser.GetPositionalArguments();
+    const auto&       positional_arguments = arg_parser.GetPositionalArguments();
     const std::string input_filename       = positional_arguments[0];
     const std::string output_filename      = GetOutputFileName(arg_parser, input_filename);
 


### PR DESCRIPTION
Fixes #833

Part of https://github.com/LunarG/gfxreconstruct/issues/818

Best reviewed after https://github.com/LunarG/gfxreconstruct/pull/830.

gfxrecon-convert is currently disabled in the build but this PR has previously passed CI with it temporarily turned back on.