### PR TITLE
Added SplitString and RemoveWhitespace Functions

### DIFF
--- a/framework/decode/dx12_ascii_consumer_base.h
+++ b/framework/decode/dx12_ascii_consumer_base.h
@@ -130,7 +130,7 @@ class Dx12AsciiConsumerBase : public Dx12Consumer
                 const auto& parametersStr = ObjectToString(to_string_flags_, tabCount, tabSize, toStringFunction);
                 for (auto c : parametersStr)
                 {
-                    if (c != '{' && !isspace(static_cast<int>(c)) && c != '}')
+                    if (c != '{' && !isspace(static_cast<unsigned char>(c)) && c != '}')
                     {
                         FieldToString(strStrm, false, "parameters", to_string_flags_, tabCount, tabSize, parametersStr);
                         break;

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -25,6 +25,7 @@
 #include "encode/capture_settings.h"
 
 #include "util/file_path.h"
+#include "util/strings.h"
 #include "util/options.h"
 #include "util/platform.h"
 #include "util/settings_loader.h"
@@ -685,8 +686,7 @@ void CaptureSettings::ParseTrimRangeString(const std::string&                   
                 continue;
             }
 
-            // Remove whitespace.
-            range.erase(std::remove_if(range.begin(), range.end(), ::isspace), range.end());
+            util::strings::RemoveWhitespace(range);
 
             // Split string on '-' delimiter.
             bool                     invalid = false;
@@ -818,8 +818,7 @@ std::string CaptureSettings::ParseTrimKeyString(const std::string& value_string)
     if (!value_string.empty())
     {
         trim_key = value_string;
-        // Remove whitespace.
-        trim_key.erase(std::remove_if(trim_key.begin(), trim_key.end(), ::isspace), trim_key.end());
+        gfxrecon::util::strings::RemoveWhitespace(trim_key);
     }
     else
     {

--- a/framework/util/options.cpp
+++ b/framework/util/options.cpp
@@ -23,6 +23,7 @@
 */
 
 #include "options.h"
+#include "util/strings.h"
 #include "util/platform.h"
 #include "util/logging.h"
 
@@ -47,8 +48,7 @@ std::vector<FrameRange> GetFrameRanges(const std::string& args)
             continue;
         }
 
-        // Remove whitespace.
-        range.erase(std::remove_if(range.begin(), range.end(), ::isspace), range.end());
+        strings::RemoveWhitespace(range);
 
         // Split string on '-' delimiter.
         bool                     invalid = false;

--- a/framework/util/strings.cpp
+++ b/framework/util/strings.cpp
@@ -22,6 +22,8 @@
 */
 
 #include "util/strings.h"
+#include <algorithm>
+#include <sstream>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
@@ -38,6 +40,37 @@ std::string TabRight(const std::string& str)
         tabbed.replace(match, 1, "\n\t");
     }
     return tabbed;
+}
+
+std::vector<std::string> SplitString(const std::string_view compound, const char separator)
+{
+    std::vector<std::string> values;
+
+    if (!compound.empty())
+    {
+        // Avoid most of the work if the string doesn't need splitting:
+        if (std::count(compound.begin(), compound.end(), separator) < 1)
+        {
+            values.emplace_back(compound);
+            return values;
+        }
+        else
+        {
+            // Split string on separator.
+            bool               invalid = false;
+            std::istringstream range_input;
+            range_input.str(std::string{ compound });
+
+            for (std::string token; std::getline(range_input, token, separator);)
+            {
+                if (!token.empty())
+                {
+                    values.push_back(token);
+                }
+            }
+        }
+    }
+    return values;
 }
 
 GFXRECON_END_NAMESPACE(strings)

--- a/framework/util/strings.cpp
+++ b/framework/util/strings.cpp
@@ -73,6 +73,12 @@ std::vector<std::string> SplitString(const std::string_view compound, const char
     return values;
 }
 
