### PR TITLE
block EXT_shader_module_identifier

### DIFF
--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -58,6 +58,7 @@ const std::vector<VkExtensionProperties> kDeviceExtensionProps = { VkExtensionPr
 const char* const kUnsupportedDeviceExtensions[] = {
     // Supporting the CPU moving around descriptor set data directly has too many
     // perf/robustness tradeoffs to be worth it.
+    VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME,
     VK_NVX_BINARY_IMPORT_EXTENSION_NAME,
     VK_VALVE_DESCRIPTOR_SET_HOST_MAPPING_EXTENSION_NAME,
 };


### PR DESCRIPTION
As noted in #734, `VK_EXT_shader_module_identifier` allows an app to query an identifier for a shader module which then can be used in place of a `VkShaderModule` object.  This causes a crash in capture.  @ishitatsuyuki , will you give this a try?