### PR TITLE
Don't write signal for zero valued timeline semaphores

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -408,7 +408,11 @@ void VulkanStateWriter::WriteSemaphoreState(const VulkanStateTable& state_table)
             }
 
             // Write command to set semaphore value on replay
-            WriteSignalSemaphoreValue(signal_call_id, device_wrapper->handle_id, wrapper->handle_id, semaphore_value);
+            if (semaphore_value != 0)
+            {
+                WriteSignalSemaphoreValue(
+                    signal_call_id, device_wrapper->handle_id, wrapper->handle_id, semaphore_value);
+            }
         }
         else if (wrapper->signaled)
         {


### PR DESCRIPTION
The Vulkan spec says in VkSemaphoreSignalInfo:
value must have a value greater than the current value of the semaphore.

The initial value is zero, so don't signal zero-valued semaphores.