### PR TITLE
More Robust Unit Tests for UtcString() Function

### DIFF
--- a/framework/util/test/main.cpp
+++ b/framework/util/test/main.cpp
@@ -205,37 +205,45 @@ TEST_CASE("UtcString", "[datetime]")
 {
     gfxrecon::util::Log::Init(gfxrecon::util::Log::kDebugSeverity);
 
-    auto zero         = UtcString(0);
-    auto one          = UtcString(1);
-    auto two          = UtcString(2);
+    // Looking for clean output like zero: 1970-01-01T00:00:00Z
+    REQUIRE(UtcString(0) == "1970-01-01T00:00:00Z");
+    REQUIRE(UtcString(1) == "1970-01-01T00:00:01Z");
+    REQUIRE(UtcString(60 * 60) == "1970-01-01T01:00:00Z");
+    REQUIRE(UtcString(60 * 60 + 1) == "1970-01-01T01:00:01Z");
+    REQUIRE(UtcString(60 * 60 + 61) == "1970-01-01T01:01:01Z");
+    REQUIRE(UtcString(60 * 60 + 61) == "1970-01-01T01:01:01Z");
+
+    const unsigned min       = 60;
+    const unsigned hour      = min * 60;
+    const unsigned day       = hour * 24;
+    const unsigned year      = 525600 * min;
+    const unsigned leap_year = year + day;
+
+    REQUIRE(UtcString(year) == "1971-01-01T00:00:00Z");
+    REQUIRE(UtcString(year * 2) == "1972-01-01T00:00:00Z");
+    REQUIRE(UtcString(year * 8 + leap_year * 2) == "1980-01-01T00:00:00Z");
+    REQUIRE(UtcString(year * 11 + leap_year * 3 + 31 * 3 * day + 28 * day + 17 * day + 11 * hour + 28 * min + 59) ==
+            "1984-05-18T11:28:59Z");
+    REQUIRE(UtcString(year * 23 + leap_year * 7) == "2000-01-01T00:00:00Z");
+    REQUIRE(UtcString(year * 23 + leap_year * 7 + 29 * day + 31 * day * 4 + 30 * day * 2) == "2000-08-01T00:00:00Z");
+    REQUIRE(UtcString(year * 23 + leap_year * 7 + 29 * day + 31 * day * 4 + 30 * day * 2 + 30 * day) ==
+            "2000-08-31T00:00:00Z");
+    REQUIRE(UtcString(year * 23 + leap_year * 7 + 29 * day + 31 * day * 4 + 30 * day * 2 + 30 * day + 23 * hour) ==
+            "2000-08-31T23:00:00Z");
+    REQUIRE(UtcString(year * 23 + leap_year * 7 + 29 * day + 31 * day * 4 + 30 * day * 2 + 30 * day + 23 * hour +
+                      47 * min) == "2000-08-31T23:47:00Z");
+    REQUIRE(UtcString(year * 23 + leap_year * 7 + 29 * day + 31 * day * 4 + 30 * day * 2 + 30 * day + 23 * hour +
+                      47 * min + 54) == "2000-08-31T23:47:54Z");
+
     auto one_thousand = UtcString(1000);
     auto two_thousand = UtcString(2000);
-
-    // Looking for clean output like zero: 1970-00-01T00:00:00Z
-    REQUIRE(zero[18] == '0');
-    REQUIRE(zero[19] == 'Z');
-    REQUIRE(zero[4] == '-');
-    REQUIRE(zero[7] == '-');
-    REQUIRE(zero[10] == 'T');
-    REQUIRE(zero[16] == ':');
-    REQUIRE(zero[13] == ':');
-
-    REQUIRE(one[18] == '1');
-    REQUIRE(one[19] == 'Z');
-
-    REQUIRE(two[18] == '2');
-    REQUIRE(two[19] == 'Z');
-
     REQUIRE(one_thousand[19] == 'Z');
     REQUIRE(two_thousand[19] == 'Z');
-
-    REQUIRE(zero.length() == 20);
-    REQUIRE(one.length() == 20);
-    REQUIRE(two.length() == 20);
     REQUIRE(one_thousand.length() == 20);
     REQUIRE(two_thousand.length() == 20);
 
-    // Pump some random time points between -2'147'483'648 and 2'147'483'647 through conversion:
+    // Pump some random time points between -2'147'483'648 and 2'147'483'647 through conversion
+    // and check that they have the correct length and punctuation:
     const time_t time_points[]{
         1110797,    1490769,    3976212,    5465697,    6237413,    9351446,    10731844,   12202301,   15533617,
         21337614,   22327966,   24650085,   27246781,   29010007,   30729052,   32154271,   34620851,   37834780,


### PR DESCRIPTION
Rather than just looking at the punctuation and length of the output, these compare the results for semi-manually inverse-converted second counts for mornings and evening on different dates out past multiple leap years to manual reference strings.
E.g. "2000-08-31T23:47:54Z"