### PR TITLE
disable win dbg popup if GFXRECON_NO_DEBUG_POPUP has value

### DIFF
--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -36,6 +36,7 @@ Vulkan API calls on Desktop systems.
     4. [Trimmed File Optimization](#trimmed-file-optimization)
     5. [JSON Lines Conversion](#json-lines-conversion)
     6. [Command Launcher](#command-launcher)
+    7. [Options Common To All Tools](#common-options)
 
 ## Capturing API calls
 
@@ -658,3 +659,17 @@ gfxrecon.py capture -o vkcube.gfxr vkcube
 
 On Windows, after installing Python3, be sure to associate the `.py` file extension with
 the Python3 interpreter before you run the script.
+
+### Options Common To all Tools
+
+If the environment variable `GFXRECON_NO_DEBUG_POPUP` has any non-zero
+number or non-empty, non-numeric string value when running any of
+of the file processing tools, the tool will attempt to disable the
+'Abort, Retry, Ignore' message box displayed when `assert()` fails on
+Windows in a Debug build.  This behavior is slightly different than
+`--no-debug-popup` in that the message box is disabled before any other
+variable initialization.  This is probably most useful in headless or
+"Continuous Integration" builds when an on-screen message box that
+can't be automatically dismissed may hang scripts or cause directories
+to be locked.  (Note that "FALSE" and "no", as examples, are non-empty,
+non-numeric string values and will be interpreted as enabling the option.)

--- a/tools/compress/CMakeLists.txt
+++ b/tools/compress/CMakeLists.txt
@@ -33,7 +33,18 @@ target_sources(gfxrecon-compress
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
                    ${CMAKE_CURRENT_LIST_DIR}/compression_converter.h
                    ${CMAKE_CURRENT_LIST_DIR}/compression_converter.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
 )
+
+if (MSVC)
+    # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+    # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+    if(NOT CMAKE_CL_64)
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+    else()
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+    endif()
+endif()
 
 target_include_directories(gfxrecon-compress PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/tools/convert/CMakeLists.txt
+++ b/tools/convert/CMakeLists.txt
@@ -32,7 +32,18 @@ target_sources(gfxrecon-convert
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/main.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
               )
+
+if (MSVC)
+    # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+    # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+    if(NOT CMAKE_CL_64)
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+    else()
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+    endif()
+endif()
 
 target_include_directories(gfxrecon-convert PUBLIC ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/..)
 

--- a/tools/extract/CMakeLists.txt
+++ b/tools/extract/CMakeLists.txt
@@ -31,7 +31,18 @@ add_executable(gfxrecon-extract "")
 target_sources(gfxrecon-extract
                PRIVATE
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
               )
+
+if (MSVC)
+    # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+    # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+    if(NOT CMAKE_CL_64)
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+    else()
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+    endif()
+endif()
 
 target_include_directories(gfxrecon-extract PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/tools/info/CMakeLists.txt
+++ b/tools/info/CMakeLists.txt
@@ -31,7 +31,18 @@ add_executable(gfxrecon-info "")
 target_sources(gfxrecon-info
                PRIVATE
                    ${CMAKE_CURRENT_LIST_DIR}/main.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
               )
+
+if (MSVC)
+    # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+    # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+    if(NOT CMAKE_CL_64)
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+    else()
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+    endif()
+endif()
 
 target_include_directories(gfxrecon-info PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -41,7 +41,18 @@ target_sources(gfxrecon-optimize
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_resource_value_tracking_consumer.cpp>
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/block_skipping_file_processor.h>
                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/block_skipping_file_processor.cpp>
+                   ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
               )
+
+if (MSVC)
+    # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+    # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+    if(NOT CMAKE_CL_64)
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+    else()
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+    endif()
+endif()
 
 target_include_directories(gfxrecon-optimize PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/tools/platform_debug_helper.cpp
+++ b/tools/platform_debug_helper.cpp
@@ -1,0 +1,81 @@
+/*
+** Copyright (c) 2023 Valve Corporation
+** Copyright (c) 2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include <cstdlib>
+#include <cctype>
+
+#if defined(WIN32)
+
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+DWORD DisableDebugPopup(void)
+{
+    static char contents[512];
+    DWORD       stored = GetEnvironmentVariableA("GFXRECON_NO_DEBUG_POPUP", contents, sizeof(contents));
+
+    // Succeed contents for GFXRECON_NO_DEBUG_POPUP are 1 char or longer and they fit in the buffer
+    // 0 is a valid return value but that means the env var is undefined or defined but empty
+    bool non_empty     = stored >= 1;
+    bool was_too_large = stored == sizeof(contents);
+
+    if (non_empty && !was_too_large)
+    {
+        bool not_all_spaces = false;
+        for (const char* c = contents; *c; c++)
+        {
+            if (!isspace(*c))
+            {
+                not_all_spaces = true;
+                break;
+            }
+        }
+
+        char* endptr     = nullptr;
+        bool  value      = strtoul(contents, &endptr, 10);
+        bool  valid_zero = (value == 0) && (endptr == contents + strlen(contents));
+
+        if (not_all_spaces && !valid_zero)
+        {
+            _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+        }
+    }
+
+    return stored;
+}
+
+extern "C"
+{
+    // We create a new program section here which is initialized before C++ dynamic
+    // initializers, so that initializing this variable forces the function above to be called early
+    // in program execution.
+    // For more information on this linker section declaration, please see
+    // https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-170 .
+#pragma section(".CRT$XCT", read)
+    __declspec(allocate(".CRT$XCT")) DWORD gfxrecon_disable_popup_result = DisableDebugPopup();
+}
+
+#endif /* defined(WIN32) */

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(gfxrecon-replay
                     ${CMAKE_CURRENT_LIST_DIR}/../tool_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/replay_settings.h
                     ${CMAKE_CURRENT_LIST_DIR}/desktop_main.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/../platform_debug_helper.cpp
 )
 
 target_include_directories(gfxrecon-replay PUBLIC ${CMAKE_BINARY_DIR})
@@ -46,6 +47,16 @@ target_link_libraries(gfxrecon-replay
                           platform_specific
                           $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
                           $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>)
+
+if (MSVC)
+    # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+    # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+    if(NOT CMAKE_CL_64)
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+    else()
+      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+    endif()
+endif()
 
 # A multithreaded Vulkan driver loaded through dlopen() mechanism
 # won't work if libstdc++ has started in a single-threaded mode.


### PR DESCRIPTION
Add a new linker section in MSVC containing a variable with an initializer function that disables debug popups if GFXRECON_NO_DEBUG_POPUP has a non-empty value

Add some usage information for GFXRECON_NO_DEBUG_POPUP