+void RemoveWhitespace(std::string& str)
+{
+    const auto new_end{ std::remove_if(str.begin(), str.end(), [](const unsigned char c) { return std::isspace(c); }) };
+    str.erase(new_end, str.end());
+}
+
 GFXRECON_END_NAMESPACE(strings)
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/strings.h
+++ b/framework/util/strings.h
@@ -21,6 +21,7 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 /// @file Helper functions for working with strings.
+/// @see platform.h for wrappers of C-string functions.
 
 #ifndef GFXRECON_UTIL_STRINGS_H
 #define GFXRECON_UTIL_STRINGS_H
@@ -28,14 +29,21 @@
 #include "util/defines.h"
 
 #include <string>
+#include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 GFXRECON_BEGIN_NAMESPACE(strings)
 
-/// Return a a string with a tab added at the start of each new line.
+/// @return A string with a tab added at the start of each new line.
 /// A string is considered to start at a new line, even an empty string.
 std::string TabRight(const std::string& str);
+
+/// @return A vector of strings based on chopping compound everywhere that the
+/// separator character is found, adding the pieces to the returned vector from
+/// left to right in the original order and discarding the found instances of
+/// the separator.
+std::vector<std::string> SplitString(const std::string_view compound, const char separator);
 
 GFXRECON_END_NAMESPACE(strings)
 GFXRECON_END_NAMESPACE(util)

--- a/framework/util/strings.h
+++ b/framework/util/strings.h
@@ -45,6 +45,11 @@ std::string TabRight(const std::string& str);
 /// the separator.
 std::vector<std::string> SplitString(const std::string_view compound, const char separator);
 
+/// Removes all whitespace anywhere in the given string, not just trimming it
+/// from front and back of the string.
+/// @note This will turn a space separated list of numbers into one long number.
+void RemoveWhitespace(std::string& str);
+
 GFXRECON_END_NAMESPACE(strings)
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/test/main.cpp
+++ b/framework/util/test/main.cpp
@@ -154,6 +154,46 @@ TEST_CASE("SplitString", "[strings]")
     gfxrecon::util::Log::Release();
 }
 
