### PR TITLE
Registry driver version info

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -2377,8 +2377,12 @@ void D3D12CaptureManager::WriteDx12DriverInfo()
 {
     if ((GetCaptureMode() & kModeWrite) == kModeWrite)
     {
-        std::string driverinfo = "";
-        if (gfxrecon::util::driverinfo::GetDriverInfo(driverinfo, format::ApiFamilyId::ApiFamily_D3D12) == true)
+        std::string       driverinfo = "";
+        std::vector<LUID> adapter_luids;
+
+        gfxrecon::graphics::dx12::GetActiveAdapterLuids(adapters_, adapter_luids);
+
+        if (util::driverinfo::GetDriverInfo(driverinfo, format::ApiFamilyId::ApiFamily_D3D12, adapter_luids) == true)
         {
             WriteDriverInfoCommand(driverinfo);
         }

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -782,6 +782,24 @@ bool GetAdapterAndIndexbyLUID(LUID                              luid,
         success     = true;
     }
     return success;
+}
+
+void GetActiveAdapterLuids(graphics::dx12::ActiveAdapterMap adapters, std::vector<LUID>& adapter_luids)
+{
+    for (auto& adapter : adapters)
+    {
+        if (adapter.second.active == true)
+        {
+            LUID info;
+            info.HighPart = adapter.second.internal_desc.LuidHighPart;
+            info.LowPart  = adapter.second.internal_desc.LuidLowPart;
+            adapter_luids.push_back(info);
+        }
+    }
+    if (adapter_luids.empty())
+    {
+        GFXRECON_LOG_WARNING("No active adapters were found");
+    }
 }
 
 IDXGIAdapter* GetAdapterbyIndex(graphics::dx12::ActiveAdapterMap& adapters, int32_t index)

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -179,6 +179,9 @@ bool GetAdapterAndIndexbyLUID(LUID                              luid,
                               IDXGIAdapter*&                    adapter_ptr,
                               uint32_t&                         index,
                               graphics::dx12::ActiveAdapterMap& adapters);
+
+// Get list of active adapters
+void GetActiveAdapterLuids(graphics::dx12::ActiveAdapterMap adapters, std::vector<LUID>& adapter_luids);
 
 // Qeury the D3D12Device's IDXGIAdatper3 interface and the adapter's index
 bool GetAdapterAndIndexbyDevice(ID3D12Device*                     device,

--- a/framework/util/driver_info.cpp
+++ b/framework/util/driver_info.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -122,17 +122,120 @@ bool AMD_GetUMDInfo(const std::string& active_driver_path, std::string& driver_i
     return umd_read;
 }
 
-bool AMD_IsDriverActive(const std::string& umd_path)
+#if defined(WIN32)
+int GetRegSubkeys(HKEY& dx_key_handle, DWORD& num_of_adapters, DWORD& sub_key_max_length)
 {
-    return (umd_path.find(amd_d3d12_driver_32) != std::string::npos) ||
-           (umd_path.find(amd_d3d12_driver_64) != std::string::npos);
+    // Fetch registry data
+    LSTATUS return_code =
+        ::RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\DirectX", 0, KEY_READ, &dx_key_handle);
+
+    if (return_code != ERROR_SUCCESS)
+    {
+        return EXIT_FAILURE;
+    }
+
+    // Find all subkeys
+
+    return_code = ::RegQueryInfoKey(dx_key_handle,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    &num_of_adapters,
+                                    &sub_key_max_length,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr);
+    sub_key_max_length += 1; // include the null character
+
+    return return_code;
 }
 
-bool GetDriverInfo(std::string& driver_info, format::ApiFamilyId api_family)
+LSTATUS GetRegData(HKEY                     dx_key_handle,
+                   DWORD                    num_of_adapters,
+                   DWORD                    sub_key_max_length,
+                   std::string&             driver_info,
+                   const std::vector<LUID>& adapter_luids)
 {
-    static std::string cached_driver_info = "";
+    LSTATUS     return_code        = ERROR_SUCCESS;
+    std::string driver_version     = "";
+    std::string UMD_version        = "";
+    uint64_t    driver_version_raw = 0;
+    uint64_t    UMD_version_raw    = 0;
 
-    bool driver_info_available = false;
+    char* sub_key_name = new char[sub_key_max_length];
+    driver_info += "Registry Info:\n";
+    for (DWORD i = 0; i < num_of_adapters; ++i)
+    {
+        DWORD sub_key_length = sub_key_max_length;
+
+        return_code =
+            ::RegEnumKeyEx(dx_key_handle, i, sub_key_name, &sub_key_length, nullptr, nullptr, nullptr, nullptr);
+
+        if (return_code == ERROR_SUCCESS)
+        {
+            LUID  adapterLUID = {};
+            DWORD qword_size  = sizeof(uint64_t);
+
+            return_code = ::RegGetValue(
+                dx_key_handle, sub_key_name, ("AdapterLuid"), RRF_RT_QWORD, nullptr, &adapterLUID, &qword_size);
+
+            bool adapter_match = false;
+            if (return_code == ERROR_SUCCESS) // If we were able to retrieve the registry values
+                                              // and if the vendor ID and device ID match
+            {
+                for (auto adapter_info : adapter_luids)
+                {
+                    if (adapterLUID.HighPart == adapter_info.HighPart && adapterLUID.LowPart == adapter_info.LowPart)
+                    {
+                        adapter_match = true;
+                    }
+
+                    if (adapter_match == true)
+                    {
+                        // Retrieve the driver version
+
+                        if (::RegGetValue(dx_key_handle,
+                                          sub_key_name,
+                                          "DriverVersion",
+                                          RRF_RT_QWORD,
+                                          nullptr,
+                                          &driver_version_raw,
+                                          &qword_size) == ERROR_SUCCESS)
+                        {
+                            driver_version = ConvertDWORDtoVersionNumber(driver_version_raw);
+                        }
+
+                        if (::RegGetValue(dx_key_handle,
+                                          sub_key_name,
+                                          "UMDVersion",
+                                          RRF_RT_QWORD,
+                                          nullptr,
+                                          &UMD_version_raw,
+                                          &qword_size) == ERROR_SUCCESS)
+                        {
+                            UMD_version = ConvertDWORDtoVersionNumber(UMD_version_raw);
+                        }
+                        driver_info += "\tDriver Version: " + driver_version + "\n\tUMD Version: " + UMD_version + "\n";
+                    }
+                }
+            }
+        }
+    }
+
+    return_code = ::RegCloseKey(dx_key_handle);
+
+    delete[] sub_key_name;
+
+    return return_code;
+}
+
+bool GetDriverInfo(std::string& driver_info, format::ApiFamilyId api_family, std::vector<LUID>& adapter_luids)
+{
+    static std::string cached_driver_info    = "";
+    bool               driver_info_available = false;
 
     // If driver info has not been retrieved, then get it
     if (cached_driver_info.empty())
@@ -159,6 +262,12 @@ bool GetDriverInfo(std::string& driver_info, format::ApiFamilyId api_family)
                 }
             }
         }
