### PR TITLE
Assign ID3D12Object names during replay to assist debugging

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -214,6 +214,7 @@ target_sources(gfxrecon_decode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_struct_to_string.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_struct_object_mappers.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_struct_object_mappers.cpp>
+                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_call_id_to_string.h>
 )
 
 if (MSVC)

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2019-2020 Valve Corporation
 ** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -41,6 +42,7 @@ struct DxReplayOptions : public ReplayOptions
     bool                 discard_cached_psos{ false };
     std::vector<int32_t> AllowedDebugMessages;
     std::vector<int32_t> DeniedDebugMessages;
+    bool                 override_object_names{ false };
 
     ScreenshotFormat             screenshot_format{ ScreenshotFormat::kBmp };
     std::vector<ScreenshotRange> screenshot_ranges;

--- a/framework/generated/dx12_generators/dx12_call_id_to_string_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_call_id_to_string_header_generator.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import sys
+from base_generator import BaseGenerator, write
+from dx12_base_generator import Dx12BaseGenerator
+
+
+class Dx12CallIdToStringHeaderGenerator(Dx12BaseGenerator):
+
+    """Generates C++ function responsible for converting Dx12 ApiCallId to string."""
+
+    def __init__(
+        self,
+        source_dict,
+        dx12_prefix_strings,
+        err_file=sys.stderr,
+        warn_file=sys.stderr,
+        diag_file=sys.stdout
+    ):
+        Dx12BaseGenerator.__init__(
+            self, source_dict, dx12_prefix_strings, err_file, warn_file,
+            diag_file
+        )
+
+    def beginFile(self, gen_opts):
+        BaseGenerator.beginFile(self, gen_opts)
+
+        self.write_include()
+        write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(util)', file=self.outFile)
+        self.newline()
+
+    def generate_feature(self):
+        Dx12BaseGenerator.generate_feature(self)
+        self.write_function_call()
+
+    def write_include(self):
+        code = ("\n"
+                "#include \"format/api_call_id.h\"\n"
+                "#include <string>\n"
+               "\n")
+        write(code, file=self.outFile)
+
+    def write_function_call(self):
+        code = (
+            "std::wstring GetDx12CallIdString(format::ApiCallId call_id){}\n"
+            "\n"
+            .format(
+                self.get_function_call_body()
+            )
+        )
+        write(code, file=self.outFile)
+
+    def get_function_call_body(self):
+        code = '\n'\
+               '{\n'\
+               '    std::wstring out = L"Unknown";\n'\
+               '    switch (call_id)\n'\
+               '    {\n'
+
+        header_dict = self.source_dict['header_dict']
+        for k, v in header_dict.items():
+            for m in v.functions:
+                if self.is_required_function_data(m) and (
+                    not self.is_cmd_black_listed(m['name'])
+                ):
+                    code += (
+                        "    case format::ApiCallId::ApiCall_{0}:\n"
+                        "        out = L\"{0}\";\n"
+                        "        break;\n".format(m['name'])
+                    )
+
+            for class_name, class_value in v.classes.items():
+                if self.is_required_class_data(class_value):
+                    for m in class_value['methods']['public']:
+                        if not self.is_method_black_listed(
+                            class_name, m['name']
+                        ):
+                            code += (
+                                "    case format::ApiCallId::ApiCall_{0}_{1}:\n"
+                                "        out = L\"{0}_{1}\";\n"
+                                "        break;\n".format(
+                                    class_name, m['name']
+                                )
+                            )
+
+        code += '    default:\n'\
+                '        break;\n'\
+                '    }\n'\
+                '    return out;\n'\
+                '}'
+
+        return code
+
+
+    def endFile(self):
+        write('GFXRECON_END_NAMESPACE(util)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
+
+        # Finish processing in superclass
+        BaseGenerator.endFile(self)

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -221,15 +221,11 @@ class Dx12ReplayConsumerBodyGenerator(
 
                     if is_override:
                         add_object_list.append(
-                            'AddObject({0}->GetPointer(), {0}->GetHandlePointer(), '\
-                            'std::move(object_info));\n'\
-                            .format(value.name)
+                            'AddObject({0}->GetPointer(), {0}->GetHandlePointer(), std::move(object_info), format::ApiCall_{1});\n'.format(value.name, name)
                         )
                     else:
                         add_object_list.append(
-                            'AddObject(out_p_{0}, out_hp_{0});\n'.format(
-                                value.name
-                            )
+                            'AddObject(out_p_{0}, out_hp_{0}, format::ApiCall_{1});\n'.format(value.name, name)
                         )
 
                 else:

--- a/framework/generated/dx12_generators/gencode.py
+++ b/framework/generated/dx12_generators/gencode.py
@@ -56,6 +56,7 @@ from dx12_enum_to_string_header_generator import Dx12EnumToStringHeaderGenerator
 from dx12_enum_to_string_body_generator import Dx12EnumToStringBodyGenerator
 from dx12_struct_to_string_header_generator import Dx12StructToStringHeaderGenerator
 from dx12_struct_to_string_body_generator import Dx12StructToStringBodyGenerator
+from dx12_call_id_to_string_header_generator import Dx12CallIdToStringHeaderGenerator
 
 # JSON files for customizing code generation
 default_blacklists = 'blacklists.json'
@@ -580,6 +581,22 @@ def make_gen_opts(args):
             platform_types=platform_types,
             prefix_text=prefix_strings + py_prefix_strings,
             protect_file=False,
+            protect_feature=False
+        )
+    ]
+    
+    py_prefix_strings[-4] = py_prefix_strings1.format(
+        'dx12_call_id_to_string_header_generator.py'
+    )
+    gen_opts['generated_dx12_call_id_to_string.h'] = [
+        Dx12CallIdToStringHeaderGenerator,
+        Dx12GeneratorOptions(
+            filename='generated_dx12_call_id_to_string.h',
+            directory=directory,
+            blacklists=blacklists,
+            platform_types=platform_types,
+            prefix_text=prefix_strings + py_prefix_strings,
+            protect_file=True,
             protect_feature=False
         )
     ]

--- a/framework/generated/dx12_generators/replay_overrides.json
+++ b/framework/generated/dx12_generators/replay_overrides.json
@@ -117,6 +117,9 @@
     },
     "IDXGISwapChain3": {
       "ResizeBuffers1": "OverrideResizeBuffers1"
+    },
+    "ID3D12Object": {
+      "SetName": "OverrideSetName"
     }
   }
 }

