### PR TITLE
Applied Our Code Style

### DIFF
--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -82,7 +82,10 @@ class Application final
     void InitializeDx12WsiContext();
 #endif
 
-    void StopRunning() { running_ = false; }
+    void StopRunning()
+    {
+        running_ = false;
+    }
 
   private:
     // clang-format off

--- a/framework/decode/descriptor_update_template_decoder.h
+++ b/framework/decode/descriptor_update_template_decoder.h
@@ -51,14 +51,16 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
 
     Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() { return decoded_image_info_; }
     Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() { return decoded_buffer_info_; }
+
     format::HandleId* GetTexelBufferViewHandleIdsPointer() { return decoded_texel_buffer_view_handle_ids_; }
-    format::HandleId*               GetAccelerationStructureKHRHandleIdsPointer()
+    format::HandleId* GetAccelerationStructureKHRHandleIdsPointer()
     {
         return decoded_acceleration_structure_khr_handle_ids_;
     }
 
     const Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() const { return decoded_image_info_; }
     const Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() const { return decoded_buffer_info_; }
+
     const format::HandleId* GetTexelBufferViewHandleIdsPointer() const { return decoded_texel_buffer_view_handle_ids_; }
     const format::HandleId* GetAccelerationStructureKHRHandleIdsPointer() const
     {

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1763,7 +1763,7 @@ bool FileProcessor::ProcessStateMarker(const format::BlockHeader& block_header, 
 
 bool FileProcessor::ProcessAnnotation(const format::BlockHeader& block_header, format::AnnotationType annotation_type)
 {
-    bool     success      = false;
+    bool                                             success      = false;
     decltype(format::AnnotationHeader::label_length) label_length = 0;
     decltype(format::AnnotationHeader::data_length)  data_length  = 0;
 

--- a/framework/decode/test/main.cpp
+++ b/framework/decode/test/main.cpp
@@ -37,9 +37,9 @@
 #include <vector>
 
 const VkBuffer                   kBufferHandles[] = { gfxrecon::format::FromHandleId<VkBuffer>(0xabcd),
-                                    gfxrecon::format::FromHandleId<VkBuffer>(0xbcda),
-                                    gfxrecon::format::FromHandleId<VkBuffer>(0xcdab),
-                                    gfxrecon::format::FromHandleId<VkBuffer>(0xdabc) };
+                                                      gfxrecon::format::FromHandleId<VkBuffer>(0xbcda),
+                                                      gfxrecon::format::FromHandleId<VkBuffer>(0xcdab),
+                                                      gfxrecon::format::FromHandleId<VkBuffer>(0xdabc) };
 const gfxrecon::format::HandleId kBufferIds[]     = { 12, 24, 48, 96 };
 const gfxrecon::format::HandleId kDeviceId        = 6;
 

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -286,23 +286,23 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
             get_device_table(parent_info->handle)->DestroyImageView(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, ImageInfo>(
-        table,
-        GFXRECON_STR(VkDevice),
-        GFXRECON_STR(VkImage),
-        remove_entries,
-        report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitImageInfo,
-        &VulkanObjectInfoTable::RemoveImageInfo,
-        [&](const DeviceInfo* parent_info, const ImageInfo* object_info) {
-            assert((parent_info != nullptr) && (object_info != nullptr));
+    FreeChildObjects<DeviceInfo, ImageInfo>(table,
+                                            GFXRECON_STR(VkDevice),
+                                            GFXRECON_STR(VkImage),
+                                            remove_entries,
+                                            report_leaks,
+                                            &VulkanObjectInfoTable::GetDeviceInfo,
+                                            &VulkanObjectInfoTable::VisitImageInfo,
+                                            &VulkanObjectInfoTable::RemoveImageInfo,
+                                            [&](const DeviceInfo* parent_info, const ImageInfo* object_info) {
+                                                assert((parent_info != nullptr) && (object_info != nullptr));
 
-            auto allocator = parent_info->allocator.get();
-            assert(allocator != nullptr);
+                                                auto allocator = parent_info->allocator.get();
+                                                assert(allocator != nullptr);
 
-            allocator->DestroyImage(object_info->handle, nullptr, object_info->allocator_data);
-        });
+                                                allocator->DestroyImage(
+                                                    object_info->handle, nullptr, object_info->allocator_data);
+                                            });
 
     FreeChildObjects<DeviceInfo, BufferViewInfo>(
         table,
@@ -318,23 +318,23 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
             get_device_table(parent_info->handle)->DestroyBufferView(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, BufferInfo>(
-        table,
-        GFXRECON_STR(VkDevice),
-        GFXRECON_STR(VkBuffer),
-        remove_entries,
-        report_leaks,
-        &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitBufferInfo,
-        &VulkanObjectInfoTable::RemoveBufferInfo,
-        [&](const DeviceInfo* parent_info, const BufferInfo* object_info) {
-            assert((parent_info != nullptr) && (object_info != nullptr));
+    FreeChildObjects<DeviceInfo, BufferInfo>(table,
+                                             GFXRECON_STR(VkDevice),
+                                             GFXRECON_STR(VkBuffer),
+                                             remove_entries,
+                                             report_leaks,
+                                             &VulkanObjectInfoTable::GetDeviceInfo,
+                                             &VulkanObjectInfoTable::VisitBufferInfo,
+                                             &VulkanObjectInfoTable::RemoveBufferInfo,
+                                             [&](const DeviceInfo* parent_info, const BufferInfo* object_info) {
+                                                 assert((parent_info != nullptr) && (object_info != nullptr));
 
-            auto allocator = parent_info->allocator.get();
-            assert(allocator != nullptr);
+                                                 auto allocator = parent_info->allocator.get();
+                                                 assert(allocator != nullptr);
 
-            allocator->DestroyBuffer(object_info->handle, nullptr, object_info->allocator_data);
-        });
+                                                 allocator->DestroyBuffer(
+                                                     object_info->handle, nullptr, object_info->allocator_data);
+                                             });
 
     FreeChildObjects<DeviceInfo, DeviceMemoryInfo>(
         table,

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -657,7 +657,7 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
             input_assembly_info.primitiveRestartEnable = VK_FALSE;
 
             VkViewport viewport     = { 0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height),
-                                    0.0f, 1.0f };
+                                        0.0f, 1.0f };
             VkRect2D   scissor_rect = { { 0, 0 }, { extent.width, extent.height } };
 
             VkPipelineViewportStateCreateInfo viewport_info = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };

--- a/framework/encode/test/main.cpp
+++ b/framework/encode/test/main.cpp
@@ -51,7 +51,10 @@ TEST_CASE("handles can be wrapped and unwrapped", "[wrapper]")
                                           gfxrecon::encode::BufferWrapper>(
         VK_NULL_HANDLE, gfxrecon::encode::NoParentWrapper::kHandleValue, &buffer, GetHandleId);
 
-    SECTION("The handle retrieved from the wrapper is the original buffer handle") { REQUIRE(buffer == kBufferHandle); }
+    SECTION("The handle retrieved from the wrapper is the original buffer handle")
+    {
+        REQUIRE(buffer == kBufferHandle);
+    }
 
     SECTION("The handle ID retrieved from the wrapper is 12")
     {

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1186,9 +1186,15 @@ class VulkanCaptureManager : public CaptureManager
 
     virtual ~VulkanCaptureManager() override {}
 
-    virtual void CreateStateTracker() override { state_tracker_ = std::make_unique<VulkanStateTracker>(); }
+    virtual void CreateStateTracker() override
+    {
+        state_tracker_ = std::make_unique<VulkanStateTracker>();
+    }
 
-    virtual void DestroyStateTracker() override { state_tracker_ = nullptr; }
+    virtual void DestroyStateTracker() override
+    {
+        state_tracker_ = nullptr;
+    }
 
     virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
 

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -339,9 +339,9 @@ struct DriverInfoBlock
 
 struct ExeFileInfoBlock
 {
-    MetaDataHeader              meta_header;
-    format::ThreadId            thread_id;
-    util::filepath::FileInfo    info_record;
+    MetaDataHeader           meta_header;
+    format::ThreadId         thread_id;
+    util::filepath::FileInfo info_record;
 };
 
 // Not a header because this command does not include a variable length data payload.

--- a/framework/util/xcb_loader.cpp
+++ b/framework/util/xcb_loader.cpp
@@ -73,16 +73,16 @@ bool XcbLoader::Initialize()
                 reinterpret_cast<decltype(xcb_disconnect)*>(util::platform::GetProcAddress(libxcb_, "xcb_disconnect"));
             function_table_.flush =
                 reinterpret_cast<decltype(xcb_flush)*>(util::platform::GetProcAddress(libxcb_, "xcb_flush"));
-            function_table_.generate_id =
-                reinterpret_cast<decltype(xcb_generate_id)*>(util::platform::GetProcAddress(libxcb_, "xcb_generate_id"));
-            function_table_.get_geometry =
-                reinterpret_cast<decltype(xcb_get_geometry)*>(util::platform::GetProcAddress(libxcb_, "xcb_get_geometry"));
+            function_table_.generate_id = reinterpret_cast<decltype(xcb_generate_id)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_generate_id"));
+            function_table_.get_geometry = reinterpret_cast<decltype(xcb_get_geometry)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_get_geometry"));
             function_table_.get_geometry_reply = reinterpret_cast<decltype(xcb_get_geometry_reply)*>(
                 util::platform::GetProcAddress(libxcb_, "xcb_get_geometry_reply"));
             function_table_.get_setup =
                 reinterpret_cast<decltype(xcb_get_setup)*>(util::platform::GetProcAddress(libxcb_, "xcb_get_setup"));
-            function_table_.intern_atom =
-                reinterpret_cast<decltype(xcb_intern_atom)*>(util::platform::GetProcAddress(libxcb_, "xcb_intern_atom"));
+            function_table_.intern_atom = reinterpret_cast<decltype(xcb_intern_atom)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_intern_atom"));
             function_table_.intern_atom_reply = reinterpret_cast<decltype(xcb_intern_atom_reply)*>(
                 util::platform::GetProcAddress(libxcb_, "xcb_intern_atom_reply"));
             function_table_.map_window =
@@ -91,14 +91,14 @@ bool XcbLoader::Initialize()
                 util::platform::GetProcAddress(libxcb_, "xcb_poll_for_event"));
             function_table_.request_check = reinterpret_cast<decltype(xcb_request_check)*>(
                 util::platform::GetProcAddress(libxcb_, "xcb_request_check"));
-            function_table_.screen_next =
-                reinterpret_cast<decltype(xcb_screen_next)*>(util::platform::GetProcAddress(libxcb_, "xcb_screen_next"));
+            function_table_.screen_next = reinterpret_cast<decltype(xcb_screen_next)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_screen_next"));
             function_table_.send_event =
                 reinterpret_cast<decltype(xcb_send_event)*>(util::platform::GetProcAddress(libxcb_, "xcb_send_event"));
             function_table_.setup_roots_iterator = reinterpret_cast<decltype(xcb_setup_roots_iterator)*>(
                 util::platform::GetProcAddress(libxcb_, "xcb_setup_roots_iterator"));
-            function_table_.unmap_window =
-                reinterpret_cast<decltype(xcb_unmap_window)*>(util::platform::GetProcAddress(libxcb_, "xcb_unmap_window"));
+            function_table_.unmap_window = reinterpret_cast<decltype(xcb_unmap_window)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_unmap_window"));
             function_table_.wait_for_event = reinterpret_cast<decltype(xcb_wait_for_event)*>(
                 util::platform::GetProcAddress(libxcb_, "xcb_wait_for_event"));
         }

--- a/layer/trace_layer.h
+++ b/layer/trace_layer.h
@@ -35,18 +35,18 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char* pName);
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, const char* pName);
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance ourInstanceWrapper, const char* pName);
-VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevice       physicalDevice,
-                                                                  const char*            pLayerName,
-                                                                  uint32_t*              pPropertyCount,
-                                                                  VkExtensionProperties* pProperties);
-VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceExtensionProperties(const char*            pLayerName,
-                                                                    uint32_t*              pPropertyCount,
-                                                                    VkExtensionProperties* pProperties);
-VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceLayerProperties(uint32_t*          pPropertyCount,
-                                                                VkLayerProperties* pProperties);
-VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceLayerProperties(VkPhysicalDevice   physicalDevice,
-                                                              uint32_t*          pPropertyCount,
-                                                              VkLayerProperties* pProperties);
+VKAPI_ATTR VkResult VKAPI_CALL           EnumerateDeviceExtensionProperties(VkPhysicalDevice       physicalDevice,
+                                                                            const char*            pLayerName,
+                                                                            uint32_t*              pPropertyCount,
+                                                                            VkExtensionProperties* pProperties);
+VKAPI_ATTR VkResult VKAPI_CALL           EnumerateInstanceExtensionProperties(const char*            pLayerName,
+                                                                              uint32_t*              pPropertyCount,
+                                                                              VkExtensionProperties* pProperties);
+VKAPI_ATTR VkResult VKAPI_CALL           EnumerateInstanceLayerProperties(uint32_t*          pPropertyCount,
+                                                                          VkLayerProperties* pProperties);
+VKAPI_ATTR VkResult VKAPI_CALL           EnumerateDeviceLayerProperties(VkPhysicalDevice   physicalDevice,
+                                                                        uint32_t*          pPropertyCount,
+                                                                        VkLayerProperties* pProperties);
 
 VKAPI_ATTR VkResult VKAPI_CALL dispatch_CreateInstance(const VkInstanceCreateInfo*  pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator,

--- a/tools/compress/compression_converter.h
+++ b/tools/compress/compression_converter.h
@@ -51,8 +51,9 @@ class CompressionConverter : public decode::FileTransformer
 
     virtual bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id) override;
 
-    virtual bool
-    ProcessMethodCall(const format::BlockHeader& block_header, format::ApiCallId call_id, uint64_t block_index = 0) override;
+    virtual bool ProcessMethodCall(const format::BlockHeader& block_header,
+                                   format::ApiCallId          call_id,
+                                   uint64_t                   block_index = 0) override;
 
     virtual bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id) override;
 


### PR DESCRIPTION
Adding the `--code-style` option to our build script should have no affect on a fresh checkout, but it currently modifies several files. Let's apply the changes from formatting our entire tree and get it over with in one commit so that the `build.py --code-style` option does nothing on a clean checkout for our users.

Under Ubuntu 22.04.1 on a system with clang-format version: `Ubuntu clang-format version 14.0.0-1ubuntu1` (same as the Github runner), I applied this:

    python3 ./scripts/build.py -a x64 -c release --code-style

Note I originally had to leave out one modified file as it mysteriously fails the code style check on Github and locally if it is formatted automatically with the code style! `framework/decode/descriptor_update_template_decoder.h`. Follow-up commit tweaking some whitespace manually before formatting seems to have solved that.