### PR TITLE
Annotate Captures With Layer Version

### DIFF
--- a/android/framework/util/CMakeLists.txt
+++ b/android/framework/util/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(gfxrecon_util
                    ${GFXRECON_SOURCE_DIR}/framework/util/platform.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/settings_loader.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/settings_loader.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/util/strings.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/strings.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/options.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/options.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/shared_mutex.h

--- a/framework/decode/annotation_handler.h
+++ b/framework/decode/annotation_handler.h
@@ -1,5 +1,6 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2021-2022 LunarG, Inc.
+** Copyright (c) 2022 Valve Corporation
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -36,7 +37,10 @@ class AnnotationHandler
   public:
     virtual ~AnnotationHandler() {}
 
-    virtual void ProcessAnnotation(format::AnnotationType type, const std::string& label, const std::string& data) = 0;
+    virtual void ProcessAnnotation(uint64_t               block_index,
+                                   format::AnnotationType type,
+                                   const std::string&     label,
+                                   const std::string&     data) = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1290,7 +1290,9 @@ bool FileProcessor::ProcessAnnotation(const format::BlockHeader& block_header, f
         {
             std::string label;
             std::string data;
-            size_t      total_length = size_t(label_length + data_length);
+            const auto  size_sum = label_length + data_length;
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, size_sum);
+            const size_t total_length = static_cast<size_t>(size_sum);
 
             success = ReadParameterBuffer(total_length);
             if (success)
@@ -1304,7 +1306,8 @@ bool FileProcessor::ProcessAnnotation(const format::BlockHeader& block_header, f
                 if (data_length > 0)
                 {
                     auto data_start = std::next(parameter_buffer_.begin(), label_length);
-                    data.assign(data_start, std::next(data_start, size_t(data_length)));
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, data_length);
+                    data.assign(data_start, std::next(data_start, static_cast<size_t>(data_length)));
                 }
 
                 assert(annotation_handler_ != nullptr);

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2020,2022 Valve Corporation
+** Copyright (c) 2018-2020,2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -1279,8 +1279,8 @@ bool FileProcessor::ProcessStateMarker(const format::BlockHeader& block_header, 
 bool FileProcessor::ProcessAnnotation(const format::BlockHeader& block_header, format::AnnotationType annotation_type)
 {
     bool     success      = false;
-    uint32_t label_length = 0;
-    uint32_t data_length  = 0;
+    decltype(format::AnnotationHeader::label_length) label_length = 0;
+    decltype(format::AnnotationHeader::data_length)  data_length  = 0;
 
     success = ReadBytes(&label_length, sizeof(label_length));
     success = success && ReadBytes(&data_length, sizeof(data_length));
@@ -1290,7 +1290,7 @@ bool FileProcessor::ProcessAnnotation(const format::BlockHeader& block_header, f
         {
             std::string label;
             std::string data;
-            auto        total_length = label_length + data_length;
+            size_t      total_length = size_t(label_length + data_length);
 
             success = ReadParameterBuffer(total_length);
             if (success)
@@ -1304,11 +1304,11 @@ bool FileProcessor::ProcessAnnotation(const format::BlockHeader& block_header, f
                 if (data_length > 0)
                 {
                     auto data_start = std::next(parameter_buffer_.begin(), label_length);
-                    data.assign(data_start, std::next(data_start, data_length));
+                    data.assign(data_start, std::next(data_start, size_t(data_length)));
                 }
 
                 assert(annotation_handler_ != nullptr);
-                annotation_handler_->ProcessAnnotation(annotation_type, label, data);
+                annotation_handler_->ProcessAnnotation(block_index_, annotation_type, label, data);
             }
             else
             {

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -27,6 +27,38 @@
 #include "generated/generated_vulkan_ascii_consumer.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+namespace
+{
+std::string AnnotationTypeToString(const format::AnnotationType& type)
+{
+    std::string str;
+    switch (type)
+    {
+        case format::AnnotationType::kUnknown:
+            str.assign("kUnknown");
+            break;
+        case format::AnnotationType::kText:
+            str.assign("kText");
+            break;
+        case format::AnnotationType::kJson:
+            str.assign("kJson");
+            break;
+        case format::AnnotationType::kXml:
+            str.assign("kXml");
+            break;
+        default:
+            str.assign("OUT_OF_RANGE_ERROR");
+            GFXRECON_LOG_WARNING("format::AnnotationType with out of range value: %lu", (long unsigned)type);
+            break;
+    }
+    return str;
+}
+} // namespace
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 /// The version of the JSON file format which will be produced.
@@ -65,6 +97,19 @@ void VulkanAsciiConsumerBase::Destroy()
     // The file is owned elsewhere and was passed to Initialize() so don't close:
     file_ = nullptr;
     strStrm_.str(std::string{});
+}
+
+void VulkanAsciiConsumerBase::ProcessAnnotation(uint64_t               block_index,
+                                                format::AnnotationType type,
+                                                const std::string&     label,
+                                                const std::string&     data)
+{
+    fprintf(file_,
+            "{\"index\":%llu,\"annotation\":{\"type\":\"%s\",\"label\":\"%s\",\"data\":\"%s\"}}\n",
+            (long long unsigned int)block_index,
+            util::AnnotationTypeToString(type).c_str(),
+            label.c_str(),
+            util::JSONEscape(data).c_str());
 }
 
 // clang-format off

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -25,6 +25,7 @@
 #define GFXRECON_DECODE_VULKAN_ASCII_CONSUMER_BASE_H
 
 #include "format/platform_types.h"
+#include "annotation_handler.h"
 #include "generated/generated_vulkan_consumer.h"
 #include "util/defines.h"
 #include "util/to_string.h"
@@ -37,7 +38,9 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-class VulkanAsciiConsumerBase : public VulkanConsumer
+/// @brief Factor out manually-written code from the derived class
+/// VulkanAsciiConsumer which is generated.
+class VulkanAsciiConsumerBase : public VulkanConsumer, public AnnotationHandler
 {
   public:
     VulkanAsciiConsumerBase();
@@ -55,6 +58,12 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
     void Destroy();
 
     bool IsValid() const { return (file_ != nullptr); }
+
+    /// @brief Convert annotations, which are simple {type:enum, key:string, value:string} objects.
+    virtual void ProcessAnnotation(uint64_t               block_index,
+                                   format::AnnotationType type,
+                                   const std::string&     label,
+                                   const std::string&     data) override;
 
     virtual void
     Process_vkAllocateCommandBuffers(const ApiCallInfo&                                         call_info,

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -633,17 +633,18 @@ bool CaptureManager::CreateCaptureFile(const std::string& base_filename)
     {
         GFXRECON_LOG_INFO("Recording graphics API capture to %s", capture_filename.c_str());
         WriteFileHeader();
-        std::string header_annotation = "{\n"
-                                        "    \"tool\": \"capture\",\n"
-                                        "    \"gfxrecon-version\": \"" GFXRECON_PROJECT_VERSION_STRING "\",\n"
-                                        "    \"vulkan-version\": \"";
-        header_annotation += std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE));
-        header_annotation += '.';
-        header_annotation += std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE));
-        header_annotation += '.';
-        header_annotation += std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-        header_annotation += "\"\n}";
-        WriteAnnotation(format::AnnotationType::kJson, "header", header_annotation.c_str());
+        // Save parameters of the capture in an annotation.
+        std::string operation_annotation = "{\n"
+                                           "    \"tool\": \"capture\",\n"
+                                           "    \"gfxrecon-version\": \"" GFXRECON_PROJECT_VERSION_STRING "\",\n"
+                                           "    \"vulkan-version\": \"";
+        operation_annotation += std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE));
+        operation_annotation += '.';
+        operation_annotation += std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE));
+        operation_annotation += '.';
+        operation_annotation += std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
+        operation_annotation += "\"\n}";
+        WriteAnnotation(format::AnnotationType::kJson, format::kAnnotationLabelOperation, operation_annotation.c_str());
     }
     else
     {

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -725,8 +725,10 @@ void CaptureManager::WriteAnnotation(const format::AnnotationType type, const ch
         annotation.label_length      = label_length;
         annotation.data_length       = data_length;
 
-        CombineAndWriteToFile(
-            { { &annotation, sizeof(annotation) }, { label, size_t(label_length) }, { data, size_t(data_length) } });
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, data_length);
+        CombineAndWriteToFile({ { &annotation, sizeof(annotation) },
+                                { label, label_length },
+                                { data, static_cast<size_t>(data_length) } });
     }
 }
 

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -716,19 +716,18 @@ void CaptureManager::WriteAnnotation(const format::AnnotationType type, const ch
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
-        const auto label_length = decltype(format::AnnotationHeader::label_length)(util::platform::StringLength(label));
-        const auto data_length  = decltype(format::AnnotationHeader::data_length)(util::platform::StringLength(data));
+        const auto label_length = util::platform::StringLength(label);
+        const auto data_length  = util::platform::StringLength(data);
+
         format::AnnotationHeader annotation;
         annotation.block_header.size = format::GetAnnotationBlockBaseSize() + label_length + data_length;
         annotation.block_header.type = format::BlockType::kAnnotation;
         annotation.annotation_type   = type;
-        annotation.label_length      = label_length;
-        annotation.data_length       = data_length;
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uint32_t, label_length);
+        annotation.label_length = static_cast<uint32_t>(label_length);
+        annotation.data_length  = data_length;
 
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, data_length);
-        CombineAndWriteToFile({ { &annotation, sizeof(annotation) },
-                                { label, label_length },
-                                { data, static_cast<size_t>(data_length) } });
+        CombineAndWriteToFile({ { &annotation, sizeof(annotation) }, { label, label_length }, { data, data_length } });
     }
 }
 

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2018-2022 Valve Corporation
+** Copyright (c) 2018-2022 LunarG, Inc.
 ** Copyright (c) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -125,6 +125,12 @@ class CaptureManager
     bool IsTrimHotkeyPressed();
 
     void WriteDisplayMessageCmd(const char* message);
