### PR TITLE
Flush After Presents

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -700,6 +700,12 @@ void CaptureManager::EndFrame()
     }
 
     global_frame_count_++;
+
+    // Flush after presents to help avoid capture files with incomplete final blocks.
+    if (file_stream_.get() != nullptr)
+    {
+        file_stream_->Flush();
+    }
 }
 
 std::string CaptureManager::CreateTrimFilename(const std::string&                base_filename,


### PR DESCRIPTION
Flush after presents to avoid some cases of capture files with incomplete final blocks. The application logic to quit (e.g. responding to a click on an exit button) is evaluated between a present and the next Vulkan call that would be made and there is lots of code that can crash between the end of one frame's rendering and the next frame's start and between a frame's end and the clean shutdown of the process.

In the event of a clean shutdown, the C standard library is expected to flush any data we have written to our capture file and log, so our concern is with the process we are capturing crashing or being killed by the system, either in any of the logic outside the rendering portion of its main loop, or during the shutdown sequence. By selectively flushing after presents we can take care of these cases at an expected low cost and restrict our exposure to incomplete final blocks to those resulting from crashes and force-kills during the rendering of a frame.

The warning seen when running many captures through `convert`, `compress`, and `optimize` is:

    [gfxrecon] WARNING - Incomplete block at end of file

We override the size of file buffers to be 256KB, so on average, with typical real-app captures that space presents out, these flushes will happen with a buffer that is 128KB full, which should still be a big enough buffer to amortise IO overhead, especially if a frame is large enough that many full-size flushes precede the _on-average-half-size_ final one of each frame.

This is a recreation of PR https://github.com/LunarG/gfxreconstruct/pull/862, which was automatically closed on branch rename.