### PR TITLE
Optimize generated ToString compilation performance

### DIFF
--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -116,7 +116,7 @@ ObjectToString(ToStringFlags toStringFlags, uint32_t& tabCount, uint32_t tabSize
 
 inline void FieldToString(std::stringstream& strStrm,
                           bool               firstField,
-                          const std::string& fieldName,
+                          const char*        fieldName,
                           ToStringFlags      toStringFlags,
                           uint32_t           tabCount,
                           uint32_t           tabSize,


### PR DESCRIPTION
By not calling std::string constructor on every struct field ever.

generated_vulkan_struct_to_string: 79s -> 65s
generated_vulkan_struct_decoders_to_string.cpp: 73s -> 57s