### PR TITLE
Fix build with system vulkan.h

### DIFF
--- a/cmake/FindVulkanVersion.cmake
+++ b/cmake/FindVulkanVersion.cmake
@@ -9,8 +9,9 @@ set(VULKAN_VERSION_PATCH "")
 find_file (VULKAN_HEADER
             vulkan_core.h
             HINTS
-                external/Vulkan-Headers/include/vulkan
-                ../external/Vulkan-Headers/include/vulkan)
+                external/Vulkan-Headers/include
+                ../external/Vulkan-Headers/include
+            PATH_SUFFIXES vulkan)
 
 MESSAGE(STATUS "Vulkan Header = ${VULKAN_HEADER}")
 
@@ -20,8 +21,9 @@ else()
     find_file(VULKAN_HEADER
                 vulkan.h
                 HINTS
-                    external/Vulkan-Headers/include/vulkan
-                    ../external/Vulkan-Headers/include/vulkan)
+                    external/Vulkan-Headers/include
+                    ../external/Vulkan-Headers/include
+                PATH_SUFFIXES vulkan)
     set(VulkanHeaders_main_header ${VULKAN_HEADER})
 endif()
 


### PR DESCRIPTION
When I configure the build to use system installed Vulkan  headers (without initializing submodules I get following result

```
-- The CXX compiler identification is GNU 12.2.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Vulkan Header = VULKAN_HEADER-NOTFOUND
CMake Error at cmake/FindVulkanVersion.cmake:31 (file):
  file STRINGS file
  "/home/stil/tmp/gfxreconstruct-0.9.19/gfxreconstruct-0.9.19/VULKAN_HEADER-NOTFOUND"
  cannot be read.
Call Stack (most recent call first):
  CMakeLists.txt:107 (include)


CMake Error at cmake/FindVulkanVersion.cmake:60 (message):
  Failed to find major version in VULKAN_HEADER-NOTFOUND
Call Stack (most recent call first):
  CMakeLists.txt:107 (include)


-- Configuring incomplete, errors occurred!
```

because `vulkan_core.h` and `vulkan.h` are, indeed, in `vulkan` subdirectory, fix this by adding  `PATH_SUFFIXES` parameter to find_file call