### PR TITLE
Inject adapter ID into metadata and calculate submits per adapter

### DIFF
--- a/framework/decode/dx12_stats_consumer.h
+++ b/framework/decode/dx12_stats_consumer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -82,11 +82,16 @@ class Dx12StatsConsumer : public Dx12Consumer
     {
         bool insert = true;
 
-        for (const auto& adapter : adapters)
+        for (auto& adapter : adapters)
         {
             if ((adapter.LuidHighPart == new_adapter.LuidHighPart) && (adapter.LuidLowPart == new_adapter.LuidLowPart))
             {
                 insert = false;
+                if (!graphics::dx12::ExtractAdapterType(adapter.extra_info))
+                {
+                    format::AdapterType type = graphics::dx12::ExtractAdapterType(new_adapter.extra_info);
+                    graphics::dx12::InjectAdapterType(adapter.extra_info, type);
+                }
                 break;
             }
         }
@@ -113,8 +118,22 @@ class Dx12StatsConsumer : public Dx12Consumer
         new_adapter.SharedSystemMemory    = adapter_info_header.adapter_desc.SharedSystemMemory;
         new_adapter.LuidLowPart           = adapter_info_header.adapter_desc.LuidLowPart;
         new_adapter.LuidHighPart          = adapter_info_header.adapter_desc.LuidHighPart;
-        new_adapter.type                  = adapter_info_header.adapter_desc.type;
+        new_adapter.extra_info            = adapter_info_header.adapter_desc.extra_info;
         InsertAdapter(new_adapter, gfxr_cmd_adapters_);
+        format::HandleId object_id = graphics::dx12::ExtractAdapterCaptureId(new_adapter.extra_info);
+
+        const int64_t luid = (new_adapter.LuidHighPart << 31) | new_adapter.LuidLowPart;
+        adapter_submission_mapping_.adapter_to_luid_map[object_id] = luid;
+    }
+
+    virtual void Process_IDXGIAdapter4_GetDesc3(const ApiCallInfo&                                call_info,
+                                                format::HandleId                                  object_id,
+                                                HRESULT                                           return_value,
+                                                StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC3>* pDesc)
+    {
+        format::DxgiAdapterDesc new_adapter = {};
+        CopyAdapterDesc(new_adapter, pDesc);
+        InsertAdapter(new_adapter, app_get_desc_adapters);
     }
 
     virtual void
@@ -123,7 +142,6 @@ class Dx12StatsConsumer : public Dx12Consumer
                                    HRESULT                                                             return_value,
                                    gfxrecon::decode::StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC2>* pDesc)
     {
-
         format::DxgiAdapterDesc new_adapter = {};
         CopyAdapterDesc(new_adapter, pDesc);
         InsertAdapter(new_adapter, app_get_desc_adapters);
@@ -135,7 +153,6 @@ class Dx12StatsConsumer : public Dx12Consumer
                                    HRESULT                                                             return_value,
                                    gfxrecon::decode::StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC1>* pDesc)
     {
-
         format::DxgiAdapterDesc new_adapter = {};
         CopyAdapterDesc(new_adapter, pDesc);
         InsertAdapter(new_adapter, app_get_desc_adapters);
@@ -146,7 +163,6 @@ class Dx12StatsConsumer : public Dx12Consumer
                                               HRESULT                              return_value,
                                               gfxrecon::decode::StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC>* pDesc)
     {
-
         format::DxgiAdapterDesc new_adapter = {};
         CopyAdapterDesc(new_adapter, pDesc);
         InsertAdapter(new_adapter, app_get_desc_adapters);
@@ -275,6 +291,90 @@ class Dx12StatsConsumer : public Dx12Consumer
         dummy_trim_frame_count_ = current_buffer_index;
     }
 
