### PR TITLE
[Bugfix] DX12 Unknown layout texture save/restore

### DIFF
--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -278,6 +278,9 @@ struct D3D12ResourceInfo : DxObjectExtraInfo
 
     std::map<uint64_t, uint64_t>                       mapped_gpu_addresses;
     std::map<uint64_t, graphics::Dx12ShaderIdentifier> mapped_shader_ids;
+
+    D3D12_RESOURCE_DIMENSION dimension{ D3D12_RESOURCE_DIMENSION_UNKNOWN };
+    D3D12_TEXTURE_LAYOUT     layout{ D3D12_TEXTURE_LAYOUT_UNKNOWN };
 };
 
 struct D3D12CommandSignatureInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -279,8 +279,7 @@ struct D3D12ResourceInfo : DxObjectExtraInfo
     std::map<uint64_t, uint64_t>                       mapped_gpu_addresses;
     std::map<uint64_t, graphics::Dx12ShaderIdentifier> mapped_shader_ids;
 
-    D3D12_RESOURCE_DIMENSION dimension{ D3D12_RESOURCE_DIMENSION_UNKNOWN };
-    D3D12_TEXTURE_LAYOUT     layout{ D3D12_TEXTURE_LAYOUT_UNKNOWN };
+    D3D12_RESOURCE_DESC1 desc = {};
 };
 
 struct D3D12CommandSignatureInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -395,10 +395,10 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
     if (resource_info->extra_info != nullptr)
     {
         // Reserved resource has to be uploaded via staging buffer
-        auto resource_extra_info = GetExtraInfo<D3D12ResourceInfo>(resource_info);
-        is_reserved_resource     = resource_extra_info->is_reserved_resource;
-        is_texture_with_unknown_layout =
-            graphics::dx12::IsTextureWithUnknownLayout(resource_extra_info->dimension, resource_extra_info->layout);
+        auto resource_extra_info       = GetExtraInfo<D3D12ResourceInfo>(resource_info);
+        is_reserved_resource           = resource_extra_info->is_reserved_resource;
+        is_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(resource_extra_info->desc.Dimension,
+                                                                                    resource_extra_info->desc.Layout);
     }
 
     resource_init_info.try_map_and_copy = !is_reserved_resource && !is_texture_with_unknown_layout;

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -391,12 +391,17 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
     ResourceInitInfo resource_init_info = {};
     resource_init_info.resource         = resource;
     bool is_reserved_resource           = false;
+    bool is_texture_with_unknown_layout = false;
     if (resource_info->extra_info != nullptr)
     {
         // Reserved resource has to be uploaded via staging buffer
-        is_reserved_resource = GetExtraInfo<D3D12ResourceInfo>(resource_info)->is_reserved_resource;
+        auto resource_extra_info = GetExtraInfo<D3D12ResourceInfo>(resource_info);
+        is_reserved_resource     = resource_extra_info->is_reserved_resource;
+        is_texture_with_unknown_layout =
+            graphics::dx12::IsTextureWithUnknownLayout(resource_extra_info->dimension, resource_extra_info->layout);
     }
-    resource_init_info.try_map_and_copy = !is_reserved_resource;
+
+    resource_init_info.try_map_and_copy = !is_reserved_resource && !is_texture_with_unknown_layout;
 
     auto find_resource_info = resource_init_infos_.find(resource);
     if (find_resource_info == resource_init_infos_.end())

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -253,6 +253,26 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                          Decoded_GUID                                              riid,
                                          HandlePointerDecoder<void*>*                              heap);
 
+    // Helper to initialize the resource's D3D12ResourceInfo and set its Dimension and Layout.
+    template <typename T>
+    void SetResourceDimensionAndLayout(HandlePointerDecoder<void*>* resource, StructPointerDecoder<T>* desc)
+    {
+        GFXRECON_ASSERT(resource != nullptr);
+
+        auto resource_object_info = GetObjectInfo(*resource->GetPointer());
+
+        GFXRECON_ASSERT(resource_object_info != nullptr);
+
+        if (resource_object_info->extra_info == nullptr)
+        {
+            auto resource_info               = std::make_unique<D3D12ResourceInfo>();
+            resource_object_info->extra_info = std::move(resource_info);
+        }
+        auto extra_info       = reinterpret_cast<D3D12ResourceInfo*>(resource_object_info->extra_info.get());
+        extra_info->dimension = desc->GetPointer()->Dimension;
+        extra_info->layout    = desc->GetPointer()->Layout;
+    };
+
     HRESULT OverrideCreateCommittedResource(DxObjectInfo*                                        replay_object_info,
                                             HRESULT                                              original_result,
                                             StructPointerDecoder<Decoded_D3D12_HEAP_PROPERTIES>* pHeapProperties,

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -253,9 +253,18 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                          Decoded_GUID                                              riid,
                                          HandlePointerDecoder<void*>*                              heap);
 
+    template <typename T>
+    void SetResourceSamplerFeedbackMipRegion(D3D12_RESOURCE_DESC1& desc_dest, T* desc_src){};
+
+    template <>
+    void SetResourceSamplerFeedbackMipRegion(D3D12_RESOURCE_DESC1& desc_dest, D3D12_RESOURCE_DESC1* desc_src)
+    {
+        desc_dest.SamplerFeedbackMipRegion = desc_src->SamplerFeedbackMipRegion;
+    };
+
     // Helper to initialize the resource's D3D12ResourceInfo and set its Dimension and Layout.
     template <typename T>
-    void SetResourceDimensionAndLayout(HandlePointerDecoder<void*>* resource, StructPointerDecoder<T>* desc)
+    void SetResourceDesc(HandlePointerDecoder<void*>* resource, StructPointerDecoder<T>* desc)
     {
         GFXRECON_ASSERT(resource != nullptr);
 
@@ -268,9 +277,21 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
             auto resource_info               = std::make_unique<D3D12ResourceInfo>();
             resource_object_info->extra_info = std::move(resource_info);
         }
