### PR TITLE
Removed Subscript of Potentially Empty Vector

### DIFF
--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -390,7 +390,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
 
         std::vector<VkExtensionProperties> downstream_properties(downstream_property_count);
         result = instance_table->EnumerateDeviceExtensionProperties(
-            wrapped_device, pLayerName, &downstream_property_count, &downstream_properties[0]);
+            wrapped_device, pLayerName, &downstream_property_count, downstream_properties.data());
         if (result != VK_SUCCESS)
         {
             return result;


### PR DESCRIPTION
The old code was triggering a debug assertion in MS STL under rare circumstances.
Subscripting an empty vector is undefined behaviour but calling `data()` on one [is not](https://en.cppreference.com/w/cpp/container/vector/data).