### PR TITLE
Remove competing sufrace extensions with wsi option

### DIFF
--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -58,6 +58,8 @@ class Application final
 
     WsiContext* GetWsiContext(const std::string& wsi_extension, bool auto_select = false);
 
+    const std::string& GetWsiCliContext() const { return cli_wsi_extension_; }
+
     bool IsRunning() const { return running_; }
 
     void Run();

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2214,7 +2214,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
             // If a specific WSI extension was selected on the command line we need to make sure that extension is
             // loaded and other WSI extensions are disabled
             assert(application_);
-            const bool override_wsi_extensions = !application_->GetWsiContexts().empty();
+            const bool override_wsi_extensions = !application_->GetWsiCliContext().empty();
 
             for (const auto& itr : application_->GetWsiContexts())
             {


### PR DESCRIPTION
Fixes #998 
**Problem**
--wsi replay option adds relevant surface extension on instance creation without removing other surface extensions used in the trace. That makes it impossible to replay on different platforms without --remove-unsupported option.
**Solution**
Surface extensions different than the one specified with --wsi option are removed on instance creation, --remove-unsupported is no longer required.