### PR TITLE
Add USAGE_TRANSFER_SRC when trimming

### DIFF
--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -217,6 +217,7 @@ class CaptureManager
     bool                                GetPageGuardTrackAhbMemory() const { return page_guard_track_ahb_memory_; }
     PageGuardMemoryMode                 GetPageGuardMemoryMode() const { return page_guard_memory_mode_; }
     const std::string&                  GetTrimKey() const { return trim_key_; }
+    bool                                IsTrimEnabled() const { return trim_enabled_; }
     uint32_t                            GetCurrentFrame() const { return current_frame_; }
     CaptureMode                         GetCaptureMode() const { return capture_mode_; }
     bool                                GetDebugLayerSetting() const { return debug_layer_; }

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -264,6 +264,11 @@ class VulkanCaptureManager : public CaptureManager
                                   const VkAllocationCallbacks* pAllocator,
                                   VkBuffer*                    pBuffer);
 
+    VkResult OverrideCreateImage(VkDevice                     device,
+                                 const VkImageCreateInfo*     pCreateInfo,
+                                 const VkAllocationCallbacks* pAllocator,
+                                 VkImage*                     pImage);
+
     VkResult OverrideCreateAccelerationStructureKHR(VkDevice                                    device,
                                                     const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
                                                     const VkAllocationCallbacks*                pAllocator,

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -1534,17 +1534,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateImage>::Dispatch(VulkanCaptureManager::Get(), device, pCreateInfo, pAllocator, pImage);
 
-    auto handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-    const VkImageCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
-
-    VkResult result = GetDeviceTable(device)->CreateImage(device_unwrapped, pCreateInfo_unwrapped, pAllocator, pImage);
-
-    if (result >= 0)
-    {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, ImageWrapper>(device, NoParentWrapper::kHandleValue, pImage, VulkanCaptureManager::GetUniqueId);
-    }
-    else
+    VkResult result = VulkanCaptureManager::Get()->OverrideCreateImage(device, pCreateInfo, pAllocator, pImage);
+    if (result < 0)
     {
         omit_output_data = true;
     }

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -3,6 +3,7 @@
     "vkCreateInstance": "VulkanCaptureManager::OverrideCreateInstance",
     "vkCreateDevice": "VulkanCaptureManager::Get()->OverrideCreateDevice",
     "vkCreateBuffer": "VulkanCaptureManager::Get()->OverrideCreateBuffer",
+    "vkCreateImage": "VulkanCaptureManager::Get()->OverrideCreateImage",
     "vkAllocateMemory": "VulkanCaptureManager::Get()->OverrideAllocateMemory",
     "vkGetPhysicalDeviceToolPropertiesEXT": "VulkanCaptureManager::Get()->OverrideGetPhysicalDeviceToolPropertiesEXT",
     "vkCreateAccelerationStructureKHR": "VulkanCaptureManager::Get()->OverrideCreateAccelerationStructureKHR",


### PR DESCRIPTION
Buffer and image need USAGE_TRANSFER_SRC when trimming because they do copy job in VulkanStateWriter::ProcessBufferMemory and VulkanStateWriter::ProcessImageMemory.

closed: https://github.com/LunarG/gfxreconstruct/issues/771