+TEST_CASE("RemoveWhitespace", "[strings]")
+{
+    using std::string;
+    auto s = [](auto x) { return string{ x }; };
+
+    gfxrecon::util::Log::Init(gfxrecon::util::Log::kDebugSeverity);
+
+    string s1{ "1 2 3 4 5 6 7 8 9 10" };
+    gfxrecon::util::strings::RemoveWhitespace(s1);
+    REQUIRE(s1 == "12345678910");
+
+    string s2{ "    left" };
+    gfxrecon::util::strings::RemoveWhitespace(s2);
+    REQUIRE(s2 == "left");
+
+    {
+        string s{ "right      " };
+        gfxrecon::util::strings::RemoveWhitespace(s);
+        REQUIRE(s == "right");
+    }
+    {
+        string s{ " \t\n\n\n\t   £$%Keep_Me+*&  \r\f\t\f\t \f\r\t\n\n\n\n " };
+        gfxrecon::util::strings::RemoveWhitespace(s);
+        REQUIRE(s == "£$%Keep_Me+*&");
+        // Check that repeated applications don't change an already-shrunk string:
+        for (int i = 0; i < 100; ++i)
+        {
+            gfxrecon::util::strings::RemoveWhitespace(s);
+            REQUIRE(s == "£$%Keep_Me+*&");
+        }
+    }
+    {
+        string s{ " \t\n\n\n\t   £$%\t\tK  e\n\n\n\n\re \f\rp_\nM\t e+*&  \r\f\t\f\t \f\r\t\n\n\n\n " };
+        gfxrecon::util::strings::RemoveWhitespace(s);
+        REQUIRE(s == "£$%Keep_Me+*&");
+    }
+
+    gfxrecon::util::Log::Release();
+}
+
 TEST_CASE("UtcString", "[datetime]")
 {
     gfxrecon::util::Log::Init(gfxrecon::util::Log::kDebugSeverity);

--- a/framework/util/test/main.cpp
+++ b/framework/util/test/main.cpp
@@ -36,7 +36,6 @@
 using namespace gfxrecon::util::strings;
 using namespace gfxrecon::util::datetime;
 
-
 TEST_CASE("Quote", "[to_string]")
 {
     using namespace gfxrecon::util;
@@ -124,6 +123,33 @@ TEST_CASE("TabRight", "[strings]")
     REQUIRE(gfxrecon::util::strings::TabRight("\t\t") == "\t\t\t");
     REQUIRE(gfxrecon::util::strings::TabRight("l1\nl2\nl3") == "\tl1\n\tl2\n\tl3");
     REQUIRE_FALSE(gfxrecon::util::strings::TabRight("l1\nl2\n\nl3") == "\tl1\n\tl2\n\tl3");
+
+    gfxrecon::util::Log::Release();
+}
+
+TEST_CASE("SplitString", "[strings]")
+{
+    using std::string;
+    auto s = [](auto x) { return string{ x }; };
+
+    gfxrecon::util::Log::Init(gfxrecon::util::Log::kDebugSeverity);
+
+    REQUIRE(gfxrecon::util::strings::SplitString("", '+') == std::vector<string>());
+    REQUIRE(gfxrecon::util::strings::SplitString("a", '.') == std::vector<string>({ s("a") }));
+    REQUIRE(gfxrecon::util::strings::SplitString("foobar", '.') == std::vector<string>({ s("foobar") }));
+    REQUIRE(gfxrecon::util::strings::SplitString("+", '+') == std::vector<string>());
+    REQUIRE(gfxrecon::util::strings::SplitString("++", '+') == std::vector<string>());
+    REQUIRE(gfxrecon::util::strings::SplitString("+++", '+') == std::vector<string>());
+    REQUIRE(gfxrecon::util::strings::SplitString("++++++++++++++++++++", '+') == std::vector<string>());
+    REQUIRE(gfxrecon::util::strings::SplitString("+++++++++++++++++++++", '+') == std::vector<string>());
+    REQUIRE(gfxrecon::util::strings::SplitString(" + ", '+') == std::vector<string>({ s(" "), s(" ") }));
+    REQUIRE(gfxrecon::util::strings::SplitString("z+y", '+') == std::vector<string>({ s("z"), s("y") }));
+    REQUIRE(gfxrecon::util::strings::SplitString(".a..b...c....d.....", '.') ==
+            std::vector<string>({ s('a'), s('b'), s('c'), s('d') }));
+    REQUIRE(gfxrecon::util::strings::SplitString(".a..b...c....d.....", ',') ==
+            std::vector<string>({ s(".a..b...c....d.....") }));
+    REQUIRE(gfxrecon::util::strings::SplitString(".a..b...c,,,,d.....", ',') ==
+            std::vector<string>({ s(".a..b...c"), s("d.....") }));
 
     gfxrecon::util::Log::Release();
 }

--- a/tools/platform_debug_helper.cpp
+++ b/tools/platform_debug_helper.cpp
@@ -47,7 +47,7 @@ DWORD DisableDebugPopup(void)
         bool not_all_spaces = false;
         for (const char* c = contents; *c; c++)
         {
-            if (!isspace(*c))
+            if (!isspace(static_cast<unsigned char>(*c)))
             {
                 not_all_spaces = true;
                 break;

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -513,8 +513,7 @@ GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint3
 
         for (std::string& num : values)
         {
-            // Remove whitespace.
-            num.erase(std::remove_if(num.begin(), num.end(), ::isspace), num.end());
+            gfxrecon::util::strings::RemoveWhitespace(num);
 
             // Check that the range string only contains numbers.
             const size_t count = std::count_if(num.begin(), num.end(), ::isdigit);


### PR DESCRIPTION
Tidied `GetMeasurementFrameRange` using `SplitString()`.

Also refactored duplicate code into `RemoveWhitespace()` and provided a unit test and documented its current (weird) behaviour. It is used where you might imagine trimming whitespace from left and right of a token but it actually removes all whitespace inside the string it is given too. So `"  Hello World!  "` becomes `"HelloWorld!"` rather than `"Hello World!"`.

A following PR will use these functions for other purposes but this PR stands alone as a refactor that pulls an algorithm out of the body of a function and makes it reusable and de-duplicates and documents.

If reviewing, ignore the commits from https://github.com/LunarG/gfxreconstruct/pull/1101. Hopefully they'll be merged to dev before this goes in.