+
+    /// @brief Inject an Annotation block into the capture file.
+    /// @param type Identifies the contents of data as plain, xml, or json text
+    /// @param label The key or name of the annotation.
+    /// @param data The value or payload text of the annotation.
+    void WriteAnnotation(const format::AnnotationType type, const char* label, const char* data);
 
     virtual CaptureSettings::TraceSettings GetDefaultTraceSettings();
 

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2022 Valve Corporation
+** Copyright (c) 2018-2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -20,6 +20,7 @@
 ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ** DEALINGS IN THE SOFTWARE.
 */
+/// @file Definition of the capture file format.
 
 #ifndef GFXRECON_FORMAT_FORMAT_H
 #define GFXRECON_FORMAT_FORMAT_H
@@ -57,6 +58,10 @@ const uint32_t kCompressedBlockTypeBit    = 0x80000000;
 const size_t   kUuidSize                  = 16;
 const size_t   kMaxPhysicalDeviceNameSize = 256;
 const HandleId kNullHandleId              = 0;
+
+/// Label for operation annotation, which captures parameters used by tools
+/// operating on a capture file.
+const char* const kAnnotationLabelOperation = "operation";
 
 constexpr uint32_t MakeCompressedBlockType(uint32_t block_type)
 {

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -260,7 +260,7 @@ struct AnnotationHeader
     BlockHeader    block_header;
     AnnotationType annotation_type;
     uint32_t       label_length;
-    uint32_t       data_length;
+    uint64_t       data_length;
 };
 
 // Metadata block headers and data types.