--- a/framework/generated/generate_dx12.py
+++ b/framework/generated/generate_dx12.py
@@ -54,6 +54,7 @@ GENERATE_TARGETS = [
     'generated_dx12_enum_to_string.cpp',
     'generated_dx12_struct_to_string.h',
     'generated_dx12_struct_to_string.cpp',
+    'generated_dx12_call_id_to_string.h',
 ]
 
 DXGI_SOURCE_LIST = [

--- a/framework/generated/generated_dx12_call_id_to_string.h
+++ b/framework/generated/generated_dx12_call_id_to_string.h
@@ -1,0 +1,1425 @@
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to
+** deal in the Software without restriction, including without limitation the
+** rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+** sell copies of the Software, and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+** IN THE SOFTWARE.
+*/
+
+/*
+** This file is generated from dx12_call_id_to_string_header_generator.py.
+**
+*/
+
+#ifndef  GFXRECON_GENERATED_DX12_CALL_ID_TO_STRING_H
+#define  GFXRECON_GENERATED_DX12_CALL_ID_TO_STRING_H
+
+
+#include "format/api_call_id.h"
+#include <string>
+
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+std::wstring GetDx12CallIdString(format::ApiCallId call_id)
+{
+    std::wstring out = L"Unknown";
+    switch (call_id)
+    {
+    case format::ApiCallId::ApiCall_CreateDXGIFactory:
+        out = L"CreateDXGIFactory";
+        break;
+    case format::ApiCallId::ApiCall_CreateDXGIFactory1:
+        out = L"CreateDXGIFactory1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIObject_SetPrivateData:
+        out = L"IDXGIObject_SetPrivateData";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIObject_SetPrivateDataInterface:
+        out = L"IDXGIObject_SetPrivateDataInterface";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIObject_GetPrivateData:
+        out = L"IDXGIObject_GetPrivateData";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIObject_GetParent:
+        out = L"IDXGIObject_GetParent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDeviceSubObject_GetDevice:
+        out = L"IDXGIDeviceSubObject_GetDevice";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIResource_GetSharedHandle:
+        out = L"IDXGIResource_GetSharedHandle";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIResource_GetUsage:
+        out = L"IDXGIResource_GetUsage";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIResource_SetEvictionPriority:
+        out = L"IDXGIResource_SetEvictionPriority";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIResource_GetEvictionPriority:
+        out = L"IDXGIResource_GetEvictionPriority";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIKeyedMutex_AcquireSync:
+        out = L"IDXGIKeyedMutex_AcquireSync";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIKeyedMutex_ReleaseSync:
+        out = L"IDXGIKeyedMutex_ReleaseSync";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISurface_GetDesc:
+        out = L"IDXGISurface_GetDesc";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISurface_Map:
+        out = L"IDXGISurface_Map";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISurface_Unmap:
+        out = L"IDXGISurface_Unmap";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISurface1_GetDC:
+        out = L"IDXGISurface1_GetDC";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISurface1_ReleaseDC:
+        out = L"IDXGISurface1_ReleaseDC";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter_EnumOutputs:
+        out = L"IDXGIAdapter_EnumOutputs";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter_GetDesc:
+        out = L"IDXGIAdapter_GetDesc";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter_CheckInterfaceSupport:
+        out = L"IDXGIAdapter_CheckInterfaceSupport";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_GetDesc:
+        out = L"IDXGIOutput_GetDesc";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_GetDisplayModeList:
+        out = L"IDXGIOutput_GetDisplayModeList";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_FindClosestMatchingMode:
+        out = L"IDXGIOutput_FindClosestMatchingMode";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_WaitForVBlank:
+        out = L"IDXGIOutput_WaitForVBlank";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_TakeOwnership:
+        out = L"IDXGIOutput_TakeOwnership";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_ReleaseOwnership:
+        out = L"IDXGIOutput_ReleaseOwnership";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControlCapabilities:
+        out = L"IDXGIOutput_GetGammaControlCapabilities";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_SetGammaControl:
+        out = L"IDXGIOutput_SetGammaControl";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControl:
+        out = L"IDXGIOutput_GetGammaControl";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_SetDisplaySurface:
+        out = L"IDXGIOutput_SetDisplaySurface";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_GetDisplaySurfaceData:
+        out = L"IDXGIOutput_GetDisplaySurfaceData";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput_GetFrameStatistics:
+        out = L"IDXGIOutput_GetFrameStatistics";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_Present:
+        out = L"IDXGISwapChain_Present";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_GetBuffer:
+        out = L"IDXGISwapChain_GetBuffer";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_SetFullscreenState:
+        out = L"IDXGISwapChain_SetFullscreenState";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_GetFullscreenState:
+        out = L"IDXGISwapChain_GetFullscreenState";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_GetDesc:
+        out = L"IDXGISwapChain_GetDesc";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_ResizeBuffers:
+        out = L"IDXGISwapChain_ResizeBuffers";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_ResizeTarget:
+        out = L"IDXGISwapChain_ResizeTarget";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_GetContainingOutput:
+        out = L"IDXGISwapChain_GetContainingOutput";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_GetFrameStatistics:
+        out = L"IDXGISwapChain_GetFrameStatistics";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain_GetLastPresentCount:
+        out = L"IDXGISwapChain_GetLastPresentCount";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory_EnumAdapters:
+        out = L"IDXGIFactory_EnumAdapters";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory_MakeWindowAssociation:
+        out = L"IDXGIFactory_MakeWindowAssociation";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory_GetWindowAssociation:
+        out = L"IDXGIFactory_GetWindowAssociation";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory_CreateSwapChain:
+        out = L"IDXGIFactory_CreateSwapChain";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory_CreateSoftwareAdapter:
+        out = L"IDXGIFactory_CreateSoftwareAdapter";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice_GetAdapter:
+        out = L"IDXGIDevice_GetAdapter";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice_CreateSurface:
+        out = L"IDXGIDevice_CreateSurface";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice_QueryResourceResidency:
+        out = L"IDXGIDevice_QueryResourceResidency";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice_SetGPUThreadPriority:
+        out = L"IDXGIDevice_SetGPUThreadPriority";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice_GetGPUThreadPriority:
+        out = L"IDXGIDevice_GetGPUThreadPriority";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory1_EnumAdapters1:
+        out = L"IDXGIFactory1_EnumAdapters1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory1_IsCurrent:
+        out = L"IDXGIFactory1_IsCurrent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter1_GetDesc1:
+        out = L"IDXGIAdapter1_GetDesc1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice1_SetMaximumFrameLatency:
+        out = L"IDXGIDevice1_SetMaximumFrameLatency";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice1_GetMaximumFrameLatency:
+        out = L"IDXGIDevice1_GetMaximumFrameLatency";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDisplayControl_IsStereoEnabled:
+        out = L"IDXGIDisplayControl_IsStereoEnabled";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDisplayControl_SetStereoEnabled:
+        out = L"IDXGIDisplayControl_SetStereoEnabled";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetDesc:
+        out = L"IDXGIOutputDuplication_GetDesc";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_AcquireNextFrame:
+        out = L"IDXGIOutputDuplication_AcquireNextFrame";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameDirtyRects:
+        out = L"IDXGIOutputDuplication_GetFrameDirtyRects";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameMoveRects:
+        out = L"IDXGIOutputDuplication_GetFrameMoveRects";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFramePointerShape:
+        out = L"IDXGIOutputDuplication_GetFramePointerShape";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_MapDesktopSurface:
+        out = L"IDXGIOutputDuplication_MapDesktopSurface";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_UnMapDesktopSurface:
+        out = L"IDXGIOutputDuplication_UnMapDesktopSurface";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutputDuplication_ReleaseFrame:
+        out = L"IDXGIOutputDuplication_ReleaseFrame";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISurface2_GetResource:
+        out = L"IDXGISurface2_GetResource";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIResource1_CreateSubresourceSurface:
+        out = L"IDXGIResource1_CreateSubresourceSurface";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIResource1_CreateSharedHandle:
+        out = L"IDXGIResource1_CreateSharedHandle";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice2_OfferResources:
+        out = L"IDXGIDevice2_OfferResources";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice2_ReclaimResources:
+        out = L"IDXGIDevice2_ReclaimResources";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice2_EnqueueSetEvent:
+        out = L"IDXGIDevice2_EnqueueSetEvent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_GetDesc1:
+        out = L"IDXGISwapChain1_GetDesc1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_GetFullscreenDesc:
+        out = L"IDXGISwapChain1_GetFullscreenDesc";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_GetHwnd:
+        out = L"IDXGISwapChain1_GetHwnd";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_GetCoreWindow:
+        out = L"IDXGISwapChain1_GetCoreWindow";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_Present1:
+        out = L"IDXGISwapChain1_Present1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_IsTemporaryMonoSupported:
+        out = L"IDXGISwapChain1_IsTemporaryMonoSupported";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_GetRestrictToOutput:
+        out = L"IDXGISwapChain1_GetRestrictToOutput";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_SetBackgroundColor:
+        out = L"IDXGISwapChain1_SetBackgroundColor";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_GetBackgroundColor:
+        out = L"IDXGISwapChain1_GetBackgroundColor";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_SetRotation:
+        out = L"IDXGISwapChain1_SetRotation";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain1_GetRotation:
+        out = L"IDXGISwapChain1_GetRotation";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_IsWindowedStereoEnabled:
+        out = L"IDXGIFactory2_IsWindowedStereoEnabled";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForHwnd:
+        out = L"IDXGIFactory2_CreateSwapChainForHwnd";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForCoreWindow:
+        out = L"IDXGIFactory2_CreateSwapChainForCoreWindow";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_GetSharedResourceAdapterLuid:
+        out = L"IDXGIFactory2_GetSharedResourceAdapterLuid";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusWindow:
+        out = L"IDXGIFactory2_RegisterStereoStatusWindow";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusEvent:
+        out = L"IDXGIFactory2_RegisterStereoStatusEvent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_UnregisterStereoStatus:
+        out = L"IDXGIFactory2_UnregisterStereoStatus";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusWindow:
+        out = L"IDXGIFactory2_RegisterOcclusionStatusWindow";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusEvent:
+        out = L"IDXGIFactory2_RegisterOcclusionStatusEvent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_UnregisterOcclusionStatus:
+        out = L"IDXGIFactory2_UnregisterOcclusionStatus";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForComposition:
+        out = L"IDXGIFactory2_CreateSwapChainForComposition";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter2_GetDesc2:
+        out = L"IDXGIAdapter2_GetDesc2";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplayModeList1:
+        out = L"IDXGIOutput1_GetDisplayModeList1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput1_FindClosestMatchingMode1:
+        out = L"IDXGIOutput1_FindClosestMatchingMode1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplaySurfaceData1:
+        out = L"IDXGIOutput1_GetDisplaySurfaceData1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput1_DuplicateOutput:
+        out = L"IDXGIOutput1_DuplicateOutput";
+        break;
+    case format::ApiCallId::ApiCall_CreateDXGIFactory2:
+        out = L"CreateDXGIFactory2";
+        break;
+    case format::ApiCallId::ApiCall_DXGIGetDebugInterface1:
+        out = L"DXGIGetDebugInterface1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice3_Trim:
+        out = L"IDXGIDevice3_Trim";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain2_SetSourceSize:
+        out = L"IDXGISwapChain2_SetSourceSize";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain2_GetSourceSize:
+        out = L"IDXGISwapChain2_GetSourceSize";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain2_SetMaximumFrameLatency:
+        out = L"IDXGISwapChain2_SetMaximumFrameLatency";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain2_GetMaximumFrameLatency:
+        out = L"IDXGISwapChain2_GetMaximumFrameLatency";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain2_GetFrameLatencyWaitableObject:
+        out = L"IDXGISwapChain2_GetFrameLatencyWaitableObject";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain2_SetMatrixTransform:
+        out = L"IDXGISwapChain2_SetMatrixTransform";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain2_GetMatrixTransform:
+        out = L"IDXGISwapChain2_GetMatrixTransform";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput2_SupportsOverlays:
+        out = L"IDXGIOutput2_SupportsOverlays";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory3_GetCreationFlags:
+        out = L"IDXGIFactory3_GetCreationFlags";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_PresentBuffer:
+        out = L"IDXGIDecodeSwapChain_PresentBuffer";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetSourceRect:
+        out = L"IDXGIDecodeSwapChain_SetSourceRect";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetTargetRect:
+        out = L"IDXGIDecodeSwapChain_SetTargetRect";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetDestSize:
+        out = L"IDXGIDecodeSwapChain_SetDestSize";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetSourceRect:
+        out = L"IDXGIDecodeSwapChain_GetSourceRect";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetTargetRect:
+        out = L"IDXGIDecodeSwapChain_GetTargetRect";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetDestSize:
+        out = L"IDXGIDecodeSwapChain_GetDestSize";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetColorSpace:
+        out = L"IDXGIDecodeSwapChain_SetColorSpace";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetColorSpace:
+        out = L"IDXGIDecodeSwapChain_GetColorSpace";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle:
+        out = L"IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle:
+        out = L"IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChainMedia_GetFrameStatisticsMedia:
+        out = L"IDXGISwapChainMedia_GetFrameStatisticsMedia";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChainMedia_SetPresentDuration:
+        out = L"IDXGISwapChainMedia_SetPresentDuration";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChainMedia_CheckPresentDurationSupport:
+        out = L"IDXGISwapChainMedia_CheckPresentDurationSupport";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput3_CheckOverlaySupport:
+        out = L"IDXGIOutput3_CheckOverlaySupport";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain3_GetCurrentBackBufferIndex:
+        out = L"IDXGISwapChain3_GetCurrentBackBufferIndex";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain3_CheckColorSpaceSupport:
+        out = L"IDXGISwapChain3_CheckColorSpaceSupport";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain3_SetColorSpace1:
+        out = L"IDXGISwapChain3_SetColorSpace1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain3_ResizeBuffers1:
+        out = L"IDXGISwapChain3_ResizeBuffers1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput4_CheckOverlayColorSpaceSupport:
+        out = L"IDXGIOutput4_CheckOverlayColorSpaceSupport";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory4_EnumAdapterByLuid:
+        out = L"IDXGIFactory4_EnumAdapterByLuid";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory4_EnumWarpAdapter:
+        out = L"IDXGIFactory4_EnumWarpAdapter";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent:
+        out = L"IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter3_UnregisterHardwareContentProtectionTeardownStatus:
+        out = L"IDXGIAdapter3_UnregisterHardwareContentProtectionTeardownStatus";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter3_QueryVideoMemoryInfo:
+        out = L"IDXGIAdapter3_QueryVideoMemoryInfo";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter3_SetVideoMemoryReservation:
+        out = L"IDXGIAdapter3_SetVideoMemoryReservation";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent:
+        out = L"IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter3_UnregisterVideoMemoryBudgetChangeNotification:
+        out = L"IDXGIAdapter3_UnregisterVideoMemoryBudgetChangeNotification";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput5_DuplicateOutput1:
+        out = L"IDXGIOutput5_DuplicateOutput1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMetaData:
+        out = L"IDXGISwapChain4_SetHDRMetaData";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice4_OfferResources1:
+        out = L"IDXGIDevice4_OfferResources1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIDevice4_ReclaimResources1:
+        out = L"IDXGIDevice4_ReclaimResources1";
+        break;
+    case format::ApiCallId::ApiCall_DXGIDeclareAdapterRemovalSupport:
+        out = L"DXGIDeclareAdapterRemovalSupport";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIAdapter4_GetDesc3:
+        out = L"IDXGIAdapter4_GetDesc3";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput6_GetDesc1:
+        out = L"IDXGIOutput6_GetDesc1";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIOutput6_CheckHardwareCompositionSupport:
+        out = L"IDXGIOutput6_CheckHardwareCompositionSupport";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory6_EnumAdapterByGpuPreference:
+        out = L"IDXGIFactory6_EnumAdapterByGpuPreference";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory7_RegisterAdaptersChangedEvent:
+        out = L"IDXGIFactory7_RegisterAdaptersChangedEvent";
+        break;
+    case format::ApiCallId::ApiCall_IDXGIFactory7_UnregisterAdaptersChangedEvent:
+        out = L"IDXGIFactory7_UnregisterAdaptersChangedEvent";
+        break;
+    case format::ApiCallId::ApiCall_D3D12SerializeRootSignature:
+        out = L"D3D12SerializeRootSignature";
+        break;
+    case format::ApiCallId::ApiCall_D3D12SerializeVersionedRootSignature:
+        out = L"D3D12SerializeVersionedRootSignature";
+        break;
+    case format::ApiCallId::ApiCall_D3D12CreateVersionedRootSignatureDeserializer:
+        out = L"D3D12CreateVersionedRootSignatureDeserializer";
+        break;
+    case format::ApiCallId::ApiCall_D3D12CreateDevice:
+        out = L"D3D12CreateDevice";
+        break;
+    case format::ApiCallId::ApiCall_D3D12GetDebugInterface:
+        out = L"D3D12GetDebugInterface";
+        break;
+    case format::ApiCallId::ApiCall_D3D12EnableExperimentalFeatures:
+        out = L"D3D12EnableExperimentalFeatures";
+        break;
+    case format::ApiCallId::ApiCall_D3D12GetInterface:
+        out = L"D3D12GetInterface";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Object_GetPrivateData:
+        out = L"ID3D12Object_GetPrivateData";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Object_SetPrivateData:
+        out = L"ID3D12Object_SetPrivateData";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Object_SetPrivateDataInterface:
+        out = L"ID3D12Object_SetPrivateDataInterface";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Object_SetName:
+        out = L"ID3D12Object_SetName";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceChild_GetDevice:
+        out = L"ID3D12DeviceChild_GetDevice";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion:
+        out = L"ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Resource_Map:
+        out = L"ID3D12Resource_Map";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Resource_Unmap:
+        out = L"ID3D12Resource_Unmap";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Resource_GetGPUVirtualAddress:
+        out = L"ID3D12Resource_GetGPUVirtualAddress";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Resource_ReadFromSubresource:
+        out = L"ID3D12Resource_ReadFromSubresource";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Resource_GetHeapProperties:
+        out = L"ID3D12Resource_GetHeapProperties";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandAllocator_Reset:
+        out = L"ID3D12CommandAllocator_Reset";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Fence_GetCompletedValue:
+        out = L"ID3D12Fence_GetCompletedValue";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Fence_SetEventOnCompletion:
+        out = L"ID3D12Fence_SetEventOnCompletion";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Fence_Signal:
+        out = L"ID3D12Fence_Signal";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Fence1_GetCreationFlags:
+        out = L"ID3D12Fence1_GetCreationFlags";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12PipelineState_GetCachedBlob:
+        out = L"ID3D12PipelineState_GetCachedBlob";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Close:
+        out = L"ID3D12GraphicsCommandList_Close";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Reset:
+        out = L"ID3D12GraphicsCommandList_Reset";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearState:
+        out = L"ID3D12GraphicsCommandList_ClearState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawInstanced:
+        out = L"ID3D12GraphicsCommandList_DrawInstanced";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawIndexedInstanced:
+        out = L"ID3D12GraphicsCommandList_DrawIndexedInstanced";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Dispatch:
+        out = L"ID3D12GraphicsCommandList_Dispatch";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyBufferRegion:
+        out = L"ID3D12GraphicsCommandList_CopyBufferRegion";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyTextureRegion:
+        out = L"ID3D12GraphicsCommandList_CopyTextureRegion";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyResource:
+        out = L"ID3D12GraphicsCommandList_CopyResource";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyTiles:
+        out = L"ID3D12GraphicsCommandList_CopyTiles";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResolveSubresource:
+        out = L"ID3D12GraphicsCommandList_ResolveSubresource";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetPrimitiveTopology:
+        out = L"ID3D12GraphicsCommandList_IASetPrimitiveTopology";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_RSSetViewports:
+        out = L"ID3D12GraphicsCommandList_RSSetViewports";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_RSSetScissorRects:
+        out = L"ID3D12GraphicsCommandList_RSSetScissorRects";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetBlendFactor:
+        out = L"ID3D12GraphicsCommandList_OMSetBlendFactor";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetStencilRef:
+        out = L"ID3D12GraphicsCommandList_OMSetStencilRef";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetPipelineState:
+        out = L"ID3D12GraphicsCommandList_SetPipelineState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteBundle:
+        out = L"ID3D12GraphicsCommandList_ExecuteBundle";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetDescriptorHeaps:
+        out = L"ID3D12GraphicsCommandList_SetDescriptorHeaps";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootSignature:
+        out = L"ID3D12GraphicsCommandList_SetComputeRootSignature";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootSignature:
+        out = L"ID3D12GraphicsCommandList_SetGraphicsRootSignature";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootDescriptorTable:
+        out = L"ID3D12GraphicsCommandList_SetComputeRootDescriptorTable";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable:
+        out = L"ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstant:
+        out = L"ID3D12GraphicsCommandList_SetComputeRoot32BitConstant";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstant:
+        out = L"ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstant";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstants:
+        out = L"ID3D12GraphicsCommandList_SetComputeRoot32BitConstants";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstants:
+        out = L"ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstants";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootConstantBufferView:
+        out = L"ID3D12GraphicsCommandList_SetComputeRootConstantBufferView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView:
+        out = L"ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootShaderResourceView:
+        out = L"ID3D12GraphicsCommandList_SetComputeRootShaderResourceView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootShaderResourceView:
+        out = L"ID3D12GraphicsCommandList_SetGraphicsRootShaderResourceView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootUnorderedAccessView:
+        out = L"ID3D12GraphicsCommandList_SetComputeRootUnorderedAccessView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootUnorderedAccessView:
+        out = L"ID3D12GraphicsCommandList_SetGraphicsRootUnorderedAccessView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetIndexBuffer:
+        out = L"ID3D12GraphicsCommandList_IASetIndexBuffer";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetVertexBuffers:
+        out = L"ID3D12GraphicsCommandList_IASetVertexBuffers";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SOSetTargets:
+        out = L"ID3D12GraphicsCommandList_SOSetTargets";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetRenderTargets:
+        out = L"ID3D12GraphicsCommandList_OMSetRenderTargets";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearDepthStencilView:
+        out = L"ID3D12GraphicsCommandList_ClearDepthStencilView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearRenderTargetView:
+        out = L"ID3D12GraphicsCommandList_ClearRenderTargetView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewUint:
+        out = L"ID3D12GraphicsCommandList_ClearUnorderedAccessViewUint";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewFloat:
+        out = L"ID3D12GraphicsCommandList_ClearUnorderedAccessViewFloat";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DiscardResource:
+        out = L"ID3D12GraphicsCommandList_DiscardResource";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_BeginQuery:
+        out = L"ID3D12GraphicsCommandList_BeginQuery";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_EndQuery:
+        out = L"ID3D12GraphicsCommandList_EndQuery";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResolveQueryData:
+        out = L"ID3D12GraphicsCommandList_ResolveQueryData";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetPredication:
+        out = L"ID3D12GraphicsCommandList_SetPredication";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetMarker:
+        out = L"ID3D12GraphicsCommandList_SetMarker";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_BeginEvent:
+        out = L"ID3D12GraphicsCommandList_BeginEvent";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_EndEvent:
+        out = L"ID3D12GraphicsCommandList_EndEvent";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteIndirect:
+        out = L"ID3D12GraphicsCommandList_ExecuteIndirect";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT:
+        out = L"ID3D12GraphicsCommandList1_AtomicCopyBufferUINT";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT64:
+        out = L"ID3D12GraphicsCommandList1_AtomicCopyBufferUINT64";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_OMSetDepthBounds:
+        out = L"ID3D12GraphicsCommandList1_OMSetDepthBounds";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_SetSamplePositions:
+        out = L"ID3D12GraphicsCommandList1_SetSamplePositions";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_ResolveSubresourceRegion:
+        out = L"ID3D12GraphicsCommandList1_ResolveSubresourceRegion";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_SetViewInstanceMask:
+        out = L"ID3D12GraphicsCommandList1_SetViewInstanceMask";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList2_WriteBufferImmediate:
+        out = L"ID3D12GraphicsCommandList2_WriteBufferImmediate";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_UpdateTileMappings:
+        out = L"ID3D12CommandQueue_UpdateTileMappings";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_CopyTileMappings:
+        out = L"ID3D12CommandQueue_CopyTileMappings";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists:
+        out = L"ID3D12CommandQueue_ExecuteCommandLists";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_SetMarker:
+        out = L"ID3D12CommandQueue_SetMarker";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_BeginEvent:
+        out = L"ID3D12CommandQueue_BeginEvent";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_EndEvent:
+        out = L"ID3D12CommandQueue_EndEvent";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_Signal:
+        out = L"ID3D12CommandQueue_Signal";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_Wait:
+        out = L"ID3D12CommandQueue_Wait";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_GetTimestampFrequency:
+        out = L"ID3D12CommandQueue_GetTimestampFrequency";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12CommandQueue_GetClockCalibration:
+        out = L"ID3D12CommandQueue_GetClockCalibration";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_GetNodeCount:
+        out = L"ID3D12Device_GetNodeCount";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateCommandQueue:
+        out = L"ID3D12Device_CreateCommandQueue";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateCommandAllocator:
+        out = L"ID3D12Device_CreateCommandAllocator";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateGraphicsPipelineState:
+        out = L"ID3D12Device_CreateGraphicsPipelineState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateComputePipelineState:
+        out = L"ID3D12Device_CreateComputePipelineState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateCommandList:
+        out = L"ID3D12Device_CreateCommandList";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateDescriptorHeap:
+        out = L"ID3D12Device_CreateDescriptorHeap";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_GetDescriptorHandleIncrementSize:
+        out = L"ID3D12Device_GetDescriptorHandleIncrementSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateConstantBufferView:
+        out = L"ID3D12Device_CreateConstantBufferView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateShaderResourceView:
+        out = L"ID3D12Device_CreateShaderResourceView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateUnorderedAccessView:
+        out = L"ID3D12Device_CreateUnorderedAccessView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateRenderTargetView:
+        out = L"ID3D12Device_CreateRenderTargetView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateDepthStencilView:
+        out = L"ID3D12Device_CreateDepthStencilView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateSampler:
+        out = L"ID3D12Device_CreateSampler";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CopyDescriptors:
+        out = L"ID3D12Device_CopyDescriptors";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CopyDescriptorsSimple:
+        out = L"ID3D12Device_CopyDescriptorsSimple";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateCommittedResource:
+        out = L"ID3D12Device_CreateCommittedResource";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateHeap:
+        out = L"ID3D12Device_CreateHeap";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreatePlacedResource:
+        out = L"ID3D12Device_CreatePlacedResource";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateReservedResource:
+        out = L"ID3D12Device_CreateReservedResource";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateSharedHandle:
+        out = L"ID3D12Device_CreateSharedHandle";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle:
+        out = L"ID3D12Device_OpenSharedHandle";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandleByName:
+        out = L"ID3D12Device_OpenSharedHandleByName";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_MakeResident:
+        out = L"ID3D12Device_MakeResident";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_Evict:
+        out = L"ID3D12Device_Evict";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateFence:
+        out = L"ID3D12Device_CreateFence";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_GetDeviceRemovedReason:
+        out = L"ID3D12Device_GetDeviceRemovedReason";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_GetCopyableFootprints:
+        out = L"ID3D12Device_GetCopyableFootprints";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateQueryHeap:
+        out = L"ID3D12Device_CreateQueryHeap";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_SetStablePowerState:
+        out = L"ID3D12Device_SetStablePowerState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_CreateCommandSignature:
+        out = L"ID3D12Device_CreateCommandSignature";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device_GetResourceTiling:
+        out = L"ID3D12Device_GetResourceTiling";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12PipelineLibrary_StorePipeline:
+        out = L"ID3D12PipelineLibrary_StorePipeline";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12PipelineLibrary_LoadGraphicsPipeline:
+        out = L"ID3D12PipelineLibrary_LoadGraphicsPipeline";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12PipelineLibrary_LoadComputePipeline:
+        out = L"ID3D12PipelineLibrary_LoadComputePipeline";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12PipelineLibrary_GetSerializedSize:
+        out = L"ID3D12PipelineLibrary_GetSerializedSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12PipelineLibrary_Serialize:
+        out = L"ID3D12PipelineLibrary_Serialize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12PipelineLibrary1_LoadPipeline:
+        out = L"ID3D12PipelineLibrary1_LoadPipeline";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device1_SetEventOnMultipleFenceCompletion:
+        out = L"ID3D12Device1_SetEventOnMultipleFenceCompletion";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device1_SetResidencyPriority:
+        out = L"ID3D12Device1_SetResidencyPriority";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device2_CreatePipelineState:
+        out = L"ID3D12Device2_CreatePipelineState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device3_OpenExistingHeapFromAddress:
+        out = L"ID3D12Device3_OpenExistingHeapFromAddress";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device3_OpenExistingHeapFromFileMapping:
+        out = L"ID3D12Device3_OpenExistingHeapFromFileMapping";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device3_EnqueueMakeResident:
+        out = L"ID3D12Device3_EnqueueMakeResident";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12ProtectedSession_GetStatusFence:
+        out = L"ID3D12ProtectedSession_GetStatusFence";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12ProtectedSession_GetSessionStatus:
+        out = L"ID3D12ProtectedSession_GetSessionStatus";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device4_CreateCommandList1:
+        out = L"ID3D12Device4_CreateCommandList1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device4_CreateProtectedResourceSession:
+        out = L"ID3D12Device4_CreateProtectedResourceSession";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device4_CreateCommittedResource1:
+        out = L"ID3D12Device4_CreateCommittedResource1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device4_CreateHeap1:
+        out = L"ID3D12Device4_CreateHeap1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device4_CreateReservedResource1:
+        out = L"ID3D12Device4_CreateReservedResource1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12LifetimeOwner_LifetimeStateUpdated:
+        out = L"ID3D12LifetimeOwner_LifetimeStateUpdated";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetLUID:
+        out = L"ID3D12SwapChainAssistant_GetLUID";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetSwapChainObject:
+        out = L"ID3D12SwapChainAssistant_GetSwapChainObject";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue:
+        out = L"ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_InsertImplicitSync:
+        out = L"ID3D12SwapChainAssistant_InsertImplicitSync";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12LifetimeTracker_DestroyOwnedObject:
+        out = L"ID3D12LifetimeTracker_DestroyOwnedObject";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetShaderIdentifier:
+        out = L"ID3D12StateObjectProperties_GetShaderIdentifier";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetShaderStackSize:
+        out = L"ID3D12StateObjectProperties_GetShaderStackSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetPipelineStackSize:
+        out = L"ID3D12StateObjectProperties_GetPipelineStackSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12StateObjectProperties_SetPipelineStackSize:
+        out = L"ID3D12StateObjectProperties_SetPipelineStackSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_CreateLifetimeTracker:
+        out = L"ID3D12Device5_CreateLifetimeTracker";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_RemoveDevice:
+        out = L"ID3D12Device5_RemoveDevice";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommands:
+        out = L"ID3D12Device5_EnumerateMetaCommands";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommandParameters:
+        out = L"ID3D12Device5_EnumerateMetaCommandParameters";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_CreateMetaCommand:
+        out = L"ID3D12Device5_CreateMetaCommand";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_CreateStateObject:
+        out = L"ID3D12Device5_CreateStateObject";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_GetRaytracingAccelerationStructurePrebuildInfo:
+        out = L"ID3D12Device5_GetRaytracingAccelerationStructurePrebuildInfo";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device5_CheckDriverMatchingIdentifier:
+        out = L"ID3D12Device5_CheckDriverMatchingIdentifier";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetAutoBreadcrumbsEnablement:
+        out = L"ID3D12DeviceRemovedExtendedDataSettings_SetAutoBreadcrumbsEnablement";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetPageFaultEnablement:
+        out = L"ID3D12DeviceRemovedExtendedDataSettings_SetPageFaultEnablement";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetWatsonDumpEnablement:
+        out = L"ID3D12DeviceRemovedExtendedDataSettings_SetWatsonDumpEnablement";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings1_SetBreadcrumbContextEnablement:
+        out = L"ID3D12DeviceRemovedExtendedDataSettings1_SetBreadcrumbContextEnablement";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings2_UseMarkersOnlyAutoBreadcrumbs:
+        out = L"ID3D12DeviceRemovedExtendedDataSettings2_UseMarkersOnlyAutoBreadcrumbs";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData_GetAutoBreadcrumbsOutput:
+        out = L"ID3D12DeviceRemovedExtendedData_GetAutoBreadcrumbsOutput";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData_GetPageFaultAllocationOutput:
+        out = L"ID3D12DeviceRemovedExtendedData_GetPageFaultAllocationOutput";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData1_GetAutoBreadcrumbsOutput1:
+        out = L"ID3D12DeviceRemovedExtendedData1_GetAutoBreadcrumbsOutput1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData1_GetPageFaultAllocationOutput1:
+        out = L"ID3D12DeviceRemovedExtendedData1_GetPageFaultAllocationOutput1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput2:
+        out = L"ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput2";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData2_GetDeviceState:
+        out = L"ID3D12DeviceRemovedExtendedData2_GetDeviceState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device6_SetBackgroundProcessingMode:
+        out = L"ID3D12Device6_SetBackgroundProcessingMode";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12ProtectedResourceSession1_GetDesc1:
+        out = L"ID3D12ProtectedResourceSession1_GetDesc1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device7_AddToStateObject:
+        out = L"ID3D12Device7_AddToStateObject";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device7_CreateProtectedResourceSession1:
+        out = L"ID3D12Device7_CreateProtectedResourceSession1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device8_GetResourceAllocationInfo2:
+        out = L"ID3D12Device8_GetResourceAllocationInfo2";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device8_CreateCommittedResource2:
+        out = L"ID3D12Device8_CreateCommittedResource2";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device8_CreatePlacedResource1:
+        out = L"ID3D12Device8_CreatePlacedResource1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView:
+        out = L"ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device8_GetCopyableFootprints1:
+        out = L"ID3D12Device8_GetCopyableFootprints1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Resource1_GetProtectedResourceSession:
+        out = L"ID3D12Resource1_GetProtectedResourceSession";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Resource2_GetDesc1:
+        out = L"ID3D12Resource2_GetDesc1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Heap1_GetProtectedResourceSession:
+        out = L"ID3D12Heap1_GetProtectedResourceSession";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList3_SetProtectedResourceSession:
+        out = L"ID3D12GraphicsCommandList3_SetProtectedResourceSession";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12MetaCommand_GetRequiredParameterResourceSize:
+        out = L"ID3D12MetaCommand_GetRequiredParameterResourceSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BeginRenderPass:
+        out = L"ID3D12GraphicsCommandList4_BeginRenderPass";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_EndRenderPass:
+        out = L"ID3D12GraphicsCommandList4_EndRenderPass";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_InitializeMetaCommand:
+        out = L"ID3D12GraphicsCommandList4_InitializeMetaCommand";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_ExecuteMetaCommand:
+        out = L"ID3D12GraphicsCommandList4_ExecuteMetaCommand";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BuildRaytracingAccelerationStructure:
+        out = L"ID3D12GraphicsCommandList4_BuildRaytracingAccelerationStructure";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo:
+        out = L"ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_CopyRaytracingAccelerationStructure:
+        out = L"ID3D12GraphicsCommandList4_CopyRaytracingAccelerationStructure";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_SetPipelineState1:
+        out = L"ID3D12GraphicsCommandList4_SetPipelineState1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_DispatchRays:
+        out = L"ID3D12GraphicsCommandList4_DispatchRays";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_FindValue:
+        out = L"ID3D12ShaderCacheSession_FindValue";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_StoreValue:
+        out = L"ID3D12ShaderCacheSession_StoreValue";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_SetDeleteOnDestroy:
+        out = L"ID3D12ShaderCacheSession_SetDeleteOnDestroy";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_GetDesc:
+        out = L"ID3D12ShaderCacheSession_GetDesc";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device9_CreateShaderCacheSession:
+        out = L"ID3D12Device9_CreateShaderCacheSession";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device9_ShaderCacheControl:
+        out = L"ID3D12Device9_ShaderCacheControl";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device9_CreateCommandQueue1:
+        out = L"ID3D12Device9_CreateCommandQueue1";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device10_CreateCommittedResource3:
+        out = L"ID3D12Device10_CreateCommittedResource3";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device10_CreatePlacedResource2:
+        out = L"ID3D12Device10_CreatePlacedResource2";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device10_CreateReservedResource2:
+        out = L"ID3D12Device10_CreateReservedResource2";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Device11_CreateSampler2:
+        out = L"ID3D12Device11_CreateSampler2";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_ShareWithHost:
+        out = L"ID3D12VirtualizationGuestDevice_ShareWithHost";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_CreateFenceFd:
+        out = L"ID3D12VirtualizationGuestDevice_CreateFenceFd";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Tools_EnableShaderInstrumentation:
+        out = L"ID3D12Tools_EnableShaderInstrumentation";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Tools_ShaderInstrumentationEnabled:
+        out = L"ID3D12Tools_ShaderInstrumentationEnabled";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SDKConfiguration_SetSDKVersion:
+        out = L"ID3D12SDKConfiguration_SetSDKVersion";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SDKConfiguration1_CreateDeviceFactory:
+        out = L"ID3D12SDKConfiguration1_CreateDeviceFactory";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SDKConfiguration1_FreeUnusedSDKs:
+        out = L"ID3D12SDKConfiguration1_FreeUnusedSDKs";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceFactory_InitializeFromGlobalState:
+        out = L"ID3D12DeviceFactory_InitializeFromGlobalState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceFactory_ApplyToGlobalState:
+        out = L"ID3D12DeviceFactory_ApplyToGlobalState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceFactory_SetFlags:
+        out = L"ID3D12DeviceFactory_SetFlags";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceFactory_GetFlags:
+        out = L"ID3D12DeviceFactory_GetFlags";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceFactory_GetConfigurationInterface:
+        out = L"ID3D12DeviceFactory_GetConfigurationInterface";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceFactory_EnableExperimentalFeatures:
+        out = L"ID3D12DeviceFactory_EnableExperimentalFeatures";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceFactory_CreateDevice:
+        out = L"ID3D12DeviceFactory_CreateDevice";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_GetDesc:
+        out = L"ID3D12DeviceConfiguration_GetDesc";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_GetEnabledExperimentalFeatures:
+        out = L"ID3D12DeviceConfiguration_GetEnabledExperimentalFeatures";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_SerializeVersionedRootSignature:
+        out = L"ID3D12DeviceConfiguration_SerializeVersionedRootSignature";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer:
+        out = L"ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRate:
+        out = L"ID3D12GraphicsCommandList5_RSSetShadingRate";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRateImage:
+        out = L"ID3D12GraphicsCommandList5_RSSetShadingRateImage";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList6_DispatchMesh:
+        out = L"ID3D12GraphicsCommandList6_DispatchMesh";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList7_Barrier:
+        out = L"ID3D12GraphicsCommandList7_Barrier";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12GraphicsCommandList8_OMSetFrontAndBackStencilRef:
+        out = L"ID3D12GraphicsCommandList8_OMSetFrontAndBackStencilRef";
+        break;
+    case format::ApiCallId::ApiCall_ID3D10Blob_GetBufferPointer:
+        out = L"ID3D10Blob_GetBufferPointer";
+        break;
+    case format::ApiCallId::ApiCall_ID3D10Blob_GetBufferSize:
+        out = L"ID3D10Blob_GetBufferSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3DDestructionNotifier_RegisterDestructionCallback:
+        out = L"ID3DDestructionNotifier_RegisterDestructionCallback";
+        break;
+    case format::ApiCallId::ApiCall_ID3DDestructionNotifier_UnregisterDestructionCallback:
+        out = L"ID3DDestructionNotifier_UnregisterDestructionCallback";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug_EnableDebugLayer:
+        out = L"ID3D12Debug_EnableDebugLayer";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug1_EnableDebugLayer:
+        out = L"ID3D12Debug1_EnableDebugLayer";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug1_SetEnableGPUBasedValidation:
+        out = L"ID3D12Debug1_SetEnableGPUBasedValidation";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug1_SetEnableSynchronizedCommandQueueValidation:
+        out = L"ID3D12Debug1_SetEnableSynchronizedCommandQueueValidation";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug2_SetGPUBasedValidationFlags:
+        out = L"ID3D12Debug2_SetGPUBasedValidationFlags";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug3_SetEnableGPUBasedValidation:
+        out = L"ID3D12Debug3_SetEnableGPUBasedValidation";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug3_SetEnableSynchronizedCommandQueueValidation:
+        out = L"ID3D12Debug3_SetEnableSynchronizedCommandQueueValidation";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug3_SetGPUBasedValidationFlags:
+        out = L"ID3D12Debug3_SetGPUBasedValidationFlags";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug4_DisableDebugLayer:
+        out = L"ID3D12Debug4_DisableDebugLayer";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug5_SetEnableAutoName:
+        out = L"ID3D12Debug5_SetEnableAutoName";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12Debug6_SetForceLegacyBarrierValidation:
+        out = L"ID3D12Debug6_SetForceLegacyBarrierValidation";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice1_SetDebugParameter:
+        out = L"ID3D12DebugDevice1_SetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice1_GetDebugParameter:
+        out = L"ID3D12DebugDevice1_GetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice1_ReportLiveDeviceObjects:
+        out = L"ID3D12DebugDevice1_ReportLiveDeviceObjects";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice_SetFeatureMask:
+        out = L"ID3D12DebugDevice_SetFeatureMask";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice_GetFeatureMask:
+        out = L"ID3D12DebugDevice_GetFeatureMask";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice_ReportLiveDeviceObjects:
+        out = L"ID3D12DebugDevice_ReportLiveDeviceObjects";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice2_SetDebugParameter:
+        out = L"ID3D12DebugDevice2_SetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugDevice2_GetDebugParameter:
+        out = L"ID3D12DebugDevice2_GetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandQueue_AssertResourceState:
+        out = L"ID3D12DebugCommandQueue_AssertResourceState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandQueue1_AssertResourceAccess:
+        out = L"ID3D12DebugCommandQueue1_AssertResourceAccess";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandQueue1_AssertTextureLayout:
+        out = L"ID3D12DebugCommandQueue1_AssertTextureLayout";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList1_AssertResourceState:
+        out = L"ID3D12DebugCommandList1_AssertResourceState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList1_SetDebugParameter:
+        out = L"ID3D12DebugCommandList1_SetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList1_GetDebugParameter:
+        out = L"ID3D12DebugCommandList1_GetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList_AssertResourceState:
+        out = L"ID3D12DebugCommandList_AssertResourceState";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList_SetFeatureMask:
+        out = L"ID3D12DebugCommandList_SetFeatureMask";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList_GetFeatureMask:
+        out = L"ID3D12DebugCommandList_GetFeatureMask";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList2_SetDebugParameter:
+        out = L"ID3D12DebugCommandList2_SetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList2_GetDebugParameter:
+        out = L"ID3D12DebugCommandList2_GetDebugParameter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList3_AssertResourceAccess:
+        out = L"ID3D12DebugCommandList3_AssertResourceAccess";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12DebugCommandList3_AssertTextureLayout:
+        out = L"ID3D12DebugCommandList3_AssertTextureLayout";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SharingContract_Present:
+        out = L"ID3D12SharingContract_Present";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SharingContract_SharedFenceSignal:
+        out = L"ID3D12SharingContract_SharedFenceSignal";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SharingContract_BeginCapturableWork:
+        out = L"ID3D12SharingContract_BeginCapturableWork";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12SharingContract_EndCapturableWork:
+        out = L"ID3D12SharingContract_EndCapturableWork";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_SetMessageCountLimit:
+        out = L"ID3D12InfoQueue_SetMessageCountLimit";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearStoredMessages:
+        out = L"ID3D12InfoQueue_ClearStoredMessages";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesAllowedByStorageFilter:
+        out = L"ID3D12InfoQueue_GetNumMessagesAllowedByStorageFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesDeniedByStorageFilter:
+        out = L"ID3D12InfoQueue_GetNumMessagesDeniedByStorageFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumStoredMessages:
+        out = L"ID3D12InfoQueue_GetNumStoredMessages";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumStoredMessagesAllowedByRetrievalFilter:
+        out = L"ID3D12InfoQueue_GetNumStoredMessagesAllowedByRetrievalFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesDiscardedByMessageCountLimit:
+        out = L"ID3D12InfoQueue_GetNumMessagesDiscardedByMessageCountLimit";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessageCountLimit:
+        out = L"ID3D12InfoQueue_GetMessageCountLimit";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_AddStorageFilterEntries:
+        out = L"ID3D12InfoQueue_AddStorageFilterEntries";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearStorageFilter:
+        out = L"ID3D12InfoQueue_ClearStorageFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PushEmptyStorageFilter:
+        out = L"ID3D12InfoQueue_PushEmptyStorageFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PushCopyOfStorageFilter:
+        out = L"ID3D12InfoQueue_PushCopyOfStorageFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PushStorageFilter:
+        out = L"ID3D12InfoQueue_PushStorageFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PopStorageFilter:
+        out = L"ID3D12InfoQueue_PopStorageFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilterStackSize:
+        out = L"ID3D12InfoQueue_GetStorageFilterStackSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_AddRetrievalFilterEntries:
+        out = L"ID3D12InfoQueue_AddRetrievalFilterEntries";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearRetrievalFilter:
+        out = L"ID3D12InfoQueue_ClearRetrievalFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PushEmptyRetrievalFilter:
+        out = L"ID3D12InfoQueue_PushEmptyRetrievalFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PushCopyOfRetrievalFilter:
+        out = L"ID3D12InfoQueue_PushCopyOfRetrievalFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PushRetrievalFilter:
+        out = L"ID3D12InfoQueue_PushRetrievalFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_PopRetrievalFilter:
+        out = L"ID3D12InfoQueue_PopRetrievalFilter";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilterStackSize:
+        out = L"ID3D12InfoQueue_GetRetrievalFilterStackSize";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_AddMessage:
+        out = L"ID3D12InfoQueue_AddMessage";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_AddApplicationMessage:
+        out = L"ID3D12InfoQueue_AddApplicationMessage";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnCategory:
+        out = L"ID3D12InfoQueue_SetBreakOnCategory";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnSeverity:
+        out = L"ID3D12InfoQueue_SetBreakOnSeverity";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnID:
+        out = L"ID3D12InfoQueue_SetBreakOnID";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnCategory:
+        out = L"ID3D12InfoQueue_GetBreakOnCategory";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnSeverity:
+        out = L"ID3D12InfoQueue_GetBreakOnSeverity";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnID:
+        out = L"ID3D12InfoQueue_GetBreakOnID";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_SetMuteDebugOutput:
+        out = L"ID3D12InfoQueue_SetMuteDebugOutput";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMuteDebugOutput:
+        out = L"ID3D12InfoQueue_GetMuteDebugOutput";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue1_RegisterMessageCallback:
+        out = L"ID3D12InfoQueue1_RegisterMessageCallback";
+        break;
+    case format::ApiCallId::ApiCall_ID3D12InfoQueue1_UnregisterMessageCallback:
+        out = L"ID3D12InfoQueue1_UnregisterMessageCallback";
+        break;
+    case format::ApiCallId::ApiCall_IUnknown_QueryInterface:
+        out = L"IUnknown_QueryInterface";
+        break;
+    case format::ApiCallId::ApiCall_IUnknown_AddRef:
+        out = L"IUnknown_AddRef";
+        break;
+    case format::ApiCallId::ApiCall_IUnknown_Release:
+        out = L"IUnknown_Release";
+        break;
+    default:
+        break;
+    }
+    return out;
+}
+
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -45,7 +45,7 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory(
                                            out_hp_ppFactory);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppFactory, out_hp_ppFactory);
