### PR TITLE
Logging if the D3D12 folder with DLLs do not exist

### DIFF
--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -790,6 +790,32 @@ bool IsSoftwareAdapter(const format::DxgiAdapterDesc& adapter_desc)
     return software_desc;
 }
 
+bool VerifyAgilitySDKRuntime()
+{
+    char module_name[MAX_PATH] = {};
+    bool detected_runtime      = false;
+
+#if defined(D3D12_SUPPORT)
+    if (GetModuleFileNameA(nullptr, module_name, MAX_PATH))
+    {
+        const std::string tool_executable_path = module_name;
+        std::string       tool_working_dir     = "";
+        size_t            dir_location         = tool_executable_path.find_last_of(util::filepath::kAltPathLastSepStr);
+        if (dir_location >= 0)
+        {
+            tool_working_dir = tool_executable_path.substr(0, dir_location);
+        }
+        const std::string runtime_path = "\\D3D12\\D3D12Core.dll";
+        if (gfxrecon::util::filepath::IsFile(tool_working_dir + runtime_path))
+        {
+            detected_runtime = true;
+        }
+    }
+#endif
+
+    return detected_runtime;
+}
+
 bool GetAdapterAndIndexbyLUID(LUID                              luid,
                               IDXGIAdapter*&                    adapter_ptr,
                               uint32_t&                         index,

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -803,21 +803,6 @@ bool VerifyAgilitySDKRuntime()
     {
         GFXRECON_LOG_ERROR("GetModuleFileNameA failed with error code %d", GetLastError());
     }
-    else if (ret > MAX_PATH)
-    {
-        module_name.resize(ret);
-
-        ret = GetModuleFileNameA(nullptr, module_name.data(), ret);
-
-        if (ret == 0)
-        {
-            GFXRECON_LOG_ERROR("GetModuleFileNameA failed with error code %d", GetLastError());
-        }
-        else
-        {
-            tool_executable_path = module_name.data();
-        }
-    }
     else
     {
         tool_executable_path = module_name.data();

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -799,7 +799,7 @@ bool VerifyAgilitySDKRuntime()
     std::vector<char> module_name(MAX_PATH);
 
     auto ret = GetModuleFileNameA(nullptr, module_name.data(), MAX_PATH);
-    if (ret == 0)
+    if ((ret == 0) || ((ret == MAX_PATH) && (GetLastError() == ERROR_INSUFFICIENT_BUFFER)))
     {
         GFXRECON_LOG_ERROR("GetModuleFileNameA failed with error code %d", GetLastError());
     }

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -792,15 +792,41 @@ bool IsSoftwareAdapter(const format::DxgiAdapterDesc& adapter_desc)
 
 bool VerifyAgilitySDKRuntime()
 {
-    char module_name[MAX_PATH] = {};
-    bool detected_runtime      = false;
+    bool        detected_runtime = false;
+    std::string tool_executable_path;
 
 #if defined(D3D12_SUPPORT)
-    if (GetModuleFileNameA(nullptr, module_name, MAX_PATH))
+    std::vector<char> module_name(MAX_PATH);
+
+    auto ret = GetModuleFileNameA(nullptr, module_name.data(), MAX_PATH);
+    if (ret == 0)
     {
-        const std::string tool_executable_path = module_name;
-        std::string       tool_working_dir     = "";
-        size_t            dir_location         = tool_executable_path.find_last_of(util::filepath::kAltPathLastSepStr);
+        GFXRECON_LOG_ERROR("GetModuleFileNameA failed with error code %d", GetLastError());
+    }
+    else if (ret > MAX_PATH)
+    {
+        module_name.resize(ret);
+
+        ret = GetModuleFileNameA(nullptr, module_name.data(), ret);
+
+        if (ret == 0)
+        {
+            GFXRECON_LOG_ERROR("GetModuleFileNameA failed with error code %d", GetLastError());
+        }
+        else
+        {
+            tool_executable_path = module_name.data();
+        }
+    }
+    else
+    {
+        tool_executable_path = module_name.data();
+    }
+
+    if (!tool_executable_path.empty())
+    {
+        std::string tool_working_dir = "";
+        size_t      dir_location     = tool_executable_path.find_last_of(util::filepath::kAltPathLastSepStr);
         if (dir_location >= 0)
         {
             tool_working_dir = tool_executable_path.substr(0, dir_location);

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -222,6 +222,8 @@ bool IsSoftwareAdapter(const format::DxgiAdapterDesc& adapter_desc);
 
 bool IsTextureWithUnknownLayout(D3D12_RESOURCE_DIMENSION dimension, D3D12_TEXTURE_LAYOUT layout);
 
+bool VerifyAgilitySDKRuntime();
+
 GFXRECON_END_NAMESPACE(dx12)
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -266,11 +266,11 @@ bool GetDx12OptimizationInfo(const std::string&               input_filename,
 
     if (gfxrecon::graphics::dx12::VerifyAgilitySDKRuntime() == false)
     {
-        GFXRECON_LOG_FATAL("Did not find Agility SDK runtimes. Verify \\D3D12\\D3D12Core.dll exists in the same "
+        GFXRECON_LOG_ERROR("Did not find Agility SDK runtimes. Verify \\D3D12\\D3D12Core.dll exists in the same "
                            "directory as gfxrecon-optimize.exe.");
-        dxr_scan_result = false;
     }
-    else if (options.optimize_resource_values)
+
+    if (options.optimize_resource_values)
     {
         dxr_scan_result = GetDxrOptimizationInfo(input_filename, info, true, options);
 

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2022 LunarG, Inc.
-** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -264,7 +264,13 @@ bool GetDx12OptimizationInfo(const std::string&               input_filename,
         pso_scan_result = GetPsoOptimizationInfo(input_filename, options, info);
     }
 
-    if (options.optimize_resource_values)
+    if (gfxrecon::graphics::dx12::VerifyAgilitySDKRuntime() == false)
+    {
+        GFXRECON_LOG_WARNING("Did not find Agility SDK runtimes. Verify \\D3D12\\D3D12Core.dll exists in the same "
+                             "directory as gfxrecon-optimize.exe.");
+        dxr_scan_result = false;
+    }
+    else if (options.optimize_resource_values)
     {
         dxr_scan_result = GetDxrOptimizationInfo(input_filename, info, true, options);
 

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -266,8 +266,8 @@ bool GetDx12OptimizationInfo(const std::string&               input_filename,
 
     if (gfxrecon::graphics::dx12::VerifyAgilitySDKRuntime() == false)
     {
-        GFXRECON_LOG_WARNING("Did not find Agility SDK runtimes. Verify \\D3D12\\D3D12Core.dll exists in the same "
-                             "directory as gfxrecon-optimize.exe.");
+        GFXRECON_LOG_FATAL("Did not find Agility SDK runtimes. Verify \\D3D12\\D3D12Core.dll exists in the same "
+                           "directory as gfxrecon-optimize.exe.");
         dxr_scan_result = false;
     }
     else if (options.optimize_resource_values)

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -178,7 +178,7 @@ int main(int argc, const char** argv)
                 application->InitializeDx12WsiContext();
                 if (gfxrecon::graphics::dx12::VerifyAgilitySDKRuntime() == false)
                 {
-                    GFXRECON_LOG_WARNING(
+                    GFXRECON_LOG_FATAL(
                         "Did not find Agility SDK runtimes. Verify \\D3D12\\D3D12Core.dll exists in the same "
                         "directory as gfxrecon-replay.exe.");
                     return_code = -1;

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -37,6 +38,7 @@
 #include "generated/generated_dx12_decoder.h"
 #include "generated/generated_dx12_replay_consumer.h"
 #include "decode/dx12_tracking_consumer.h"
+#include "graphics/dx12_util.h"
 #endif
 
 #include <exception>
@@ -134,24 +136,24 @@ int main(int argc, const char** argv)
                 GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table);
 
             uint32_t start_frame = 0;
-            uint32_t end_frame = 0;
+            uint32_t end_frame   = 0;
 
-            bool has_mfr = false;
+            bool has_mfr                            = false;
             bool quit_after_measurement_frame_range = false;
-            bool flush_measurement_frame_range = false;
+            bool flush_measurement_frame_range      = false;
 
             if (vulkan_replay_options.enable_vulkan)
             {
-                has_mfr = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
+                has_mfr                            = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
                 quit_after_measurement_frame_range = vulkan_replay_options.quit_after_measurement_frame_range;
-                flush_measurement_frame_range = vulkan_replay_options.flush_measurement_frame_range;
+                flush_measurement_frame_range      = vulkan_replay_options.flush_measurement_frame_range;
             }
 
             gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(start_frame),
-                static_cast<uint64_t>(end_frame),
-                has_mfr,
-                quit_after_measurement_frame_range,
-                flush_measurement_frame_range);
+                                                 static_cast<uint64_t>(end_frame),
+                                                 has_mfr,
+                                                 quit_after_measurement_frame_range,
+                                                 flush_measurement_frame_range);
 
             gfxrecon::decode::VulkanReplayConsumer vulkan_replay_consumer(application, vulkan_replay_options);
             gfxrecon::decode::VulkanDecoder        vulkan_decoder;
@@ -174,73 +176,84 @@ int main(int argc, const char** argv)
             if (dx_replay_options.enable_d3d12)
             {
                 application->InitializeDx12WsiContext();
-
-                dx12_replay_consumer.SetFatalErrorHandler(
-                    [](const char* message) { throw std::runtime_error(message); });
-                dx12_replay_consumer.SetFpsInfo(&fps_info);
-
-                // check for user option if first pass tracking is enabled
-                if (dx_replay_options.enable_d3d12_two_pass_replay)
-                {
-                    gfxrecon::decode::FileProcessor              file_processor_tracking;
-                    gfxrecon::decode::Dx12TrackedObjectInfoTable tracked_object_info_table;
-                    auto                                         tracking_consumer =
-                        new gfxrecon::decode::DX12TrackingConsumer(dx_replay_options, &tracked_object_info_table);
-                    if (file_processor_tracking.Initialize(filename))
-                    {
-                        dx12_decoder.AddConsumer(tracking_consumer);
-                        file_processor_tracking.AddDecoder(&dx12_decoder);
-                        file_processor_tracking.ProcessAllFrames();
-                        file_processor_tracking.RemoveDecoder(&dx12_decoder);
-                        dx12_decoder.RemoveConsumer(tracking_consumer);
-                    }
-                }
-                dx12_decoder.AddConsumer(&dx12_replay_consumer);
-                file_processor.AddDecoder(&dx12_decoder);
-            }
-#endif
-
-            // Warn if the capture layer is active.
-            CheckActiveLayers(gfxrecon::util::platform::GetEnv(kLayerEnvVar));
-
-            fps_info.BeginFile();
-
-            application->SetPauseFrame(GetPauseFrame(arg_parser));
-            application->SetFpsInfo(&fps_info);
-            application->Run();
-
-            // XXX if the final frame ended with a Present, this would be the *next* frame
-            // Add one so that it matches the trim range frame number semantic
-            fps_info.EndFile(file_processor.GetCurrentFrameNumber() + 1);
-
-            if ((file_processor.GetCurrentFrameNumber() > 0) &&
-                (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
-            {
-                if (file_processor.GetCurrentFrameNumber() < start_frame)
+                if (gfxrecon::graphics::dx12::VerifyAgilitySDKRuntime() == false)
                 {
                     GFXRECON_LOG_WARNING(
-                        "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
-                        "Measurements were never started, cannot calculate measurement range FPS.",
-                        start_frame,
-                        file_processor.GetCurrentFrameNumber());
+                        "Did not find Agility SDK runtimes. Verify \\D3D12\\D3D12Core.dll exists in the same "
+                        "directory as gfxrecon-replay.exe.");
+                    return_code = -1;
                 }
                 else
                 {
-#if defined(D3D12_SUPPORT)
-                    dx12_replay_consumer.PostReplay();
-#endif
+                    dx12_replay_consumer.SetFatalErrorHandler(
+                        [](const char* message) { throw std::runtime_error(message); });
+                    dx12_replay_consumer.SetFpsInfo(&fps_info);
 
-                    fps_info.LogToConsole();
+                    // check for user option if first pass tracking is enabled
+                    if (dx_replay_options.enable_d3d12_two_pass_replay)
+                    {
+                        gfxrecon::decode::FileProcessor              file_processor_tracking;
+                        gfxrecon::decode::Dx12TrackedObjectInfoTable tracked_object_info_table;
+                        auto                                         tracking_consumer =
+                            new gfxrecon::decode::DX12TrackingConsumer(dx_replay_options, &tracked_object_info_table);
+                        if (file_processor_tracking.Initialize(filename))
+                        {
+                            dx12_decoder.AddConsumer(tracking_consumer);
+                            file_processor_tracking.AddDecoder(&dx12_decoder);
+                            file_processor_tracking.ProcessAllFrames();
+                            file_processor_tracking.RemoveDecoder(&dx12_decoder);
+                            dx12_decoder.RemoveConsumer(tracking_consumer);
+                        }
+                    }
+                    dx12_decoder.AddConsumer(&dx12_replay_consumer);
+                    file_processor.AddDecoder(&dx12_decoder);
                 }
             }
-            else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
+#endif
+            if (return_code == 0)
             {
-                GFXRECON_WRITE_CONSOLE("A failure has occurred during replay");
-                return_code = -1;
-            }
-            else
-            {
-                GFXRECON_WRITE_CONSOLE("File did not contain any frames");
+                // Warn if the capture layer is active.
+                CheckActiveLayers(gfxrecon::util::platform::GetEnv(kLayerEnvVar));
+
+                fps_info.BeginFile();
+
+                application->SetPauseFrame(GetPauseFrame(arg_parser));
+                application->SetFpsInfo(&fps_info);
+                application->Run();
+
+                // XXX if the final frame ended with a Present, this would be the *next* frame
+                // Add one so that it matches the trim range frame number semantic
+                fps_info.EndFile(file_processor.GetCurrentFrameNumber() + 1);
+
+                if ((file_processor.GetCurrentFrameNumber() > 0) &&
+                    (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
+                {
+                    if (file_processor.GetCurrentFrameNumber() < start_frame)
+                    {
+                        GFXRECON_LOG_WARNING(
+                            "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
+                            "Measurements were never started, cannot calculate measurement range FPS.",
+                            start_frame,
+                            file_processor.GetCurrentFrameNumber());
+                    }
+                    else
+                    {
+#if defined(D3D12_SUPPORT)
+                        dx12_replay_consumer.PostReplay();
+#endif
+
+                        fps_info.LogToConsole();
+                    }
+                }
+                else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
+                {
+                    GFXRECON_WRITE_CONSOLE("A failure has occurred during replay");
+                    return_code = -1;
+                }
+                else
+                {
+                    GFXRECON_WRITE_CONSOLE("File did not contain any frames");
+                }
             }
         }
     }


### PR DESCRIPTION
**The problem**
During replay some traces required agility SDK's D3D12 folder with dlls for it. We need a warning mechanism to notify the user.

**The solution**
I created `VerifyAgilitySDKRuntime` function in `dx12_util` that retrieves executable folder and checking that Agility SDK runtime is in place.

**Result**
Tested with replaying captures. Warning issues during replay if Agility SDK runtime is missing. Also optimizing process tested and warning issued when `--dxr` option was used. 