+    virtual void Process_D3D12CreateDevice(const ApiCallInfo&           call_info,
+                                           HRESULT                      return_value,
+                                           format::HandleId             pAdapter,
+                                           D3D_FEATURE_LEVEL            MinimumFeatureLevel,
+                                           Decoded_GUID                 riid,
+                                           HandlePointerDecoder<void*>* ppDevice)
+    {
+        GFXRECON_ASSERT(ppDevice != nullptr);
+        GFXRECON_ASSERT(pAdapter != format::kNullHandleId)
+
+        if (ppDevice != nullptr && ppDevice->GetPointer() != nullptr)
+        {
+            format::HandleId device_id                                   = *(ppDevice->GetPointer());
+            adapter_submission_mapping_.device_to_adapter_map[device_id] = pAdapter;
+        }
+    }
+
+    virtual void Process_ID3D12Device_CreateCommandQueue(const ApiCallInfo& call_info,
+                                                         format::HandleId   object_id,
+                                                         HRESULT            return_value,
+                                                         StructPointerDecoder<Decoded_D3D12_COMMAND_QUEUE_DESC>* pDesc,
+                                                         Decoded_GUID                                            riid,
+                                                         HandlePointerDecoder<void*>* ppCommandQueue)
+    {
+        GFXRECON_ASSERT(ppCommandQueue != nullptr);
+        GFXRECON_ASSERT(object_id != format::kNullHandleId);
+
+        if (ppCommandQueue != nullptr && ppCommandQueue->GetPointer() != nullptr)
+        {
+            format::HandleId command_queue_id                                 = *ppCommandQueue->GetPointer();
+            adapter_submission_mapping_.queue_to_device_map[command_queue_id] = object_id;
+        }
+    }
+
+    virtual void
+    Process_ID3D12CommandQueue_ExecuteCommandLists(const ApiCallInfo&                        call_info,
+                                                   format::HandleId                          object_id,
+                                                   UINT                                      NumCommandLists,
+                                                   HandlePointerDecoder<ID3D12CommandList*>* ppCommandLists)
+    {
+        GFXRECON_ASSERT(object_id != format::kNullHandleId)
+        adapter_submission_mapping_.adapter_submit_counts[object_id]++;
+    }
+
+    void CalcAdapterWorkload(std::unordered_map<int64_t, std::string>& adapter_workload)
+    {
+        uint64_t total_adapter_submits = 0;
+
+        // calculate total amount of ExecuteCommandLists calls
+        for (const auto& curr_adapter_id : adapter_submission_mapping_.adapter_submit_counts)
+        {
+            total_adapter_submits += curr_adapter_id.second;
+        }
+        std::unordered_map<int64_t, uint64_t> adapter_count_map;
+
+        // calculate total calls per LUIDs. We can have several queue IDs per adapter LUID
+        for (const auto& queue_map : adapter_submission_mapping_.queue_to_device_map)
+        {
+            format::HandleId adapter_id         = adapter_submission_mapping_.device_to_adapter_map[queue_map.second];
+            int64_t          adapter_luid       = adapter_submission_mapping_.adapter_to_luid_map[adapter_id];
+            uint64_t         queue_submit_count = adapter_submission_mapping_.adapter_submit_counts[queue_map.first];
+            if (adapter_count_map[adapter_luid])
+            {
+                adapter_count_map[adapter_luid] += queue_submit_count;
+            }
+            else
+            {
+                adapter_count_map[adapter_luid] = queue_submit_count;
+            }
+        }
+
+        // calculate workload of adapter and convert it to string
+        for (const auto& workload : adapter_count_map)
+        {
+            std::string workload_value = std::to_string(100.0 * workload.second / total_adapter_submits);
+            auto        dot_pos        = workload_value.find('.');
+            if (dot_pos != std::string::npos)
+            {
+                workload_value.erase(dot_pos + 2);
+            }
+            adapter_workload[workload.first] = workload_value;
+        }
+    }
+
   private:
     // Holds adapter descs that were obtained from the app calling GetDesc()
     // This list is only here to support older captures which do contain kDxgiAdapterInfoCommand
