### PR TITLE
Fix JSON generated on Array2DMatrixToString

### DIFF
--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -295,10 +295,16 @@ inline std::string Array2DMatrixToString(size_t m,
                                          uint32_t      tabSize       = 4)
 {
     std::stringstream strStrm;
+    strStrm << '[';
     for (size_t i = 0; i < m; ++i)
     {
+        if (i)
+        {
+            strStrm << ',';
+        }
         strStrm << ArrayToString(n, &pObjs[i][0], toStringFlags, tabCount, tabSize);
     }
+    strStrm << ']';
     return strStrm.str();
 }
 


### PR DESCRIPTION
A 2D matrix in valid json is [[1,1],[1,1]], while now is represented as [1,1][1,1] which is invalid and jq fails to parse.

This patch fixes it.