### PR TITLE
Keep HandleWrappers for invalid handles

### DIFF
--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(gfxrecon_encode
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_handle_wrappers.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_state_table.h
+                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_wrapper_handle_list.h
 
 )
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -30,6 +30,7 @@
 #include "encode/vulkan_state_writer.h"
 #include "format/format_util.h"
 #include "generated/generated_vulkan_struct_handle_wrappers.h"
+#include "generated/generated_vulkan_wrapper_handle_list.h"
 #include "graphics/vulkan_device_util.h"
 #include "util/compressor.h"
 #include "util/logging.h"
@@ -54,6 +55,8 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 VulkanCaptureManager* VulkanCaptureManager::instance_ = nullptr;
 LayerTable            VulkanCaptureManager::layer_table_;
+
+VulkanWrapperHandleList VulkanWrapperHandleList::instance_;
 
 bool VulkanCaptureManager::CreateInstance()
 {

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -28,6 +28,7 @@
 #include "format/format.h"
 #include "format/format_util.h"
 #include "generated/generated_vulkan_dispatch_table.h"
+#include "generated/generated_vulkan_wrapper_handle_list.h"
 #include "util/defines.h"
 
 #include <algorithm>
@@ -129,6 +130,7 @@ void CreateWrappedDispatchHandle(typename ParentWrapper::HandleType parent,
         }
 
         (*handle) = reinterpret_cast<typename Wrapper::HandleType>(wrapper);
+        VulkanWrapperHandleList::Get()->AddWrapperHandle(wrapper);
     }
 }
 
@@ -143,6 +145,7 @@ void CreateWrappedNonDispatchHandle(typename Wrapper::HandleType* handle, PFN_Ge
         wrapper->handle    = (*handle);
         wrapper->handle_id = get_id();
         (*handle)          = reinterpret_cast<typename Wrapper::HandleType>(wrapper);
+        VulkanWrapperHandleList::Get()->AddWrapperHandle(wrapper);
     }
 }
 

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -113,6 +113,7 @@ void CreateWrappedDispatchHandle(typename ParentWrapper::HandleType parent,
     if ((*handle) != VK_NULL_HANDLE)
     {
         Wrapper* wrapper      = new Wrapper;
+        wrapper->active       = true;
         wrapper->dispatch_key = *reinterpret_cast<void**>(*handle);
         wrapper->handle       = (*handle);
         wrapper->handle_id    = get_id();
@@ -138,6 +139,7 @@ void CreateWrappedNonDispatchHandle(typename Wrapper::HandleType* handle, PFN_Ge
     if ((*handle) != VK_NULL_HANDLE)
     {
         Wrapper* wrapper   = new Wrapper;
+        wrapper->active    = true;
         wrapper->handle    = (*handle);
         wrapper->handle_id = get_id();
         (*handle)          = reinterpret_cast<typename Wrapper::HandleType>(wrapper);
@@ -426,7 +428,7 @@ void DestroyWrappedHandle(typename Wrapper::HandleType handle)
 {
     if (handle != VK_NULL_HANDLE)
     {
-        delete reinterpret_cast<Wrapper*>(handle);
+        reinterpret_cast<Wrapper*>(handle)->active = false;
     }
 }
 
@@ -444,16 +446,16 @@ inline void DestroyWrappedHandle<InstanceWrapper>(VkInstance handle)
             {
                 for (auto display_mode_wrapper : display_wrapper->child_display_modes)
                 {
-                    delete display_mode_wrapper;
+                    display_mode_wrapper->active = false;
                 }
 
-                delete display_wrapper;
+                display_wrapper->active = false;
             }
 
-            delete physical_device_wrapper;
+            physical_device_wrapper->active = false;
         }
 
-        delete wrapper;
+        wrapper->active = false;
     }
 }
 
@@ -467,10 +469,10 @@ inline void DestroyWrappedHandle<DeviceWrapper>(VkDevice handle)
 
         for (auto queue_wrapper : wrapper->child_queues)
         {
-            delete queue_wrapper;
+            queue_wrapper->active = false;
         }
 
-        delete wrapper;
+        wrapper->active = false;
     }
 }
 
@@ -483,7 +485,7 @@ inline void DestroyWrappedHandle<CommandBufferWrapper>(VkCommandBuffer handle)
         auto wrapper = reinterpret_cast<CommandBufferWrapper*>(handle);
         wrapper->parent_pool->child_buffers.erase(wrapper->handle_id);
 
