### PR TITLE
Lazily resize tracked swapchain images vector

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4560,6 +4560,11 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
             auto table = GetDeviceTable(device);
             assert(table != nullptr);
 
+            if (captured_index >= static_cast<uint32_t>(swapchain_info->acquired_indices.size()))
+            {
+                swapchain_info->acquired_indices.resize(captured_index + 1);
+            }
+
             swapchain_info->acquired_indices[captured_index] = captured_index;
 
             // The image has already been acquired. Swap the synchronization objects.
@@ -4592,6 +4597,11 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
 
             result = swapchain_->AcquireNextImageKHR(
                 func, device_info, swapchain_info, timeout, semaphore_info, fence_info, captured_index, replay_index);
+
+            if (captured_index >= static_cast<uint32_t>(swapchain_info->acquired_indices.size()))
+            {
+                swapchain_info->acquired_indices.resize(captured_index + 1);
+            }
 
             // Track the index that was acquired on replay, which may be different than the captured index.
             swapchain_info->acquired_indices[captured_index] = (*replay_index);

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1222,7 +1222,13 @@ void VulkanStateTracker::TrackAcquireImage(
 {
     auto wrapper = reinterpret_cast<SwapchainKHRWrapper*>(swapchain);
 
-    assert((wrapper != nullptr) && (image_index < wrapper->image_acquired_info.size()));
+    assert(wrapper != nullptr);
+
+    if (image_index >= wrapper->image_acquired_info.size())
+    {
+        wrapper->image_acquired_info.resize(image_index + 1);
+        wrapper->image_acquired_info[image_index].last_presented_queue = VK_NULL_HANDLE;
+    }
 
     wrapper->image_acquired_info[image_index].is_acquired           = true;
     wrapper->image_acquired_info[image_index].acquired_device_mask  = deviceMask;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -657,8 +657,6 @@ inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, v
     wrapper->samples            = VK_SAMPLE_COUNT_1_BIT;
     wrapper->tiling             = VK_IMAGE_TILING_OPTIMAL;
     wrapper->queue_family_index = swapchain_wrapper->queue_family_index;
-
-    swapchain_wrapper->image_acquired_info.emplace_back(ImageAcquiredInfo{});
 }
 
 template <>

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1937,11 +1937,12 @@ void VulkanStateWriter::WriteMappedMemoryState(const VulkanStateTable& state_tab
 void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_table)
 {
     state_table.VisitWrappers([&](const SwapchainKHRWrapper* wrapper) {
-        assert((wrapper != nullptr) && (wrapper->device != nullptr) &&
-               (wrapper->child_images.size() == wrapper->image_acquired_info.size()));
+        assert(wrapper != nullptr && wrapper->device != nullptr);
 
         const DeviceWrapper* device_wrapper = wrapper->device;
-        size_t               image_count    = wrapper->child_images.size();
+        size_t               image_count    = wrapper->child_images.size() > wrapper->image_acquired_info.size()
+                                                  ? wrapper->image_acquired_info.size()
+                                                  : wrapper->child_images.size();
 
         format::SetSwapchainImageStateCommandHeader header;
         format::SwapchainImageStateInfo             info;
@@ -1957,11 +1958,11 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
         header.device_id                = device_wrapper->handle_id;
         header.swapchain_id             = wrapper->handle_id;
         header.last_presented_image     = wrapper->last_presented_image;
-        header.image_info_count         = static_cast<uint32_t>(wrapper->child_images.size());
+        header.image_info_count         = static_cast<uint32_t>(image_count);
 
         output_stream_->Write(&header, sizeof(header));
 
-        for (size_t i = 0; i < wrapper->child_images.size(); ++i)
+        for (size_t i = 0; i < image_count; ++i)
         {
             ImageWrapper* image_wrapper = wrapper->child_images[i];
 


### PR DESCRIPTION
Calling vkAcquireNextImage before vkGetSwapchainImages is a valid use
case but was not being handled properly when capturing (tracking)
outside of a trimmed range.

This commit fixes this issue for capturing and replaying