### PR TITLE
Include missing adapters in trimmed traces

### DIFF
--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -652,7 +652,7 @@ void TrackAdapters(HRESULT result, void** ppFactory, graphics::dx12::ActiveAdapt
         if (SUCCEEDED(factory1->QueryInterface(__uuidof(IDXGIFactory1), reinterpret_cast<void**>(&factory1))))
         {
             // Get a fresh enumeration, in case it was previously filled by 1.0 tracking
-            adapters.clear();
+            RemoveDeactivatedAdapters(adapters);
 
             // Enumerate 1.1 adapters and fetch data with GetDesc1()
             IDXGIAdapter1* adapter1 = nullptr;
@@ -700,6 +700,23 @@ void TrackAdapters(HRESULT result, void** ppFactory, graphics::dx12::ActiveAdapt
                 }
             }
         }
+    }
+}
+
+void RemoveDeactivatedAdapters(graphics::dx12::ActiveAdapterMap& adapters)
+{
+    std::vector<int64_t> deactivated_adapters;
+    for (const auto& adapter : adapters)
+    {
+        if (adapter.second.active == false)
+        {
+            deactivated_adapters.push_back(adapter.first);
+        }
+    }
+
+    for (auto deactive_adapter : deactivated_adapters)
+    {
+        adapters.erase(deactive_adapter);
     }
 }
 

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -170,6 +170,8 @@ uint64_t GetSubresourceWriteDataSize(
 
 void TrackAdapters(HRESULT result, void** ppfactory, graphics::dx12::ActiveAdapterMap& adapters);
 
+void RemoveDeactivatedAdapters(graphics::dx12::ActiveAdapterMap& adapters);
+
 format::DxgiAdapterDesc* MarkActiveAdapter(ID3D12Device* device, graphics::dx12::ActiveAdapterMap& adapters);
 
 // Query adapter and index by LUID


### PR DESCRIPTION
**The problem**
Trimmed traces often exclude adapter info. The problem is in clearing adapters in `TrackAdapters` method. For trimmed trace we have additional `TrackAdapters` call after `PostProcess_D3D12CreateDevice` (this is where we retrieve which adapter is active). As a result, we are losing track of active adapter. Once it happened no data recorded to file about it.   

**The solution**
The solution is to clear only not active adapter instead of clearing all. This way we are not losing track of what is active at any moment.   

**Results + testing**
As a result of this fix, we have D3D12 adapter info available in every case (including titles where adapter info was missing). Tests performed on normal and trimmed traces.  

Example before changes:
![before](https://user-images.githubusercontent.com/73676794/215578042-c8eb2f1a-ae4c-4b6c-b4e3-501f0437a7c8.JPG)

After:
![after](https://user-images.githubusercontent.com/73676794/215578095-f0c30400-acd9-4005-b30c-1a8c0db4e985.JPG)