-        delete wrapper;
+        wrapper->active = false;
     }
 }
 
@@ -497,10 +499,10 @@ inline void DestroyWrappedHandle<CommandPoolWrapper>(VkCommandPool handle)
 
         for (const auto& buffer_wrapper : wrapper->child_buffers)
         {
-            delete buffer_wrapper.second;
+            buffer_wrapper.second->active = false;
         }
 
-        delete wrapper;
+        wrapper->active = false;
     }
 }
 
@@ -513,7 +515,7 @@ inline void DestroyWrappedHandle<DescriptorSetWrapper>(VkDescriptorSet handle)
         auto wrapper = reinterpret_cast<DescriptorSetWrapper*>(handle);
         wrapper->parent_pool->child_sets.erase(wrapper->handle_id);
 
-        delete wrapper;
+        wrapper->active = false;
     }
 }
 
@@ -527,10 +529,10 @@ inline void DestroyWrappedHandle<DescriptorPoolWrapper>(VkDescriptorPool handle)
 
         for (const auto& set_wrapper : wrapper->child_sets)
         {
-            delete set_wrapper.second;
+            set_wrapper.second->active = false;
         }
 
-        delete wrapper;
+        wrapper->active = false;
     }
 }
 
@@ -544,10 +546,10 @@ inline void DestroyWrappedHandle<SwapchainKHRWrapper>(VkSwapchainKHR handle)
 
         for (auto image_wrapper : wrapper->child_images)
         {
-            delete image_wrapper;
+            image_wrapper->active = false;
         }
 
-        delete wrapper;
+        wrapper->active = false;
     }
 }
 
@@ -571,7 +573,7 @@ inline void ResetDescriptorPoolWrapper(VkDescriptorPool handle)
     auto wrapper = reinterpret_cast<DescriptorPoolWrapper*>(handle);
     for (const auto& set_wrapper : wrapper->child_sets)
     {
-        delete set_wrapper.second;
+        set_wrapper.second->active = false;
     }
     wrapper->child_sets.clear();
 }

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -62,6 +62,8 @@ struct HandleWrapper
     format::HandleId  handle_id{ format::kNullHandleId }; // Globally unique ID assigned to the handle by the layer.
     format::ApiCallId create_call_id{ format::ApiCallId::ApiCall_Unknown };
     CreateParameters  create_parameters;
