### PR TITLE
Fix dx12 code generations

### DIFF
--- a/framework/generated/base_generators/base_struct_decoders_body_generator.py
+++ b/framework/generated/base_generators/base_struct_decoders_body_generator.py
@@ -119,7 +119,9 @@ class BaseStructDecodersBodyGenerator():
 
                 if is_static_array:
                     array_dimension = ''
-                    if value.array_dimension and value.array_dimension > 0 and not value.is_array:
+                    # dx12 treats 2d array as 1d array. EX: [8][2] -> [16], so dx12's 2d array needs *. 
+                    # But vk keeps 2d array.
+                    if self.is_dx12_class() and value.array_dimension and value.array_dimension > 0:
                         array_dimension = '*'
                     # The pointer decoder will write directly to the struct member's memory.
                     body += '    wrapper->{name}{}SetExternalMemory({}value->{name}, {arraylen});\n'.format(

--- a/framework/generated/generate_dx12.py
+++ b/framework/generated/generate_dx12.py
@@ -29,6 +29,7 @@ LIB_CPPHEADERPARSER_PATH = '../../external'
 LIB_REGISTRY_PATH = '../../external/Vulkan-Headers/registry'
 VULKAN_GENERATOR_PATH = './vulkan_generators'
 BASE_GENERATOR_PATH = './base_generators'
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 
 # File names to provide to the dxgi generator script.
 GENERATE_TARGETS = [
@@ -131,7 +132,7 @@ if __name__ == '__main__':
                     ] = Dx12CppHeader(source_file)
 
     for source in DX12_SOURCE_LIST:
-        source_file = os.path.join('..', '..', 'external', 'AgilitySDK', 'inc', source)
+        source_file = os.path.join(SCRIPT_DIR, '..', '..', 'external', 'AgilitySDK', 'inc', source)
 
         print('Parsing', source_file)
         header_dict[source[source.find('\\') + 1:]] = Dx12CppHeader(source_file)

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -341,7 +341,7 @@ class BaseGenerator(OutputGenerator):
     # Default C++ code indentation size.
     INDENT_SIZE = 4
 
-    VIDEO_TREE = {}
+    VIDEO_TREE = None
 
     generate_video = False
 
@@ -465,6 +465,9 @@ class BaseGenerator(OutputGenerator):
             self.generate_video = True
 
     def gen_video_type(self):
+        if not self.VIDEO_TREE:
+            return
+        
         if self.process_structs:
             types = self.VIDEO_TREE.find('types')
             for element in types.iter('type'):


### PR DESCRIPTION
1. Use absolute path for external/AgilitySDK
2. VIDEO_TREE is for vk, avoid it to fail on dx12.
3. dx12 treats 2d array as 1d array, that's different to vk