### PR TITLE
Regress Required CMake Version for Ubuntu 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 # Description: CMake script for framework util target
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.17.0)
+cmake_minimum_required(VERSION 3.10.2)
 project(GFXReconstruct LANGUAGES CXX)
 
 set_property(GLOBAL PROPERTY TEST_SCRIPT ${CMAKE_ROOT})


### PR DESCRIPTION
EDIT: don't merge this, SDK support starts at 20.04 which brings us up to 3.16.3

Since the Vulkan SDK supports 18.04 we can't require CMake beyond the version that it provides.
<https://launchpad.net/ubuntu/+source/cmake>