@@ -291,6 +391,8 @@ class Dx12StatsConsumer : public Dx12Consumer
     UINT             dummy_trim_frame_count_;
 
     format::Dx12RuntimeInfo runtime_info_;
+
+    graphics::dx12::AdapterSubmissionMapping adapter_submission_mapping_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2020,2022 Valve Corporation
 ** Copyright (c) 2018-2020,2022 LunarG, Inc.
+** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -1668,8 +1669,8 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                                        sizeof(adapter_info_header.adapter_desc.LuidLowPart));
         success = success && ReadBytes(&adapter_info_header.adapter_desc.LuidHighPart,
                                        sizeof(adapter_info_header.adapter_desc.LuidHighPart));
-        success = success && ReadBytes(&adapter_info_header.adapter_desc.type, 
-                                       sizeof(adapter_info_header.adapter_desc.type));
+        success = success && ReadBytes(&adapter_info_header.adapter_desc.extra_info,
+                                       sizeof(adapter_info_header.adapter_desc.extra_info));
 
         if (success)
         {

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -1887,9 +1887,22 @@ void D3D12CaptureManager::PostProcess_D3D12CreateDevice(
                 format::DxgiAdapterDesc* active_adapter = graphics::dx12::MarkActiveAdapter(device, adapters_);
 
                 // Write adapter desc to file if it was marked active, and has not already been seen
+                auto adapter_id = GetDx12WrappedId<IUnknown>(pAdapter);
                 if (active_adapter != nullptr)
                 {
+                    graphics::dx12::InjectAdapterCaptureId(active_adapter->extra_info, adapter_id);
                     WriteDxgiAdapterInfoCommand(*active_adapter);
+                }
+                else
+                {
+                    // we have to write adapter if it is already marked active and as a result active_adapter is null
+                    // this is essential for marking active adapter for system with multiple GPUs
+                    auto parent_adapter = graphics::dx12::GetAdapterDescByLUID(device->GetAdapterLuid(), adapters_);
+                    if (parent_adapter != nullptr)
+                    {
+                        graphics::dx12::InjectAdapterCaptureId(parent_adapter->extra_info, adapter_id);
+                        WriteDxgiAdapterInfoCommand(*parent_adapter);
+                    }
                 }
             }
         }

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -102,7 +102,7 @@ enum AnnotationType : uint32_t
     kXml     = 3
 };
 
