### PR TITLE
Make signal handler watcher thread more configurable

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -170,6 +170,7 @@ Page Guard Align Buffer Sizes | debug.gfxrecon.page_guard_align_buffer_sizes | B
 Omit calls with NULL AHardwareBuffer* | debug.gfxrecon.omit_null_hardware_buffers | BOOL | Some GFXReconstruct capture files may replay with a NULL AHardwareBuffer* parameter, for example, vkGetAndroidHardwareBufferPropertiesANDROID.  Although this is invalid Vulkan usage, some drivers may ignore these calls and some may not. This option causes replay to omit Vulkan calls for which the AHardwareBuffer* would be NULL. Default is `false`
 Page guard unblock SIGSEGV | debug.gfxrecon.page_guard_unblock_sigsegv | BOOL | When the `page_guard` memory tracking mode is enabled and in the case that SIGSEGV has been marked as blocked in thread's signal mask, setting this enviroment variable to `true` will forcibly re-enable the signal in the thread's signal mask. Default is `false`
 Page guard signal handler watcher | debug.gfxrecon.page_guard_signal_handler_watcher | BOOL | When the `page_guard` memory tracking mode is enabled, setting this enviroment variable to `true` will spawn a thread which will periodically reinstall the `SIGSEGV` handler if it has been replaced by the application being traced. Default is `false`
+Page guard signal handler watcher max restores | debug.gfxrecon.page_guard_signal_handler_watcher_max_restores | INTEGER | Sets the number of times the watcher will attempt to restore the signal handler. Setting it to a negative value will make the watcher thread run indefinitely. Default is `1`
 
 #### Memory Tracking Known Issues
 

--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -179,6 +179,7 @@ Page Guard Persistent Memory | GFXRECON_PAGE_GUARD_PERSISTENT_MEMORY | BOOL | Wh
 Page Guard Align Buffer Sizes | GFXRECON_PAGE_GUARD_ALIGN_BUFFER_SIZES | BOOL | When the `page_guard` memory tracking mode is enabled, this option overrides the Vulkan API calls that report buffer memory properties to report that buffer sizes and alignments must be a multiple of the system page size.  This option is intended to be used with applications that perform CPU writes and GPU writes/copies to different buffers that are bound to the same page of mapped memory, which may result in data being lost when copying pages from the `page_guard` shadow allocation to the real allocation.  This data loss can result in visible corruption during capture.  Forcing buffer sizes and alignments to a multiple of the system page size prevents multiple buffers from being bound to the same page, avoiding data loss from simultaneous CPU writes to the shadow allocation and GPU writes to the real allocation for different buffers bound to the same page.  This option is only available for the Vulkan API.  Default is `false`
 Page guard unblock SIGSEGV | GFXRECON_PAGE_GUARD_UNBLOCK_SIGSEGV | BOOL | When the `page_guard` memory tracking mode is enabled and in the case that SIGSEGV has been marked as blocked in thread's signal mask, setting this enviroment variable to `true` will forcibly re-enable the signal in the thread's signal mask. Default is `false`
 Page guard signal handler watcher | GFXRECON_PAGE_GUARD_SIGNAL_HANDLER_WATCHER | BOOL | When the `page_guard` memory tracking mode is enabled, setting this enviroment variable to `true` will spawn a thread which will will periodically reinstall the `SIGSEGV` handler if it has been replaced by the application being traced. Default is `false`
+Page guard signal handler watcher max restores | GFXRECON_PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES | INTEGER | Sets the number of times the watcher will attempt to restore the signal handler. Setting it to a negative will make the watcher thread run indefinitely. Default is `1`
 
 #### Memory Tracking Known Issues
 
@@ -446,10 +447,10 @@ Optional arguments:
                                         to different allocations with different
                                         offsets.  Uses VMA to manage allocations
                                         and suballocations.
-  --use-captured-swapchain-indices 
-                        Use the swapchain indices stored in the capture directly on the swapchain 
+  --use-captured-swapchain-indices
+                        Use the swapchain indices stored in the capture directly on the swapchain
                         setup for replay. The default without this option is to use a Virtual Swapchain