+        AddObject(out_p_ppFactory, out_hp_ppFactory, format::ApiCall_CreateDXGIFactory);
     }
     CheckReplayResult("CreateDXGIFactory", return_value, replay_result);
 }
@@ -63,7 +63,7 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory1(
                                             out_hp_ppFactory);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppFactory, out_hp_ppFactory);
+        AddObject(out_p_ppFactory, out_hp_ppFactory, format::ApiCall_CreateDXGIFactory1);
     }
     CheckReplayResult("CreateDXGIFactory1", return_value, replay_result);
 }
@@ -84,7 +84,7 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory2(
                                                     ppFactory);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(ppFactory->GetPointer(), ppFactory->GetHandlePointer(), std::move(object_info));
+        AddObject(ppFactory->GetPointer(), ppFactory->GetHandlePointer(), std::move(object_info), format::ApiCall_CreateDXGIFactory2);
     }
     CheckReplayResult("CreateDXGIFactory2", return_value, replay_result);
 }
@@ -104,7 +104,7 @@ void Dx12ReplayConsumer::Process_DXGIGetDebugInterface1(
                                                 out_hp_pDebug);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_pDebug, out_hp_pDebug);
+        AddObject(out_p_pDebug, out_hp_pDebug, format::ApiCall_DXGIGetDebugInterface1);
     }
     CheckReplayResult("DXGIGetDebugInterface1", return_value, replay_result);
 }
