### PR TITLE
Print gfxr info even if frame number is 0

### DIFF
--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -536,8 +536,7 @@ int main(int argc, const char** argv)
         file_processor.AddDecoder(&decoder);
         file_processor.ProcessAllFrames();
 
-        if ((file_processor.GetCurrentFrameNumber() > 0) &&
-            (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
+        if (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone)
         {
             GFXRECON_WRITE_CONSOLE("File info:");
 
@@ -618,10 +617,15 @@ int main(int argc, const char** argv)
                 }
             }
 
+            auto alocation_count = stats_consumer.GetAllocationCount();
             GFXRECON_WRITE_CONSOLE("\nDevice memory allocation info:");
-            GFXRECON_WRITE_CONSOLE("\tTotal allocations: %" PRIu64, stats_consumer.GetAllocationCount());
-            GFXRECON_WRITE_CONSOLE("\tMin allocation size: %" PRIu64, stats_consumer.GetMinAllocationSize());
-            GFXRECON_WRITE_CONSOLE("\tMax allocation size: %" PRIu64, stats_consumer.GetMaxAllocationSize());
+            GFXRECON_WRITE_CONSOLE("\tTotal allocations: %" PRIu64, alocation_count);
+
+            if (alocation_count > 0)
+            {
+                GFXRECON_WRITE_CONSOLE("\tMin allocation size: %" PRIu64, stats_consumer.GetMinAllocationSize());
+                GFXRECON_WRITE_CONSOLE("\tMax allocation size: %" PRIu64, stats_consumer.GetMaxAllocationSize());
+            }
 
             GFXRECON_WRITE_CONSOLE("\nPipeline info:");
             GFXRECON_WRITE_CONSOLE("\tTotal graphics pipelines: %" PRIu64, stats_consumer.GetGraphicsPipelineCount());
@@ -632,16 +636,17 @@ int main(int argc, const char** argv)
             // GFXRECON_WRITE_CONSOLE("\nDraw/dispatch call info:");
             // GFXRECON_WRITE_CONSOLE("\tTotal draw calls: %" PRIu64, stats_consumer.GetDrawCount());
             // GFXRECON_WRITE_CONSOLE("\tTotal dispatch calls: %" PRIu64, stats_consumer.GetDispatchCount());
+
+            if (file_processor.GetCurrentFrameNumber() == 0)
+            {
+                GFXRECON_WRITE_CONSOLE("\nFile did not contain any frames");
+            }
         }
-        else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
+        else
         {
             GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
             gfxrecon::util::Log::Release();
             exit(-1);
-        }
-        else
-        {
-            GFXRECON_WRITE_CONSOLE("File did not contain any frames");
         }
     }
 


### PR DESCRIPTION
https://github.com/LunarG/gfxreconstruct/issues/585
sample: `lunarg@tcubumes:/media/nas/smb_traces/vulkan/gfxr/windows-nvidia/vulkaninfo-new/vulkaninfo_20211005T094235.gfxr`
```
Info:
File info:
        Compression format: LZ4
        Total frames: 0

Application info:
        Application name: vulkaninfo
        Application version: 1
        Engine name:
        Engine version: 0
        Target API version: 4194304 (1.0.0)

Physical device info:
        Device name: GeForce RTX 2070
        Device ID: 0x1f07
        Vendor ID: 0x10de
        Driver version: 1917288448 (0x72478000)
        API version: 4202638 (1.2.142)

Device memory allocation info:
        Total allocations: 0
        Min allocation size: 0
        Max allocation size: 0

Pipeline info:
        Total graphics pipelines: 0
        Total compute pipelines: 0

File did not contain any frames
```
The engine name and engine version is null and 0 in the captured file. It looks no problem to print the info even if the frame number is 0. I don't know why the original code requires frame number has to be larger than 0.