### PR TITLE
Check Whether a Device is UMA During Staging

### DIFF
--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -225,6 +225,9 @@ struct D3D12DeviceInfo : DxObjectExtraInfo
 
     std::shared_ptr<DescriptorIncrements> capture_increments{ std::make_shared<DescriptorIncrements>() };
     std::shared_ptr<DescriptorIncrements> replay_increments{ std::make_shared<DescriptorIncrements>() };
+
+    // Cache features of the device to avoid repeated queries
+    bool is_uma{ false };
 };
 
 struct D3D12DescriptorHeapInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -382,6 +382,7 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
     auto extra_device_info = GetExtraInfo<D3D12DeviceInfo>(device_info);
     auto resource_info     = GetObjectInfo(command_header.resource_id);
     auto resource          = static_cast<ID3D12Resource*>(resource_info->object);
+    bool is_uma            = graphics::dx12::IsUma(device);
 
     GFXRECON_ASSERT(MapObject<ID3D12Resource>(command_header.resource_id) == resource);
 
@@ -405,7 +406,7 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
         GFXRECON_ASSERT(command_header.subresource == 0);
 
         const double max_cpu_mem_usage = 15.0 / 16.0;
-        if (!graphics::dx12::IsMemoryAvailable(total_size_in_bytes, extra_device_info->adapter3, max_cpu_mem_usage))
+        if (!graphics::dx12::IsMemoryAvailable(total_size_in_bytes, extra_device_info->adapter3, max_cpu_mem_usage, is_uma))
         {
             // If neither system memory or GPU memory are able to accommodate next resource,
             // execute the Copy() calls and release temp buffer to free memory

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -382,7 +382,6 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
     auto extra_device_info = GetExtraInfo<D3D12DeviceInfo>(device_info);
     auto resource_info     = GetObjectInfo(command_header.resource_id);
     auto resource          = static_cast<ID3D12Resource*>(resource_info->object);
-    bool is_uma            = graphics::dx12::IsUma(device);
 
     GFXRECON_ASSERT(MapObject<ID3D12Resource>(command_header.resource_id) == resource);
 
@@ -406,7 +405,8 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
         GFXRECON_ASSERT(command_header.subresource == 0);
 
         const double max_cpu_mem_usage = 15.0 / 16.0;
-        if (!graphics::dx12::IsMemoryAvailable(total_size_in_bytes, extra_device_info->adapter3, max_cpu_mem_usage, is_uma))
+        if (!graphics::dx12::IsMemoryAvailable(
+                total_size_in_bytes, extra_device_info->adapter3, max_cpu_mem_usage, extra_device_info->is_uma))
         {
             // If neither system memory or GPU memory are able to accommodate next resource,
             // execute the Copy() calls and release temp buffer to free memory
@@ -925,6 +925,8 @@ HRESULT Dx12ReplayConsumerBase::OverrideD3D12CreateDevice(HRESULT               
                                                    device_info->adapter3,
                                                    device_info->adapter_node_index,
                                                    adapters_);
+        device_info->is_uma = graphics::dx12::IsUma(device_ptr);
+
         SetExtraInfo(device, std::move(device_info));
 
         graphics::dx12::MarkActiveAdapter(device_ptr, adapters_);

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -367,12 +367,17 @@ void D3D12CaptureManager::InitializeID3D12DeviceInfo(IUnknown* adapter, void** d
 
     if ((device != nullptr) && (*device != nullptr))
     {
-        auto info = reinterpret_cast<ID3D12Device_Wrapper*>(*device)->GetObjectInfo();
+        auto device_wrapper = reinterpret_cast<ID3D12Device_Wrapper*>(*device);
+        auto info = device_wrapper->GetObjectInfo();
 
         if (info != nullptr)
         {
             graphics::dx12::GetAdapterAndIndexbyDevice(
                 reinterpret_cast<ID3D12Device*>(*device), info->adapter3, info->adapter_node_index, adapters_);
+
+            // Cache info on device features:
+            auto wrapped_device = device_wrapper->GetWrappedObjectAs<ID3D12Device>();
+            info->is_uma        = graphics::dx12::IsUma(wrapped_device);
         }
     }
 }

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -351,6 +351,9 @@ struct ID3D12DeviceInfo : public DxWrapperInfo
     uint32_t       adapter_node_index{ 0 };
 
     std::unordered_map<format::HandleId, D3D12_RESIDENCY_PRIORITY> residency_priorities; // ID3D12Pageable
+
+    // Cache features of the device to avoid repeated queries
+    bool is_uma{ false };
 };
 
 struct ID3D12ResourceInfo : public DxWrapperInfo

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -747,7 +747,9 @@ void Dx12StateWriter::WriteResourceSnapshots(
                 auto     device_info   = device_wrapper->GetObjectInfo();
 
                 const double max_cpu_mem_usage = 7.0 / 8.0;
-                if (!graphics::dx12::IsMemoryAvailable(size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage))
+
+                const bool isUma = graphics::dx12::IsUma(device_wrapper->GetWrappedObjectAs<ID3D12Device>());
+                if (!graphics::dx12::IsMemoryAvailable(size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage, isUma))
                 {
                     // If neither system memory or GPU memory are able to accommodate next resource,
                     // execute the existing Copy() calls and release temp buffer to free memory

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -748,8 +748,8 @@ void Dx12StateWriter::WriteResourceSnapshots(
 
                 const double max_cpu_mem_usage = 7.0 / 8.0;
 
-                const bool isUma = graphics::dx12::IsUma(device_wrapper->GetWrappedObjectAs<ID3D12Device>());
-                if (!graphics::dx12::IsMemoryAvailable(size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage, isUma))
+                const bool is_uma = device_wrapper->GetObjectInfo()->is_uma;
+                if (!graphics::dx12::IsMemoryAvailable(size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage, is_uma))
                 {
                     // If neither system memory or GPU memory are able to accommodate next resource,
                     // execute the existing Copy() calls and release temp buffer to free memory

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -187,16 +187,23 @@ bool GetAdapterAndIndexbyDevice(ID3D12Device*                     device,
 // Get the adapter at specified index
 IDXGIAdapter* GetAdapterbyIndex(graphics::dx12::ActiveAdapterMap& adapters, int32_t index);
 
+// Returns whether the device passed represents a unified memory architecture
+// (UMA) GPU as with most integrated graphics / APUs and mobile SOCs.
+// The pointer is assumed to be valid.
+// If the underlying D3D call fails, the function will also return false and the
+// error will be logged.
+bool IsUma(ID3D12Device* device);
+
 // This function is used to get available GPU virtual memory.
 // The input is current adapter which created current device.
-uint64_t GetAvailableGpuAdapterMemory(IDXGIAdapter3* adapter);
+uint64_t GetAvailableGpuAdapterMemory(IDXGIAdapter3* adapter, bool is_uma);
 
 // This function is used to get available CPU memory.
 uint64_t GetAvailableCpuMemory(double max_usage);
 
 // Give require memory size to check if there are enough CPU&GPU memory to allocate the resource. If max_cpu_mem_usage
 // > 1.0, the result is not limited by available physical memory.
-bool IsMemoryAvailable(uint64_t requried_memory, IDXGIAdapter3* adapter, double max_cpu_mem_usage);
+bool IsMemoryAvailable(uint64_t requried_memory, IDXGIAdapter3* adapter, double max_cpu_mem_usage, bool is_uma);
 
 // Get GPU memory usage by resource desc
 uint64_t GetResourceSizeInBytes(ID3D12Device* device, const D3D12_RESOURCE_DESC* desc);


### PR DESCRIPTION
This patch queries for whether each device created on encode and decode side is based on a Unified Memory Architecture (UMA) and stores that information alongside the device wrappers . The stored bool is used during trimming to transfer data via the correct `DXGI_MEMORY_SEGMENT_GROUP`.
Unified Memory Architecture devices lack the `DXGI_MEMORY_SEGMENT_GROUP` `..._NON_LOCAL` since all memory is device-visible for them. For UMA devices like those on mobile SOCs and PC integrated GPUs we therefore use the `DXGI_MEMORY_SEGMENT_GROUP` `..._LOCAL` for our own transfers.

Fixes #954.