@@ -137,8 +137,8 @@ void Dx12ReplayConsumer::Process_D3D12SerializeRootSignature(
                                                      out_hp_ppErrorBlob);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppBlob, out_hp_ppBlob);
-        AddObject(out_p_ppErrorBlob, out_hp_ppErrorBlob);
+        AddObject(out_p_ppBlob, out_hp_ppBlob, format::ApiCall_D3D12SerializeRootSignature);
+        AddObject(out_p_ppErrorBlob, out_hp_ppErrorBlob, format::ApiCall_D3D12SerializeRootSignature);
     }
     CheckReplayResult("D3D12SerializeRootSignature", return_value, replay_result);
 }
@@ -160,7 +160,7 @@ void Dx12ReplayConsumer::Process_D3D12CreateRootSignatureDeserializer(
                                                               out_hp_ppRootSignatureDeserializer);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppRootSignatureDeserializer, out_hp_ppRootSignatureDeserializer);
+        AddObject(out_p_ppRootSignatureDeserializer, out_hp_ppRootSignatureDeserializer, format::ApiCall_D3D12CreateRootSignatureDeserializer);
     }
     CheckReplayResult("D3D12CreateRootSignatureDeserializer", return_value, replay_result);
 }
@@ -183,8 +183,8 @@ void Dx12ReplayConsumer::Process_D3D12SerializeVersionedRootSignature(
                                                               out_hp_ppErrorBlob);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppBlob, out_hp_ppBlob);