-                        of images which match the swapchain in effect at capture time and which are 
+                        of images which match the swapchain in effect at capture time and which are
                         copied to the underlying swapchain of the implementation being replayed on.
 ```
 

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -353,7 +353,8 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
                                            trace_settings.page_guard_separate_read,
                                            util::PageGuardManager::kDefaultEnableReadWriteSamePage,
                                            trace_settings.page_guard_unblock_sigsegv,
-                                           trace_settings.page_guard_signal_handler_watcher);
+                                           trace_settings.page_guard_signal_handler_watcher,
+                                           trace_settings.page_guard_signal_handler_watcher_max_restores);
         }
 
         if ((capture_mode_ & kModeTrack) == kModeTrack)

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -41,73 +41,74 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 // Available settings (upper and lower-case)
 // clang-format off
-#define CAPTURE_COMPRESSION_TYPE_LOWER          "capture_compression_type"
-#define CAPTURE_COMPRESSION_TYPE_UPPER          "CAPTURE_COMPRESSION_TYPE"
-#define CAPTURE_FILE_NAME_LOWER                 "capture_file"
-#define CAPTURE_FILE_NAME_UPPER                 "CAPTURE_FILE"
-#define CAPTURE_FILE_USE_TIMESTAMP_LOWER        "capture_file_timestamp"
-#define CAPTURE_FILE_USE_TIMESTAMP_UPPER        "CAPTURE_FILE_TIMESTAMP"
-#define CAPTURE_FILE_FLUSH_LOWER                "capture_file_flush"
-#define CAPTURE_FILE_FLUSH_UPPER                "CAPTURE_FILE_FLUSH"
-#define LOG_ALLOW_INDENTS_LOWER                 "log_allow_indents"
-#define LOG_ALLOW_INDENTS_UPPER                 "LOG_ALLOW_INDENTS"
-#define LOG_BREAK_ON_ERROR_LOWER                "log_break_on_error"
-#define LOG_BREAK_ON_ERROR_UPPER                "LOG_BREAK_ON_ERROR"
-#define LOG_ERRORS_TO_STDERR_LOWER              "log_errors_to_stderr"
-#define LOG_ERRORS_TO_STDERR_UPPER              "LOG_ERRORS_TO_STDERR"
-#define LOG_DETAILED_LOWER                      "log_detailed"
-#define LOG_DETAILED_UPPER                      "LOG_DETAILED"
-#define LOG_FILE_NAME_LOWER                     "log_file"
-#define LOG_FILE_NAME_UPPER                     "LOG_FILE"
-#define LOG_FILE_CREATE_NEW_LOWER               "log_file_create_new"
-#define LOG_FILE_CREATE_NEW_UPPER               "LOG_FILE_CREATE_NEW"
-#define LOG_FILE_FLUSH_AFTER_WRITE_LOWER        "log_file_flush_after_write"
-#define LOG_FILE_FLUSH_AFTER_WRITE_UPPER        "LOG_FILE_FLUSH_AFTER_WRITE"
-#define LOG_FILE_KEEP_OPEN_LOWER                "log_file_keep_open"
-#define LOG_FILE_KEEP_OPEN_UPPER                "LOG_FILE_KEEP_OPEN"
-#define LOG_LEVEL_LOWER                         "log_level"
-#define LOG_LEVEL_UPPER                         "LOG_LEVEL"
-#define LOG_OUTPUT_TO_CONSOLE_LOWER             "log_output_to_console"
-#define LOG_OUTPUT_TO_CONSOLE_UPPER             "LOG_OUTPUT_TO_CONSOLE"
-#define LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER     "log_output_to_os_debug_string"
-#define LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER     "LOG_OUTPUT_TO_OS_DEBUG_STRING"
-#define MEMORY_TRACKING_MODE_LOWER              "memory_tracking_mode"
-#define MEMORY_TRACKING_MODE_UPPER              "MEMORY_TRACKING_MODE"
-#define SCREENSHOT_DIR_LOWER                    "screenshot_dir"
-#define SCREENSHOT_DIR_UPPER                    "SCREENSHOT_DIR"
-#define SCREENSHOT_FRAMES_LOWER                 "screenshot_frames"
-#define SCREENSHOT_FRAMES_UPPER                 "SCREENSHOT_FRAMES"
-#define CAPTURE_FRAMES_LOWER                    "capture_frames"
-#define CAPTURE_FRAMES_UPPER                    "CAPTURE_FRAMES"
-#define CAPTURE_TRIGGER_LOWER                   "capture_trigger"
-#define CAPTURE_TRIGGER_UPPER                   "CAPTURE_TRIGGER"
-#define CAPTURE_TRIGGER_FRAMES_LOWER            "capture_trigger_frames"
-#define CAPTURE_TRIGGER_FRAMES_UPPER            "CAPTURE_TRIGGER_FRAMES"
-#define CAPTURE_ANDROID_USE_TRIGGER_LOWER       "capture_android_use_trigger"
-#define CAPTURE_ANDROID_USE_TRIGGER_UPPER       "CAPTURE_ANDROID_USE_TRIGGER"
-#define CAPTURE_ANDROID_TRIGGER_LOWER           "capture_android_trigger"
-#define CAPTURE_ANDROID_TRIGGER_UPPER           "CAPTURE_ANDROID_TRIGGER"
-#define PAGE_GUARD_COPY_ON_MAP_LOWER            "page_guard_copy_on_map"
-#define PAGE_GUARD_COPY_ON_MAP_UPPER            "PAGE_GUARD_COPY_ON_MAP"
-#define PAGE_GUARD_SEPARATE_READ_LOWER          "page_guard_separate_read"
-#define PAGE_GUARD_SEPARATE_READ_UPPER          "PAGE_GUARD_SEPARATE_READ"
-#define PAGE_GUARD_PERSISTENT_MEMORY_LOWER      "page_guard_persistent_memory"
-#define PAGE_GUARD_PERSISTENT_MEMORY_UPPER      "PAGE_GUARD_PERSISTENT_MEMORY"
-#define PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER     "page_guard_align_buffer_sizes"
-#define PAGE_GUARD_ALIGN_BUFFER_SIZES_UPPER     "PAGE_GUARD_ALIGN_BUFFER_SIZES"
-#define PAGE_GUARD_TRACK_AHB_MEMORY_LOWER       "page_guard_track_ahb_memory"
-#define PAGE_GUARD_TRACK_AHB_MEMORY_UPPER       "PAGE_GUARD_TRACK_AHB_MEMORY"
-#define PAGE_GUARD_EXTERNAL_MEMORY_LOWER        "page_guard_external_memory"
-#define PAGE_GUARD_EXTERNAL_MEMORY_UPPER        "PAGE_GUARD_EXTERNAL_MEMORY"
-#define PAGE_GUARD_UNBLOCK_SIGSEGV_LOWER        "page_guard_unblock_sigsegv"
-#define PAGE_GUARD_UNBLOCK_SIGSEGV_UPPER        "PAGE_GUARD_UNBLOCK_SIGSEGV"
-#define PAGE_GUARD_SIGNAL_HANDLER_WATCHER_LOWER "page_guard_signal_handler_watcher"
-#define PAGE_GUARD_SIGNAL_HANDLER_WATCHER_UPPER "PAGE_GUARD_SIGNAL_HANDLER_WATCHER"
-#define DEBUG_LAYER_LOWER                       "debug_layer"
-#define DEBUG_LAYER_UPPER                       "DEBUG_LAYER"
-#define DEBUG_DEVICE_LOST_LOWER                 "debug_device_lost"
-#define DEBUG_DEVICE_LOST_UPPER                 "DEBUG_DEVICE_LOST"
-// clang-format on
+#define CAPTURE_COMPRESSION_TYPE_LOWER                       "capture_compression_type"
+#define CAPTURE_COMPRESSION_TYPE_UPPER                       "CAPTURE_COMPRESSION_TYPE"
+#define CAPTURE_FILE_NAME_LOWER                              "capture_file"
+#define CAPTURE_FILE_NAME_UPPER                              "CAPTURE_FILE"
+#define CAPTURE_FILE_USE_TIMESTAMP_LOWER                     "capture_file_timestamp"
+#define CAPTURE_FILE_USE_TIMESTAMP_UPPER                     "CAPTURE_FILE_TIMESTAMP"
+#define CAPTURE_FILE_FLUSH_LOWER                             "capture_file_flush"
+#define CAPTURE_FILE_FLUSH_UPPER                             "CAPTURE_FILE_FLUSH"
+#define LOG_ALLOW_INDENTS_LOWER                              "log_allow_indents"
+#define LOG_ALLOW_INDENTS_UPPER                              "LOG_ALLOW_INDENTS"
+#define LOG_BREAK_ON_ERROR_LOWER                             "log_break_on_error"
+#define LOG_BREAK_ON_ERROR_UPPER                             "LOG_BREAK_ON_ERROR"
+#define LOG_ERRORS_TO_STDERR_LOWER                           "log_errors_to_stderr"
+#define LOG_ERRORS_TO_STDERR_UPPER                           "LOG_ERRORS_TO_STDERR"
+#define LOG_DETAILED_LOWER                                   "log_detailed"
+#define LOG_DETAILED_UPPER                                   "LOG_DETAILED"
+#define LOG_FILE_NAME_LOWER                                  "log_file"
+#define LOG_FILE_NAME_UPPER                                  "LOG_FILE"
+#define LOG_FILE_CREATE_NEW_LOWER                            "log_file_create_new"
+#define LOG_FILE_CREATE_NEW_UPPER                            "LOG_FILE_CREATE_NEW"
+#define LOG_FILE_FLUSH_AFTER_WRITE_LOWER                     "log_file_flush_after_write"
+#define LOG_FILE_FLUSH_AFTER_WRITE_UPPER                     "LOG_FILE_FLUSH_AFTER_WRITE"
+#define LOG_FILE_KEEP_OPEN_LOWER                             "log_file_keep_open"
+#define LOG_FILE_KEEP_OPEN_UPPER                             "LOG_FILE_KEEP_OPEN"
+#define LOG_LEVEL_LOWER                                      "log_level"
+#define LOG_LEVEL_UPPER                                      "LOG_LEVEL"
+#define LOG_OUTPUT_TO_CONSOLE_LOWER                          "log_output_to_console"
+#define LOG_OUTPUT_TO_CONSOLE_UPPER                          "LOG_OUTPUT_TO_CONSOLE"
+#define LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER                  "log_output_to_os_debug_string"
+#define LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER                  "LOG_OUTPUT_TO_OS_DEBUG_STRING"
+#define MEMORY_TRACKING_MODE_LOWER                           "memory_tracking_mode"
+#define MEMORY_TRACKING_MODE_UPPER                           "MEMORY_TRACKING_MODE"
+#define SCREENSHOT_DIR_LOWER                                 "screenshot_dir"
+#define SCREENSHOT_DIR_UPPER                                 "SCREENSHOT_DIR"
+#define SCREENSHOT_FRAMES_LOWER                              "screenshot_frames"
+#define SCREENSHOT_FRAMES_UPPER                              "SCREENSHOT_FRAMES"
+#define CAPTURE_FRAMES_LOWER                                 "capture_frames"
+#define CAPTURE_FRAMES_UPPER                                 "CAPTURE_FRAMES"
+#define CAPTURE_TRIGGER_LOWER                                "capture_trigger"
+#define CAPTURE_TRIGGER_UPPER                                "CAPTURE_TRIGGER"
+#define CAPTURE_TRIGGER_FRAMES_LOWER                         "capture_trigger_frames"
+#define CAPTURE_TRIGGER_FRAMES_UPPER                         "CAPTURE_TRIGGER_FRAMES"
+#define CAPTURE_ANDROID_USE_TRIGGER_LOWER                    "capture_android_use_trigger"
+#define CAPTURE_ANDROID_USE_TRIGGER_UPPER                    "CAPTURE_ANDROID_USE_TRIGGER"
+#define CAPTURE_ANDROID_TRIGGER_LOWER                        "capture_android_trigger"
+#define CAPTURE_ANDROID_TRIGGER_UPPER                        "CAPTURE_ANDROID_TRIGGER"
+#define PAGE_GUARD_COPY_ON_MAP_LOWER                         "page_guard_copy_on_map"
+#define PAGE_GUARD_COPY_ON_MAP_UPPER                         "PAGE_GUARD_COPY_ON_MAP"
+#define PAGE_GUARD_SEPARATE_READ_LOWER                       "page_guard_separate_read"
+#define PAGE_GUARD_SEPARATE_READ_UPPER                       "PAGE_GUARD_SEPARATE_READ"
+#define PAGE_GUARD_PERSISTENT_MEMORY_LOWER                   "page_guard_persistent_memory"
+#define PAGE_GUARD_PERSISTENT_MEMORY_UPPER                   "PAGE_GUARD_PERSISTENT_MEMORY"
+#define PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER                  "page_guard_align_buffer_sizes"
+#define PAGE_GUARD_ALIGN_BUFFER_SIZES_UPPER                  "PAGE_GUARD_ALIGN_BUFFER_SIZES"
+#define PAGE_GUARD_TRACK_AHB_MEMORY_LOWER                    "page_guard_track_ahb_memory"
+#define PAGE_GUARD_TRACK_AHB_MEMORY_UPPER                    "PAGE_GUARD_TRACK_AHB_MEMORY"
+#define PAGE_GUARD_EXTERNAL_MEMORY_LOWER                     "page_guard_external_memory"
+#define PAGE_GUARD_EXTERNAL_MEMORY_UPPER                     "PAGE_GUARD_EXTERNAL_MEMORY"
+#define PAGE_GUARD_UNBLOCK_SIGSEGV_LOWER                     "page_guard_unblock_sigsegv"
+#define PAGE_GUARD_UNBLOCK_SIGSEGV_UPPER                     "PAGE_GUARD_UNBLOCK_SIGSEGV"
+#define PAGE_GUARD_SIGNAL_HANDLER_WATCHER_LOWER              "page_guard_signal_handler_watcher"
+#define PAGE_GUARD_SIGNAL_HANDLER_WATCHER_UPPER              "PAGE_GUARD_SIGNAL_HANDLER_WATCHER"
+#define PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES_LOWER "page_guard_signal_handler_watcher_max_restores"
+#define PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES_UPPER "PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES"
+#define DEBUG_LAYER_LOWER                                    "debug_layer"
+#define DEBUG_LAYER_UPPER                                    "DEBUG_LAYER"
+#define DEBUG_DEVICE_LOST_LOWER                              "debug_device_lost"
+#define DEBUG_DEVICE_LOST_UPPER                              "DEBUG_DEVICE_LOST"
 
 #if defined(__ANDROID__)
 // Android Properties
@@ -115,39 +116,40 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 const char CaptureSettings::kDefaultCaptureFileName[] = "/sdcard/gfxrecon_capture" GFXRECON_FILE_EXTENSION;
 
-const char kCaptureCompressionTypeEnvVar[]        = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_LOWER;
-const char kCaptureFileFlushEnvVar[]              = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FLUSH_LOWER;
-const char kCaptureFileNameEnvVar[]               = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_LOWER;
-const char kCaptureFileUseTimestampEnvVar[]       = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_LOWER;
-const char kLogAllowIndentsEnvVar[]               = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_LOWER;
-const char kLogBreakOnErrorEnvVar[]               = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_LOWER;
-const char kLogDetailedEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_LOWER;
-const char kLogErrorsToStderrEnvVar[]             = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_LOWER;
-const char kLogFileNameEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_LOWER;
-const char kLogFileCreateNewEnvVar[]              = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_LOWER;
-const char kLogFileFlushAfterWriteEnvVar[]        = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_LOWER;
-const char kLogFileKeepFileOpenEnvVar[]           = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_LOWER;
-const char kLogLevelEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_LOWER;
-const char kLogOutputToConsoleEnvVar[]            = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_LOWER;
-const char kLogOutputToOsDebugStringEnvVar[]      = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER;
-const char kMemoryTrackingModeEnvVar[]            = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_LOWER;
-const char kScreenshotDirEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_DIR_LOWER;
-const char kScreenshotFramesEnvVar[]              = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_FRAMES_LOWER;
-const char kCaptureFramesEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_LOWER;
-const char kCaptureTriggerEnvVar[]                = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_LOWER;
-const char kCaptureTriggerFramesEnvVar[]          = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_FRAMES_LOWER;
-const char kPageGuardCopyOnMapEnvVar[]            = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_LOWER;
-const char kPageGuardSeparateReadEnvVar[]         = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_LOWER;
-const char kPageGuardPersistentMemoryEnvVar[]     = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_PERSISTENT_MEMORY_LOWER;
-const char kPageGuardAlignBufferSizesEnvVar[]     = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER;
-const char kPageGuardTrackAhbMemoryEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_TRACK_AHB_MEMORY_LOWER;
-const char kPageGuardExternalMemoryEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_LOWER;
-const char kPageGuardUnblockSIGSEGVEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_UNBLOCK_SIGSEGV_LOWER;
-const char kPageGuardSignalHandlerWatcherEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SIGNAL_HANDLER_WATCHER_LOWER;
-const char kDebugLayerEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX DEBUG_LAYER_LOWER;
-const char kDebugDeviceLostEnvVar[]               = GFXRECON_ENV_VAR_PREFIX DEBUG_DEVICE_LOST_LOWER;
-const char kCaptureAndroidUseTriggerEnvVar[]      = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_USE_TRIGGER_LOWER;
-const char kCaptureAndroidTriggerEnvVar[]         = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_TRIGGER_LOWER;
+const char kCaptureCompressionTypeEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_LOWER;
+const char kCaptureFileFlushEnvVar[]                         = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FLUSH_LOWER;
+const char kCaptureFileNameEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_LOWER;
+const char kCaptureFileUseTimestampEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_LOWER;
+const char kLogAllowIndentsEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_LOWER;
+const char kLogBreakOnErrorEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_LOWER;
+const char kLogDetailedEnvVar[]                              = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_LOWER;
+const char kLogErrorsToStderrEnvVar[]                        = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_LOWER;
+const char kLogFileNameEnvVar[]                              = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_LOWER;
+const char kLogFileCreateNewEnvVar[]                         = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_LOWER;
+const char kLogFileFlushAfterWriteEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_LOWER;
+const char kLogFileKeepFileOpenEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_LOWER;
+const char kLogLevelEnvVar[]                                 = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_LOWER;
+const char kLogOutputToConsoleEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_LOWER;
+const char kLogOutputToOsDebugStringEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER;
+const char kMemoryTrackingModeEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_LOWER;
+const char kScreenshotDirEnvVar[]                            = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_DIR_LOWER;
+const char kScreenshotFramesEnvVar[]                         = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_FRAMES_LOWER;
+const char kCaptureFramesEnvVar[]                            = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_LOWER;
+const char kCaptureTriggerEnvVar[]                           = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_LOWER;
+const char kCaptureTriggerFramesEnvVar[]                     = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_FRAMES_LOWER;
+const char kPageGuardCopyOnMapEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_LOWER;
+const char kPageGuardSeparateReadEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_LOWER;
+const char kPageGuardPersistentMemoryEnvVar[]                = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_PERSISTENT_MEMORY_LOWER;
+const char kPageGuardAlignBufferSizesEnvVar[]                = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER;
+const char kPageGuardTrackAhbMemoryEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_TRACK_AHB_MEMORY_LOWER;
+const char kPageGuardExternalMemoryEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_LOWER;
+const char kPageGuardUnblockSIGSEGVEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_UNBLOCK_SIGSEGV_LOWER;
+const char kPageGuardSignalHandlerWatcherEnvVar[]            = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SIGNAL_HANDLER_WATCHER_LOWER;
+const char kPageGuardSignalHandlerWatcherMaxRestoresEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES_LOWER;
+const char kDebugLayerEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DEBUG_LAYER_LOWER;
+const char kDebugDeviceLostEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX DEBUG_DEVICE_LOST_LOWER;
+const char kCaptureAndroidUseTriggerEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_USE_TRIGGER_LOWER;
+const char kCaptureAndroidTriggerEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_TRIGGER_LOWER;
 
 #else
 // Desktop environment settings
@@ -155,78 +157,79 @@ const char kCaptureAndroidTriggerEnvVar[]         = GFXRECON_ENV_VAR_PREFIX CAPT
 
 const char CaptureSettings::kDefaultCaptureFileName[] = "gfxrecon_capture" GFXRECON_FILE_EXTENSION;
 
-const char kCaptureCompressionTypeEnvVar[]        = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_UPPER;
-const char kCaptureFileFlushEnvVar[]              = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FLUSH_UPPER;
-const char kCaptureFileNameEnvVar[]               = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_UPPER;
-const char kCaptureFileUseTimestampEnvVar[]       = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_UPPER;
-const char kLogAllowIndentsEnvVar[]               = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_UPPER;
-const char kLogBreakOnErrorEnvVar[]               = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_UPPER;
-const char kLogDetailedEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_UPPER;
-const char kLogErrorsToStderrEnvVar[]             = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_UPPER;
-const char kLogFileNameEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_UPPER;
-const char kLogFileCreateNewEnvVar[]              = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_UPPER;
-const char kLogFileFlushAfterWriteEnvVar[]        = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_UPPER;
-const char kLogFileKeepFileOpenEnvVar[]           = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_UPPER;
-const char kLogLevelEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_UPPER;
-const char kLogOutputToConsoleEnvVar[]            = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_UPPER;
-const char kLogOutputToOsDebugStringEnvVar[]      = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER;
-const char kMemoryTrackingModeEnvVar[]            = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_UPPER;
-const char kScreenshotDirEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_DIR_UPPER;
-const char kScreenshotFramesEnvVar[]              = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_FRAMES_UPPER;
-const char kCaptureFramesEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_UPPER;
-const char kPageGuardCopyOnMapEnvVar[]            = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_UPPER;
-const char kPageGuardSeparateReadEnvVar[]         = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_UPPER;
-const char kPageGuardPersistentMemoryEnvVar[]     = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_PERSISTENT_MEMORY_UPPER;
-const char kPageGuardAlignBufferSizesEnvVar[]     = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_ALIGN_BUFFER_SIZES_UPPER;
-const char kPageGuardTrackAhbMemoryEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_TRACK_AHB_MEMORY_UPPER;
-const char kPageGuardExternalMemoryEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_UPPER;
-const char kPageGuardUnblockSIGSEGVEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_UNBLOCK_SIGSEGV_UPPER;
-const char kPageGuardSignalHandlerWatcherEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SIGNAL_HANDLER_WATCHER_UPPER;
-const char kCaptureTriggerEnvVar[]                = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_UPPER;
-const char kCaptureTriggerFramesEnvVar[]          = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_FRAMES_UPPER;
-const char kDebugLayerEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX DEBUG_LAYER_UPPER;
-const char kDebugDeviceLostEnvVar[]               = GFXRECON_ENV_VAR_PREFIX DEBUG_DEVICE_LOST_UPPER;
-const char kCaptureAndroidUseTriggerEnvVar[]      = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_USE_TRIGGER_UPPER;
-const char kCaptureAndroidTriggerEnvVar[]         = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_TRIGGER_UPPER;
+const char kCaptureCompressionTypeEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_UPPER;
+const char kCaptureFileFlushEnvVar[]                         = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FLUSH_UPPER;
+const char kCaptureFileNameEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_UPPER;
+const char kCaptureFileUseTimestampEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_UPPER;
+const char kLogAllowIndentsEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_UPPER;
+const char kLogBreakOnErrorEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_UPPER;
+const char kLogDetailedEnvVar[]                              = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_UPPER;
+const char kLogErrorsToStderrEnvVar[]                        = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_UPPER;
+const char kLogFileNameEnvVar[]                              = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_UPPER;
+const char kLogFileCreateNewEnvVar[]                         = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_UPPER;
+const char kLogFileFlushAfterWriteEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_UPPER;
+const char kLogFileKeepFileOpenEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_UPPER;
+const char kLogLevelEnvVar[]                                 = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_UPPER;
+const char kLogOutputToConsoleEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_UPPER;
+const char kLogOutputToOsDebugStringEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER;
+const char kMemoryTrackingModeEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_UPPER;
+const char kScreenshotDirEnvVar[]                            = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_DIR_UPPER;
+const char kScreenshotFramesEnvVar[]                         = GFXRECON_ENV_VAR_PREFIX SCREENSHOT_FRAMES_UPPER;
+const char kCaptureFramesEnvVar[]                            = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_UPPER;
+const char kPageGuardCopyOnMapEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_UPPER;
+const char kPageGuardSeparateReadEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_UPPER;
+const char kPageGuardPersistentMemoryEnvVar[]                = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_PERSISTENT_MEMORY_UPPER;
+const char kPageGuardAlignBufferSizesEnvVar[]                = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_ALIGN_BUFFER_SIZES_UPPER;
+const char kPageGuardTrackAhbMemoryEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_TRACK_AHB_MEMORY_UPPER;
+const char kPageGuardExternalMemoryEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_UPPER;
+const char kPageGuardUnblockSIGSEGVEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_UNBLOCK_SIGSEGV_UPPER;
+const char kPageGuardSignalHandlerWatcherEnvVar[]            = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SIGNAL_HANDLER_WATCHER_UPPER;
+const char kPageGuardSignalHandlerWatcherMaxRestoresEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES_UPPER;
+const char kCaptureTriggerEnvVar[]                           = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_UPPER;
+const char kCaptureTriggerFramesEnvVar[]                     = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_FRAMES_UPPER;
+const char kDebugLayerEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DEBUG_LAYER_UPPER;
+const char kDebugDeviceLostEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX DEBUG_DEVICE_LOST_UPPER;
+const char kCaptureAndroidUseTriggerEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_USE_TRIGGER_UPPER;
+const char kCaptureAndroidTriggerEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX CAPTURE_ANDROID_TRIGGER_UPPER;
 #endif
 
 // Capture options for settings file.
-// clang-format off
 const char kSettingsFilter[] = "lunarg_gfxreconstruct.";
 
-const std::string kOptionKeyCaptureCompressionType        = std::string(kSettingsFilter) + std::string(CAPTURE_COMPRESSION_TYPE_LOWER);
-const std::string kOptionKeyCaptureFile                   = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_NAME_LOWER);
-const std::string kOptionKeyCaptureFileForceFlush         = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_FLUSH_LOWER);
-const std::string kOptionKeyCaptureFileUseTimestamp       = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_USE_TIMESTAMP_LOWER);
-const std::string kOptionKeyLogAllowIndents               = std::string(kSettingsFilter) + std::string(LOG_ALLOW_INDENTS_LOWER);
-const std::string kOptionKeyLogBreakOnError               = std::string(kSettingsFilter) + std::string(LOG_BREAK_ON_ERROR_LOWER);
-const std::string kOptionKeyLogDetailed                   = std::string(kSettingsFilter) + std::string(LOG_DETAILED_LOWER);
-const std::string kOptionKeyLogErrorsToStderr             = std::string(kSettingsFilter) + std::string(LOG_ERRORS_TO_STDERR_LOWER);
-const std::string kOptionKeyLogFile                       = std::string(kSettingsFilter) + std::string(LOG_FILE_NAME_LOWER);
-const std::string kOptionKeyLogFileCreateNew              = std::string(kSettingsFilter) + std::string(LOG_FILE_CREATE_NEW_LOWER);
-const std::string kOptionKeyLogFileFlushAfterWrite        = std::string(kSettingsFilter) + std::string(LOG_FILE_FLUSH_AFTER_WRITE_LOWER);
-const std::string kOptionKeyLogFileKeepOpen               = std::string(kSettingsFilter) + std::string(LOG_FILE_KEEP_OPEN_LOWER);
-const std::string kOptionKeyLogLevel                      = std::string(kSettingsFilter) + std::string(LOG_LEVEL_LOWER);
-const std::string kOptionKeyLogOutputToConsole            = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_CONSOLE_LOWER);
-const std::string kOptionKeyLogOutputToOsDebugString      = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER);
-const std::string kOptionKeyMemoryTrackingMode            = std::string(kSettingsFilter) + std::string(MEMORY_TRACKING_MODE_LOWER);
-const std::string kOptionKeyScreenshotDir                 = std::string(kSettingsFilter) + std::string(SCREENSHOT_DIR_LOWER);
-const std::string kOptionKeyScreenshotFrames              = std::string(kSettingsFilter) + std::string(SCREENSHOT_FRAMES_LOWER);
-const std::string kOptionKeyCaptureFrames                 = std::string(kSettingsFilter) + std::string(CAPTURE_FRAMES_LOWER);
-const std::string kOptionKeyCaptureTrigger                = std::string(kSettingsFilter) + std::string(CAPTURE_TRIGGER_LOWER);
-const std::string kOptionKeyCaptureTriggerFrames          = std::string(kSettingsFilter) + std::string(CAPTURE_TRIGGER_FRAMES_LOWER);
-const std::string kOptionKeyPageGuardCopyOnMap            = std::string(kSettingsFilter) + std::string(PAGE_GUARD_COPY_ON_MAP_LOWER);
-const std::string kOptionKeyPageGuardSeparateRead         = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SEPARATE_READ_LOWER);
-const std::string kOptionKeyPageGuardPersistentMemory     = std::string(kSettingsFilter) + std::string(PAGE_GUARD_PERSISTENT_MEMORY_LOWER);
-const std::string kOptionKeyPageGuardAlignBufferSizes     = std::string(kSettingsFilter) + std::string(PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER);
-const std::string kOptionKeyPageGuardTrackAhbMemory       = std::string(kSettingsFilter) + std::string(PAGE_GUARD_TRACK_AHB_MEMORY_LOWER);
-const std::string kOptionKeyPageGuardExternalMemory       = std::string(kSettingsFilter) + std::string(PAGE_GUARD_EXTERNAL_MEMORY_LOWER);
-const std::string kOptionKeyPageGuardUnblockSigSegV       = std::string(kSettingsFilter) + std::string(PAGE_GUARD_UNBLOCK_SIGSEGV_LOWER);
-const std::string kOptionKeyPageGuardSignalHandlerWatcher = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SIGNAL_HANDLER_WATCHER_LOWER);
-const std::string kDebugLayer                             = std::string(kSettingsFilter) + std::string(DEBUG_LAYER_LOWER);
-const std::string kDebugDeviceLost                        = std::string(kSettingsFilter) + std::string(DEBUG_DEVICE_LOST_LOWER);
-const std::string kOptionKeyCaptureAndroidUseTrigger      = std::string(kSettingsFilter) + std::string(CAPTURE_ANDROID_USE_TRIGGER_LOWER);
-const std::string kOptionKeyCaptureAndroidTrigger         = std::string(kSettingsFilter) + std::string(CAPTURE_ANDROID_TRIGGER_LOWER);
+const std::string kOptionKeyCaptureCompressionType                   = std::string(kSettingsFilter) + std::string(CAPTURE_COMPRESSION_TYPE_LOWER);
+const std::string kOptionKeyCaptureFile                              = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_NAME_LOWER);
+const std::string kOptionKeyCaptureFileForceFlush                    = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_FLUSH_LOWER);
+const std::string kOptionKeyCaptureFileUseTimestamp                  = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_USE_TIMESTAMP_LOWER);
+const std::string kOptionKeyLogAllowIndents                          = std::string(kSettingsFilter) + std::string(LOG_ALLOW_INDENTS_LOWER);
+const std::string kOptionKeyLogBreakOnError                          = std::string(kSettingsFilter) + std::string(LOG_BREAK_ON_ERROR_LOWER);
+const std::string kOptionKeyLogDetailed                              = std::string(kSettingsFilter) + std::string(LOG_DETAILED_LOWER);
+const std::string kOptionKeyLogErrorsToStderr                        = std::string(kSettingsFilter) + std::string(LOG_ERRORS_TO_STDERR_LOWER);
+const std::string kOptionKeyLogFile                                  = std::string(kSettingsFilter) + std::string(LOG_FILE_NAME_LOWER);
+const std::string kOptionKeyLogFileCreateNew                         = std::string(kSettingsFilter) + std::string(LOG_FILE_CREATE_NEW_LOWER);
+const std::string kOptionKeyLogFileFlushAfterWrite                   = std::string(kSettingsFilter) + std::string(LOG_FILE_FLUSH_AFTER_WRITE_LOWER);
+const std::string kOptionKeyLogFileKeepOpen                          = std::string(kSettingsFilter) + std::string(LOG_FILE_KEEP_OPEN_LOWER);
+const std::string kOptionKeyLogLevel                                 = std::string(kSettingsFilter) + std::string(LOG_LEVEL_LOWER);
+const std::string kOptionKeyLogOutputToConsole                       = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_CONSOLE_LOWER);
+const std::string kOptionKeyLogOutputToOsDebugString                 = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER);
+const std::string kOptionKeyMemoryTrackingMode                       = std::string(kSettingsFilter) + std::string(MEMORY_TRACKING_MODE_LOWER);
+const std::string kOptionKeyScreenshotDir                            = std::string(kSettingsFilter) + std::string(SCREENSHOT_DIR_LOWER);
+const std::string kOptionKeyScreenshotFrames                         = std::string(kSettingsFilter) + std::string(SCREENSHOT_FRAMES_LOWER);
+const std::string kOptionKeyCaptureFrames                            = std::string(kSettingsFilter) + std::string(CAPTURE_FRAMES_LOWER);
+const std::string kOptionKeyCaptureTrigger                           = std::string(kSettingsFilter) + std::string(CAPTURE_TRIGGER_LOWER);
+const std::string kOptionKeyCaptureTriggerFrames                     = std::string(kSettingsFilter) + std::string(CAPTURE_TRIGGER_FRAMES_LOWER);
+const std::string kOptionKeyPageGuardCopyOnMap                       = std::string(kSettingsFilter) + std::string(PAGE_GUARD_COPY_ON_MAP_LOWER);
+const std::string kOptionKeyPageGuardSeparateRead                    = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SEPARATE_READ_LOWER);
+const std::string kOptionKeyPageGuardPersistentMemory                = std::string(kSettingsFilter) + std::string(PAGE_GUARD_PERSISTENT_MEMORY_LOWER);
+const std::string kOptionKeyPageGuardAlignBufferSizes                = std::string(kSettingsFilter) + std::string(PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER);
+const std::string kOptionKeyPageGuardTrackAhbMemory                  = std::string(kSettingsFilter) + std::string(PAGE_GUARD_TRACK_AHB_MEMORY_LOWER);
+const std::string kOptionKeyPageGuardExternalMemory                  = std::string(kSettingsFilter) + std::string(PAGE_GUARD_EXTERNAL_MEMORY_LOWER);
+const std::string kOptionKeyPageGuardUnblockSigSegV                  = std::string(kSettingsFilter) + std::string(PAGE_GUARD_UNBLOCK_SIGSEGV_LOWER);
+const std::string kOptionKeyPageGuardSignalHandlerWatcher            = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SIGNAL_HANDLER_WATCHER_LOWER);
+const std::string kOptionKeyPageGuardSignalHandlerWatcherMaxRestores = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SIGNAL_HANDLER_WATCHER_MAX_RESTORES_LOWER);
+const std::string kDebugLayer                                        = std::string(kSettingsFilter) + std::string(DEBUG_LAYER_LOWER);
+const std::string kDebugDeviceLost                                   = std::string(kSettingsFilter) + std::string(DEBUG_DEVICE_LOST_LOWER);
+const std::string kOptionKeyCaptureAndroidUseTrigger                 = std::string(kSettingsFilter) + std::string(CAPTURE_ANDROID_USE_TRIGGER_LOWER);
+const std::string kOptionKeyCaptureAndroidTrigger                    = std::string(kSettingsFilter) + std::string(CAPTURE_ANDROID_TRIGGER_LOWER);
 
 #if defined(ENABLE_LZ4_COMPRESSION)
 const format::CompressionType kDefaultCompressionType = format::CompressionType::kLz4;
@@ -348,6 +351,8 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     LoadSingleOptionEnvVar(options, kPageGuardUnblockSIGSEGVEnvVar, kOptionKeyPageGuardUnblockSigSegV);
     LoadSingleOptionEnvVar(options, kPageGuardSignalHandlerWatcherEnvVar, kOptionKeyPageGuardSignalHandlerWatcher);
     LoadSingleOptionEnvVar(options, kCaptureAndroidUseTriggerEnvVar, kOptionKeyCaptureAndroidUseTrigger);
+    LoadSingleOptionEnvVar(
+        options, kPageGuardSignalHandlerWatcherMaxRestoresEnvVar, kOptionKeyPageGuardSignalHandlerWatcherMaxRestores);
 
     // Debug environment variables
     LoadSingleOptionEnvVar(options, kDebugLayerEnvVar, kDebugLayer);
@@ -451,6 +456,9 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
                         settings->trace_settings_.page_guard_signal_handler_watcher);
     settings->trace_settings_.trim_android_use_trigger = ParseBoolString(
         FindOption(options, kOptionKeyCaptureAndroidUseTrigger), settings->trace_settings_.trim_android_use_trigger);
+    settings->trace_settings_.page_guard_signal_handler_watcher_max_restores =
+        ParseIntegerString(FindOption(options, kOptionKeyPageGuardSignalHandlerWatcherMaxRestores),
+                           settings->trace_settings_.page_guard_signal_handler_watcher_max_restores);
 
     // Debug options
     settings->trace_settings_.debug_layer =
@@ -523,6 +531,21 @@ std::string CaptureSettings::FindOption(OptionsMap* options, const std::string& 
 bool CaptureSettings::ParseBoolString(const std::string& value_string, bool default_value)
 {
     return gfxrecon::util::ParseBoolString(value_string, default_value);
+}
+
+int CaptureSettings::ParseIntegerString(const std::string& value_string, int default_value)
+{
+    std::string::const_iterator it = value_string.begin();
+    while (it != value_string.end() && (std::isdigit(*it) || *it == '-' || *it == '+')) ++it;
+    const bool is_integer = !value_string.empty() && it == value_string.end();
+
+    if (!is_integer)
+    {
+        GFXRECON_LOG_WARNING("Settings Loader: Ignoring unrecognized Integer option value \"%s\"",
+                             value_string.c_str());
+    }
+
+    return is_integer ? atoi(value_string.c_str()) : default_value;
 }
 
 CaptureSettings::MemoryTrackingMode

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -76,6 +76,7 @@ class CaptureSettings
         uint32_t                      trim_key_frames{ 0 };
         bool                          trim_android_use_trigger{ false };
         bool                          trim_android_trigger{ false };
+        int                           page_guard_signal_handler_watcher_max_restores{ 1 };
         bool                          page_guard_copy_on_map{ util::PageGuardManager::kDefaultEnableCopyOnMap };
         bool                          page_guard_separate_read{ util::PageGuardManager::kDefaultEnableSeparateRead };
         bool                          page_guard_persistent_memory{ false };
@@ -130,6 +131,8 @@ class CaptureSettings
     static std::string FindOption(OptionsMap* options, const std::string& key, const std::string& default_value = "");
 
     static bool ParseBoolString(const std::string& value_string, bool default_value);
+
+    static int ParseIntegerString(const std::string& value_string, int default_value);
 
     static MemoryTrackingMode ParseMemoryTrackingModeString(const std::string& value_string,
                                                             MemoryTrackingMode default_value);

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -47,11 +47,12 @@ GFXRECON_BEGIN_NAMESPACE(util)
 class PageGuardManager
 {
   public:
-    static const bool kDefaultEnableCopyOnMap            = true;
-    static const bool kDefaultEnableSeparateRead         = true;
-    static const bool kDefaultEnableReadWriteSamePage    = true;
-    static const bool kDefaultUnblockSIGSEGV             = false;
-    static const bool kDefaultEnableSignalHandlerWatcher = false;
+    static const bool kDefaultEnableCopyOnMap                 = true;
+    static const bool kDefaultEnableSeparateRead              = true;
+    static const bool kDefaultEnableReadWriteSamePage         = true;
+    static const bool kDefaultUnblockSIGSEGV                  = false;
+    static const bool kDefaultEnableSignalHandlerWatcher      = false;
+    static const int  kDefaultSignalHandlerWatcherMaxRestores = 1;
 
     static const uintptr_t kNullShadowHandle = 0;
 
@@ -66,7 +67,8 @@ class PageGuardManager
                        bool enable_separate_read,
                        bool expect_read_write_same_page,
                        bool unblock_SIGSEGV,
-                       bool enable_signal_handler_watcher);
+                       bool enable_signal_handler_watcher,
+                       int  signal_handler_watcher_max_restores);
 
     static void Destroy();
 
@@ -122,7 +124,8 @@ class PageGuardManager
                      bool enable_separate_read,
                      bool expect_read_write_same_page,
                      bool unblock_SIGSEGV,
-                     bool enable_signal_handler_watcher);
+                     bool enable_signal_handler_watcher,
+                     int  signal_handler_watcher_max_restores);
 
     ~PageGuardManager();
 
@@ -236,6 +239,7 @@ class PageGuardManager
     const bool               enable_separate_read_;
     const bool               unblock_sigsegv_;
     bool                     enable_signal_handler_watcher_;
+    int                      signal_handler_watcher_max_restores_;
 
     // Only applies to WIN32 builds and Linux/Android builds with PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION defined.
     const bool enable_read_write_same_page_;
@@ -247,10 +251,7 @@ class PageGuardManager
     static bool  CheckSignalHandler();
     void         MarkAllTrackedMemoryAsDirty();
 
-    // Configures how many times the signal handler watcher thread will fix the signal handler.
-    // Then the thread will terminate
-    static constexpr uint32_t signal_handler_watcher_max_restores_{ 1 };
-    static uint32_t           signal_handler_watcher_restores_;
+    static uint32_t signal_handler_watcher_restores_;
 #endif
 };
 


### PR DESCRIPTION
This commit adds the possibility to configure the numer of times the signal handler watcher thread will attempt to restore the signal handler by setting an env variable. Setting the variable to a negative number will make the watcher thread run indefinitely.