### PR TITLE
Mark captures that don't use DXR/EI as optimized

### DIFF
--- a/framework/decode/dx12_consumer_base.h
+++ b/framework/decode/dx12_consumer_base.h
@@ -173,11 +173,11 @@ class Dx12ConsumerBase
 
     void SetCurrentBlockIndex(uint64_t block_index) { current_block_index_ = block_index; };
 
-    bool ContainsDxrWorkload() { return dxr_workload_; }
+    bool ContainsDxrWorkload() const { return dxr_workload_; }
 
-    bool ContainsEiWorkload() { return ei_workload_; }
+    bool ContainsEiWorkload() const { return ei_workload_; }
 
-    bool ContainsOptFillMem() { return opt_fillmem_; }
+    bool ContainsOptFillMem() const { return opt_fillmem_; }
 
   protected:
     auto GetCurrentBlockIndex() { return current_block_index_; }

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -288,7 +288,15 @@ void Dx12ReplayConsumerBase::ProcessFillMemoryResourceValueCommand(
     if (resource_value_mapper_ != nullptr)
     {
         resource_value_mapper_ = nullptr;
-        GFXRECON_LOG_DEBUG("Found data to enable optimized playback of DXR and/or ExecuteIndirect commands.");
+        if (resource_value_count > 0)
+        {
+            GFXRECON_LOG_DEBUG("Found data to enable optimized playback of DXR and/or ExecuteIndirect commands.");
+        }
+        else
+        {
+            GFXRECON_LOG_DEBUG("This file was processed by the DXR/EI optimizer. It did not contain any DXR/EI "
+                               "commands that require additional replay processing.");
+        }
     }
 
     opt_fillmem_ = true;

--- a/tools/optimize/dx12_file_optimizer.cpp
+++ b/tools/optimize/dx12_file_optimizer.cpp
@@ -130,9 +130,8 @@ bool Dx12FileOptimizer::ProcessMetaData(const format::BlockHeader& block_header,
             {
                 if (!AddFillMemoryResourceValueCommand(block_header, meta_data_id))
                 {
-                    GFXRECON_LOG_ERROR(
-                        "Failed to write the FillMemoryResourceValueCommand needed for DXR optimization. "
-                        "Optimized file may be invalid.");
+                    GFXRECON_LOG_ERROR("Failed to write the FillMemoryResourceValueCommand needed for DXR or EI "
+                                       "optimization. Optimized file may be invalid.");
                 }
             }
         }

--- a/tools/optimize/dx12_file_optimizer.h
+++ b/tools/optimize/dx12_file_optimizer.h
@@ -32,9 +32,13 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 class Dx12FileOptimizer : public FileOptimizer
 {
   public:
-    Dx12FileOptimizer() : fill_command_resource_values_(nullptr), num_optimized_fill_commands_(0) {}
+    Dx12FileOptimizer() :
+        fill_command_resource_values_(nullptr), inject_noop_resource_value_optimization_(false),
+        num_optimized_fill_commands_(0)
+    {}
 
-    void SetFillCommandResourceValues(const decode::Dx12FillCommandResourceValueMap* fill_command_resource_values);
+    void SetFillCommandResourceValues(const decode::Dx12FillCommandResourceValueMap* fill_command_resource_values,
+                                      bool inject_noop_resource_value_optimization);
 
     uint64_t GetNumOptimizedFillCommands() { return num_optimized_fill_commands_; }
 
@@ -45,6 +49,7 @@ class Dx12FileOptimizer : public FileOptimizer
 
     const decode::Dx12FillCommandResourceValueMap*          fill_command_resource_values_;
     decode::Dx12FillCommandResourceValueMap::const_iterator resource_values_iter_;
+    bool                                                    inject_noop_resource_value_optimization_;
 
     size_t num_optimized_fill_commands_;
 

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -198,13 +198,14 @@ bool GetDxrOptimizationInfo(const std::string&                     input_filenam
         // If this is a second pass, set unassociated resource values on Dx12ResourceValueTracker.
         if (first_pass)
         {
-            GFXRECON_WRITE_CONSOLE("Scanning D3D12 capture %s for DXR optimization information.",
+            GFXRECON_WRITE_CONSOLE("Scanning D3D12 capture %s for DXR/EI optimization information.",
                                    input_filename.c_str());
         }
         else
         {
-            GFXRECON_WRITE_CONSOLE("Scanning D3D12 file %s another time for additional DXR optimization information.",
-                                   input_filename.c_str());
+            GFXRECON_WRITE_CONSOLE(
+                "Scanning D3D12 file %s another time for additional DXR/EI optimization information.",
+                input_filename.c_str());
             resource_value_tracking_consumer->SetUnassociatedResourceValues(
                 std::move(info.fill_command_resource_values), std::move(info.unassociated_resource_values));
         }
@@ -229,22 +230,22 @@ bool GetDxrOptimizationInfo(const std::string&                     input_filenam
             resource_value_tracking_consumer->GetTrackedResourceValues(info.fill_command_resource_values);
             resource_value_tracking_consumer->GetUnassociatedResourceValues(info.unassociated_resource_values);
 
-            GFXRECON_WRITE_CONSOLE("Finished scanning capture file for DXR optimization.");
+            GFXRECON_WRITE_CONSOLE("Finished scanning capture file for DXR/EI optimization.");
 
             dxr_scan_result = true;
         }
         else if (dxr_pass_file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
         {
-            GFXRECON_WRITE_CONSOLE("A failure has occurred during capture processing for DXR optimization");
+            GFXRECON_WRITE_CONSOLE("A failure has occurred during capture processing for DXR/EI optimization");
         }
         else if (!dxr_pass_file_processor.EntireFileWasProcessed())
         {
-            GFXRECON_WRITE_CONSOLE("Failed to process the entire capture file for DXR optimization.");
+            GFXRECON_WRITE_CONSOLE("Failed to process the entire capture file for DXR/EI optimization.");
         }
         else
         {
             GFXRECON_WRITE_CONSOLE(
-                "DXR optimization detected invalid capture. Please ensure that traces input to the optimizer "
+                "DXR/EI optimization detected invalid capture. Please ensure that traces input to the optimizer "
                 "already replay on their own.");
         }
     }
@@ -278,8 +279,8 @@ bool GetDx12OptimizationInfo(const std::string&               input_filename,
         if (options.optimize_resource_values_experimental && (info.unassociated_resource_values.size() > 0))
         {
             GFXRECON_WRITE_CONSOLE(
-                "The first pass of experimental DXR optimization was unable to find all required optimization data. A "
-                "second pass will attempt to find this data using a brute-force search.");
+                "The first pass of experimental DXR/EI optimization was unable to find all required optimization data. "
+                "A second pass will attempt to find this data using a brute-force search.");
             dxr_scan_result = dxr_scan_result && GetDxrOptimizationInfo(input_filename, info, false, options);
         }
     }
@@ -333,12 +334,12 @@ bool ApplyDx12OptimizationInfo(const std::string&                     input_file
         if (!info.fill_command_resource_values.empty())
         {
             found_optimization_data = true;
-            GFXRECON_WRITE_CONSOLE("Optimizing %zu FillMemoryCommand blocks for DXR replay.",
+            GFXRECON_WRITE_CONSOLE("Optimizing %zu FillMemoryCommand blocks for DXR/EI replay.",
                                    info.fill_command_resource_values.size());
         }
         else
         {
-            GFXRECON_WRITE_CONSOLE("Found no DXR optimization info. Skipping DXR optimization.");
+            GFXRECON_WRITE_CONSOLE("Found no DXR or EI optimization info. Skipping DXR/EI optimization.");
         }
     }
 

--- a/tools/optimize/dx12_resource_value_tracking_consumer.cpp
+++ b/tools/optimize/dx12_resource_value_tracking_consumer.cpp
@@ -85,6 +85,8 @@ void Dx12ResourceValueTrackingConsumer::ProcessInitDx12AccelerationStructureComm
     std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
     const uint8_t*                                                  build_inputs_data)
 {
+    dxr_workload_ = true;
+
     if (replay_resource_value_calls_)
     {
         Dx12ReplayConsumer::ProcessInitDx12AccelerationStructureCommand(
@@ -100,6 +102,8 @@ void Dx12ResourceValueTrackingConsumer::OverrideExecuteIndirect(DxObjectInfo* co
                                                                 DxObjectInfo* count_buffer_object_info,
                                                                 UINT64        count_buffer_offset)
 {
+    ei_workload_ = true;
+
     auto command_list      = static_cast<ID3D12GraphicsCommandList*>(command_list_object_info->object);
     auto command_signature = static_cast<ID3D12CommandSignature*>(command_signature_object_info->object);
     auto argument_buffer   = static_cast<ID3D12Resource*>(argument_buffer_object_info->object);
@@ -145,6 +149,8 @@ void Dx12ResourceValueTrackingConsumer::OverrideBuildRaytracingAccelerationStruc
 {
     GFXRECON_ASSERT(command_list4_object_info != nullptr);
     GFXRECON_ASSERT(command_list4_object_info->object != nullptr);
+
+    dxr_workload_ = true;
 
     auto command_list4 = static_cast<ID3D12GraphicsCommandList4*>(command_list4_object_info->object);
 


### PR DESCRIPTION
If a capture file does not use DXR or EI, mark it as optimized. This
makes log messages more consistent and prevents unnecessary tracking
work done by `Dx12ResourceValueMapper` during replay.

Also make DXR/EI optimizer log messages more consistent.