-        AddObject(out_p_ppErrorBlob, out_hp_ppErrorBlob);
+        AddObject(out_p_ppBlob, out_hp_ppBlob, format::ApiCall_D3D12SerializeVersionedRootSignature);
+        AddObject(out_p_ppErrorBlob, out_hp_ppErrorBlob, format::ApiCall_D3D12SerializeVersionedRootSignature);
     }
     CheckReplayResult("D3D12SerializeVersionedRootSignature", return_value, replay_result);
 }
@@ -206,7 +206,7 @@ void Dx12ReplayConsumer::Process_D3D12CreateVersionedRootSignatureDeserializer(
                                                                        out_hp_ppRootSignatureDeserializer);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppRootSignatureDeserializer, out_hp_ppRootSignatureDeserializer);
+        AddObject(out_p_ppRootSignatureDeserializer, out_hp_ppRootSignatureDeserializer, format::ApiCall_D3D12CreateVersionedRootSignatureDeserializer);
     }
     CheckReplayResult("D3D12CreateVersionedRootSignatureDeserializer", return_value, replay_result);
 }
@@ -230,7 +230,7 @@ void Dx12ReplayConsumer::Process_D3D12CreateDevice(
                                                    ppDevice);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(ppDevice->GetPointer(), ppDevice->GetHandlePointer(), std::move(object_info));
