### PR TITLE
android: Update target/compiled SDK versions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -338,7 +338,7 @@ from gfxreconstruct's root source directory. Then install with `make install`.
 
 - The latest version of [Android Studio](https://developer.android.com/studio/) with additional items:
   - The [Android Platform tools](https://developer.android.com/studio/releases/platform-tools) for your specific platform
-  - [Android SDK 26 (8.0 Oreo) or newer](https://guides.codepath.com/android/installing-android-sdk-tools)
+  - [Android SDK 33 (13 Tiramisu) or newer](https://guides.codepath.com/android/installing-android-sdk-tools)
   - [Android NDK 21.3.6528147 (r21d)](https://developer.android.com/ndk/guides/)
 - [Java JDK 1.11](https://jdk.java.net/11)
 

--- a/HOWTO_android.md
+++ b/HOWTO_android.md
@@ -294,6 +294,33 @@ From the top of the source pulled down from the repo by using the
 ./android/scripts/gfxrecon.py install-apk android/tools/replay/build/outputs/apk/debug/replay-debug.apk
 ```
 
+#### Additional Permissions
+
+A recent change to enable the replay tool on Android 12 and greater has resulted
+in the need of enabling additional permissions on some versions of Android.
+This was the result of updating the replay's Android Manifest file to add the
+`MANAGE_EXTERNAL_STORAGE` permission flag.
+
+##### Android 10
+
+For replay devices running Android 10, the replay tool now requires the enabling
+of legacy storage access:
+
+```bash
+adb shell appops set com.lunarg.gfxreconstruct.replay android:legacy_storage allow
+```
+
+##### Android 11 and Newer
+
+For replay devices running Android 11 and newer, the replay tool requires that
+the Android permission for `MANAGE_EXTERNAL_STORAGE` be granted either through
+the following `adb` command or by clicking on the permission dialog when it
+opens up:
+
+```bash
+adb shell appops set com.lunarg.gfxreconstruct.replay MANAGE_EXTERNAL_STORAGE allow
+```
+
 ### 9. Run the replay
 
 Try running the replay using the `gfxrecon.py` script:
@@ -514,3 +541,7 @@ Try running the replay using the `gfxrecon.py` script:
 ```bash
 ./android/scripts/gfxrecon.py replay /storage/emulated/0/Download/sacredpath_capture_frames_100_through_200_20221215T174939.gfxr
 ```
+
+**NOTE:** Please refer to [Additional Permissions](#additional-permissions)
+above for additional permissions that may need to be enabled to run the
+replay application on certain versions of Android.

--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -693,6 +693,33 @@ python scripts/gfxrecon.py install-apk tools/replay/build/outputs/apk/debug/repl
 popd
 ```
 
+#### Additional Permissions
+
+A recent change to enable the replay tool on Android 12 and greater has resulted
+in the need of enabling additional permissions on some versions of Android.
+This was the result of updating the replay's Android Manifest file to add the
+`MANAGE_EXTERNAL_STORAGE` permission flag.
+
+##### Android 10
+
+For replay devices running Android 10, the replay tool now requires the enabling
+of legacy storage access:
+
+```bash
+adb shell appops set com.lunarg.gfxreconstruct.replay android:legacy_storage allow
+```
+
+##### Android 11 and Newer
+
+For replay devices running Android 11 and newer, the replay tool requires that
+the Android permission for `MANAGE_EXTERNAL_STORAGE` be granted either through
+the following `adb` command or by clicking on the permission dialog when it
+opens up:
+
+```bash
+adb shell appops set com.lunarg.gfxreconstruct.replay MANAGE_EXTERNAL_STORAGE allow
+```
+
 ### Replay Command
 
 The `gfxrecon.py replay` command has the following usage:

--- a/android/layer/build.gradle
+++ b/android/layer/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 33
     ndkVersion '21.3.6528147'
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 27
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/layer/src/main/AndroidManifest.xml
+++ b/android/layer/src/main/AndroidManifest.xml
@@ -3,5 +3,6 @@
     package="com.lunarg.gfxreconstruct.layer">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
 
 </manifest>

--- a/android/tools/replay/build.gradle
+++ b/android/tools/replay/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 33
     ndkVersion '21.3.6528147'
     defaultConfig {
         applicationId "com.lunarg.gfxreconstruct.replay"
         minSdkVersion 26
-        targetSdkVersion 27
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/tools/replay/src/main/AndroidManifest.xml
+++ b/android/tools/replay/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:extractNativeLibs="true"
         android:hasCode="false">
         <activity android:name="android.app.NativeActivity"
+                  android:exported="true"
                   android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
                   android:screenOrientation="unspecified">
             <meta-data android:name="android.app.lib_name"

--- a/android/tools/replay/src/main/AndroidManifest.xml
+++ b/android/tools/replay/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
 
     <!-- This .apk has no Java code itself, so set hasCode to false. -->
     <application


### PR DESCRIPTION
There was a request to update our targetSdkVersion and compiledSdkVersion to a much more recent version.
Meanwhile, the minSdkVersion will continue to target the same Android release as before.