### PR TITLE
Disable Debug Assert Popups in Unit Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,9 +133,9 @@ if(MSVC)
 
     # Default to using the precompiled LZ4 and ZLIB binaries for VisualStudio builds.
     set (PRECOMPILED_ARCH "64")
-    if(NOT CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         set (PRECOMPILED_ARCH "32")
-    endif(NOT CMAKE_CL_64)
+    endif(CMAKE_SIZEOF_VOID_P EQUAL 4)
 
     if(GFXR_ARM_WINDOWS_BUILD)
         set (PRECOMPILED_ARCH "64-arm")

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -84,7 +84,7 @@ if (${RUN_TESTS})
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-        if(NOT CMAKE_CL_64)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             target_link_options(gfxrecon_application_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
         else()
             target_link_options(gfxrecon_application_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -78,8 +78,18 @@ common_build_directives(gfxrecon_application)
 if (${RUN_TESTS})
     add_executable(gfxrecon_application_test "")
     target_sources(gfxrecon_application_test PRIVATE
-            ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+            ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp)
     target_link_libraries(gfxrecon_application_test PRIVATE gfxrecon_application)
+    if (MSVC)
+        # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+        # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+        if(NOT CMAKE_CL_64)
+            target_link_options(gfxrecon_application_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+        else()
+            target_link_options(gfxrecon_application_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+        endif()
+    endif()
     common_build_directives(gfxrecon_application_test)
     common_test_directives(gfxrecon_application_test)
 endif()

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -231,8 +231,18 @@ common_build_directives(gfxrecon_decode)
 if (${RUN_TESTS})
     add_executable(gfxrecon_decode_test "")
     target_sources(gfxrecon_decode_test PRIVATE
-            ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+            ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp)
     target_link_libraries(gfxrecon_decode_test PRIVATE gfxrecon_decode)
+    if (MSVC)
+        # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+        # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+        if(NOT CMAKE_CL_64)
+            target_link_options(gfxrecon_decode_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+        else()
+            target_link_options(gfxrecon_decode_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+        endif()
+    endif()
     common_build_directives(gfxrecon_decode_test)
     common_test_directives(gfxrecon_decode_test)
 endif()

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -237,7 +237,7 @@ if (${RUN_TESTS})
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-        if(NOT CMAKE_CL_64)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             target_link_options(gfxrecon_decode_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
         else()
             target_link_options(gfxrecon_decode_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -135,8 +135,18 @@ common_build_directives(gfxrecon_encode)
 if (${RUN_TESTS})
     add_executable(gfxrecon_encode_test "")
     target_sources(gfxrecon_encode_test PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+        ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp)
     target_link_libraries(gfxrecon_encode_test PRIVATE gfxrecon_encode)
+    if (MSVC)
+        # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+        # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+        if(NOT CMAKE_CL_64)
+            target_link_options(gfxrecon_encode_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+        else()
+            target_link_options(gfxrecon_encode_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+        endif()
+    endif()
     common_build_directives(gfxrecon_encode_test)
     common_test_directives(gfxrecon_encode_test)
 endif()

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -141,7 +141,7 @@ if (${RUN_TESTS})
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-        if(NOT CMAKE_CL_64)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             target_link_options(gfxrecon_encode_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
         else()
             target_link_options(gfxrecon_encode_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/framework/format/CMakeLists.txt
+++ b/framework/format/CMakeLists.txt
@@ -50,8 +50,18 @@ common_build_directives(gfxrecon_format)
 if (${RUN_TESTS})
     add_executable(gfxrecon_format_test "")
     target_sources(gfxrecon_format_test PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+        ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp)
     target_link_libraries(gfxrecon_format_test PRIVATE gfxrecon_format)
+    if (MSVC)
+        # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+        # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+        if(NOT CMAKE_CL_64)
+            target_link_options(gfxrecon_format_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+        else()
+            target_link_options(gfxrecon_format_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+        endif()
+    endif()
     common_build_directives(gfxrecon_format_test)
     common_test_directives(gfxrecon_format_test)
 endif()

--- a/framework/format/CMakeLists.txt
+++ b/framework/format/CMakeLists.txt
@@ -56,7 +56,7 @@ if (${RUN_TESTS})
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-        if(NOT CMAKE_CL_64)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             target_link_options(gfxrecon_format_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
         else()
             target_link_options(gfxrecon_format_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -65,7 +65,7 @@ if (${RUN_TESTS})
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-        if(NOT CMAKE_CL_64)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             target_link_options(gfxrecon_graphics_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
         else()
             target_link_options(gfxrecon_graphics_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -59,8 +59,18 @@ common_build_directives(gfxrecon_graphics)
 if (${RUN_TESTS})
     add_executable(gfxrecon_graphics_test "")
     target_sources(gfxrecon_graphics_test PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+        ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp)
     target_link_libraries(gfxrecon_graphics_test PRIVATE gfxrecon_graphics)
+    if (MSVC)
+        # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+        # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+        if(NOT CMAKE_CL_64)
+            target_link_options(gfxrecon_graphics_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+        else()
+            target_link_options(gfxrecon_graphics_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+        endif()
+    endif()
     common_build_directives(gfxrecon_graphics_test)
     common_test_directives(gfxrecon_graphics_test)
 endif()

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -200,7 +200,7 @@ if (${RUN_TESTS})
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-        if(NOT CMAKE_CL_64)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             target_link_options(gfxrecon_util_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
         else()
             target_link_options(gfxrecon_util_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -185,6 +185,7 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_util_test "")
     target_sources(gfxrecon_util_test PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/../../tools/platform_debug_helper.cpp
             $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/test/dx_pointers.h>
             $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/test/dx12_utils.cpp>
             $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/test/gpu_va_map_tests.cpp>
@@ -196,6 +197,15 @@ if (${RUN_TESTS})
                             gfxrecon_util
                             $<$<BOOL:${D3D12_SUPPORT}>:d3d12.lib>
                             $<$<BOOL:${D3D12_SUPPORT}>:dxgi.lib>)
+    if (MSVC)
+        # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+        # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+        if(NOT CMAKE_CL_64)
+            target_link_options(gfxrecon_util_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+        else()
+            target_link_options(gfxrecon_util_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+        endif()
+    endif()
     common_build_directives(gfxrecon_util_test)
     common_test_directives(gfxrecon_util_test)
 endif()

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -100,7 +100,7 @@ if (${RUN_TESTS})
     if (MSVC)
         # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
         # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-        if(NOT CMAKE_CL_64)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
             target_link_options(VkLayer_gfxreconstruct_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
         else()
             target_link_options(VkLayer_gfxreconstruct_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -94,9 +94,18 @@ if (${RUN_TESTS})
     add_executable(VkLayer_gfxreconstruct_test "")
 
     target_sources(VkLayer_gfxreconstruct_test PRIVATE
-            ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+            ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/../tools/platform_debug_helper.cpp)
     target_link_libraries(VkLayer_gfxreconstruct_test PRIVATE VkLayer_gfxreconstruct)
-
+    if (MSVC)
+        # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
+        # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
+        if(NOT CMAKE_CL_64)
+            target_link_options(VkLayer_gfxreconstruct_test PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+        else()
+            target_link_options(VkLayer_gfxreconstruct_test PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+        endif()
+    endif()
     common_build_directives(VkLayer_gfxreconstruct_test)
     common_test_directives(VkLayer_gfxreconstruct_test)
 endif()

--- a/tools/compress/CMakeLists.txt
+++ b/tools/compress/CMakeLists.txt
@@ -39,7 +39,7 @@ target_sources(gfxrecon-compress
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-    if(NOT CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/tools/convert/CMakeLists.txt
+++ b/tools/convert/CMakeLists.txt
@@ -35,7 +35,7 @@ target_sources(gfxrecon-convert
 if (MSVC)
       # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
       # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-      if(NOT CMAKE_CL_64)
+      if(CMAKE_SIZEOF_VOID_P EQUAL 4)
          target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
       else()
             target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/tools/extract/CMakeLists.txt
+++ b/tools/extract/CMakeLists.txt
@@ -37,7 +37,7 @@ target_sources(gfxrecon-extract
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-    if(NOT CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/tools/info/CMakeLists.txt
+++ b/tools/info/CMakeLists.txt
@@ -37,7 +37,7 @@ target_sources(gfxrecon-info
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-    if(NOT CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -47,7 +47,7 @@ target_sources(gfxrecon-optimize
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-    if(NOT CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(gfxrecon-replay
 if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
-    if(NOT CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
       target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")


### PR DESCRIPTION
We run unit tests on CI so cannot have interactive UI elements blocking them.