### PR TITLE
Escaped Strings in JSON Header

### DIFF
--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -85,9 +85,9 @@ void VulkanAsciiConsumerBase::Initialize(FILE*      file,
         fprintf(file_,
                 "{\"header\":{\"source-path\":\"%s\",\"json-version\":"
                 "\"" GFXRECON_CONVERT_JSON_VERSION "\",\"gfxrecon-version\":\"%s\",\"vulkan-version\":\"%s\"}}\n",
-                inputFilepath,
-                gfxrVersion,
-                vulkanVersion);
+                util::JSONEscape(inputFilepath).c_str(),
+                util::JSONEscape(gfxrVersion).c_str(),
+                util::JSONEscape(vulkanVersion).c_str());
         fflush(file_);
     }
 }


### PR DESCRIPTION
Absolute path to gfxr trace file verified as accepted by chocolatey-installed jq under ARM64 Windows 11 Powershell.

Fixes #1014