### PR TITLE
Changed JSON index From Just Functions to all Blocks.

### DIFF
--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -139,7 +139,8 @@ class FileProcessor
     std::vector<uint8_t>                parameter_buffer_;
     std::vector<uint8_t>                compressed_parameter_buffer_;
     util::Compressor*                   compressor_;
-    uint64_t                            api_call_index_;
+    /// @brief Incremented at the end of every block successfully processed.
+    uint64_t block_index_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/tools/convert/README.md
+++ b/tools/convert/README.md
@@ -245,9 +245,11 @@ All values of a header are strings.
 
 ### vkFunc Objects
 
-Vulkan function objects contain `"index"` at the top level which is a
-JSON number representing the position of the call in the sequence recorded in
-the capture and a nested object under the key `"vkFunc"` which contains the data captured from a Vulkan call.
+Vulkan function objects contain `"index"` at the top level, which is a
+JSON number representing the position of the call in the sequence of
+successfully-decoded blocks in the original binary capture file,
+and a nested object under the key `"vkFunc"` which contains the data captured
+from a Vulkan call.
 
 ```json
 {
@@ -263,7 +265,7 @@ the capture and a nested object under the key `"vkFunc"` which contains the data
 ```
 
 When debugging during replay, the value of the `"index"` field can be matched
-to the value of the GFXReconstruct `FileProcessor::api_call_index_` member
+to the value of the GFXReconstruct `FileProcessor::block_index_` member
 variable.
 This allows a developer to see the history of calls in JSON form up to the point
 of interest in their debugger.


### PR DESCRIPTION
It seems to be a fairly trivial change @bradgrantham-lunarg.

It only counts blocks that were not skipped. Skipped ones are corrupt or were generated by a newer release of the gfxrecon layer than the one being used to convert it.

Alternatives:
1. Count Blocks that failed to decode too.
2. Expand the capture file format to hold the index and have capture write it in there for replay and tools to read out without having to count blocks themselves.

Not that this makes holes in the sequence of calls reported by `Convert`:
```json
{"index":0,"vkFunc":{"name":"vkCreateInstance","return":"VK_SUCCESS","args":{...
{"index":1,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":2,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":7,"vkFunc":{"name":"vkGetPhysicalDeviceProperties","args":{"physical...
{"index":8,"vkFunc":{"name":"vkGetPhysicalDeviceProperties2","args":{"physica...
{"index":9,"vkFunc":{"name":"vkGetPhysicalDeviceProperties","args":{"physical...
{"index":10,"vkFunc":{"name":"vkGetPhysicalDeviceProperties2","args":{"physic...
{"index":11,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCES...
{"index":12,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCES...


{"index":0,"vkFunc":{"name":"vkCreateInstance","return":"VK_SUCCESS","args":{...
{"index":1,"vkFunc":{"name":"vkCreateDebugReportCallbackEXT","return":"VK_SUC...
{"index":2,"vkFunc":{"name":"vkCreateXcbSurfaceKHR","return":"VK_SUCCESS","ar...
{"index":3,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":4,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":11,"vkFunc":{"name":"vkGetPhysicalDeviceProperties","args":{"physica...
{"index":12,"vkFunc":{"name":"vkGetPhysicalDeviceFeatures2","args":{"physical...
{"index":13,"vkFunc":{"name":"vkGetPhysicalDeviceMemoryProperties","args":{"p...
{"index":14,"vkFunc":{"name":"vkGetPhysicalDeviceQueueFamilyProperties","args...


{"index":1,"vkFunc":{"name":"vkCreateInstance","return":"VK_SUCCESS","args":{...
{"index":2,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":5,"vkFunc":{"name":"vkGetPhysicalDeviceQueueFamilyProperties","args"...
{"index":6,"vkFunc":{"name":"vkGetPhysicalDeviceQueueFamilyProperties","args"...
{"index":7,"vkFunc":{"name":"vkCreateDevice","return":"VK_SUCCESS","args":{"p...
{"index":8,"vkFunc":{"name":"vkGetDeviceQueue","args":{"device":4,"queueFamil...
{"index":9,"vkFunc":{"name":"vkCreateFence","return":"VK_SUCCESS","args":{"de...
{"index":10,"vkFunc":{"name":"vkCreateFence","return":"VK_SUCCESS","args":{"d...
{"index":11,"vkFunc":{"name":"vkCreateSemaphore","return":"VK_SUCCESS","args"...


{"index":0,"vkFunc":{"name":"vkCreateInstance","return":"VK_SUCCESS","args":{...
{"index":1,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":2,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":5,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":6,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":7,"vkFunc":{"name":"vkGetPhysicalDeviceProperties","args":{"physical...
{"index":8,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":9,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS...
{"index":10,"vkFunc":{"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCES...
```