### PR TITLE
Removed VkPerformanceCounterResultKHR ToString

### DIFF
--- a/framework/util/custom_vulkan_to_string.cpp
+++ b/framework/util/custom_vulkan_to_string.cpp
@@ -175,22 +175,6 @@ std::string ToString<VkDeviceOrHostAddressKHR>(const VkDeviceOrHostAddressKHR& o
 }
 
 template <>
-std::string ToString<VkPerformanceCounterResultKHR>(const VkPerformanceCounterResultKHR& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
-{
-    return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
-        {
-            FieldToString(strStrm, true, "int32", toStringFlags, tabCount, tabSize, ToString(obj.int32, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "int64", toStringFlags, tabCount, tabSize, ToString(obj.int64, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "uint32", toStringFlags, tabCount, tabSize, ToString(obj.uint32, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "uint64", toStringFlags, tabCount, tabSize, ToString(obj.uint64, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "float32", toStringFlags, tabCount, tabSize, ToString(obj.float32, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "float64", toStringFlags, tabCount, tabSize, ToString(obj.float64, toStringFlags, tabCount, tabSize));
-        }
-    );
-}
-
-template <>
 std::string ToString<VkPerformanceValueINTEL>(const VkPerformanceValueINTEL& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,

--- a/framework/util/custom_vulkan_to_string.h
+++ b/framework/util/custom_vulkan_to_string.h
@@ -84,12 +84,6 @@ std::string ToString<VkLayerProperties>(const VkLayerProperties& obj,
                                         uint32_t                 tabSize);
 
 template <>
-std::string ToString<VkPerformanceCounterResultKHR>(const VkPerformanceCounterResultKHR& obj,
-                                                    ToStringFlags                        toStringFlags,
-                                                    uint32_t                             tabCount,
-                                                    uint32_t                             tabSize);
-
-template <>
 std::string ToString<VkPerformanceValueINTEL>(const VkPerformanceValueINTEL& obj,
                                               ToStringFlags                  toStringFlags,
                                               uint32_t                       tabCount,


### PR DESCRIPTION
The VkPerformanceCounterResultKHR type never appears in the API because it is referred to by a void*, for example by vkGetQueryPoolResults(). Our layer can therefore never see it and have a need to convert it. We lack the local context when converting it to get the type out of the void pointer so adding back in this currently dead code would be a small part of a hypothetical future PR which achieved that feat.
The extension this is part of has also not seen broad support (VK_KHR_performance_query).