+        AddObject(ppDevice->GetPointer(), ppDevice->GetHandlePointer(), std::move(object_info), format::ApiCall_D3D12CreateDevice);
     }
     CheckReplayResult("D3D12CreateDevice", return_value, replay_result);
 }
@@ -248,7 +248,7 @@ void Dx12ReplayConsumer::Process_D3D12GetDebugInterface(
                                                 out_hp_ppvDebug);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppvDebug, out_hp_ppvDebug);
+        AddObject(out_p_ppvDebug, out_hp_ppvDebug, format::ApiCall_D3D12GetDebugInterface);
     }
     CheckReplayResult("D3D12GetDebugInterface", return_value, replay_result);
 }
@@ -283,7 +283,7 @@ void Dx12ReplayConsumer::Process_D3D12GetInterface(
                                            out_hp_ppvDebug);
     if (SUCCEEDED(replay_result))
     {
-        AddObject(out_p_ppvDebug, out_hp_ppvDebug);
+        AddObject(out_p_ppvDebug, out_hp_ppvDebug, format::ApiCall_D3D12GetInterface);
     }
     CheckReplayResult("D3D12GetInterface", return_value, replay_result);
 }
@@ -357,7 +357,7 @@ void Dx12ReplayConsumer::Process_IDXGIObject_GetParent(
                                                       out_hp_ppParent);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppParent, out_hp_ppParent);
+            AddObject(out_p_ppParent, out_hp_ppParent, format::ApiCall_IDXGIObject_GetParent);
         }
         CheckReplayResult("IDXGIObject_GetParent", return_value, replay_result);
     }
@@ -380,7 +380,7 @@ void Dx12ReplayConsumer::Process_IDXGIDeviceSubObject_GetDevice(
                                                       out_hp_ppDevice);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppDevice, out_hp_ppDevice);
+            AddObject(out_p_ppDevice, out_hp_ppDevice, format::ApiCall_IDXGIDeviceSubObject_GetDevice);
         }
         CheckReplayResult("IDXGIDeviceSubObject_GetDevice", return_value, replay_result);
     }
@@ -576,7 +576,7 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter_EnumOutputs(
                                                         out_hp_ppOutput);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppOutput, out_hp_ppOutput);
+            AddObject(out_p_ppOutput, out_hp_ppOutput, format::ApiCall_IDXGIAdapter_EnumOutputs);
         }
         CheckReplayResult("IDXGIAdapter_EnumOutputs", return_value, replay_result);
     }
@@ -831,7 +831,7 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetBuffer(
                                                ppSurface);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppSurface->GetPointer(), ppSurface->GetHandlePointer(), std::move(object_info));
+            AddObject(ppSurface->GetPointer(), ppSurface->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGISwapChain_GetBuffer);
         }
         CheckReplayResult("IDXGISwapChain_GetBuffer", return_value, replay_result);
     }
@@ -873,7 +873,7 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetFullscreenState(
                                                                out_hp_ppTarget);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppTarget, out_hp_ppTarget);
+            AddObject(out_p_ppTarget, out_hp_ppTarget, format::ApiCall_IDXGISwapChain_GetFullscreenState);
         }
         CheckReplayResult("IDXGISwapChain_GetFullscreenState", return_value, replay_result);
     }
@@ -946,7 +946,7 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetContainingOutput(
         auto replay_result = replay_object->GetContainingOutput(out_hp_ppOutput);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppOutput, out_hp_ppOutput);
+            AddObject(out_p_ppOutput, out_hp_ppOutput, format::ApiCall_IDXGISwapChain_GetContainingOutput);
         }
         CheckReplayResult("IDXGISwapChain_GetContainingOutput", return_value, replay_result);
     }
@@ -997,7 +997,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_EnumAdapters(
                                                          out_hp_ppAdapter);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppAdapter, out_hp_ppAdapter);
+            AddObject(out_p_ppAdapter, out_hp_ppAdapter, format::ApiCall_IDXGIFactory_EnumAdapters);
         }
         CheckReplayResult("IDXGIFactory_EnumAdapters", return_value, replay_result);
     }
@@ -1063,7 +1063,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_CreateSwapChain(
                                                      ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info));
+            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory_CreateSwapChain);
         }
         CheckReplayResult("IDXGIFactory_CreateSwapChain", return_value, replay_result);
     }
@@ -1087,7 +1087,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_CreateSoftwareAdapter(
                                                                   out_hp_ppAdapter);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppAdapter, out_hp_ppAdapter);
+            AddObject(out_p_ppAdapter, out_hp_ppAdapter, format::ApiCall_IDXGIFactory_CreateSoftwareAdapter);
         }
         CheckReplayResult("IDXGIFactory_CreateSoftwareAdapter", return_value, replay_result);
     }
@@ -1108,7 +1108,7 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_GetAdapter(
         auto replay_result = replay_object->GetAdapter(out_hp_pAdapter);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_pAdapter, out_hp_pAdapter);
+            AddObject(out_p_pAdapter, out_hp_pAdapter, format::ApiCall_IDXGIDevice_GetAdapter);
         }
         CheckReplayResult("IDXGIDevice_GetAdapter", return_value, replay_result);
     }
@@ -1137,7 +1137,7 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_CreateSurface(
                                                           out_hp_ppSurface);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppSurface, out_hp_ppSurface);
+            AddObject(out_p_ppSurface, out_hp_ppSurface, format::ApiCall_IDXGIDevice_CreateSurface);
         }
         CheckReplayResult("IDXGIDevice_CreateSurface", return_value, replay_result);
     }
@@ -1207,7 +1207,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory1_EnumAdapters1(
                                                           out_hp_ppAdapter);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppAdapter, out_hp_ppAdapter);
+            AddObject(out_p_ppAdapter, out_hp_ppAdapter, format::ApiCall_IDXGIFactory1_EnumAdapters1);
         }
         CheckReplayResult("IDXGIFactory1_EnumAdapters1", return_value, replay_result);
     }
@@ -1322,7 +1322,7 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_AcquireNextFrame(
                                                              out_hp_ppDesktopResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppDesktopResource, out_hp_ppDesktopResource);
+            AddObject(out_p_ppDesktopResource, out_hp_ppDesktopResource, format::ApiCall_IDXGIOutputDuplication_AcquireNextFrame);
         }
         CheckReplayResult("IDXGIOutputDuplication_AcquireNextFrame", return_value, replay_result);
     }
@@ -1443,7 +1443,7 @@ void Dx12ReplayConsumer::Process_IDXGISurface2_GetResource(
                                                         pSubresourceIndex->GetPointer());
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppParentResource, out_hp_ppParentResource);
+            AddObject(out_p_ppParentResource, out_hp_ppParentResource, format::ApiCall_IDXGISurface2_GetResource);
         }
         CheckReplayResult("IDXGISurface2_GetResource", return_value, replay_result);
     }
@@ -1466,7 +1466,7 @@ void Dx12ReplayConsumer::Process_IDXGIResource1_CreateSubresourceSurface(
                                                                      out_hp_ppSurface);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppSurface, out_hp_ppSurface);
+            AddObject(out_p_ppSurface, out_hp_ppSurface, format::ApiCall_IDXGIResource1_CreateSubresourceSurface);
         }
         CheckReplayResult("IDXGIResource1_CreateSubresourceSurface", return_value, replay_result);
     }
@@ -1618,7 +1618,7 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetCoreWindow(
                                                           out_hp_ppUnk);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppUnk, out_hp_ppUnk);
+            AddObject(out_p_ppUnk, out_hp_ppUnk, format::ApiCall_IDXGISwapChain1_GetCoreWindow);
         }
         CheckReplayResult("IDXGISwapChain1_GetCoreWindow", return_value, replay_result);
     }
@@ -1671,7 +1671,7 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetRestrictToOutput(
         auto replay_result = replay_object->GetRestrictToOutput(out_hp_ppRestrictToOutput);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppRestrictToOutput, out_hp_ppRestrictToOutput);
+            AddObject(out_p_ppRestrictToOutput, out_hp_ppRestrictToOutput, format::ApiCall_IDXGISwapChain1_GetRestrictToOutput);
         }
         CheckReplayResult("IDXGISwapChain1_GetRestrictToOutput", return_value, replay_result);
     }
@@ -1774,7 +1774,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForHwnd(
                                                             ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info));
+            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory2_CreateSwapChainForHwnd);
         }
         CheckReplayResult("IDXGIFactory2_CreateSwapChainForHwnd", return_value, replay_result);
     }
@@ -1808,7 +1808,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForCoreWindow(
                                                                   ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info));
+            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory2_CreateSwapChainForCoreWindow);
         }
         CheckReplayResult("IDXGIFactory2_CreateSwapChainForCoreWindow", return_value, replay_result);
     }
@@ -1952,7 +1952,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForComposition(
                                                                    ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info));
+            AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory2_CreateSwapChainForComposition);
         }
         CheckReplayResult("IDXGIFactory2_CreateSwapChainForComposition", return_value, replay_result);
     }
@@ -2044,7 +2044,7 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_DuplicateOutput(
                                                             out_hp_ppOutputDuplication);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppOutputDuplication, out_hp_ppOutputDuplication);
+            AddObject(out_p_ppOutputDuplication, out_hp_ppOutputDuplication, format::ApiCall_IDXGIOutput1_DuplicateOutput);
         }
         CheckReplayResult("IDXGIOutput1_DuplicateOutput", return_value, replay_result);
     }
@@ -2343,7 +2343,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactoryMedia_CreateSwapChainForComposition
                                                                                        out_hp_ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppSwapChain, out_hp_ppSwapChain);
+            AddObject(out_p_ppSwapChain, out_hp_ppSwapChain, format::ApiCall_IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle);
         }
         CheckReplayResult("IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle", return_value, replay_result);
     }
@@ -2378,7 +2378,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactoryMedia_CreateDecodeSwapChainForCompo
                                                                                              out_hp_ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppSwapChain, out_hp_ppSwapChain);
+            AddObject(out_p_ppSwapChain, out_hp_ppSwapChain, format::ApiCall_IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle);
         }
         CheckReplayResult("IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle", return_value, replay_result);
     }
@@ -2560,7 +2560,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory4_EnumAdapterByLuid(
                                                               out_hp_ppvAdapter);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvAdapter, out_hp_ppvAdapter);
+            AddObject(out_p_ppvAdapter, out_hp_ppvAdapter, format::ApiCall_IDXGIFactory4_EnumAdapterByLuid);
         }
         CheckReplayResult("IDXGIFactory4_EnumAdapterByLuid", return_value, replay_result);
     }
