### PR TITLE
Flush After Presents

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -444,6 +444,13 @@ void CaptureManager::EndApiCallCapture()
             WriteToFile(parameter_buffer->GetHeaderData(),
                         parameter_buffer->GetHeaderDataSize() + parameter_buffer->GetDataSize());
         }
+
+        // Flush after presents to avoid capture files with incomplete final
+        // blocks.
+        if (thread_data->call_id_ == format::ApiCall_vkQueuePresentKHR)
+        {
+            file_stream_->Flush();
+        }
     }
 }
 


### PR DESCRIPTION
**Try the approach in Issue #876 before falling back to something like this**
If 876 is successful, this still might be useful but only to flush the last frame to account for application hard crashes between frame end and next frame start.

Flush after presents to avoid capture files with incomplete final blocks. The last block in a capture is often a present since the logic to quit is evaluated between a present and the next Vulkan call that would be made. By selctively flushing after presents we can take care of these cases without the cost (if any) of the option to flush after every block is written.

The warning seen when running many captures through `convert`, `compress`, and `optimize` is:

    [gfxrecon] WARNING - Incomplete block at end of file



It might be worth investigating whether something like this was also needed to get data all the way out of even OS disk cache to storage on clean shutdown:
```cpp
inline int32_t FileClose(FILE* stream)
{
#if defined(__USE_POSIX)
    fflush(stream);
    fsync(fileno(stream));
#endif
    return fclose(stream);
}
```