### PR TITLE
Choose lower apiVersion for VMA

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1821,7 +1821,8 @@ void VulkanReplayConsumerBase::InitializeResourceAllocator(const PhysicalDeviceI
     auto replay_device_info = physical_device_info->replay_device_info;
     assert(replay_device_info->memory_properties != nullptr);
 
-    VkResult result = allocator->Initialize(physical_device_info->parent_api_version,
+    VkResult result = allocator->Initialize(std::min(physical_device_info->parent_api_version,
+                                                     physical_device_info->replay_device_info->properties->apiVersion),
                                             physical_device_info->parent,
                                             physical_device_info->handle,
                                             device,


### PR DESCRIPTION
Compare VkPhysicalDevice's ApiVersion and VkInstance's ApiVersion. Lower apiVersion could prevent unsupported issues on VMA.

vkspec:
`If we modify the above example so that the application sets apiVersion to 1.1, then the application must not use Vulkan 1.2 functionality on the physical device that supports Vulkan 1.2.`
It means if vkPhysicalDevice's ApiVersion is higher then vkInstance's apiVersion, the higher version's device's functions shouldn't be used, so we should choose lower apiVersion.

closed: https://github.com/LunarG/gfxreconstruct/issues/883