@@ -2583,7 +2583,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory4_EnumWarpAdapter(
                                                             out_hp_ppvAdapter);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvAdapter, out_hp_ppvAdapter);
+            AddObject(out_p_ppvAdapter, out_hp_ppvAdapter, format::ApiCall_IDXGIFactory4_EnumWarpAdapter);
         }
         CheckReplayResult("IDXGIFactory4_EnumWarpAdapter", return_value, replay_result);
     }
@@ -2707,7 +2707,7 @@ void Dx12ReplayConsumer::Process_IDXGIOutput5_DuplicateOutput1(
                                                              out_hp_ppOutputDuplication);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppOutputDuplication, out_hp_ppOutputDuplication);
+            AddObject(out_p_ppOutputDuplication, out_hp_ppOutputDuplication, format::ApiCall_IDXGIOutput5_DuplicateOutput1);
         }
         CheckReplayResult("IDXGIOutput5_DuplicateOutput1", return_value, replay_result);
     }
@@ -2834,7 +2834,7 @@ void Dx12ReplayConsumer::Process_IDXGIFactory6_EnumAdapterByGpuPreference(
                                                                        out_hp_ppvAdapter);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvAdapter, out_hp_ppvAdapter);
+            AddObject(out_p_ppvAdapter, out_hp_ppvAdapter, format::ApiCall_IDXGIFactory6_EnumAdapterByGpuPreference);
         }
         CheckReplayResult("IDXGIFactory6_EnumAdapterByGpuPreference", return_value, replay_result);
     }
@@ -2930,10 +2930,12 @@ void Dx12ReplayConsumer::Process_ID3D12Object_SetName(
     HRESULT                                     return_value,
     WStringDecoder*                             Name)
 {
-    auto replay_object = MapObject<ID3D12Object>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetName(Name->GetPointer());
+        auto replay_result = OverrideSetName(replay_object,
+                                             return_value,
+                                             Name);
         CheckReplayResult("ID3D12Object_SetName", return_value, replay_result);
     }
 }
@@ -2955,7 +2957,7 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceChild_GetDevice(
                                                       out_hp_ppvDevice);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvDevice, out_hp_ppvDevice);
+            AddObject(out_p_ppvDevice, out_hp_ppvDevice, format::ApiCall_ID3D12DeviceChild_GetDevice);
         }
         CheckReplayResult("ID3D12DeviceChild_GetDevice", return_value, replay_result);
     }
@@ -3205,7 +3207,7 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineState_GetCachedBlob(
         auto replay_result = replay_object->GetCachedBlob(out_hp_ppBlob);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppBlob, out_hp_ppBlob);
+            AddObject(out_p_ppBlob, out_hp_ppBlob, format::ApiCall_ID3D12PipelineState_GetCachedBlob);
         }
         CheckReplayResult("ID3D12PipelineState_GetCachedBlob", return_value, replay_result);
     }
@@ -4497,7 +4499,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandQueue(
                                                         ppCommandQueue);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppCommandQueue->GetPointer(), ppCommandQueue->GetHandlePointer(), std::move(object_info));
+            AddObject(ppCommandQueue->GetPointer(), ppCommandQueue->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateCommandQueue);
         }
         CheckReplayResult("ID3D12Device_CreateCommandQueue", return_value, replay_result);
     }
@@ -4522,7 +4524,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandAllocator(
                                                                    out_hp_ppCommandAllocator);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppCommandAllocator, out_hp_ppCommandAllocator);
+            AddObject(out_p_ppCommandAllocator, out_hp_ppCommandAllocator, format::ApiCall_ID3D12Device_CreateCommandAllocator);
         }
         CheckReplayResult("ID3D12Device_CreateCommandAllocator", return_value, replay_result);
     }
@@ -4550,7 +4552,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateGraphicsPipelineState(
                                                                  ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info));
+            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateGraphicsPipelineState);
         }
         CheckReplayResult("ID3D12Device_CreateGraphicsPipelineState", return_value, replay_result);
     }
@@ -4578,7 +4580,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateComputePipelineState(
                                                                 ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info));
+            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateComputePipelineState);
         }
         CheckReplayResult("ID3D12Device_CreateComputePipelineState", return_value, replay_result);
     }
@@ -4613,7 +4615,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandList(
                                                        ppCommandList);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppCommandList->GetPointer(), ppCommandList->GetHandlePointer(), std::move(object_info));
+            AddObject(ppCommandList->GetPointer(), ppCommandList->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateCommandList);
         }
         CheckReplayResult("ID3D12Device_CreateCommandList", return_value, replay_result);
     }
@@ -4640,7 +4642,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateDescriptorHeap(
                                                           ppvHeap);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateDescriptorHeap);
         }
         CheckReplayResult("ID3D12Device_CreateDescriptorHeap", return_value, replay_result);
     }
@@ -4686,7 +4688,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateRootSignature(
                                                          ppvRootSignature);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvRootSignature->GetPointer(), ppvRootSignature->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvRootSignature->GetPointer(), ppvRootSignature->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateRootSignature);
         }
         CheckReplayResult("ID3D12Device_CreateRootSignature", return_value, replay_result);
     }
@@ -4906,7 +4908,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommittedResource(
                                                              ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateCommittedResource);
         }
         CheckReplayResult("ID3D12Device_CreateCommittedResource", return_value, replay_result);
     }
@@ -4931,7 +4933,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateHeap(
                                                        out_hp_ppvHeap);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvHeap, out_hp_ppvHeap);
+            AddObject(out_p_ppvHeap, out_hp_ppvHeap, format::ApiCall_ID3D12Device_CreateHeap);
         }
         CheckReplayResult("ID3D12Device_CreateHeap", return_value, replay_result);
     }
@@ -4965,7 +4967,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreatePlacedResource(
                                                                  out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource);
+            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device_CreatePlacedResource);
         }
         CheckReplayResult("ID3D12Device_CreatePlacedResource", return_value, replay_result);
     }
@@ -4996,7 +4998,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateReservedResource(
                                                             ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateReservedResource);
         }
         CheckReplayResult("ID3D12Device_CreateReservedResource", return_value, replay_result);
     }
@@ -5052,7 +5054,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_OpenSharedHandle(
                                                              out_hp_ppvObj);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvObj, out_hp_ppvObj);
+            AddObject(out_p_ppvObj, out_hp_ppvObj, format::ApiCall_ID3D12Device_OpenSharedHandle);
         }
         CheckReplayResult("ID3D12Device_OpenSharedHandle", return_value, replay_result);
     }
@@ -5140,7 +5142,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateFence(
                                                  ppFence);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppFence->GetPointer(), ppFence->GetHandlePointer(), std::move(object_info));
+            AddObject(ppFence->GetPointer(), ppFence->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateFence);
         }
         CheckReplayResult("ID3D12Device_CreateFence", return_value, replay_result);
     }
@@ -5204,7 +5206,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateQueryHeap(
                                                             out_hp_ppvHeap);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvHeap, out_hp_ppvHeap);
+            AddObject(out_p_ppvHeap, out_hp_ppvHeap, format::ApiCall_ID3D12Device_CreateQueryHeap);
         }
         CheckReplayResult("ID3D12Device_CreateQueryHeap", return_value, replay_result);
     }
@@ -5248,7 +5250,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandSignature(
                                                             ppvCommandSignature);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvCommandSignature->GetPointer(), ppvCommandSignature->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvCommandSignature->GetPointer(), ppvCommandSignature->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateCommandSignature);
         }
         CheckReplayResult("ID3D12Device_CreateCommandSignature", return_value, replay_result);
     }
@@ -5332,7 +5334,7 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadGraphicsPipeline(
                                                           ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info));
+            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12PipelineLibrary_LoadGraphicsPipeline);
         }
         CheckReplayResult("ID3D12PipelineLibrary_LoadGraphicsPipeline", return_value, replay_result);
     }
@@ -5362,7 +5364,7 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadComputePipeline(
                                                          ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info));
+            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12PipelineLibrary_LoadComputePipeline);
         }
         CheckReplayResult("ID3D12PipelineLibrary_LoadComputePipeline", return_value, replay_result);
     }
@@ -5420,7 +5422,7 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary1_LoadPipeline(
                                                   ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info));
+            AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12PipelineLibrary1_LoadPipeline);
         }
         CheckReplayResult("ID3D12PipelineLibrary1_LoadPipeline", return_value, replay_result);
     }
@@ -5449,7 +5451,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device1_CreatePipelineLibrary(
                                                            ppPipelineLibrary);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppPipelineLibrary->GetPointer(), ppPipelineLibrary->GetHandlePointer(), std::move(object_info));
+            AddObject(ppPipelineLibrary->GetPointer(), ppPipelineLibrary->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device1_CreatePipelineLibrary);
         }
         CheckReplayResult("ID3D12Device1_CreatePipelineLibrary", return_value, replay_result);
     }
@@ -5518,7 +5520,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device2_CreatePipelineState(
                                                                 out_hp_ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppPipelineState, out_hp_ppPipelineState);
+            AddObject(out_p_ppPipelineState, out_hp_ppPipelineState, format::ApiCall_ID3D12Device2_CreatePipelineState);
         }
         CheckReplayResult("ID3D12Device2_CreatePipelineState", return_value, replay_result);
     }
@@ -5545,7 +5547,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_OpenExistingHeapFromAddress(
                                                                  ppvHeap);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device3_OpenExistingHeapFromAddress);
         }
         CheckReplayResult("ID3D12Device3_OpenExistingHeapFromAddress", return_value, replay_result);
     }
@@ -5571,7 +5573,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_OpenExistingHeapFromFileMapping(
                                                                             out_hp_ppvHeap);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvHeap, out_hp_ppvHeap);
+            AddObject(out_p_ppvHeap, out_hp_ppvHeap, format::ApiCall_ID3D12Device3_OpenExistingHeapFromFileMapping);
         }
         CheckReplayResult("ID3D12Device3_OpenExistingHeapFromFileMapping", return_value, replay_result);
     }
@@ -5620,7 +5622,7 @@ void Dx12ReplayConsumer::Process_ID3D12ProtectedSession_GetStatusFence(
                                                            out_hp_ppFence);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppFence, out_hp_ppFence);
+            AddObject(out_p_ppFence, out_hp_ppFence, format::ApiCall_ID3D12ProtectedSession_GetStatusFence);
         }
         CheckReplayResult("ID3D12ProtectedSession_GetStatusFence", return_value, replay_result);
     }
@@ -5675,7 +5677,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommandList1(
                                                         ppCommandList);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppCommandList->GetPointer(), ppCommandList->GetHandlePointer(), std::move(object_info));
+            AddObject(ppCommandList->GetPointer(), ppCommandList->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device4_CreateCommandList1);
         }
         CheckReplayResult("ID3D12Device4_CreateCommandList1", return_value, replay_result);
     }
@@ -5700,7 +5702,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateProtectedResourceSession(
                                                                            out_hp_ppSession);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppSession, out_hp_ppSession);
+            AddObject(out_p_ppSession, out_hp_ppSession, format::ApiCall_ID3D12Device4_CreateProtectedResourceSession);
         }
         CheckReplayResult("ID3D12Device4_CreateProtectedResourceSession", return_value, replay_result);
     }
@@ -5738,7 +5740,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommittedResource1(
                                                               ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device4_CreateCommittedResource1);
         }
         CheckReplayResult("ID3D12Device4_CreateCommittedResource1", return_value, replay_result);
     }
@@ -5766,7 +5768,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateHeap1(
                                                         out_hp_ppvHeap);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvHeap, out_hp_ppvHeap);