-enum AdapterType : uint32_t
+enum AdapterType
 {
     kUnknownAdapter  = 0,
     kSoftwareAdapter = 1,
@@ -585,17 +585,17 @@ struct InitDx12AccelerationStructureGeometryDesc
 
 struct DxgiAdapterDesc
 {
-    wchar_t     Description[kAdapterDescriptionSize];
-    uint32_t    VendorId;
-    uint32_t    DeviceId;
-    uint32_t    SubSysId;
-    uint32_t    Revision;
-    uint64_t    DedicatedVideoMemory;
-    uint64_t    DedicatedSystemMemory;
-    uint64_t    SharedSystemMemory;
-    uint32_t    LuidLowPart;
-    int32_t     LuidHighPart;
-    AdapterType type;
+    wchar_t  Description[kAdapterDescriptionSize];
+    uint32_t VendorId;
+    uint32_t DeviceId;
+    uint32_t SubSysId;
+    uint32_t Revision;
+    uint64_t DedicatedVideoMemory;
+    uint64_t DedicatedSystemMemory;
+    uint64_t SharedSystemMemory;
+    uint32_t LuidLowPart;
+    int32_t  LuidHighPart;
+    uint32_t extra_info; // 2 bits (LSB) to store Type and 30 bits for object ID
 };
 
 struct DxgiAdapterInfoCommandHeader

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -78,6 +78,19 @@ struct ActiveAdapterInfo
 
 typedef std::map<int64_t, ActiveAdapterInfo> ActiveAdapterMap;
 
+static const uint8_t  kAdapterTypeMask  = 0x3;
+static const uint32_t kAdapterTypeShift = 0;
+static const uint32_t kAdapterIdMask    = 0xFFFFFFFc;
+static const uint32_t kAdapterIdShift   = 2;
+
+struct AdapterSubmissionMapping
+{
+    std::unordered_map<format::HandleId, format::HandleId> queue_to_device_map;
+    std::unordered_map<format::HandleId, format::HandleId> device_to_adapter_map;
+    std::unordered_map<format::HandleId, int64_t>          adapter_to_luid_map;
+    std::unordered_map<format::HandleId, uint64_t>         adapter_submit_counts;
+};
+
 struct ResourceStateInfo
 {
     D3D12_RESOURCE_STATES        states{};
@@ -194,6 +207,8 @@ bool GetAdapterAndIndexbyDevice(ID3D12Device*                     device,
                                 uint32_t&                         index,
                                 graphics::dx12::ActiveAdapterMap& adapters);
 
+format::DxgiAdapterDesc* GetAdapterDescByLUID(LUID parent_adapter_luid, graphics::dx12::ActiveAdapterMap& adapters);
+
 // Get the adapter at specified index
 IDXGIAdapter* GetAdapterbyIndex(graphics::dx12::ActiveAdapterMap& adapters, int32_t index);
 
@@ -224,6 +239,28 @@ bool IsSoftwareAdapter(const format::DxgiAdapterDesc& adapter_desc);
 bool IsTextureWithUnknownLayout(D3D12_RESOURCE_DIMENSION dimension, D3D12_TEXTURE_LAYOUT layout);
 
 bool VerifyAgilitySDKRuntime();
+
+inline void InjectAdapterCaptureId(uint32_t& extra_info, format::HandleId capture_id)
+{
+    extra_info &= ~(kAdapterIdMask);
+    extra_info |= static_cast<format::HandleId>(capture_id) << kAdapterIdShift;
+}
+
+inline void InjectAdapterType(uint32_t& extra_info, format::AdapterType type)
+{
+    extra_info &= ~(kAdapterTypeMask);
+    extra_info |= static_cast<format::AdapterType>(type) << kAdapterTypeShift;
+}
+
+inline format::HandleId ExtractAdapterCaptureId(uint32_t extra_info)
+{
+    return static_cast<format::HandleId>((extra_info & kAdapterIdMask) >> kAdapterIdShift);
+}
+
+inline format::AdapterType ExtractAdapterType(uint32_t extra_info)
+{
+    return static_cast<format::AdapterType>((extra_info & kAdapterTypeMask));
+}
 
 GFXRECON_END_NAMESPACE(dx12)
 GFXRECON_END_NAMESPACE(graphics)

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -429,7 +429,7 @@ void PrintDx12AdapterInfo(gfxrecon::decode::Dx12StatsConsumer& dx12_consumer)
     if (adapters.empty() == false)
     {
         std::unordered_map<int64_t, std::string> adapter_workload;
-        dx12_consumer.CalcAdapterWorkload(adapter_workload);
+        dx12_consumer.CalcAdapterWorkload(adapter_workload, adapters);
 
         for (const auto& adapter : adapters)
         {


### PR DESCRIPTION
**The problem**
When we run gfxrecon-info tool on the trace that was captured on the system with 2 GPUs we do not have information which of the adapters were active.

**The solution**
To determine the active adapter, we can track the Object_id by reading the adapters that recorded during capture (based on 'capture_id'), mapping it based on D3D12CreateDevice, CreateCommandQueue, and finally counting with ExecuteCommandLists. The ID with the largest count would indicate the active adapter. The Object_id could be associated with the LUID that belongs to the active adapter.

**Result and Test**
Test on dual GPU:

before:
<img width="462" alt="before" src="https://user-images.githubusercontent.com/73676794/223310691-15853b14-178a-4ed1-ac28-63dd59440222.PNG">

after:
<img width="463" alt="after" src="https://user-images.githubusercontent.com/73676794/223310720-c15772f1-1b7c-485c-a8a8-ab403e465bfd.PNG">