-        auto extra_info       = reinterpret_cast<D3D12ResourceInfo*>(resource_object_info->extra_info.get());
-        extra_info->dimension = desc->GetPointer()->Dimension;
-        extra_info->layout    = desc->GetPointer()->Layout;
+
+        auto extra_info = reinterpret_cast<D3D12ResourceInfo*>(resource_object_info->extra_info.get());
+
+        extra_info->desc.Dimension        = desc->GetPointer()->Dimension;
+        extra_info->desc.Alignment        = desc->GetPointer()->Alignment;
+        extra_info->desc.Width            = desc->GetPointer()->Width;
+        extra_info->desc.Height           = desc->GetPointer()->Height;
+        extra_info->desc.DepthOrArraySize = desc->GetPointer()->DepthOrArraySize;
+        extra_info->desc.MipLevels        = desc->GetPointer()->MipLevels;
+        extra_info->desc.Format           = desc->GetPointer()->Format;
+        extra_info->desc.SampleDesc       = desc->GetPointer()->SampleDesc;
+        extra_info->desc.Layout           = desc->GetPointer()->Layout;
+        extra_info->desc.Flags            = desc->GetPointer()->Flags;
+
+        SetResourceSamplerFeedbackMipRegion(extra_info->desc, desc->GetPointer());
     };
 
     HRESULT OverrideCreateCommittedResource(DxObjectInfo*                                        replay_object_info,

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -244,6 +244,7 @@ void D3D12CaptureManager::ResizeSwapChainImages(IDXGISwapChain_Wrapper* wrapper,
 void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    device_wrapper,
                                                        ID3D12Resource_Wrapper*  resource_wrapper,
                                                        D3D12_RESOURCE_DIMENSION dimension,
+                                                       D3D12_TEXTURE_LAYOUT     layout,
                                                        UINT64                   width,
                                                        UINT64                   size,
                                                        D3D12_HEAP_TYPE          heap_type,
@@ -263,6 +264,8 @@ void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    
     info->memory_pool     = memory_pool;
     info->has_write_watch = has_write_watch;
     info->size_in_bytes   = size;
+    info->dimension       = dimension;
+    info->layout          = layout;
 
     if (dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
@@ -752,6 +755,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateCommittedResource(
             wrapper,
             resource_wrapper,
             desc->Dimension,
+            desc->Layout,
             desc->Width,
             total_size_in_bytes,
             heap_properties->Type,
@@ -791,6 +795,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreatePlacedResource(ID3D12De
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
+                                     desc->Layout,
                                      desc->Width,
                                      total_size_in_bytes,
                                      heap_info->heap_type,
@@ -823,6 +828,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateReservedResource(
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
+                                     desc->Layout,
                                      desc->Width,
                                      total_size_in_bytes,
                                      D3D12_HEAP_TYPE_DEFAULT,
@@ -834,14 +840,14 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateReservedResource(
 }
 
 void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateReservedResource1(
-    ID3D12Device4_Wrapper*     wrapper,
-    HRESULT                    result,
-    const D3D12_RESOURCE_DESC* desc,
-    D3D12_RESOURCE_STATES      initial_state,
-    const D3D12_CLEAR_VALUE*   optimized_clear_value,
+    ID3D12Device4_Wrapper*          wrapper,
+    HRESULT                         result,
+    const D3D12_RESOURCE_DESC*      desc,
+    D3D12_RESOURCE_STATES           initial_state,
+    const D3D12_CLEAR_VALUE*        optimized_clear_value,
     ID3D12ProtectedResourceSession* protected_session,
-    REFIID                     riid,
-    void**                     resource)
+    REFIID                          riid,
+    void**                          resource)
 {
     GFXRECON_UNREFERENCED_PARAMETER(optimized_clear_value);
     GFXRECON_UNREFERENCED_PARAMETER(protected_session);
@@ -857,6 +863,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateReservedResource1(
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
+                                     desc->Layout,
                                      desc->Width,
                                      total_size_in_bytes,
                                      D3D12_HEAP_TYPE_DEFAULT,
@@ -961,6 +968,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateCommittedResource1(
             wrapper,
             resource_wrapper,
             desc->Dimension,
+            desc->Layout,
             desc->Width,
             total_size_in_bytes,
             heap_properties->Type,
@@ -1000,6 +1008,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreateCommittedResource2(
             wrapper,
             resource_wrapper,
             desc->Dimension,
+            desc->Layout,
             desc->Width,
             total_size_in_bytes,
             heap_properties->Type,
@@ -1040,6 +1049,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreatePlacedResource1(
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
+                                     desc->Layout,
                                      desc->Width,
                                      total_size_in_bytes,
                                      heap_info->heap_type,

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -332,8 +332,6 @@ class D3D12CaptureManager : public CaptureManager
                                                             REFIID                          riid,
                                                             void**                          resource);
 
-    // TODO: add post process function for ID3D12Device4::CreateReservedResource1
-
     void PostProcess_ID3D12Device8_CreateCommittedResource2(ID3D12Device8_Wrapper*          wrapper,
                                                             HRESULT                         result,
                                                             const D3D12_HEAP_PROPERTIES*    heap_properties,

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -332,6 +332,8 @@ class D3D12CaptureManager : public CaptureManager
                                                             REFIID                          riid,
                                                             void**                          resource);
 
+    // TODO: add post process function for ID3D12Device4::CreateReservedResource1
+
     void PostProcess_ID3D12Device8_CreateCommittedResource2(ID3D12Device8_Wrapper*          wrapper,
                                                             HRESULT                         result,
                                                             const D3D12_HEAP_PROPERTIES*    heap_properties,
@@ -662,6 +664,7 @@ class D3D12CaptureManager : public CaptureManager
     void InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    device_wrapper,
                                       ID3D12Resource_Wrapper*  resource_wrapper,
                                       D3D12_RESOURCE_DIMENSION dimension,
+                                      D3D12_TEXTURE_LAYOUT     layout,
                                       UINT64                   width,
                                       UINT64                   size,
                                       D3D12_HEAP_TYPE          heap_type,

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -367,7 +367,8 @@ struct ID3D12ResourceInfo : public DxWrapperInfo
     D3D12_CPU_PAGE_PROPERTY              page_property{};
     D3D12_MEMORY_POOL                    memory_pool{};
     uint64_t                             size_in_bytes{ 0 };
-
+    D3D12_RESOURCE_DIMENSION             dimension{ D3D12_RESOURCE_DIMENSION_UNKNOWN };
+    D3D12_TEXTURE_LAYOUT                 layout{ D3D12_TEXTURE_LAYOUT_UNKNOWN };
     //// State tracking data:
 
     // Most recent transitions for each subresource.

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -628,8 +628,8 @@ void Dx12StateWriter::WriteResourceCreationState(
     {
         auto     mappable_resource = map_info.resource_wrapper->GetWrappedObjectAs<ID3D12Resource>();
         uint8_t* result_ptr        = nullptr;
-        bool     is_special_mapping =
-            gfxrecon::graphics::Dx12ResourceDataUtil::IsTextureWithUnknownLayout(mappable_resource);
+        bool     is_special_mapping = graphics::dx12::IsTextureWithUnknownLayout(mappable_resource);
+
         graphics::dx12::MapSubresource(
             mappable_resource, map_info.subresource, &graphics::dx12::kZeroRange, result_ptr, is_special_mapping);
 

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -800,7 +800,8 @@ void Dx12StateWriter::WriteResourceSnapshots(
                           (resource_info.get()->create_call_id !=
                            format::ApiCall_ID3D12Device4_CreateReservedResource1)));
 
-                bool target_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(resource, nullptr);
+                bool target_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(
+                    resource_info.get()->dimension, resource_info.get()->layout);
 
                 if ((is_cpu_accessible == false) || (is_cpu_accessible && target_texture_with_unknown_layout))
                 {

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -237,7 +237,7 @@ class Dx12ReplayConsumerBodyGenerator(
                             )
                         )
                     set_resource_dimension_layout_list.append(
-                        'SetResourceDimensionAndLayout({0}, pDesc);\n'.format(
+                        'SetResourceDesc({0}, pDesc);\n'.format(
                             value.name
                         )
                     )

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -172,10 +172,12 @@ class Dx12ReplayConsumerBodyGenerator(
         code = ''
         arg_list = []
         add_object_list = []
+        set_resource_dimension_layout_list = []
         struct_add_object_list = []
         post_extenal_object_list = []
 
         is_override = name in self.REPLAY_OVERRIDES
+        is_resource_creation_methods = False
         is_object = True if name.find('_') != -1 else False
         if is_object:
             class_name = name[:name.find('_')]
@@ -183,6 +185,9 @@ class Dx12ReplayConsumerBodyGenerator(
             if class_name in self.REPLAY_OVERRIDES['classmethods']:
                 is_override = method_name in self.REPLAY_OVERRIDES[
                     'classmethods'][class_name]
+            resource_creation_methods = ["CreateCommittedResource", "CreatePlacedResource", "CreateReservedResource", "CreateCommittedResource1", "CreateReservedResource1", "CreateCommittedResource2", "CreatePlacedResource1"]
+            if method_name in resource_creation_methods:
+                is_resource_creation_methods = True
         else:
             is_override = name in self.REPLAY_OVERRIDES['functions']
 
@@ -231,7 +236,11 @@ class Dx12ReplayConsumerBodyGenerator(
                                 value.name
                             )
                         )
-
+                    set_resource_dimension_layout_list.append(
+                        'SetResourceDimensionAndLayout({0}, pDesc);\n'.format(
+                            value.name
+                        )
+                    )
                 else:
                     if value.pointer_count == 2:
                         if is_override:
@@ -437,6 +446,9 @@ class Dx12ReplayConsumerBodyGenerator(
                     code += '        {}'.format(e)
                 for e in struct_add_object_list:
                     code += '        {}'.format(e)
+                if is_resource_creation_methods:
+                    for e in set_resource_dimension_layout_list:
+                        code += '        {}'.format(e)
                 code += "    }\n"
 
             code += (

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -4907,6 +4907,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommittedResource(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            SetResourceDimensionAndLayout(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreateCommittedResource", return_value, replay_result);
     }
@@ -4966,6 +4967,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreatePlacedResource(
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource);
+            SetResourceDimensionAndLayout(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreatePlacedResource", return_value, replay_result);
     }
@@ -4997,6 +4999,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateReservedResource(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            SetResourceDimensionAndLayout(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreateReservedResource", return_value, replay_result);
     }
@@ -5739,6 +5742,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommittedResource1(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            SetResourceDimensionAndLayout(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device4_CreateCommittedResource1", return_value, replay_result);
     }
@@ -5801,6 +5805,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateReservedResource1(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            SetResourceDimensionAndLayout(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device4_CreateReservedResource1", return_value, replay_result);
     }
@@ -6453,6 +6458,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreateCommittedResource2(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            SetResourceDimensionAndLayout(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device8_CreateCommittedResource2", return_value, replay_result);
     }
@@ -6487,6 +6493,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreatePlacedResource1(
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource);
+            SetResourceDimensionAndLayout(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device8_CreatePlacedResource1", return_value, replay_result);
     }

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -4907,7 +4907,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommittedResource(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
-            SetResourceDimensionAndLayout(ppvResource, pDesc);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreateCommittedResource", return_value, replay_result);
     }
@@ -4967,7 +4967,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreatePlacedResource(
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource);
-            SetResourceDimensionAndLayout(ppvResource, pDesc);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreatePlacedResource", return_value, replay_result);
     }
@@ -4999,7 +4999,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateReservedResource(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
-            SetResourceDimensionAndLayout(ppvResource, pDesc);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreateReservedResource", return_value, replay_result);
     }
@@ -5742,7 +5742,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommittedResource1(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
-            SetResourceDimensionAndLayout(ppvResource, pDesc);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device4_CreateCommittedResource1", return_value, replay_result);
     }
@@ -5805,7 +5805,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateReservedResource1(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
-            SetResourceDimensionAndLayout(ppvResource, pDesc);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device4_CreateReservedResource1", return_value, replay_result);
     }
@@ -6458,7 +6458,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreateCommittedResource2(
         if (SUCCEEDED(replay_result))
         {
             AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
-            SetResourceDimensionAndLayout(ppvResource, pDesc);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device8_CreateCommittedResource2", return_value, replay_result);
     }
@@ -6493,7 +6493,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreatePlacedResource1(
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource);
-            SetResourceDimensionAndLayout(ppvResource, pDesc);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device8_CreatePlacedResource1", return_value, replay_result);
     }

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -377,18 +377,16 @@ HRESULT Dx12ResourceDataUtil::ReadFromResource(ID3D12Resource*                  
 
     data.clear();
     data.resize(static_cast<size_t>(required_data_size));
-    bool target_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(target_resource, nullptr);
 
     // If the resource can be mapped, map it, copy the data, and return success.
-    if (try_map_and_copy && (!target_texture_with_unknown_layout) &&
-        CopyMappableResource(target_resource,
-                             before_states,
-                             after_states,
-                             kCopyTypeRead,
-                             &data,
-                             nullptr,
-                             subresource_offsets,
-                             subresource_sizes))
+    if (try_map_and_copy && CopyMappableResource(target_resource,
+                                                 before_states,
+                                                 after_states,
+                                                 kCopyTypeRead,
+                                                 &data,
+                                                 nullptr,
+                                                 subresource_offsets,
+                                                 subresource_sizes))
     {
         return S_OK;
     }
@@ -446,19 +444,16 @@ HRESULT Dx12ResourceDataUtil::WriteToResource(ID3D12Resource*                   
                         layout_sizes,
                         temp_subresource_layouts_,
                         required_data_size);
-    bool target_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(target_resource, nullptr);
 
-    // If the resource can be mapped and the resource is not a texture with
-    // unknown layout, map it, copy the data, and return success.
-    if (try_map_and_copy && (!target_texture_with_unknown_layout) &&
-        CopyMappableResource(target_resource,
-                             before_states,
-                             after_states,
-                             kCopyTypeWrite,
-                             nullptr,
-                             &data,
-                             subresource_offsets,
-                             subresource_sizes))
+    // If the resource can be mapped, map it, copy the data, and return success.
+    if (try_map_and_copy && CopyMappableResource(target_resource,
+                                                 before_states,
+                                                 after_states,
+                                                 kCopyTypeWrite,
+                                                 nullptr,
+                                                 &data,
+                                                 subresource_offsets,
+                                                 subresource_sizes))
     {
         return S_OK;
     }

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -44,7 +44,10 @@ Dx12ResourceDataUtil::MapSubresourceAndReadData(ID3D12Resource* resource, UINT s
     return result;
 }
 
-HRESULT MapSubresourceAndWriteData(ID3D12Resource* resource, UINT subresource, size_t size, const uint8_t* data)
+HRESULT Dx12ResourceDataUtil::MapSubresourceAndWriteData(ID3D12Resource* resource,
+                                                         UINT            subresource,
+                                                         size_t          size,
+                                                         const uint8_t*  data)
 {
     uint8_t* subresource_data;
     HRESULT  result = dx12::MapSubresource(resource, subresource, &dx12::kZeroRange, subresource_data);
@@ -53,6 +56,108 @@ HRESULT MapSubresourceAndWriteData(ID3D12Resource* resource, UINT subresource, s
         util::platform::MemoryCopy(subresource_data, size, data, size);
         resource->Unmap(subresource, nullptr);
     }
+    return result;
+}
+
+HRESULT
+Dx12ResourceDataUtil::MapSubresourceAndReadDataForUnknownLayoutTexture(ID3D12Resource*          resource,
+                                                                       UINT                     subresource,
+                                                                       size_t                   size,
+                                                                       uint8_t*                 data,
+                                                                       D3D12_RESOURCE_DIMENSION resource_dimension,
+                                                                       const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* layout)
+{
+    uint8_t* subresource_data = nullptr;
+    HRESULT  result           = dx12::MapSubresource(resource, subresource, nullptr, subresource_data, true);
+
+    GFXRECON_ASSERT(layout != nullptr);
+
+    if (SUCCEEDED(result))
+    {
+        const D3D12_BOX dstbox = {
+            0, 0, 0, layout->Footprint.Width, layout->Footprint.Height, layout->Footprint.Depth
+        };
+        size_t target_depth_pitch   = 0;
+        bool   is_invalid_dimension = false;
+
+        switch (resource_dimension)
+        {
+            case D3D12_RESOURCE_DIMENSION_TEXTURE1D:
+            case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
+                target_depth_pitch = size;
+                break;
+            case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
+                target_depth_pitch = static_cast<size_t>(layout->Footprint.RowPitch) *
+                                     layout->Footprint.Height; // keep same unpadding process to be consistent with
+                                                               // Dx12ResourceDataUtil::GetResourceCopyInfo.
+                break;
+            default:
+                is_invalid_dimension = true;
+                GFXRECON_LOG_ERROR("Unsupported resource dimension: %d", resource_dimension);
+                break;
+        }
+
+        result = E_INVALIDARG;
+
+        if (!is_invalid_dimension)
+        {
+            result = resource->ReadFromSubresource(
+                data, layout->Footprint.RowPitch, static_cast<UINT>(target_depth_pitch), subresource, &dstbox);
+        }
+
+        resource->Unmap(subresource, &dx12::kZeroRange);
+    }
+
+    return result;
+}
+
+HRESULT Dx12ResourceDataUtil::MapSubresourceAndWriteDataForUnknownLayoutTexture(
+    ID3D12Resource*                           resource,
+    UINT                                      subresource,
+    size_t                                    size,
+    const uint8_t*                            data,
+    D3D12_RESOURCE_DIMENSION                  resource_dimension,
+    const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* layout)
+{
+    uint8_t* subresource_data = nullptr;
+    HRESULT  result           = dx12::MapSubresource(resource, subresource, &dx12::kZeroRange, subresource_data, true);
+
+    GFXRECON_ASSERT(layout != nullptr);
+
+    if (SUCCEEDED(result))
+    {
+        const D3D12_BOX dstbox = {
+            0, 0, 0, layout->Footprint.Width, layout->Footprint.Height, layout->Footprint.Depth
+        };
+        size_t source_depth_pitch   = 0;
+        bool   is_invalid_dimension = false;
+
+        switch (resource_dimension)
+        {
+            case D3D12_RESOURCE_DIMENSION_TEXTURE1D:
+            case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
+                source_depth_pitch = size;
+                break;
+            case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
+                source_depth_pitch = static_cast<size_t>(layout->Footprint.RowPitch) * layout->Footprint.Height;
+                break;
+            default:
+                is_invalid_dimension = true;
+                GFXRECON_LOG_ERROR("Unsupported resource dimension: %d", resource_dimension);
+                break;
+        }
+
+        result = E_INVALIDARG;
+
+        if (!is_invalid_dimension)
+        {
+            result = resource->WriteToSubresource(
+                subresource, &dstbox, data, layout->Footprint.RowPitch, static_cast<UINT>(source_depth_pitch));
+        }
+
+        resource->Unmap(subresource, nullptr);
+    }
+
     return result;
 }
 
@@ -243,6 +348,25 @@ Dx12ResourceDataUtil::Dx12ResourceDataUtil(ID3D12Device* device, uint64_t min_bu
                 if (SUCCEEDED(result))
                 {
                     result = device_->CreateFence(fence_value_, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&command_fence_));
+
+                    if (SUCCEEDED(result))
+                    {
+                        result = device_->CreateCommandAllocator(
+                            list_type, IID_PPV_ARGS(&command_allocator_for_unknown_layout_texture_));
+                        if (SUCCEEDED(result))
+                        {
+                            result =
+                                device_->CreateCommandList(0,
+                                                           list_type,
+                                                           command_allocator_for_unknown_layout_texture_,
+                                                           nullptr,
+                                                           IID_PPV_ARGS(&command_list_for_unknown_layout_texture_));
+                            if (SUCCEEDED(result))
+                            {
+                                result = command_list_for_unknown_layout_texture_->Close();
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -450,7 +574,8 @@ HRESULT Dx12ResourceDataUtil::WriteToResource(ID3D12Resource*                   
                                                  nullptr,
                                                  &data,
                                                  subresource_offsets,
-                                                 subresource_sizes))
+                                                 subresource_sizes,
+                                                 &temp_subresource_layouts_))
     {
         return S_OK;
     }
@@ -519,6 +644,97 @@ HRESULT Dx12ResourceDataUtil::WriteToResource(ID3D12Resource*                   
     return result;
 }
 
+bool Dx12ResourceDataUtil::ChangeResourceStateForUnknownLayoutTexture(
+    ID3D12Resource*                             resource,
+    const std::vector<dx12::ResourceStateInfo>& before_states,
+    bool                                        transition_to_state_common)
+{
+    HRESULT result = E_FAIL;
+
+    result = command_allocator_for_unknown_layout_texture_->Reset();
+    if (SUCCEEDED(result))
+    {
+        result =
+            command_list_for_unknown_layout_texture_->Reset(command_allocator_for_unknown_layout_texture_, nullptr);
+    }
+
+    if (FAILED(result))
+    {
+        GFXRECON_LOG_ERROR("Could not reset command list for state transition of unknown layout texture. (error = %lx)",
+                           result);
+    }
+
+    for (UINT subresource = 0; subresource < before_states.size(); subresource++)
+    {
+        if (transition_to_state_common)
+        {
+            if (before_states.at(subresource).states != D3D12_RESOURCE_STATE_COMMON)
+            {
+                dx12::ResourceStateInfo new_state_info = before_states.at(subresource);
+                new_state_info.states                  = D3D12_RESOURCE_STATE_COMMON;
+                if (AddTransitionBarrier(command_list_for_unknown_layout_texture_,
+                                         resource,
+                                         subresource,
+                                         before_states.at(subresource),
+                                         new_state_info) != true)
+                {
+                    GFXRECON_LOG_ERROR("Failed to change resource state to D3D12_RESOURCE_STATE_COMMON!");
+                }
+            }
+        }
+        else
+        {
+            if (before_states.at(subresource).states != D3D12_RESOURCE_STATE_COMMON)
+            {
+                dx12::ResourceStateInfo old_state_info = before_states.at(subresource);
+                old_state_info.states                  = D3D12_RESOURCE_STATE_COMMON;
+                if (AddTransitionBarrier(command_list_for_unknown_layout_texture_,
+                                         resource,
+                                         subresource,
+                                         old_state_info,
+                                         before_states.at(subresource)) != true)
+                {
+                    GFXRECON_LOG_ERROR("Failed to restore resource state!");
+                }
+            }
+        }
+    }
+
+    result = command_list_for_unknown_layout_texture_->Close();
+
+    if (SUCCEEDED(result))
+    {
+        ID3D12CommandList* cmd_lists[] = { command_list_for_unknown_layout_texture_ };
+        command_queue_->ExecuteCommandLists(1, cmd_lists);
+        result = dx12::WaitForQueue(command_queue_, command_fence_, ++fence_value_);
+    }
+
+    return SUCCEEDED(result);
+}
+
+bool Dx12ResourceDataUtil::IsTextureWithUnknownLayout(ID3D12Resource*           target_resource,
+                                                      D3D12_RESOURCE_DIMENSION* dimension)
+{
+    bool                is_texture_with_unknown_layout = false;
+    D3D12_RESOURCE_DESC target_resource_desc           = target_resource->GetDesc();
+
+    if (((target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D) ||
+         (target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) ||
+         (target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D)) &&
+        (target_resource_desc.Layout == D3D12_TEXTURE_LAYOUT_UNKNOWN))
+    {
+        is_texture_with_unknown_layout = true;
+    }
+
+    if (dimension != nullptr)
+    {
+        *dimension = target_resource_desc.Dimension;
+    }
+
+    return is_texture_with_unknown_layout;
+}
+
+// If target_resource belong to special mapping case, layouts must point to valid data, otherwise, it can be nullptr.
 bool Dx12ResourceDataUtil::CopyMappableResource(ID3D12Resource*                             target_resource,
                                                 const std::vector<dx12::ResourceStateInfo>& before_states,
                                                 const std::vector<dx12::ResourceStateInfo>& after_states,
@@ -526,7 +742,8 @@ bool Dx12ResourceDataUtil::CopyMappableResource(ID3D12Resource*                 
                                                 std::vector<uint8_t>*                       read_data,
                                                 const std::vector<uint8_t>*                 write_data,
                                                 const std::vector<uint64_t>&                subresource_offsets,
-                                                const std::vector<uint64_t>&                subresource_sizes)
+                                                const std::vector<uint64_t>&                subresource_sizes,
+                                                const std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>* layouts)
 {
     uint64_t subresource_count = subresource_offsets.size();
 
@@ -545,28 +762,99 @@ bool Dx12ResourceDataUtil::CopyMappableResource(ID3D12Resource*                 
 
         if (is_cpu_accessible)
         {
-            for (UINT i = 0; i < subresource_count; ++i)
-            {
-                GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, subresource_sizes[i]);
-                size_t subresource_size = static_cast<size_t>(subresource_sizes[i]);
+            D3D12_RESOURCE_DIMENSION target_resource_dimension;
+            bool                     need_special_mapping_handling =
+                IsTextureWithUnknownLayout(target_resource, &target_resource_dimension);
 
-                if (copy_type == kCopyTypeRead)
+            if (!need_special_mapping_handling)
+            {
+                for (UINT i = 0; i < subresource_count; ++i)
                 {
-                    GFXRECON_ASSERT(read_data != nullptr);
-                    result = MapSubresourceAndReadData(
-                        target_resource, i, subresource_size, read_data->data() + subresource_offsets[i]);
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, subresource_sizes[i]);
+                    size_t subresource_size = static_cast<size_t>(subresource_sizes[i]);
+
+                    if (copy_type == kCopyTypeRead)
+                    {
+                        GFXRECON_ASSERT(read_data != nullptr);
+                        result = MapSubresourceAndReadData(
+                            target_resource, i, subresource_size, read_data->data() + subresource_offsets[i]);
+                    }
+                    else
+                    {
+                        GFXRECON_ASSERT(write_data != nullptr);
+                        result = MapSubresourceAndWriteData(
+                            target_resource, i, subresource_size, write_data->data() + subresource_offsets[i]);
+                    }
+                    if (before_states[i].states != after_states[i].states)
+                    {
+                        GFXRECON_LOG_ERROR_ONCE("CPU buffer state not match");
+                    }
+                    return SUCCEEDED(result);
                 }
-                else
+            }
+            else
+            {
+                // Quote: "Textures must be in the D3D12_RESOURCE_STATE_COMMON state for CPU access through
+                //         WriteToSubresource and ReadFromSubresource to be legal;"
+                //
+                // Source:
+                // https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12resource-writetosubresource
+                //
+                // The cpu accessible resource is a texture with unknown layout, we need the following special mapping
+                // handling to copy its data:
+                //
+                // 1. If the state of the resource is not D3D12_RESOURCE_STATE_COMMON, change its state to
+                // D3D12_RESOURCE_STATE_COMMON so
+                //    ID3D12Resource::WriteToSubresource and ID3D12Resource::ReadFromSubresource can be used to copy
+                //    data to (from) the resource.
+                //
+                // 2. Call MapSubresourceAndReadDataForUnknownLayoutTexture or
+                // MapSubresourceAndWriteDataForUnknownLayoutTexture function to finish
+                //    actual copy. The two functions call ID3D12Resource::WriteToSubresource or
+                //    ID3D12Resource::ReadFromSubresource to proceed copy operation.
+                //
+                // 3. After copy, if the original state of the resource is not D3D12_RESOURCE_STATE_COMMON, change its
+                // state back to its original state.
+
+                GFXRECON_ASSERT(layouts != nullptr);
+
+                Dx12ResourceDataUtil::ChangeResourceStateForUnknownLayoutTexture(target_resource, before_states, true);
+
+                for (UINT i = 0; i < subresource_count; ++i)
                 {
-                    GFXRECON_ASSERT(write_data != nullptr);
-                    result = MapSubresourceAndWriteData(
-                        target_resource, i, subresource_size, write_data->data() + subresource_offsets[i]);
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, subresource_sizes[i]);
+                    size_t subresource_size = static_cast<size_t>(subresource_sizes[i]);
+
+                    if (copy_type == kCopyTypeRead)
+                    {
+                        GFXRECON_ASSERT(read_data != nullptr);
+                        result =
+                            MapSubresourceAndReadDataForUnknownLayoutTexture(target_resource,
+                                                                             i,
+                                                                             subresource_size,
+                                                                             read_data->data() + subresource_offsets[i],
+                                                                             target_resource_dimension,
+                                                                             &layouts->at(i));
+                    }
+                    else
+                    {
+                        GFXRECON_ASSERT(write_data != nullptr);
+                        result = MapSubresourceAndWriteDataForUnknownLayoutTexture(target_resource,
+                                                                                   i,
+                                                                                   subresource_size,
+                                                                                   write_data->data() +
+                                                                                       subresource_offsets[i],
+                                                                                   target_resource_dimension,
+                                                                                   &layouts->at(i));
+                    }
+                    if (before_states[i].states != after_states[i].states)
+                    {
+                        GFXRECON_LOG_ERROR_ONCE("CPU buffer state not match");
+                    }
+                    return SUCCEEDED(result);
                 }
-                if (before_states[i].states != after_states[i].states)
-                {
-                    GFXRECON_LOG_ERROR_ONCE("CPU buffer state not match");
-                }
-                return SUCCEEDED(result);
+
+                Dx12ResourceDataUtil::ChangeResourceStateForUnknownLayoutTexture(target_resource, before_states, false);
             }
         }
     }

--- a/framework/graphics/dx12_resource_data_util.h
+++ b/framework/graphics/dx12_resource_data_util.h
@@ -76,15 +76,24 @@ class Dx12ResourceDataUtil
                              std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>& layouts,
                              uint64_t&                                        total_size);
 
+    bool Dx12ResourceDataUtil::ChangeResourceStateForUnknownLayoutTexture(
+        ID3D12Resource*                             resource,
+        const std::vector<dx12::ResourceStateInfo>& before_states,
+        bool                                        transition_to_state_common);
+
+    static bool IsTextureWithUnknownLayout(ID3D12Resource*           target_resource,
+                                           D3D12_RESOURCE_DIMENSION* dimension = nullptr);
+
     // Copy data to or from a mappable resource. Also transitions the resource to after_states.
-    bool CopyMappableResource(ID3D12Resource*                             target_resource,
-                              const std::vector<dx12::ResourceStateInfo>& before_states,
-                              const std::vector<dx12::ResourceStateInfo>& after_states,
-                              CopyType                                    copy_type,
-                              std::vector<uint8_t>*                       read_data,
-                              const std::vector<uint8_t>*                 write_data,
-                              const std::vector<uint64_t>&                subresource_offsets,
-                              const std::vector<uint64_t>&                subresource_sizes);
+    bool CopyMappableResource(ID3D12Resource*                                        target_resource,
+                              const std::vector<dx12::ResourceStateInfo>&            before_states,
+                              const std::vector<dx12::ResourceStateInfo>&            after_states,
+                              CopyType                                               copy_type,
+                              std::vector<uint8_t>*                                  read_data,
+                              const std::vector<uint8_t>*                            write_data,
+                              const std::vector<uint64_t>&                           subresource_offsets,
+                              const std::vector<uint64_t>&                           subresource_sizes,
+                              const std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>* layouts = nullptr);
 
     HRESULT ExecuteAndWaitForCommandList();
 
@@ -112,6 +121,24 @@ class Dx12ResourceDataUtil
 
     HRESULT MapSubresourceAndReadData(ID3D12Resource* resource, UINT subresource, size_t size, uint8_t* data);
 
+    HRESULT MapSubresourceAndWriteData(ID3D12Resource* resource, UINT subresource, size_t size, const uint8_t* data);
+
+    HRESULT
+    MapSubresourceAndReadDataForUnknownLayoutTexture(ID3D12Resource*                           resource,
+                                                     UINT                                      subresource,
+                                                     size_t                                    size,
+                                                     uint8_t*                                  data,
+                                                     D3D12_RESOURCE_DIMENSION                  resource_dimension,
+                                                     const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* layout);
+
+    HRESULT
+    MapSubresourceAndWriteDataForUnknownLayoutTexture(ID3D12Resource*                           resource,
+                                                      UINT                                      subresource,
+                                                      size_t                                    size,
+                                                      const uint8_t*                            data,
+                                                      D3D12_RESOURCE_DIMENSION                  resource_dimension,
+                                                      const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* layout);
+
   private:
     ID3D12Device*                         device_;
     dx12::ID3D12CommandQueueComPtr        command_queue_;
@@ -122,6 +149,8 @@ class Dx12ResourceDataUtil
     uint64_t                              staging_buffer_sizes_[2];
     const uint64_t                        min_buffer_size_;
     uint64_t                              fence_value_;
+    dx12::ID3D12GraphicsCommandListComPtr command_list_for_unknown_layout_texture_;
+    dx12::ID3D12CommandAllocatorComPtr    command_allocator_for_unknown_layout_texture_;
 
     // Temporary buffers.
     std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> temp_subresource_layouts_;

--- a/framework/graphics/dx12_resource_data_util.h
+++ b/framework/graphics/dx12_resource_data_util.h
@@ -81,9 +81,6 @@ class Dx12ResourceDataUtil
         const std::vector<dx12::ResourceStateInfo>& before_states,
         bool                                        transition_to_state_common);
 
-    static bool IsTextureWithUnknownLayout(ID3D12Resource*           target_resource,
-                                           D3D12_RESOURCE_DIMENSION* dimension = nullptr);
-
     // Copy data to or from a mappable resource. Also transitions the resource to after_states.
     bool CopyMappableResource(ID3D12Resource*                                        target_resource,
                               const std::vector<dx12::ResourceStateInfo>&            before_states,

--- a/framework/graphics/dx12_resource_data_util.h
+++ b/framework/graphics/dx12_resource_data_util.h
@@ -76,21 +76,15 @@ class Dx12ResourceDataUtil
                              std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>& layouts,
                              uint64_t&                                        total_size);
 
-    bool Dx12ResourceDataUtil::ChangeResourceStateForUnknownLayoutTexture(
-        ID3D12Resource*                             resource,
-        const std::vector<dx12::ResourceStateInfo>& before_states,
-        bool                                        transition_to_state_common);
-
     // Copy data to or from a mappable resource. Also transitions the resource to after_states.
-    bool CopyMappableResource(ID3D12Resource*                                        target_resource,
-                              const std::vector<dx12::ResourceStateInfo>&            before_states,
-                              const std::vector<dx12::ResourceStateInfo>&            after_states,
-                              CopyType                                               copy_type,
-                              std::vector<uint8_t>*                                  read_data,
-                              const std::vector<uint8_t>*                            write_data,
-                              const std::vector<uint64_t>&                           subresource_offsets,
-                              const std::vector<uint64_t>&                           subresource_sizes,
-                              const std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>* layouts = nullptr);
+    bool CopyMappableResource(ID3D12Resource*                             target_resource,
+                              const std::vector<dx12::ResourceStateInfo>& before_states,
+                              const std::vector<dx12::ResourceStateInfo>& after_states,
+                              CopyType                                    copy_type,
+                              std::vector<uint8_t>*                       read_data,
+                              const std::vector<uint8_t>*                 write_data,
+                              const std::vector<uint64_t>&                subresource_offsets,
+                              const std::vector<uint64_t>&                subresource_sizes);
 
     HRESULT ExecuteAndWaitForCommandList();
 
@@ -120,22 +114,6 @@ class Dx12ResourceDataUtil
 
     HRESULT MapSubresourceAndWriteData(ID3D12Resource* resource, UINT subresource, size_t size, const uint8_t* data);
 
-    HRESULT
-    MapSubresourceAndReadDataForUnknownLayoutTexture(ID3D12Resource*                           resource,
-                                                     UINT                                      subresource,
-                                                     size_t                                    size,
-                                                     uint8_t*                                  data,
-                                                     D3D12_RESOURCE_DIMENSION                  resource_dimension,
-                                                     const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* layout);
-
-    HRESULT
-    MapSubresourceAndWriteDataForUnknownLayoutTexture(ID3D12Resource*                           resource,
-                                                      UINT                                      subresource,
-                                                      size_t                                    size,
-                                                      const uint8_t*                            data,
-                                                      D3D12_RESOURCE_DIMENSION                  resource_dimension,
-                                                      const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* layout);
-
   private:
     ID3D12Device*                         device_;
     dx12::ID3D12CommandQueueComPtr        command_queue_;
@@ -146,8 +124,6 @@ class Dx12ResourceDataUtil
     uint64_t                              staging_buffer_sizes_[2];
     const uint64_t                        min_buffer_size_;
     uint64_t                              fence_value_;
-    dx12::ID3D12GraphicsCommandListComPtr command_list_for_unknown_layout_texture_;
-    dx12::ID3D12CommandAllocatorComPtr    command_allocator_for_unknown_layout_texture_;
 
     // Temporary buffers.
     std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> temp_subresource_layouts_;

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -120,24 +120,48 @@ void TakeScreenshot(std::unique_ptr<graphics::DX12ImageRenderer>& image_renderer
     }
 }
 
-HRESULT MapSubresource(ID3D12Resource* resource, UINT subresource, const D3D12_RANGE* read_range, uint8_t*& data_ptr)
+HRESULT MapSubresource(ID3D12Resource*    resource,
+                       UINT               subresource,
+                       const D3D12_RANGE* read_range,
+                       uint8_t*&          data_ptr,
+                       bool               is_texture_with_unknown_layout)
 {
     HRESULT result = E_FAIL;
 
     // Map the readable resource.
-    void* void_ptr = nullptr;
-    result         = resource->Map(subresource, read_range, &void_ptr);
-    if (SUCCEEDED(result))
+    if (!is_texture_with_unknown_layout)
     {
-        data_ptr = static_cast<uint8_t*>(void_ptr);
-        if (data_ptr == nullptr)
+        void* void_ptr = nullptr;
+        result         = resource->Map(subresource, read_range, &void_ptr);
+        if (SUCCEEDED(result))
         {
-            D3D12_RANGE write_range = { 0, 0 };
-            resource->Unmap(subresource, &write_range);
-            result = E_POINTER;
+            data_ptr = static_cast<uint8_t*>(void_ptr);
+            if (data_ptr == nullptr)
+            {
+                D3D12_RANGE write_range = { 0, 0 };
+                resource->Unmap(subresource, &write_range);
+                result = E_POINTER;
+            }
         }
     }
+    else
+    {
+        // Quote: "A null pointer is valid and is useful to cache a CPU virtual address range for methods like
+        // WriteToSubresource."
+        //
+        // Source: https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12resource-map
+        //
+        // Compared with other types of resource, it has the following difference for mapping
+        // and access data of texture with unknown layout:
+        //
+        // 1. Map call cannot get map pointer and ppData parameter must be nullptr.
+        //
+        // 2. After mapping, the following access to the resource data need call
+        //    ID3D12Resource::WriteToSubresource or ID3D12Resource::ReadFromSubresource.
 
+        result   = resource->Map(subresource, read_range, nullptr);
+        data_ptr = nullptr;
+    }
     return result;
 }
 

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -1014,13 +1014,6 @@ bool IsTextureWithUnknownLayout(D3D12_RESOURCE_DIMENSION dimension, D3D12_TEXTUR
     return is_texture_with_unknown_layout;
 }
 
-bool IsTextureWithUnknownLayout(ID3D12Resource* target_resource, D3D12_RESOURCE_DIMENSION* dimension)
-{
-    GFXRECON_ASSERT(target_resource != nullptr);
-    D3D12_RESOURCE_DESC target_resource_desc = target_resource->GetDesc();
-    return IsTextureWithUnknownLayout(target_resource_desc.Dimension, target_resource_desc.Layout);
-}
-
 GFXRECON_END_NAMESPACE(dx12)
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -998,27 +998,27 @@ uint64_t GetResourceSizeInBytes(ID3D12Device8* device, const D3D12_RESOURCE_DESC
     return size;
 }
 
-bool IsTextureWithUnknownLayout(ID3D12Resource* target_resource, D3D12_RESOURCE_DIMENSION* dimension)
+bool IsTextureWithUnknownLayout(D3D12_RESOURCE_DIMENSION dimension, D3D12_TEXTURE_LAYOUT layout)
 {
-    bool                is_texture_with_unknown_layout = false;
-    D3D12_RESOURCE_DESC target_resource_desc           = target_resource->GetDesc();
+    bool is_texture_with_unknown_layout = false;
 
-    if (target_resource_desc.Layout == D3D12_TEXTURE_LAYOUT_UNKNOWN)
+    if (layout == D3D12_TEXTURE_LAYOUT_UNKNOWN)
     {
-        if ((target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D) ||
-            (target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) ||
-            (target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D))
+        if ((dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D) || (dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) ||
+            (dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D))
         {
             is_texture_with_unknown_layout = true;
         }
     }
 
-    if (dimension != nullptr)
-    {
-        *dimension = target_resource_desc.Dimension;
-    }
-
     return is_texture_with_unknown_layout;
+}
+
+bool IsTextureWithUnknownLayout(ID3D12Resource* target_resource, D3D12_RESOURCE_DIMENSION* dimension)
+{
+    GFXRECON_ASSERT(target_resource != nullptr);
+    D3D12_RESOURCE_DESC target_resource_desc = target_resource->GetDesc();
+    return IsTextureWithUnknownLayout(target_resource_desc.Dimension, target_resource_desc.Layout);
 }
 
 GFXRECON_END_NAMESPACE(dx12)

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -162,6 +162,7 @@ HRESULT MapSubresource(ID3D12Resource*    resource,
         result   = resource->Map(subresource, read_range, nullptr);
         data_ptr = nullptr;
     }
+
     return result;
 }
 
@@ -995,6 +996,29 @@ uint64_t GetResourceSizeInBytes(ID3D12Device8* device, const D3D12_RESOURCE_DESC
     }
 
     return size;
+}
+
+bool IsTextureWithUnknownLayout(ID3D12Resource* target_resource, D3D12_RESOURCE_DIMENSION* dimension)
+{
+    bool                is_texture_with_unknown_layout = false;
+    D3D12_RESOURCE_DESC target_resource_desc           = target_resource->GetDesc();
+
+    if (target_resource_desc.Layout == D3D12_TEXTURE_LAYOUT_UNKNOWN)
+    {
+        if ((target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D) ||
+            (target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) ||
+            (target_resource_desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D))
+        {
+            is_texture_with_unknown_layout = true;
+        }
+    }
+
+    if (dimension != nullptr)
+    {
+        *dimension = target_resource_desc.Dimension;
+    }
+
+    return is_texture_with_unknown_layout;
 }
 
 GFXRECON_END_NAMESPACE(dx12)

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -94,7 +94,11 @@ void TakeScreenshot(std::unique_ptr<gfxrecon::graphics::DX12ImageRenderer>& imag
                     const std::string&                                      filename_prefix);
 
 // Maps a given sub resource and returns a pointer to the mapped region in data_ptr.
-HRESULT MapSubresource(ID3D12Resource* resource, UINT subresource, const D3D12_RANGE* read_range, uint8_t*& data_ptr);
+HRESULT MapSubresource(ID3D12Resource*    resource,
+                       UINT               subresource,
+                       const D3D12_RANGE* read_range,
+                       uint8_t*&          data_ptr,
+                       bool               is_texture_with_unknown_layout = false);
 
 // Waits for the given queue to complete all pending tasks.
 HRESULT WaitForQueue(ID3D12CommandQueue* queue, ID3D12Fence* fence = nullptr, uint64_t fence_value = 0);

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -220,6 +220,8 @@ uint64_t GetResourceSizeInBytes(ID3D12Device8* device, const D3D12_RESOURCE_DESC
 
 bool IsSoftwareAdapter(const format::DxgiAdapterDesc& adapter_desc);
 
+bool IsTextureWithUnknownLayout(ID3D12Resource* target_resource, D3D12_RESOURCE_DIMENSION* dimension = nullptr);
+
 GFXRECON_END_NAMESPACE(dx12)
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -220,7 +220,6 @@ uint64_t GetResourceSizeInBytes(ID3D12Device8* device, const D3D12_RESOURCE_DESC
 
 bool IsSoftwareAdapter(const format::DxgiAdapterDesc& adapter_desc);
 
-bool IsTextureWithUnknownLayout(ID3D12Resource* target_resource, D3D12_RESOURCE_DIMENSION* dimension = nullptr);
 bool IsTextureWithUnknownLayout(D3D12_RESOURCE_DIMENSION dimension, D3D12_TEXTURE_LAYOUT layout);
 
 GFXRECON_END_NAMESPACE(dx12)

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -221,6 +221,7 @@ uint64_t GetResourceSizeInBytes(ID3D12Device8* device, const D3D12_RESOURCE_DESC
 bool IsSoftwareAdapter(const format::DxgiAdapterDesc& adapter_desc);
 
 bool IsTextureWithUnknownLayout(ID3D12Resource* target_resource, D3D12_RESOURCE_DIMENSION* dimension = nullptr);
+bool IsTextureWithUnknownLayout(D3D12_RESOURCE_DIMENSION dimension, D3D12_TEXTURE_LAYOUT layout);
 
 GFXRECON_END_NAMESPACE(dx12)
 GFXRECON_END_NAMESPACE(graphics)


### PR DESCRIPTION
**The problem**
In current trim process, if a resource is CPU accessible texture with unknown layout, when saving its data to trimmed trace file during capture, or uploading data to restore resource state during playback, normal resource mapping will be used to save or upload the resource data. However, this shouldn't be the case because texture with unknown layout is a special case for mapping and mapping such resource to get a mapped pointer is invalid. Such trim handling error cause GFXR failed to save or upload the resource data and make trim trace of some title missing HUD text because the title use texture with unknown layout for rendering these HUD text.

**The solution**
The pull request is the fix for the trim handling error. It avoid using normal resource map/unmap when saving/uploading resource data for such resource, instead, using CPU non-accessible resource code path in trim handling which first copy the resource data to staging buffer then using map/unmap.

Using ```ID3D12Resource::WriteToSubresource / ID3D12Resource::ReadFromSubresource``` calls can also fix the issue and avoid using the staging buffer, after analyzing both ways for fixing the issue, using staging buffer can reuse existing code path and make less changes to existing code, so the pull-request uses existing CPU non-accessible resource code path in trim handling as the final solution.

**Result**
All tests passed for the target title and other titles include trim trace and full trace capture/playback, these test results show the pull-request fixed the trim issue for target title and doesn't affect other titles.