### PR TITLE
Exit replay on D3D12_ERROR_INVALID_REDIST error

### DIFF
--- a/framework/decode/dx12_enum_util.h
+++ b/framework/decode/dx12_enum_util.h
@@ -75,6 +75,7 @@ static std::string GetResultValueString(HRESULT result)
         case DXGI_ERROR_WAS_STILL_DRAWING:              return "DXGI_ERROR_WAS_STILL_DRAWING";
         case D3D12_ERROR_ADAPTER_NOT_FOUND:             return "D3D12_ERROR_ADAPTER_NOT_FOUND";
         case D3D12_ERROR_DRIVER_VERSION_MISMATCH:       return "D3D12_ERROR_DRIVER_VERSION_MISMATCH";
+        case D3D12_ERROR_INVALID_REDIST:                return "D3D12_ERROR_INVALID_REDIST";
         default:                                        return std::to_string(result);
     }
     // clang-format on
@@ -83,8 +84,8 @@ static std::string GetResultValueString(HRESULT result)
 /**
  * Get HRESULT code description.
  *
- * Returns a string describing the specified HRESULT code.  The description is based on the language in the Dx12 API
- * specification.
+ * Returns a string describing the specified HRESULT code.  The descriptions are based on the language in the Dx12 API
+ * specification or winerror.h.
  *
  * @param value HRESULT code to process.
  * @return String describing the specified HRESULT code.
@@ -132,6 +133,7 @@ static const char* GetResultDescription(HRESULT result)
         case DXGI_ERROR_WAS_STILL_DRAWING:              return "The GPU was busy at the moment when a call was made to perform an operation, and did not execute or schedule the operation.";
         case D3D12_ERROR_ADAPTER_NOT_FOUND:             return "The specified cached PSO was created on a different adapter and cannot be reused on the current adapter.";
         case D3D12_ERROR_DRIVER_VERSION_MISMATCH:       return "The specified cached PSO was created on a different driver version and cannot be reused on the current adapter.";
+        case D3D12_ERROR_INVALID_REDIST:                return "The D3D12 SDK version configuration of the host exe is invalid.";
         default:                                        return "An error has occurred";
     }
     // clang-format on

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -599,10 +599,10 @@ void Dx12ReplayConsumerBase::CheckReplayResult(const char* call_name, HRESULT ca
 {
     if (capture_result != replay_result)
     {
-        if (replay_result == DXGI_ERROR_DEVICE_REMOVED)
+        if ((replay_result == DXGI_ERROR_DEVICE_REMOVED) || (replay_result == D3D12_ERROR_INVALID_REDIST))
         {
             GFXRECON_LOG_FATAL(
-                "%s returned %s, which does not match the value returned at capture %s.  Replay cannot continue.",
+                "%s returned %s, which does not match the value returned at capture %s. Replay cannot continue.",
                 call_name,
                 enumutil::GetResultValueString(replay_result).c_str(),
                 enumutil::GetResultValueString(capture_result).c_str());


### PR DESCRIPTION
If an API call returns D3D12_ERROR_INVALID_REDIST, the expected version of the DX12 Agility SDK was not found and replay cannot continue.

With this change and PR #978, the behavior of replay is to log the below messages and exit when a failed API call is encoutered.
```
[gfxrecon] ERROR - Did not find Agility SDK runtimes. Verify \D3D12\D3D12Core.dll exists in the same directory as gfxrecon-replay.exe.
[gfxrecon] FATAL - D3D12CreateDevice returned D3D12_ERROR_INVALID_REDIST, which does not match the value returned at capture S_OK. Replay cannot continue.
Replay has encountered a fatal error and cannot continue: The D3D12 SDK version configuration of the host exe is invalid.
```