--- a/framework/format/format_util.h
+++ b/framework/format/format_util.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018, 2022 Valve Corporation
+** Copyright (c) 2018, 2022 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -20,7 +20,7 @@
 ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ** DEALINGS IN THE SOFTWARE.
 */
-
+/// @file Helpers for the capture file format.
 #ifndef GFXRECON_FORMAT_FORMAT_UTIL_H
 #define GFXRECON_FORMAT_FORMAT_UTIL_H
 
@@ -79,6 +79,12 @@ template <typename T>
 uint64_t GetMetaDataBlockBaseSize(const T& block)
 {
     return (sizeof(block) - sizeof(block.meta_header.block_header));
+}
+
+/// @return The size of an annotation block header minus the size of the header
+constexpr size_t GetAnnotationBlockBaseSize()
+{
+    return (sizeof(AnnotationHeader) - sizeof(BlockHeader));
 }
 
 // Utilities for format validation.

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -66,6 +66,8 @@ target_sources(gfxrecon_util
                     ${CMAKE_CURRENT_LIST_DIR}/settings_loader.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/shared_mutex.h
                     ${CMAKE_CURRENT_LIST_DIR}/shared_mutex.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/strings.h
+                    ${CMAKE_CURRENT_LIST_DIR}/strings.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/to_string.h
                     ${CMAKE_CURRENT_LIST_DIR}/options.h
                     ${CMAKE_CURRENT_LIST_DIR}/options.cpp

--- a/framework/util/strings.cpp
+++ b/framework/util/strings.cpp
@@ -1,0 +1,45 @@
+/*
+** Copyright (c) 2022 Valve Corporation
+** Copyright (c) 2022 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "util/strings.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+GFXRECON_BEGIN_NAMESPACE(strings)
+
+/// @note A deliberately simple, slow implementation for low-frequency use.
+///       Feel free to tune it if it shows up in a profile.
+std::string TabRight(const std::string& str)
+{
+    auto   tabbed = "\t" + str;
+    size_t match  = 0;
+    while ((match = tabbed.find('\n', match + 1)) != std::string::npos)
+    {
+        tabbed.replace(match, 1, "\n\t");
+    }
+    return tabbed;
+}
+
+GFXRECON_END_NAMESPACE(strings)
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/strings.h
+++ b/framework/util/strings.h
@@ -1,0 +1,44 @@
+/*
+** Copyright (c) 2022 Valve Corporation
+** Copyright (c) 2022 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+/// @file Helper functions for working with strings.
+
+#ifndef GFXRECON_UTIL_STRINGS_H
+#define GFXRECON_UTIL_STRINGS_H
+
+#include "util/defines.h"
+
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+GFXRECON_BEGIN_NAMESPACE(strings)
+
+/// Return a a string with a tab added at the start of each new line.
+/// A string is considered to start at a new line, even an empty string.
+std::string TabRight(const std::string& str);
+
+GFXRECON_END_NAMESPACE(strings)
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_STRINGS_H

--- a/framework/util/test/main.cpp
+++ b/framework/util/test/main.cpp
@@ -102,3 +102,19 @@ TEST_CASE("JSONEscape", "[to_string]")
 
     gfxrecon::util::Log::Release();
 }
+
+#include "util/strings.h"
+
+TEST_CASE("TabRight", "[strings]")
+{
+    gfxrecon::util::Log::Init(gfxrecon::util::Log::kErrorSeverity);
+
+    REQUIRE(gfxrecon::util::strings::TabRight("") == "\t");
+    REQUIRE(gfxrecon::util::strings::TabRight("\n") == "\t\n\t");
+    REQUIRE(gfxrecon::util::strings::TabRight("\t") == "\t\t");
+    REQUIRE(gfxrecon::util::strings::TabRight("\t\t") == "\t\t\t");
+    REQUIRE(gfxrecon::util::strings::TabRight("l1\nl2\nl3") == "\tl1\n\tl2\n\tl3");
+    REQUIRE_FALSE(gfxrecon::util::strings::TabRight("l1\nl2\n\nl3") == "\tl1\n\tl2\n\tl3");
+
+    gfxrecon::util::Log::Release();
+}

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -246,6 +246,16 @@ inline void JSONEscape(const char* cstr, std::string& escaped)
     }
 }
 
+inline std::string JSONEscape(const std::string& str)
+{
+    std::string escaped;
+    for (const auto c : str)
+    {
+        JSONEscape(c, escaped);
+    }
+    return escaped;
+}
+
 /// @brief  A single point for the conversion of C-style strings to the JSON
 /// string type or null.
 inline std::string CStrToString(const char* const cstr)

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -143,6 +143,7 @@ int main(int argc, const char** argv)
             gfxrecon::decode::VulkanDecoder decoder;
             decoder.AddConsumer(&ascii_consumer);
             file_processor.AddDecoder(&decoder);
+            file_processor.SetAnnotationProcessor(&ascii_consumer);
             file_processor.ProcessAllFrames();
             ascii_consumer.Destroy();
             if (output_file != stdout)

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -28,6 +28,7 @@
 #include "generated/generated_vulkan_consumer.h"
 #include "generated/generated_vulkan_decoder.h"
 #include "util/argument_parser.h"
+#include "util/strings.h"
 #include "util/logging.h"
 
 #include "vulkan/vulkan.h"
@@ -152,7 +153,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer, public gfxr
         trimmed_frame_ = static_cast<uint32_t>(frame_number);
     }
 
-    /// @brief Count all annotations and save the header ones which contain data
+    /// @brief Count all annotations and save the operation ones which contain data
     /// such as build versions from the tools that have processed the file.
     virtual void ProcessAnnotation(uint64_t                         block_index,
                                    gfxrecon::format::AnnotationType type,
@@ -662,16 +663,9 @@ int main(int argc, const char** argv)
                 if (operation_annotation_datas.size() > 0)
                 {
                     GFXRECON_WRITE_CONSOLE("\tOperation annotations: %" PRIu64 "\n", operation_annotation_datas.size());
-                    for (const auto& header : operation_annotation_datas)
+                    for (const auto& operation : operation_annotation_datas)
                     {
-                        // Tab out the json file to line up with output:
-                        auto   tabbed = "\t" + header;
-                        size_t match  = 0;
-                        while ((match = tabbed.find('\n', match + 1)) != std::string::npos)
-                        {
-                            tabbed.replace(match, 1, "\n\t");
-                        }
-
+                        auto tabbed = gfxrecon::util::strings::TabRight(operation);
                         GFXRECON_WRITE_CONSOLE(tabbed.c_str());
                     }
                 }

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -115,22 +115,24 @@ static std::string GetVersionString(uint32_t api_version)
     return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
 }
 
-class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
+class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer, public gfxrecon::decode::AnnotationHandler
 {
   public:
-    uint32_t           GetTrimmedStartFrame() const { return trimmed_frame_; }
-    const std::string& GetAppName() const { return app_name_; }
-    uint32_t           GetAppVersion() const { return app_version_; }
-    const std::string& GetEngineName() const { return engine_name_; }
-    uint32_t           GetEngineVersion() const { return engine_version_; }
-    uint32_t           GetApiVersion() const { return api_version_; }
-    uint64_t           GetGraphicsPipelineCount() const { return graphics_pipelines_; }
-    uint64_t           GetComputePipelineCount() const { return compute_pipelines_; }
-    uint64_t           GetDrawCount() const { return draw_count_; }
-    uint64_t           GetDispatchCount() const { return dispatch_count_; }
-    uint64_t           GetAllocationCount() const { return allocation_count_; }
-    uint64_t           GetMinAllocationSize() const { return min_allocation_size_; }
-    uint64_t           GetMaxAllocationSize() const { return max_allocation_size_; }
+    uint32_t                        GetTrimmedStartFrame() const { return trimmed_frame_; }
+    const std::string&              GetAppName() const { return app_name_; }
+    uint32_t                        GetAppVersion() const { return app_version_; }
+    const std::string&              GetEngineName() const { return engine_name_; }
+    uint32_t                        GetEngineVersion() const { return engine_version_; }
+    uint32_t                        GetApiVersion() const { return api_version_; }
+    uint64_t                        GetGraphicsPipelineCount() const { return graphics_pipelines_; }
+    uint64_t                        GetComputePipelineCount() const { return compute_pipelines_; }
+    uint64_t                        GetDrawCount() const { return draw_count_; }
+    uint64_t                        GetDispatchCount() const { return dispatch_count_; }
+    uint64_t                        GetAllocationCount() const { return allocation_count_; }
+    uint64_t                        GetMinAllocationSize() const { return min_allocation_size_; }
+    uint64_t                        GetMaxAllocationSize() const { return max_allocation_size_; }
+    uint64_t                        GetAnnotationCount() const { return annotation_count_; }
+    const std::vector<std::string>& GetHeaderAnnotationDatas() const { return header_annotation_datas_; }
 
     const std::set<gfxrecon::format::HandleId>& GetInstantiatedDevices() const { return used_physical_devices_; }
     const VkPhysicalDeviceProperties*           GetDeviceProperties(gfxrecon::format::HandleId id) const
@@ -148,6 +150,20 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     {
         // Theres should only be one of these in a capture file.
         trimmed_frame_ = static_cast<uint32_t>(frame_number);
+    }
+
+    /// @brief Count all annotations and save the header ones which contain data
+    /// such as build versions from the tools that have processed the file.
+    virtual void ProcessAnnotation(uint64_t                         block_index,
+                                   gfxrecon::format::AnnotationType type,
+                                   const std::string&               label,
+                                   const std::string&               data) override
+    {
+        ++annotation_count_;
+        if (type == gfxrecon::format::AnnotationType::kJson && label.compare("header") == 0)
+        {
+            header_annotation_datas_.push_back(data);
+        }
     }
 
     virtual void Process_vkCreateInstance(
@@ -493,6 +509,10 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     uint64_t allocation_count_{ 0 };
     uint64_t min_allocation_size_{ std::numeric_limits<uint64_t>::max() };
     uint64_t max_allocation_size_{ 0 };
+
+    // Annotation info.
+    std::vector<std::string> header_annotation_datas_;
+    uint64_t                 annotation_count_{ 0 };
 };
 
 int main(int argc, const char** argv)
@@ -534,6 +554,7 @@ int main(int argc, const char** argv)
         decoder.AddConsumer(&stats_consumer);
 
         file_processor.AddDecoder(&decoder);
+        file_processor.SetAnnotationProcessor(&stats_consumer);
         file_processor.ProcessAllFrames();
 
         if (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone)
@@ -631,8 +652,32 @@ int main(int argc, const char** argv)
             GFXRECON_WRITE_CONSOLE("\tTotal graphics pipelines: %" PRIu64, stats_consumer.GetGraphicsPipelineCount());
             GFXRECON_WRITE_CONSOLE("\tTotal compute pipelines: %" PRIu64, stats_consumer.GetComputePipelineCount());
 
-            // TODO: This is the number of recorded draw calls, which will not reflect the number of draw calls executed
-            // when recorded once to a command buffer that is submitted/replayed more than once.
+            const auto annotation_count = stats_consumer.GetAnnotationCount();
+            if (annotation_count > 0)
+            {
+                GFXRECON_WRITE_CONSOLE("\nAnnotation info:");
+                GFXRECON_WRITE_CONSOLE("\tTotal annotations: %" PRIu64, annotation_count);
+                auto& header_annotation_datas = stats_consumer.GetHeaderAnnotationDatas();
+                if (header_annotation_datas.size() > 0)
+                {
+                    GFXRECON_WRITE_CONSOLE("\tHeader annotations: %" PRIu64 "\n", header_annotation_datas.size());
+                    for (const auto& header : header_annotation_datas)
+                    {
+                        // Tab out the json file to line up with output:
+                        auto   tabbed = "\t" + header;
+                        size_t match  = 0;
+                        while ((match = tabbed.find('\n', match + 1)) != std::string::npos)
+                        {
+                            tabbed.replace(match, 1, "\n\t");
+                        }
+
+                        GFXRECON_WRITE_CONSOLE(tabbed.c_str());
+                    }
+                }
+            }
+
+            // TODO: This is the number of recorded draw calls, which will not reflect the number of draw calls
+            // executed when recorded once to a command buffer that is submitted/replayed more than once.
             // GFXRECON_WRITE_CONSOLE("\nDraw/dispatch call info:");
             // GFXRECON_WRITE_CONSOLE("\tTotal draw calls: %" PRIu64, stats_consumer.GetDrawCount());
             // GFXRECON_WRITE_CONSOLE("\tTotal dispatch calls: %" PRIu64, stats_consumer.GetDispatchCount());

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -132,7 +132,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer, public gfxr
     uint64_t                        GetMinAllocationSize() const { return min_allocation_size_; }
     uint64_t                        GetMaxAllocationSize() const { return max_allocation_size_; }
     uint64_t                        GetAnnotationCount() const { return annotation_count_; }
-    const std::vector<std::string>& GetHeaderAnnotationDatas() const { return header_annotation_datas_; }
+    const std::vector<std::string>& GetOperationAnnotationDatas() const { return operation_annotation_datas_; }
 
     const std::set<gfxrecon::format::HandleId>& GetInstantiatedDevices() const { return used_physical_devices_; }
     const VkPhysicalDeviceProperties*           GetDeviceProperties(gfxrecon::format::HandleId id) const
@@ -160,9 +160,10 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer, public gfxr
                                    const std::string&               data) override
     {
         ++annotation_count_;
-        if (type == gfxrecon::format::AnnotationType::kJson && label.compare("header") == 0)
+        if (type == gfxrecon::format::AnnotationType::kJson &&
+            label.compare(gfxrecon::format::kAnnotationLabelOperation) == 0)
         {
-            header_annotation_datas_.push_back(data);
+            operation_annotation_datas_.push_back(data);
         }
     }
 
@@ -511,7 +512,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer, public gfxr
     uint64_t max_allocation_size_{ 0 };
 
     // Annotation info.
-    std::vector<std::string> header_annotation_datas_;
+    std::vector<std::string> operation_annotation_datas_;
     uint64_t                 annotation_count_{ 0 };
 };
 
@@ -657,11 +658,11 @@ int main(int argc, const char** argv)
             {
                 GFXRECON_WRITE_CONSOLE("\nAnnotation info:");
                 GFXRECON_WRITE_CONSOLE("\tTotal annotations: %" PRIu64, annotation_count);
-                auto& header_annotation_datas = stats_consumer.GetHeaderAnnotationDatas();
-                if (header_annotation_datas.size() > 0)
+                auto& operation_annotation_datas = stats_consumer.GetOperationAnnotationDatas();
+                if (operation_annotation_datas.size() > 0)
                 {
-                    GFXRECON_WRITE_CONSOLE("\tHeader annotations: %" PRIu64 "\n", header_annotation_datas.size());
-                    for (const auto& header : header_annotation_datas)
+                    GFXRECON_WRITE_CONSOLE("\tOperation annotations: %" PRIu64 "\n", operation_annotation_datas.size());
+                    for (const auto& header : operation_annotation_datas)
                     {
                         // Tab out the json file to line up with output:
                         auto   tabbed = "\t" + header;


### PR DESCRIPTION
convert outputs the annotations.
```
{"index":0,"annotation":{"type":"kJson","label":"operation","data":"{\n    \"tool\": \"capture\",\n    \"gfxrecon-version\": \"0.9.15-dev (andy-fix-831-annotate-captures-with-layer-version:621b79a*)\",\n    \"vulkan-version\": \"1.3.231\"\n}\n"}}
```
info counts them and outputs the operation ones.
```
Annotation info:
        Total annotations: 1
        Operation annotations: 1
    
        {
            "tool": "capture",
            "gfxrecon-version": "0.9.15-dev",
            "vulkan-version": "1.3.231"
        }

```
The other tools pass them through unchanged or ignore them as appropriate.

Fixes #831.