+        else if (RegistryDxDriverVersion(cached_driver_info, adapter_luids))
+        {
+            driver_info = cached_driver_info;
+
+            driver_info_available = true;
+        }
     }
 
     // If driver info has already been retrieved, then return that one
@@ -170,6 +279,48 @@ bool GetDriverInfo(std::string& driver_info, format::ApiFamilyId api_family)
     }
 
     return driver_info_available;
+}
+
+bool RegistryDxDriverVersion(std::string& driver_info, const std::vector<LUID>& adapter_luids)
+{
+    bool driver_info_found = false;
+
+    HKEY    dx_key_handle      = nullptr;
+    DWORD   num_of_adapters    = 0;
+    DWORD   sub_key_max_length = 0;
+    LSTATUS return_code        = GetRegSubkeys(dx_key_handle, num_of_adapters, sub_key_max_length);
+    if (return_code == ERROR_SUCCESS)
+    {
+        return_code = GetRegData(dx_key_handle, num_of_adapters, sub_key_max_length, driver_info, adapter_luids);
+        if (return_code == ERROR_SUCCESS)
+        {
+            driver_info_found = true;
+        }
+    }
+
+    return driver_info_found;
+}
+
+#endif
+
+std::string ConvertDWORDtoVersionNumber(uint64_t dword)
+{
+    uint32_t    version[4]  = {};
+    std::string str_version = "";
+    version[0]              = (unsigned int)((dword & 0xFFFF000000000000) >> 16 * 3);
+    version[1]              = (unsigned int)((dword & 0x0000FFFF00000000) >> 16 * 2);
+    version[2]              = (unsigned int)((dword & 0x00000000FFFF0000) >> 16 * 1);
+    version[3]              = (unsigned int)((dword & 0x000000000000FFFF));
+    str_version = std::to_string(version[0]) + "." + std::to_string(version[1]) + "." + std::to_string(version[2]) +
+                  "." + std::to_string(version[3]) + ".";
+
+    return str_version;
+}
+
+bool AMD_IsDriverActive(const std::string& umd_path)
+{
+    return (umd_path.find(amd_d3d12_driver_32) != std::string::npos) ||
+           (umd_path.find(amd_d3d12_driver_64) != std::string::npos);
 }
 
 GFXRECON_END_NAMESPACE(driverinfo)

--- a/framework/util/driver_info.h
+++ b/framework/util/driver_info.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -47,7 +47,21 @@ bool AMD_GetUMDInfo(const std::string& active_driver_path, std::string& driver_i
 
 bool AMD_IsDriverActive(const std::string& umd_path);
 
-bool GetDriverInfo(std::string& driver_info, format::ApiFamilyId api_family);
+#if defined(WIN32)
+bool GetDriverInfo(std::string& driver_info, format::ApiFamilyId api_family, std::vector<LUID>& adapter_luids);
+
+bool RegistryDxDriverVersion(std::string& driver_info, const std::vector<LUID>& adapter_luids);
+
+int GetRegSubkeys(HKEY& dx_key_handle, DWORD& num_of_adapters, DWORD& sub_key_max_length);
+
+LSTATUS GetRegData(HKEY               dx_key_handle,
+                   DWORD              num_of_adapters,
+                   DWORD              sub_key_max_length,
+                   std::string&       driver_info,
+                   std::vector<LUID>& adapter_luids);
+#endif
+
+std::string ConvertDWORDtoVersionNumber(uint64_t dword);
 
 GFXRECON_END_NAMESPACE(driverinfo)
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/driver_info.h
+++ b/framework/util/driver_info.h
@@ -61,7 +61,7 @@ LSTATUS GetRegData(HKEY               dx_key_handle,
                    std::vector<LUID>& adapter_luids);
 #endif
 
-std::string ConvertDWORDtoVersionNumber(uint64_t dword);
+std::string ConvertDataToVersionNumber(uint64_t data);
 
 GFXRECON_END_NAMESPACE(driverinfo)
 GFXRECON_END_NAMESPACE(util)


### PR DESCRIPTION
**The problem**
We need alternative solution to retrieve driver info in case AGS library would fail to retrieve it   

**The solution**
Read registry from `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DirectX\*` and write it to file 

**Result**
We can use it as an alternative way to retrieve driver.

Example of registry info
![NVIDIA driver info](https://user-images.githubusercontent.com/73676794/221629148-0c9ec0a3-6218-44f6-918d-9a039c8c7a57.PNG)