+
+    bool active{ false };
 };
 
 //

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -50,7 +50,6 @@ generate_targets = [
     'generated_vulkan_api_call_encoders.h',
     'generated_vulkan_api_call_encoders.cpp',
     'generated_vulkan_command_buffer_util.h',
-    'generated_vulkan_object_info_table_base2.h',
     'generated_vulkan_command_buffer_util.cpp',
     'generated_vulkan_dispatch_table.h',
     'generated_layer_func_table.h',
@@ -79,7 +78,8 @@ generate_targets = [
     'generated_vulkan_struct_decoders_to_string.cpp',
     'generated_vulkan_pnext_decoders_to_string.cpp',
     'generated_vulkan_object_info_table_base2.h',
-    'generated_vulkan_state_table.h'
+    'generated_vulkan_state_table.h',
+    'generated_vulkan_wrapper_handle_list.h',
 ]
 
 if __name__ == '__main__':

--- a/framework/generated/generated_vulkan_wrapper_handle_list.h
+++ b/framework/generated/generated_vulkan_wrapper_handle_list.h
@@ -1,0 +1,137 @@
+/*
+** Copyright (c) 2018-2021 Valve Corporation
+** Copyright (c) 2018-2022 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+/*
+** This file is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+#ifndef  GFXRECON_GENERATED_VULKAN_WRAPPER_HANDLE_LIST_H
+#define  GFXRECON_GENERATED_VULKAN_WRAPPER_HANDLE_LIST_H
+
+#include "encode/vulkan_handle_wrappers.h"
+
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+class VulkanWrapperHandleList
+{
+  public:
+    static VulkanWrapperHandleList* Get() { return &instance_; }
+
+    void AddWrapperHandle(AccelerationStructureKHRWrapper* wrapper) { AccelerationStructureKHRWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(AccelerationStructureNVWrapper* wrapper) { AccelerationStructureNVWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(BufferWrapper* wrapper) { BufferWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(BufferViewWrapper* wrapper) { BufferViewWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(CommandBufferWrapper* wrapper) { CommandBufferWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(CommandPoolWrapper* wrapper) { CommandPoolWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DebugReportCallbackEXTWrapper* wrapper) { DebugReportCallbackEXTWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DebugUtilsMessengerEXTWrapper* wrapper) { DebugUtilsMessengerEXTWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DeferredOperationKHRWrapper* wrapper) { DeferredOperationKHRWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DescriptorPoolWrapper* wrapper) { DescriptorPoolWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DescriptorSetWrapper* wrapper) { DescriptorSetWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DescriptorSetLayoutWrapper* wrapper) { DescriptorSetLayoutWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DescriptorUpdateTemplateWrapper* wrapper) { DescriptorUpdateTemplateWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DeviceWrapper* wrapper) { DeviceWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DeviceMemoryWrapper* wrapper) { DeviceMemoryWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DisplayKHRWrapper* wrapper) { DisplayKHRWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(DisplayModeKHRWrapper* wrapper) { DisplayModeKHRWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(EventWrapper* wrapper) { EventWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(FenceWrapper* wrapper) { FenceWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(FramebufferWrapper* wrapper) { FramebufferWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(ImageWrapper* wrapper) { ImageWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(ImageViewWrapper* wrapper) { ImageViewWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(IndirectCommandsLayoutNVWrapper* wrapper) { IndirectCommandsLayoutNVWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(InstanceWrapper* wrapper) { InstanceWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(MicromapEXTWrapper* wrapper) { MicromapEXTWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(OpticalFlowSessionNVWrapper* wrapper) { OpticalFlowSessionNVWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(PerformanceConfigurationINTELWrapper* wrapper) { PerformanceConfigurationINTELWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(PhysicalDeviceWrapper* wrapper) { PhysicalDeviceWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(PipelineWrapper* wrapper) { PipelineWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(PipelineCacheWrapper* wrapper) { PipelineCacheWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(PipelineLayoutWrapper* wrapper) { PipelineLayoutWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(PrivateDataSlotWrapper* wrapper) { PrivateDataSlotWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(QueryPoolWrapper* wrapper) { QueryPoolWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(QueueWrapper* wrapper) { QueueWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(RenderPassWrapper* wrapper) { RenderPassWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(SamplerWrapper* wrapper) { SamplerWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(SamplerYcbcrConversionWrapper* wrapper) { SamplerYcbcrConversionWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(SemaphoreWrapper* wrapper) { SemaphoreWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(ShaderModuleWrapper* wrapper) { ShaderModuleWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(SurfaceKHRWrapper* wrapper) { SurfaceKHRWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(SwapchainKHRWrapper* wrapper) { SwapchainKHRWrapper_list_.emplace_back(wrapper); }
+    void AddWrapperHandle(ValidationCacheEXTWrapper* wrapper) { ValidationCacheEXTWrapper_list_.emplace_back(wrapper); }
+
+  private:
+    VulkanWrapperHandleList(){}
+    static VulkanWrapperHandleList instance_;
+
+    std::vector<std::shared_ptr<AccelerationStructureKHRWrapper>> AccelerationStructureKHRWrapper_list_;
+    std::vector<std::shared_ptr<AccelerationStructureNVWrapper>> AccelerationStructureNVWrapper_list_;
+    std::vector<std::shared_ptr<BufferWrapper>> BufferWrapper_list_;
+    std::vector<std::shared_ptr<BufferViewWrapper>> BufferViewWrapper_list_;
+    std::vector<std::shared_ptr<CommandBufferWrapper>> CommandBufferWrapper_list_;
+    std::vector<std::shared_ptr<CommandPoolWrapper>> CommandPoolWrapper_list_;
+    std::vector<std::shared_ptr<DebugReportCallbackEXTWrapper>> DebugReportCallbackEXTWrapper_list_;
+    std::vector<std::shared_ptr<DebugUtilsMessengerEXTWrapper>> DebugUtilsMessengerEXTWrapper_list_;
+    std::vector<std::shared_ptr<DeferredOperationKHRWrapper>> DeferredOperationKHRWrapper_list_;
+    std::vector<std::shared_ptr<DescriptorPoolWrapper>> DescriptorPoolWrapper_list_;
+    std::vector<std::shared_ptr<DescriptorSetWrapper>> DescriptorSetWrapper_list_;
+    std::vector<std::shared_ptr<DescriptorSetLayoutWrapper>> DescriptorSetLayoutWrapper_list_;
+    std::vector<std::shared_ptr<DescriptorUpdateTemplateWrapper>> DescriptorUpdateTemplateWrapper_list_;
+    std::vector<std::shared_ptr<DeviceWrapper>> DeviceWrapper_list_;
+    std::vector<std::shared_ptr<DeviceMemoryWrapper>> DeviceMemoryWrapper_list_;
+    std::vector<std::shared_ptr<DisplayKHRWrapper>> DisplayKHRWrapper_list_;
+    std::vector<std::shared_ptr<DisplayModeKHRWrapper>> DisplayModeKHRWrapper_list_;
+    std::vector<std::shared_ptr<EventWrapper>> EventWrapper_list_;
+    std::vector<std::shared_ptr<FenceWrapper>> FenceWrapper_list_;
+    std::vector<std::shared_ptr<FramebufferWrapper>> FramebufferWrapper_list_;
+    std::vector<std::shared_ptr<ImageWrapper>> ImageWrapper_list_;
+    std::vector<std::shared_ptr<ImageViewWrapper>> ImageViewWrapper_list_;
+    std::vector<std::shared_ptr<IndirectCommandsLayoutNVWrapper>> IndirectCommandsLayoutNVWrapper_list_;
+    std::vector<std::shared_ptr<InstanceWrapper>> InstanceWrapper_list_;
+    std::vector<std::shared_ptr<MicromapEXTWrapper>> MicromapEXTWrapper_list_;
+    std::vector<std::shared_ptr<OpticalFlowSessionNVWrapper>> OpticalFlowSessionNVWrapper_list_;
+    std::vector<std::shared_ptr<PerformanceConfigurationINTELWrapper>> PerformanceConfigurationINTELWrapper_list_;
+    std::vector<std::shared_ptr<PhysicalDeviceWrapper>> PhysicalDeviceWrapper_list_;
+    std::vector<std::shared_ptr<PipelineWrapper>> PipelineWrapper_list_;
+    std::vector<std::shared_ptr<PipelineCacheWrapper>> PipelineCacheWrapper_list_;
+    std::vector<std::shared_ptr<PipelineLayoutWrapper>> PipelineLayoutWrapper_list_;
+    std::vector<std::shared_ptr<PrivateDataSlotWrapper>> PrivateDataSlotWrapper_list_;
+    std::vector<std::shared_ptr<QueryPoolWrapper>> QueryPoolWrapper_list_;
+    std::vector<std::shared_ptr<QueueWrapper>> QueueWrapper_list_;
+    std::vector<std::shared_ptr<RenderPassWrapper>> RenderPassWrapper_list_;
+    std::vector<std::shared_ptr<SamplerWrapper>> SamplerWrapper_list_;
+    std::vector<std::shared_ptr<SamplerYcbcrConversionWrapper>> SamplerYcbcrConversionWrapper_list_;
+    std::vector<std::shared_ptr<SemaphoreWrapper>> SemaphoreWrapper_list_;
+    std::vector<std::shared_ptr<ShaderModuleWrapper>> ShaderModuleWrapper_list_;
+    std::vector<std::shared_ptr<SurfaceKHRWrapper>> SurfaceKHRWrapper_list_;
+    std::vector<std::shared_ptr<SwapchainKHRWrapper>> SwapchainKHRWrapper_list_;
+    std::vector<std::shared_ptr<ValidationCacheEXTWrapper>> ValidationCacheEXTWrapper_list_;
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -73,6 +73,7 @@ from vulkan_command_buffer_util_body_generator import VulkanCommandBufferUtilBod
 from vulkan_command_buffer_util_header_generator import VulkanCommandBufferUtilHeaderGenerator, VulkanCommandBufferUtilHeaderGeneratorOptions
 from vulkan_dispatch_table_generator import VulkanDispatchTableGenerator, VulkanDispatchTableGeneratorOptions
 from layer_func_table_generator import LayerFuncTableGenerator, LayerFuncTableGeneratorOptions
+from vulkan_wrapper_handle_list_header_generator import VulkanWrapperHandleListHeaderGeneratorOptions, VulkanWrapperHandleListHeaderGenerator
 
 # Struct Encoders
 from vulkan_struct_encoders_body_generator import VulkanStructEncodersBodyGenerator, VulkanStructEncodersBodyGeneratorOptions
@@ -584,6 +585,20 @@ def make_gen_opts(args):
             extraVulkanHeaders=extraVulkanHeaders
         )
     ]
+
+    gen_opts['generated_vulkan_wrapper_handle_list.h'] = [
+        VulkanWrapperHandleListHeaderGenerator,
+        VulkanWrapperHandleListHeaderGeneratorOptions(
+            filename='generated_vulkan_wrapper_handle_list.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platform_types,
+            prefixText=prefix_strings + vk_prefix_strings,
+            protectFile=True,
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders
+        )
+    ]    
 
     #
     # To string generators

--- a/framework/generated/vulkan_generators/vulkan_wrapper_handle_list_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_wrapper_handle_list_header_generator.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2021 LunarG, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import os, re, sys
+from base_generator import *
+
+
+class VulkanWrapperHandleListHeaderGeneratorOptions(BaseGeneratorOptions):
+    """Options for generating C++ function declarations for Vulkan API parameter encoding"""
+
+    def __init__(
+        self,
+        blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+        platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+        filename=None,
+        directory='.',
+        prefixText='',
+        protectFile=False,
+        protectFeature=True,
+        extraVulkanHeaders=[]
+    ):
+        BaseGeneratorOptions.__init__(
+            self,
+            blacklists,
+            platformTypes,
+            filename,
+            directory,
+            prefixText,
+            protectFile,
+            protectFeature,
+            extraVulkanHeaders=extraVulkanHeaders
+        )
+
+
+# Generates declarations for functions for Vulkan object info table
+class VulkanWrapperHandleListHeaderGenerator(BaseGenerator):
+
+    def __init__(
+        self, err_file=sys.stderr, warn_file=sys.stderr, diag_file=sys.stdout
+    ):
+        BaseGenerator.__init__(
+            self,
+            process_cmds=True,
+            process_structs=False,
+            feature_break=True,
+            err_file=err_file,
+            warn_file=warn_file,
+            diag_file=diag_file
+        )
+
+    # Method override
+    # yapf: disable
+    def beginFile(self, genOpts):
+        BaseGenerator.beginFile(self, genOpts)
+        self.write_include()
+        write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
+    # yapf: enable
+
+    # Method override
+    # yapf: disable
+    def endFile(self):
+        self.generate_all()
+        write('GFXRECON_END_NAMESPACE(encode)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
+
+        # Finish processing in superclass
+        BaseGenerator.endFile(self)
+    # yapf: enable
+
+    # yapf: disable
+    def generate_all(self):
+        add_code = ''
+        list_code = ''
+
+        for handle_name in sorted(self.handle_names):
+            if handle_name in self.DUPLICATE_HANDLE_TYPES:
+                continue
+            handle_name = handle_name[2:]
+            handle_wrapper = handle_name + 'Wrapper'
+            handle_list = handle_wrapper + '_list_'
+            add_code += '    void AddWrapperHandle({0}* wrapper) {{ {1}.emplace_back(wrapper); }}\n'.format(handle_wrapper, handle_list)
+            list_code += '    std::vector<std::shared_ptr<{0}>> {1};\n'.format(handle_wrapper, handle_list)
+
+        self.newline()
+        code = 'class VulkanWrapperHandleList\n'
+        code += '{\n'
+        code += '  public:\n'
+        code += '    static VulkanWrapperHandleList* Get() { return &instance_; }\n'
+        code += '\n'
+        code += add_code
+        code += '\n'
+        code += '  private:\n'
+        code += '    VulkanWrapperHandleList(){}\n'
+        code += '    static VulkanWrapperHandleList instance_;\n'
+        code += '\n'
+        code += list_code
+        code += '};\n'
+        write(code, file=self.outFile)
+    # yapf: enable
+
+    def write_include(self):
+        write(
+            '#include "encode/vulkan_handle_wrappers.h"\n',
+            file=self.outFile
+        )
+        self.newline()


### PR DESCRIPTION
The application might use invalid handles that have destroyed. If
HandleWrappers are deleted when the handles are destroyed, it will get
invalid pointer address of HandleWrappers to crash when the application uses
invalid handles. So don't delete HandleWrappers when the handles are
destroyed. Delete HandleWrappers in the ending.

closed: https://github.com/LunarG/gfxreconstruct/issues/677