+            AddObject(out_p_ppvHeap, out_hp_ppvHeap, format::ApiCall_ID3D12Device4_CreateHeap1);
         }
         CheckReplayResult("ID3D12Device4_CreateHeap1", return_value, replay_result);
     }
@@ -5800,7 +5802,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateReservedResource1(
                                                              ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device4_CreateReservedResource1);
         }
         CheckReplayResult("ID3D12Device4_CreateReservedResource1", return_value, replay_result);
     }
@@ -5866,7 +5868,7 @@ void Dx12ReplayConsumer::Process_ID3D12SwapChainAssistant_GetSwapChainObject(
                                                                out_hp_ppv);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppv, out_hp_ppv);
+            AddObject(out_p_ppv, out_hp_ppv, format::ApiCall_ID3D12SwapChainAssistant_GetSwapChainObject);
         }
         CheckReplayResult("ID3D12SwapChainAssistant_GetSwapChainObject", return_value, replay_result);
     }
@@ -5896,8 +5898,8 @@ void Dx12ReplayConsumer::Process_ID3D12SwapChainAssistant_GetCurrentResourceAndC
                                                                               out_hp_ppvQueue);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource);
-            AddObject(out_p_ppvQueue, out_hp_ppvQueue);
+            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue);
+            AddObject(out_p_ppvQueue, out_hp_ppvQueue, format::ApiCall_ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue);
         }
         CheckReplayResult("ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue", return_value, replay_result);
     }
@@ -6003,7 +6005,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateLifetimeTracker(
                                                                   out_hp_ppvTracker);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvTracker, out_hp_ppvTracker);
+            AddObject(out_p_ppvTracker, out_hp_ppvTracker, format::ApiCall_ID3D12Device5_CreateLifetimeTracker);
         }
         CheckReplayResult("ID3D12Device5_CreateLifetimeTracker", return_value, replay_result);
     }
@@ -6083,7 +6085,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateMetaCommand(
                                                               out_hp_ppMetaCommand);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppMetaCommand, out_hp_ppMetaCommand);
+            AddObject(out_p_ppMetaCommand, out_hp_ppMetaCommand, format::ApiCall_ID3D12Device5_CreateMetaCommand);
         }
         CheckReplayResult("ID3D12Device5_CreateMetaCommand", return_value, replay_result);
     }
@@ -6111,7 +6113,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateStateObject(
                                                        ppStateObject);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppStateObject->GetPointer(), ppStateObject->GetHandlePointer(), std::move(object_info));
+            AddObject(ppStateObject->GetPointer(), ppStateObject->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device5_CreateStateObject);
         }
         CheckReplayResult("ID3D12Device5_CreateStateObject", return_value, replay_result);
     }
@@ -6370,7 +6372,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device7_AddToStateObject(
                                                       ppNewStateObject);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppNewStateObject->GetPointer(), ppNewStateObject->GetHandlePointer(), std::move(object_info));
+            AddObject(ppNewStateObject->GetPointer(), ppNewStateObject->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device7_AddToStateObject);
         }
         CheckReplayResult("ID3D12Device7_AddToStateObject", return_value, replay_result);
     }
@@ -6395,7 +6397,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device7_CreateProtectedResourceSession1(
                                                                             out_hp_ppSession);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppSession, out_hp_ppSession);
+            AddObject(out_p_ppSession, out_hp_ppSession, format::ApiCall_ID3D12Device7_CreateProtectedResourceSession1);
         }
         CheckReplayResult("ID3D12Device7_CreateProtectedResourceSession1", return_value, replay_result);
     }
@@ -6452,7 +6454,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreateCommittedResource2(
                                                               ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info));
+            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device8_CreateCommittedResource2);
         }
         CheckReplayResult("ID3D12Device8_CreateCommittedResource2", return_value, replay_result);
     }
@@ -6486,7 +6488,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreatePlacedResource1(
                                                                   out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource);
+            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device8_CreatePlacedResource1);
         }
         CheckReplayResult("ID3D12Device8_CreatePlacedResource1", return_value, replay_result);
     }
@@ -6554,7 +6556,7 @@ void Dx12ReplayConsumer::Process_ID3D12Resource1_GetProtectedResourceSession(
                                                                         out_hp_ppProtectedSession);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppProtectedSession, out_hp_ppProtectedSession);
+            AddObject(out_p_ppProtectedSession, out_hp_ppProtectedSession, format::ApiCall_ID3D12Resource1_GetProtectedResourceSession);
         }
         CheckReplayResult("ID3D12Resource1_GetProtectedResourceSession", return_value, replay_result);
     }
@@ -6589,7 +6591,7 @@ void Dx12ReplayConsumer::Process_ID3D12Heap1_GetProtectedResourceSession(
                                                                         out_hp_ppProtectedSession);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppProtectedSession, out_hp_ppProtectedSession);
+            AddObject(out_p_ppProtectedSession, out_hp_ppProtectedSession, format::ApiCall_ID3D12Heap1_GetProtectedResourceSession);
         }
         CheckReplayResult("ID3D12Heap1_GetProtectedResourceSession", return_value, replay_result);
     }
@@ -6856,7 +6858,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device9_CreateShaderCacheSession(
                                                                      out_hp_ppvSession);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvSession, out_hp_ppvSession);
+            AddObject(out_p_ppvSession, out_hp_ppvSession, format::ApiCall_ID3D12Device9_CreateShaderCacheSession);
         }
         CheckReplayResult("ID3D12Device9_CreateShaderCacheSession", return_value, replay_result);
     }
@@ -6899,7 +6901,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device9_CreateCommandQueue1(
                                                                 out_hp_ppCommandQueue);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppCommandQueue, out_hp_ppCommandQueue);
+            AddObject(out_p_ppCommandQueue, out_hp_ppCommandQueue, format::ApiCall_ID3D12Device9_CreateCommandQueue1);
         }
         CheckReplayResult("ID3D12Device9_CreateCommandQueue1", return_value, replay_result);
     }
@@ -6939,7 +6941,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateCommittedResource3(
                                                                      out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource);
+            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreateCommittedResource3);
         }
         CheckReplayResult("ID3D12Device10_CreateCommittedResource3", return_value, replay_result);
     }
@@ -6977,7 +6979,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreatePlacedResource2(
                                                                   out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource);
+            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreatePlacedResource2);
         }
         CheckReplayResult("ID3D12Device10_CreatePlacedResource2", return_value, replay_result);
     }
@@ -7013,7 +7015,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateReservedResource2(
                                                                     out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource);
+            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreateReservedResource2);
         }
         CheckReplayResult("ID3D12Device10_CreateReservedResource2", return_value, replay_result);
     }
@@ -7138,7 +7140,7 @@ void Dx12ReplayConsumer::Process_ID3D12SDKConfiguration1_CreateDeviceFactory(
                                                                 out_hp_ppvFactory);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvFactory, out_hp_ppvFactory);
+            AddObject(out_p_ppvFactory, out_hp_ppvFactory, format::ApiCall_ID3D12SDKConfiguration1_CreateDeviceFactory);
         }
         CheckReplayResult("ID3D12SDKConfiguration1_CreateDeviceFactory", return_value, replay_result);
     }
@@ -7226,7 +7228,7 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_GetConfigurationInterface(
                                                                       out_hp_ppv);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppv, out_hp_ppv);
+            AddObject(out_p_ppv, out_hp_ppv, format::ApiCall_ID3D12DeviceFactory_GetConfigurationInterface);
         }
         CheckReplayResult("ID3D12DeviceFactory_GetConfigurationInterface", return_value, replay_result);
     }
@@ -7274,7 +7276,7 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_CreateDevice(
                                                          out_hp_ppvDevice);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvDevice, out_hp_ppvDevice);
+            AddObject(out_p_ppvDevice, out_hp_ppvDevice, format::ApiCall_ID3D12DeviceFactory_CreateDevice);
         }
         CheckReplayResult("ID3D12DeviceFactory_CreateDevice", return_value, replay_result);
     }
@@ -7330,8 +7332,8 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceConfiguration_SerializeVersionedRoo
                                                                             out_hp_ppError);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppResult, out_hp_ppResult);
-            AddObject(out_p_ppError, out_hp_ppError);
+            AddObject(out_p_ppResult, out_hp_ppResult, format::ApiCall_ID3D12DeviceConfiguration_SerializeVersionedRootSignature);
+            AddObject(out_p_ppError, out_hp_ppError, format::ApiCall_ID3D12DeviceConfiguration_SerializeVersionedRootSignature);
         }
         CheckReplayResult("ID3D12DeviceConfiguration_SerializeVersionedRootSignature", return_value, replay_result);
     }
@@ -7358,7 +7360,7 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceConfiguration_CreateVersionedRootSi
                                                                                      out_hp_ppvDeserializer);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvDeserializer, out_hp_ppvDeserializer);
+            AddObject(out_p_ppvDeserializer, out_hp_ppvDeserializer, format::ApiCall_ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer);
         }
         CheckReplayResult("ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer", return_value, replay_result);
     }
@@ -8547,7 +8549,7 @@ void Dx12ReplayConsumer::Process_IUnknown_QueryInterface(
                                                            out_hp_ppvObject);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvObject, out_hp_ppvObject);
+            AddObject(out_p_ppvObject, out_hp_ppvObject, format::ApiCall_IUnknown_QueryInterface);
         }
         CheckReplayResult("IUnknown_QueryInterface", return_value, replay_result);
     }

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019-2022 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -29,7 +30,8 @@ const char kOptions[] =
     "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
-    "range,--fmr|--flush-measurement-range,--use-captured-swapchain-indices,--dcp,--discard-cached-psos";
+    "range,--fmr|--flush-measurement-range,--use-captured-swapchain-indices,--dcp,--discard-cached-psos,"
+    "--dx12-override-object-names";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2019-2022 LunarG, Inc.
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -100,8 +100,9 @@ const char kQuitAfterMeasurementRangeOption[]    = "--quit-after-measurement-ran
 const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
 const char kEnableUseCapturedSwapchainIndices[]  = "--use-captured-swapchain-indices";
 #if defined(WIN32)
-const char kApiFamilyOption[] = "--api";
-const char kDxTwoPassReplay[] = "--dx12-two-pass-replay";
+const char kApiFamilyOption[]       = "--api";
+const char kDxTwoPassReplay[]       = "--dx12-two-pass-replay";
+const char kDxOverrideObjectNames[] = "--dx12-override-object-names";
 #endif
 
 enum class WsiPlatform
@@ -822,6 +823,11 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     if (arg_parser.IsOptionSet(kDiscardCachedPsosLongOption) || arg_parser.IsOptionSet(kDiscardCachedPsosShortOption))
     {
         replay_options.discard_cached_psos = true;
+    }
+
+    if (arg_parser.IsOptionSet(kDxOverrideObjectNames))
+    {
+        replay_options.override_object_names = true;
     }
 
     replay_options.screenshot_ranges      = GetScreenshotRanges(arg_parser);


### PR DESCRIPTION
**The problem**
ID3D12 objects only have names captured if the app called SetName() on them. If the app did not assign names, then debugging replay becomes harder since GFXR does not have any names recorded for them.

**The solution**
Add a new switch  `--dx12-override-object-names` for the replayer. Default is **off**. This will:
- Generate a `"gfxr_obj_N (creator)"` string when an object is created during replay
 (i.e. `"gfxr_obj_8 (ID3D12Device8_CreateCommittedResource2"`)
- Call `SetName()` using that string on all objects
- Bypass any object naming performed by the app


**Testing**
Verified that object names are generated and markers are emitted with a UE4 app.