### PR TITLE
rebind for coping no layouts info of images

### DIFF
--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -282,6 +282,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
 
         // Image layouts for performing mapped memory writes to linear images with different capture/replay memory
         // alignments.
+        SubresourceLayouts              init_layouts;
         std::vector<SubresourceLayouts> layouts;
     };
 


### PR DESCRIPTION
If a image doesn't have layouts info, it can't be copied correctly on BindImageMemory. But the layouts info is recorded on GetImageSubresourceLayout. The application could run BindImageMemory first, and then GetImageSubresourceLayout. It causes it can't copy image correctly and get warning `Image subresource layout info is not available for mapped memory write; capture/replay memory alignment differences will not be handled properly`, so give it an init layouts on CreateImage.