### PR TITLE
DX12 trimming fixes

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -404,7 +404,8 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
         // If no entry exists in resource_init_infos_, this is the first subresource of a new resource.
         GFXRECON_ASSERT(command_header.subresource == 0);
 
-        if (!graphics::dx12::IsMemoryAvailable(total_size_in_bytes, extra_device_info->adapter3))
+        const double max_cpu_mem_usage = 15.0 / 16.0;
+        if (!graphics::dx12::IsMemoryAvailable(total_size_in_bytes, extra_device_info->adapter3, max_cpu_mem_usage))
         {
             // If neither system memory or GPU memory are able to accommodate next resource,
             // execute the Copy() calls and release temp buffer to free memory

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -745,7 +745,9 @@ void Dx12StateWriter::WriteResourceSnapshots(
 
                 uint64_t size_in_bytes = resource_info.get()->size_in_bytes;
                 auto     device_info   = device_wrapper->GetObjectInfo();
-                if (!graphics::dx12::IsMemoryAvailable(size_in_bytes, device_info.get()->adapter3))
+
+                const double max_cpu_mem_usage = 7.0 / 8.0;
+                if (!graphics::dx12::IsMemoryAvailable(size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage))
                 {
                     // If neither system memory or GPU memory are able to accommodate next resource,
                     // execute the existing Copy() calls and release temp buffer to free memory

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -625,11 +625,8 @@ Dx12ResourceDataUtil::ExecuteCopyCommandList(ID3D12Resource*                    
                                              ID3D12Resource*                                        staging_buffer,
                                              bool                                                   batching)
 {
-    const dx12::ResourceStateInfo kReadState  = { D3D12_RESOURCE_STATE_GENERIC_READ, D3D12_RESOURCE_BARRIER_FLAG_NONE };
-    const dx12::ResourceStateInfo kWriteState = { D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_BARRIER_FLAG_NONE };
-
     // The resource state required to copy data to the target resource.
-    const dx12::ResourceStateInfo copy_state = (copy_type == kCopyTypeRead) ? kReadState : kWriteState;
+    const dx12::ResourceStateInfo copy_state = { D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_BARRIER_FLAG_NONE };
 
     uint64_t subresource_count = subresource_layouts.size();
 

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -191,11 +191,12 @@ IDXGIAdapter* GetAdapterbyIndex(graphics::dx12::ActiveAdapterMap& adapters, int3
 // The input is current adapter which created current device.
 uint64_t GetAvailableGpuAdapterMemory(IDXGIAdapter3* adapter);
 
-// This function is used to get available CPU virtual memory.
-uint64_t GetAvailableCpuVirtualMemory();
+// This function is used to get available CPU memory.
+uint64_t GetAvailableCpuMemory(double max_usage);
 
-// Give require memory size to check if there are enough CPU&GPU memory to allocate the resource
-bool IsMemoryAvailable(uint64_t requried_memory, IDXGIAdapter3* adapter);
+// Give require memory size to check if there are enough CPU&GPU memory to allocate the resource. If max_cpu_mem_usage
+// > 1.0, the result is not limited by available physical memory.
+bool IsMemoryAvailable(uint64_t requried_memory, IDXGIAdapter3* adapter, double max_cpu_mem_usage);
 
 // Get GPU memory usage by resource desc
 uint64_t GetResourceSizeInBytes(ID3D12Device* device, const D3D12_RESOURCE_DESC* desc);


### PR DESCRIPTION
- Limit amount of mem used to read/write trim state
  - To prevent paging memory to disk while reading or writing trim state.
- Use STATE_COMMON to read/write resource data
  - To prevent occasional corruption of first frame in trimmed capture.