### PR TITLE
Replace stringstream With in or out Versions

### DIFF
--- a/framework/decode/custom_dx12_ascii_consumer.cpp
+++ b/framework/decode/custom_dx12_ascii_consumer.cpp
@@ -41,7 +41,7 @@ void Dx12AsciiConsumer::Process_ID3D12RootSignatureDeserializer_GetRootSignature
     writeApiCallToFileInfo.pFunctionName = "GetRootSignatureDesc";
     auto returnValue = ToString(*return_value->GetPointer(), to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -60,7 +60,7 @@ void Dx12AsciiConsumer::Process_ID3D12VersionedRootSignatureDeserializer_GetUnco
     writeApiCallToFileInfo.pFunctionName = "GetUnconvertedRootSignatureDesc";
     auto returnValue = ToString(*return_value->GetPointer(), to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -78,7 +78,7 @@ void Dx12AsciiConsumer::Process_ID3D12Heap_GetDesc(const ApiCallInfo&      call_
     writeApiCallToFileInfo.pFunctionName = "GetDesc";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -96,7 +96,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource_GetDesc(const ApiCallInfo&       
     writeApiCallToFileInfo.pFunctionName = "GetDesc";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -114,7 +114,7 @@ void Dx12AsciiConsumer::Process_ID3D12DescriptorHeap_GetDesc(const ApiCallInfo& 
     writeApiCallToFileInfo.pFunctionName = "GetDesc";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -131,7 +131,7 @@ void Dx12AsciiConsumer::Process_ID3D12DescriptorHeap_GetCPUDescriptorHandleForHe
     writeApiCallToFileInfo.pFunctionName = "GetCPUDescriptorHandleForHeapStart";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -148,7 +148,7 @@ void Dx12AsciiConsumer::Process_ID3D12DescriptorHeap_GetGPUDescriptorHandleForHe
     writeApiCallToFileInfo.pFunctionName = "GetGPUDescriptorHandleForHeapStart";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -166,7 +166,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_GetDesc(const ApiCallInfo&   
     writeApiCallToFileInfo.pFunctionName = "GetDesc";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -189,7 +189,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetResourceAllocationInfo(
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "visibleMask", to_string_flags_, tab_count, tab_size, ToString(visibleMask, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "numResourceDescs", to_string_flags_, tab_count, tab_size, ToString(numResourceDescs, to_string_flags_, tab_count, tab_size));
@@ -216,7 +216,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetCustomHeapProperties(const ApiCa
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "nodeMask", to_string_flags_, tab_count, tab_size, ToString(nodeMask, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "heapType", to_string_flags_, tab_count, tab_size, '"' + ToString(heapType, to_string_flags_, tab_count, tab_size) + '"');
@@ -239,7 +239,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetAdapterLuid(const ApiCallInfo& c
     writeApiCallToFileInfo.pFunctionName = "GetAdapterLuid";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -258,7 +258,7 @@ void Dx12AsciiConsumer::Process_ID3D12ProtectedResourceSession_GetDesc(
     writeApiCallToFileInfo.pFunctionName = "GetDesc";
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) { });
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) { });
     // clang-format on
 }
 
@@ -282,7 +282,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device4_GetResourceAllocationInfo1(
     auto returnValue = ToString(*return_value.decoded_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "visibleMask", to_string_flags_, tab_count, tab_size, ToString(visibleMask, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "numResourceDescs", to_string_flags_, tab_count, tab_size, ToString(numResourceDescs, to_string_flags_, tab_count, tab_size));
@@ -308,7 +308,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ResourceBarrier(
     writeApiCallToFileInfo.handleId = object_id;
     writeApiCallToFileInfo.pFunctionName = "ResourceBarrier";
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumBarriers", to_string_flags_, tab_count, tab_size, ToString(NumBarriers, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pBarriers", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumBarriers, pBarriers, to_string_flags_, tab_count, tab_size));
@@ -335,7 +335,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetMessage(const ApiCallInfo&   
     auto returnValue = ToString(return_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "MessageIndex", to_string_flags_, tab_count, tab_size, ToString(MessageIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pMessage", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(pMessageByteLength, pMessage, to_string_flags_, tab_count, tab_size));
@@ -363,7 +363,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetStorageFilter(
     auto returnValue = ToString(return_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pFilter", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(pFilterByteLength, pFilter, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pFilterByteLength", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pFilterByteLength, to_string_flags_, tab_count, tab_size));
@@ -390,7 +390,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetRetrievalFilter(
     auto returnValue = ToString(return_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pFilter", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(pFilterByteLength, pFilter, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pFilterByteLength", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pFilterByteLength, to_string_flags_, tab_count, tab_size));
@@ -419,7 +419,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateRootSignature(const ApiCallIn
     auto returnValue = ToString(return_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "nodeMask", to_string_flags_, tab_count, tab_size, ToString(nodeMask, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pBlobWithRootSignature", to_string_flags_, tab_count, tab_size, HandleIdToString(pBlobWithRootSignature));
@@ -448,7 +448,7 @@ void Dx12AsciiConsumer::Process_D3D12CreateRootSignatureDeserializer(
     auto returnValue = ToString(return_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pSrcData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(SrcDataSizeInBytes, pSrcData, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SrcDataSizeInBytes", to_string_flags_, tab_count, tab_size, ToString(SrcDataSizeInBytes, to_string_flags_, tab_count, tab_size));
@@ -474,7 +474,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandList_GetType(const ApiCallInfo&    
     std::string returnValue = '"' + DX12ReturnValueToString(return_value, to_string_flags_, tab_count, tab_size) + '"';
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -501,7 +501,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device1_CreatePipelineLibrary(const ApiCal
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pLibraryBlob", to_string_flags_, tab_count, tab_size, "\"" + PtrToString(pLibraryBlob->GetPointer()) + "\"");
             FieldToString(str_strm, false, "BlobLength", to_string_flags_, tab_count, tab_size, ToString(BlobLength, to_string_flags_, tab_count, tab_size));

--- a/framework/decode/custom_dx12_to_string.cpp
+++ b/framework/decode/custom_dx12_to_string.cpp
@@ -40,7 +40,7 @@ std::string ToString<D3D12_CPU_DESCRIPTOR_HANDLE>(const D3D12_CPU_DESCRIPTOR_HAN
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ptr", toStringFlags, tabCount, tabSize, ToString(obj.ptr, toStringFlags, tabCount, tabSize));
         }
@@ -56,7 +56,7 @@ std::string ToString<D3D12_GPU_DESCRIPTOR_HANDLE>(const D3D12_GPU_DESCRIPTOR_HAN
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ptr", toStringFlags, tabCount, tabSize, ToString(obj.ptr, toStringFlags, tabCount, tabSize));
         }
@@ -70,7 +70,7 @@ ToString<LARGE_INTEGER>(const LARGE_INTEGER& obj, ToStringFlags toStringFlags, u
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "QuadPart", toStringFlags, tabCount, tabSize, ToString(obj.QuadPart, toStringFlags, tabCount, tabSize));
         }
@@ -86,7 +86,7 @@ std::string ToString<D3D12_VERSIONED_ROOT_SIGNATURE_DESC>(const D3D12_VERSIONED_
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Version", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Version, toStringFlags, tabCount, tabSize) + '"');
             switch (obj.Version) {
@@ -115,7 +115,7 @@ std::string ToString<D3D12_TEXTURE_COPY_LOCATION>(const D3D12_TEXTURE_COPY_LOCAT
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pResource", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pResource));
             FieldToString(strStrm, false, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
@@ -145,7 +145,7 @@ std::string ToString<D3D12_SHADER_RESOURCE_VIEW_DESC>(const D3D12_SHADER_RESOURC
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "ViewDimension", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ViewDimension, toStringFlags, tabCount, tabSize) + '"');
@@ -212,7 +212,7 @@ std::string ToString<D3D12_UNORDERED_ACCESS_VIEW_DESC>(const D3D12_UNORDERED_ACC
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "ViewDimension", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ViewDimension, toStringFlags, tabCount, tabSize) + '"');
@@ -258,7 +258,7 @@ std::string ToString<D3D12_RENDER_TARGET_VIEW_DESC>(const D3D12_RENDER_TARGET_VI
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "ViewDimension", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ViewDimension, toStringFlags, tabCount, tabSize) + '"');
@@ -312,7 +312,7 @@ std::string ToString<D3D12_DEPTH_STENCIL_VIEW_DESC>(const D3D12_DEPTH_STENCIL_VI
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "ViewDimension", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ViewDimension, toStringFlags, tabCount, tabSize) + '"');
@@ -359,7 +359,7 @@ std::string ToString<D3D12_CLEAR_VALUE>(const D3D12_CLEAR_VALUE& obj,
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             switch (obj.Format) {
@@ -388,7 +388,7 @@ std::string ToString<D3D12_PIPELINE_STATE_STREAM_DESC>(const D3D12_PIPELINE_STAT
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pPipelineStateSubobjectStream", toStringFlags, tabCount, tabSize, '"' + PtrToString(obj.pPipelineStateSubobjectStream) + '"');
@@ -405,7 +405,7 @@ std::string ToString<D3D12_STATE_OBJECT_DESC>(const D3D12_STATE_OBJECT_DESC& obj
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "NumSubobjects", toStringFlags, tabCount, tabSize, ToString(obj.NumSubobjects, toStringFlags, tabCount, tabSize));
@@ -424,7 +424,7 @@ std::string ToString<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS>(
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
@@ -467,7 +467,7 @@ std::string ToString<D3D12_RENDER_PASS_BEGINNING_ACCESS>(const D3D12_RENDER_PASS
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             switch (obj.Type) {
@@ -492,7 +492,7 @@ std::string ToString<D3D12_RENDER_PASS_ENDING_ACCESS>(const D3D12_RENDER_PASS_EN
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             switch (obj.Type) {
@@ -517,7 +517,7 @@ std::string ToString<D3D12_ROOT_PARAMETER>(const D3D12_ROOT_PARAMETER& obj,
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ParameterType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ParameterType, toStringFlags, tabCount, tabSize) + '"');
             switch (obj.ParameterType) {
@@ -551,7 +551,7 @@ std::string ToString<D3D12_ROOT_PARAMETER1>(const D3D12_ROOT_PARAMETER1& obj,
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ParameterType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ParameterType, toStringFlags, tabCount, tabSize) + '"');
             switch (obj.ParameterType) {
@@ -585,7 +585,7 @@ std::string ToString<D3D12_INDIRECT_ARGUMENT_DESC>(const D3D12_INDIRECT_ARGUMENT
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             switch (obj.Type) {
@@ -628,7 +628,7 @@ std::string ToString<DXGI_DISPLAY_COLOR_SPACE>(const DXGI_DISPLAY_COLOR_SPACE& o
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             // TODO : Generic 2D array handler...
             FieldToString(strStrm, true, "PrimaryCoordinates", toStringFlags, tabCount, tabSize, ArrayToString(0, obj.PrimaryCoordinates[0], toStringFlags, tabCount, tabSize));
@@ -646,7 +646,7 @@ std::string ToString<D3D12_RAYTRACING_INSTANCE_DESC>(const D3D12_RAYTRACING_INST
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             std::string strs[3][4];
             size_t maxStrLength = 0;
@@ -666,7 +666,7 @@ std::string ToString<D3D12_RAYTRACING_INSTANCE_DESC>(const D3D12_RAYTRACING_INST
                     },
                     [&](size_t y)
                     {
-                        std::stringstream rowStrStrm;
+                        std::ostringstream rowStrStrm;
                         rowStrStrm << '[' << GetWhitespaceString(toStringFlags);
                         for (size_t x = 0; x < 4; ++x)
                         {
@@ -704,7 +704,7 @@ ToString<D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION>(const D3D12_DXIL_SUBOBJECT
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SubobjectToAssociate", toStringFlags, tabCount, tabSize, '"' + PtrToString(obj.SubobjectToAssociate) + '"');
             FieldToString(strStrm, false, "NumExports", toStringFlags, tabCount, tabSize, ToString(obj.NumExports, toStringFlags, tabCount, tabSize));
@@ -722,7 +722,7 @@ std::string ToString<D3D12_RESOURCE_BARRIER>(const D3D12_RESOURCE_BARRIER& obj,
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
@@ -756,7 +756,7 @@ std::string ToString<D3D12_STATE_SUBOBJECT>(const D3D12_STATE_SUBOBJECT& obj,
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pDesc", toStringFlags, tabCount, tabSize, '"' + PtrToString(obj.pDesc) + '"');
@@ -773,7 +773,7 @@ std::string ToString<D3D12_RAYTRACING_GEOMETRY_DESC>(const D3D12_RAYTRACING_GEOM
 {
     // clang-format off
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Flags", toStringFlags, tabCount, tabSize, '"' + PtrToString(obj.Flags) + '"');

--- a/framework/decode/dx12_ascii_consumer_base.cpp
+++ b/framework/decode/dx12_ascii_consumer_base.cpp
@@ -70,7 +70,7 @@ void Dx12AsciiConsumerBase::Process_ID3D12Device_CheckFeatureSupport(format::Han
     auto returnValue = ToString(original_result, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             #if 0
             FieldToString(str_strm, true, "feature", to_string_flags_, tab_count, tab_size, ToString(feature, to_string_flags_, tab_count, tab_size));
@@ -313,7 +313,7 @@ void Dx12AsciiConsumerBase::Process_IDXGIFactory5_CheckFeatureSupport(format::Ha
     auto returnValue = ToString(original_result, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             #if 0
             FieldToString(str_strm, true, "feature", to_string_flags_, tab_count, tab_size, ToString(feature, to_string_flags_, tab_count, tab_size));
@@ -355,7 +355,7 @@ void Dx12AsciiConsumerBase::Process_ID3D12Resource_WriteToSubresource(format::Ha
     writeApiCallToFileInfo.pFunctionName   = "WriteToSubresource";
     std::string returnValue             = DX12ReturnValueToString(return_value, to_string_flags_, tab_count, tab_size);
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
-    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::ostringstream& str_strm) {
         FieldToString(str_strm,
                       true,
                       "DstSubresource",

--- a/framework/decode/dx12_ascii_consumer_base.h
+++ b/framework/decode/dx12_ascii_consumer_base.h
@@ -97,7 +97,7 @@ class Dx12AsciiConsumerBase : public Dx12Consumer
         }
 
         fprintf(file_, "%s", ObjectToString(to_string_flags_, tabCount, tabSize,
-            [&](std::stringstream& strStrm)
+            [&](std::ostringstream& strStrm)
             {
                 // Output the API call index
                 FieldToString(strStrm, true, "index", to_string_flags_, tabCount, tabSize, ToString(api_call_count_++, to_string_flags_, tabCount, tabSize));
@@ -111,7 +111,7 @@ class Dx12AsciiConsumerBase : public Dx12Consumer
                 if (writeApiCallToFileInfo.pObjectTypeName) {
                     FieldToString(strStrm, false, "object", to_string_flags_, tabCount, tabSize,
                         ObjectToString(to_string_flags_, tabCount, tabSize,
-                            [&](std::stringstream& objectStrStrm)
+                            [&](std::ostringstream& objectStrStrm)
                             {
                                 FieldToString(objectStrStrm, true, "type", to_string_flags_, tabCount, tabSize, '"' + std::string(writeApiCallToFileInfo.pObjectTypeName) + '"');
                                 FieldToString(objectStrStrm, false, "handle", to_string_flags_, tabCount, tabSize, HandleIdToString(writeApiCallToFileInfo.handleId));

--- a/framework/generated/dx12_generators/dx12_ascii_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_ascii_consumer_body_generator.py
@@ -118,7 +118,7 @@ class Dx12AsciiConsumerBodyGenerator(Dx12AsciiConsumerHeaderGenerator):
                 writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
                 WriteApiCallToFile(
                     writeApiCallToFileInfo, tab_count, tab_size,
-                    [&](std::stringstream& str_strm)
+                    [&](std::ostringstream& str_strm)
                     {{
             '''.format(
                 '"' + class_name + '"' if class_name else 'nullptr',

--- a/framework/generated/dx12_generators/dx12_struct_to_string_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_to_string_body_generator.py
@@ -73,7 +73,7 @@ class Dx12StructToStringBodyGenerator(Dx12BaseGenerator):
                     template <> std::string ToString<{0}>(const {0}& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
                     {{
                         return ObjectToString(toStringFlags, tabCount, tabSize,
-                            [&](std::stringstream& strStrm)
+                            [&](std::ostringstream& strStrm)
                             {{
                     '''.format(k))
                 body += '\n'

--- a/framework/generated/generated_dx12_ascii_consumer.cpp
+++ b/framework/generated/generated_dx12_ascii_consumer.cpp
@@ -57,7 +57,7 @@ void Dx12AsciiConsumer::Process_CreateDXGIFactory(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppFactory", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppFactory));
@@ -82,7 +82,7 @@ void Dx12AsciiConsumer::Process_CreateDXGIFactory1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppFactory", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppFactory));
@@ -109,7 +109,7 @@ void Dx12AsciiConsumer::Process_IDXGIObject_SetPrivateData(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Name", to_string_flags_, tab_count, tab_size, ToString(*Name.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DataSize", to_string_flags_, tab_count, tab_size, ToString(DataSize, to_string_flags_, tab_count, tab_size));
@@ -136,7 +136,7 @@ void Dx12AsciiConsumer::Process_IDXGIObject_SetPrivateDataInterface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Name", to_string_flags_, tab_count, tab_size, ToString(*Name.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pUnknown", to_string_flags_, tab_count, tab_size, HandleIdToString(pUnknown));
@@ -163,7 +163,7 @@ void Dx12AsciiConsumer::Process_IDXGIObject_GetPrivateData(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Name", to_string_flags_, tab_count, tab_size, ToString(*Name.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pDataSize", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pDataSize, to_string_flags_, tab_count, tab_size));
@@ -190,7 +190,7 @@ void Dx12AsciiConsumer::Process_IDXGIObject_GetParent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppParent", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppParent));
@@ -216,7 +216,7 @@ void Dx12AsciiConsumer::Process_IDXGIDeviceSubObject_GetDevice(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppDevice", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppDevice));
@@ -241,7 +241,7 @@ void Dx12AsciiConsumer::Process_IDXGIResource_GetSharedHandle(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pSharedHandle", to_string_flags_, tab_count, tab_size, HandleIdToString(pSharedHandle));
         }
@@ -265,7 +265,7 @@ void Dx12AsciiConsumer::Process_IDXGIResource_GetUsage(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pUsage", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pUsage, to_string_flags_, tab_count, tab_size));
         }
@@ -289,7 +289,7 @@ void Dx12AsciiConsumer::Process_IDXGIResource_SetEvictionPriority(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "EvictionPriority", to_string_flags_, tab_count, tab_size, ToString(EvictionPriority, to_string_flags_, tab_count, tab_size));
         }
@@ -313,7 +313,7 @@ void Dx12AsciiConsumer::Process_IDXGIResource_GetEvictionPriority(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pEvictionPriority", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pEvictionPriority, to_string_flags_, tab_count, tab_size));
         }
@@ -338,7 +338,7 @@ void Dx12AsciiConsumer::Process_IDXGIKeyedMutex_AcquireSync(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Key", to_string_flags_, tab_count, tab_size, ToString(Key, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "dwMilliseconds", to_string_flags_, tab_count, tab_size, ToString(dwMilliseconds, to_string_flags_, tab_count, tab_size));
@@ -363,7 +363,7 @@ void Dx12AsciiConsumer::Process_IDXGIKeyedMutex_ReleaseSync(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Key", to_string_flags_, tab_count, tab_size, ToString(Key, to_string_flags_, tab_count, tab_size));
         }
@@ -387,7 +387,7 @@ void Dx12AsciiConsumer::Process_IDXGISurface_GetDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -412,7 +412,7 @@ void Dx12AsciiConsumer::Process_IDXGISurface_Map(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pLockedRect", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pLockedRect, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "MapFlags", to_string_flags_, tab_count, tab_size, ToString(MapFlags, to_string_flags_, tab_count, tab_size));
@@ -436,7 +436,7 @@ void Dx12AsciiConsumer::Process_IDXGISurface_Unmap(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -460,7 +460,7 @@ void Dx12AsciiConsumer::Process_IDXGISurface1_GetDC(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Discard", to_string_flags_, tab_count, tab_size, ToString(Discard, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]phdc", to_string_flags_, tab_count, tab_size, HandleIdToString(phdc));
@@ -485,7 +485,7 @@ void Dx12AsciiConsumer::Process_IDXGISurface1_ReleaseDC(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDirtyRect", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDirtyRect, to_string_flags_, tab_count, tab_size));
         }
@@ -510,7 +510,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter_EnumOutputs(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Output", to_string_flags_, tab_count, tab_size, ToString(Output, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppOutput", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppOutput));
@@ -535,7 +535,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter_GetDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -560,7 +560,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter_CheckInterfaceSupport(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "InterfaceName", to_string_flags_, tab_count, tab_size, ToString(*InterfaceName.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pUMDVersion", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pUMDVersion, to_string_flags_, tab_count, tab_size));
@@ -585,7 +585,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_GetDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -612,7 +612,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_GetDisplayModeList(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "EnumFormat", to_string_flags_, tab_count, tab_size, '"' + ToString(EnumFormat, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "Flags", to_string_flags_, tab_count, tab_size, ToString(Flags, to_string_flags_, tab_count, tab_size));
@@ -641,7 +641,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_FindClosestMatchingMode(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pModeToMatch", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pModeToMatch, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pClosestMatch", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pClosestMatch, to_string_flags_, tab_count, tab_size));
@@ -666,7 +666,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_WaitForVBlank(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -690,7 +690,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_TakeOwnership(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "Exclusive", to_string_flags_, tab_count, tab_size, ToString(Exclusive, to_string_flags_, tab_count, tab_size));
@@ -713,7 +713,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_ReleaseOwnership(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -736,7 +736,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_GetGammaControlCapabilities(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pGammaCaps", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pGammaCaps, to_string_flags_, tab_count, tab_size));
         }
@@ -760,7 +760,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_SetGammaControl(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pArray", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pArray, to_string_flags_, tab_count, tab_size));
         }
@@ -784,7 +784,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_GetGammaControl(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pArray", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pArray, to_string_flags_, tab_count, tab_size));
         }
@@ -808,7 +808,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_SetDisplaySurface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pScanoutSurface", to_string_flags_, tab_count, tab_size, HandleIdToString(pScanoutSurface));
         }
@@ -832,7 +832,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_GetDisplaySurfaceData(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDestination", to_string_flags_, tab_count, tab_size, HandleIdToString(pDestination));
         }
@@ -856,7 +856,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput_GetFrameStatistics(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pStats", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pStats, to_string_flags_, tab_count, tab_size));
         }
@@ -881,7 +881,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_Present(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "SyncInterval", to_string_flags_, tab_count, tab_size, ToString(SyncInterval, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Flags", to_string_flags_, tab_count, tab_size, ToString(Flags, to_string_flags_, tab_count, tab_size));
@@ -908,7 +908,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_GetBuffer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Buffer", to_string_flags_, tab_count, tab_size, ToString(Buffer, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -935,7 +935,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_SetFullscreenState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Fullscreen", to_string_flags_, tab_count, tab_size, ToString(Fullscreen, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pTarget", to_string_flags_, tab_count, tab_size, HandleIdToString(pTarget));
@@ -961,7 +961,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_GetFullscreenState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pFullscreen", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pFullscreen, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppTarget", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppTarget));
@@ -986,7 +986,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_GetDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -1014,7 +1014,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_ResizeBuffers(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "BufferCount", to_string_flags_, tab_count, tab_size, ToString(BufferCount, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Width", to_string_flags_, tab_count, tab_size, ToString(Width, to_string_flags_, tab_count, tab_size));
@@ -1042,7 +1042,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_ResizeTarget(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pNewTargetParameters", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pNewTargetParameters, to_string_flags_, tab_count, tab_size));
         }
@@ -1066,7 +1066,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_GetContainingOutput(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]ppOutput", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppOutput));
         }
@@ -1090,7 +1090,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_GetFrameStatistics(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pStats", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pStats, to_string_flags_, tab_count, tab_size));
         }
@@ -1114,7 +1114,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain_GetLastPresentCount(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pLastPresentCount", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pLastPresentCount, to_string_flags_, tab_count, tab_size));
         }
@@ -1139,7 +1139,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory_EnumAdapters(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Adapter", to_string_flags_, tab_count, tab_size, ToString(Adapter, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppAdapter", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppAdapter));
@@ -1165,7 +1165,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory_MakeWindowAssociation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "WindowHandle", to_string_flags_, tab_count, tab_size, HandleIdToString(WindowHandle));
             FieldToString(str_strm, false, "Flags", to_string_flags_, tab_count, tab_size, ToString(Flags, to_string_flags_, tab_count, tab_size));
@@ -1190,7 +1190,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory_GetWindowAssociation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pWindowHandle", to_string_flags_, tab_count, tab_size, HandleIdToString(pWindowHandle));
         }
@@ -1216,7 +1216,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory_CreateSwapChain(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -1243,7 +1243,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory_CreateSoftwareAdapter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Module", to_string_flags_, tab_count, tab_size, HandleIdToString(Module));
             FieldToString(str_strm, false, "[out]ppAdapter", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppAdapter));
@@ -1268,7 +1268,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice_GetAdapter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pAdapter", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(pAdapter));
         }
@@ -1296,7 +1296,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice_CreateSurface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NumSurfaces", to_string_flags_, tab_count, tab_size, ToString(NumSurfaces, to_string_flags_, tab_count, tab_size));
@@ -1326,7 +1326,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice_QueryResourceResidency(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ppResources", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumResources, ppResources, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pResidencyStatus", to_string_flags_, tab_count, tab_size, EnumPointerDecoderArrayToString(NumResources, pResidencyStatus, to_string_flags_, tab_count, tab_size));
@@ -1352,7 +1352,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice_SetGPUThreadPriority(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Priority", to_string_flags_, tab_count, tab_size, ToString(Priority, to_string_flags_, tab_count, tab_size));
         }
@@ -1376,7 +1376,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice_GetGPUThreadPriority(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pPriority", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pPriority, to_string_flags_, tab_count, tab_size));
         }
@@ -1401,7 +1401,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory1_EnumAdapters1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Adapter", to_string_flags_, tab_count, tab_size, ToString(Adapter, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppAdapter", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppAdapter));
@@ -1425,7 +1425,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory1_IsCurrent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -1448,7 +1448,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter1_GetDesc1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -1472,7 +1472,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice1_SetMaximumFrameLatency(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "MaxLatency", to_string_flags_, tab_count, tab_size, ToString(MaxLatency, to_string_flags_, tab_count, tab_size));
         }
@@ -1496,7 +1496,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice1_GetMaximumFrameLatency(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pMaxLatency", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pMaxLatency, to_string_flags_, tab_count, tab_size));
         }
@@ -1523,7 +1523,7 @@ void Dx12AsciiConsumer::Process_IDXGIDisplayControl_IsStereoEnabled(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -1545,7 +1545,7 @@ void Dx12AsciiConsumer::Process_IDXGIDisplayControl_SetStereoEnabled(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "enabled", to_string_flags_, tab_count, tab_size, ToString(enabled, to_string_flags_, tab_count, tab_size));
         }
@@ -1568,7 +1568,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_GetDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -1594,7 +1594,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_AcquireNextFrame(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "TimeoutInMilliseconds", to_string_flags_, tab_count, tab_size, ToString(TimeoutInMilliseconds, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pFrameInfo", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pFrameInfo, to_string_flags_, tab_count, tab_size));
@@ -1622,7 +1622,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_GetFrameDirtyRects(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "DirtyRectsBufferSize", to_string_flags_, tab_count, tab_size, ToString(DirtyRectsBufferSize, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pDirtyRectsBuffer", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(DirtyRectsBufferSize/sizeof tagRECT, pDirtyRectsBuffer, to_string_flags_, tab_count, tab_size));
@@ -1650,7 +1650,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_GetFrameMoveRects(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "MoveRectsBufferSize", to_string_flags_, tab_count, tab_size, ToString(MoveRectsBufferSize, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pMoveRectBuffer", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(MoveRectsBufferSize/sizeof DXGI_OUTDUPL_MOVE_RECT, pMoveRectBuffer, to_string_flags_, tab_count, tab_size));
@@ -1679,7 +1679,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_GetFramePointerShape(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "PointerShapeBufferSize", to_string_flags_, tab_count, tab_size, ToString(PointerShapeBufferSize, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pPointerShapeBuffer", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(PointerShapeBufferSize, pPointerShapeBuffer, to_string_flags_, tab_count, tab_size));
@@ -1706,7 +1706,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_MapDesktopSurface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pLockedRect", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pLockedRect, to_string_flags_, tab_count, tab_size));
         }
@@ -1729,7 +1729,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_UnMapDesktopSurface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -1751,7 +1751,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutputDuplication_ReleaseFrame(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -1776,7 +1776,7 @@ void Dx12AsciiConsumer::Process_IDXGISurface2_GetResource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppParentResource", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppParentResource));
@@ -1803,7 +1803,7 @@ void Dx12AsciiConsumer::Process_IDXGIResource1_CreateSubresourceSurface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "index", to_string_flags_, tab_count, tab_size, ToString(index, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppSurface", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppSurface));
@@ -1831,7 +1831,7 @@ void Dx12AsciiConsumer::Process_IDXGIResource1_CreateSharedHandle(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pAttributes", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pAttributes, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "dwAccess", to_string_flags_, tab_count, tab_size, ToString(dwAccess, to_string_flags_, tab_count, tab_size));
@@ -1860,7 +1860,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice2_OfferResources(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumResources", to_string_flags_, tab_count, tab_size, ToString(NumResources, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppResources", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumResources, ppResources, to_string_flags_, tab_count, tab_size));
@@ -1888,7 +1888,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice2_ReclaimResources(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumResources", to_string_flags_, tab_count, tab_size, ToString(NumResources, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppResources", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumResources, ppResources, to_string_flags_, tab_count, tab_size));
@@ -1914,7 +1914,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice2_EnqueueSetEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hEvent", to_string_flags_, tab_count, tab_size, HandleIdToString(hEvent));
         }
@@ -1938,7 +1938,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_GetDesc1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -1962,7 +1962,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_GetFullscreenDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -1986,7 +1986,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_GetHwnd(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pHwnd", to_string_flags_, tab_count, tab_size, HandleIdToString(pHwnd));
         }
@@ -2011,7 +2011,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_GetCoreWindow(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "refiid", to_string_flags_, tab_count, tab_size, ToString(*refiid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppUnk", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppUnk));
@@ -2038,7 +2038,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_Present1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "SyncInterval", to_string_flags_, tab_count, tab_size, ToString(SyncInterval, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "PresentFlags", to_string_flags_, tab_count, tab_size, ToString(PresentFlags, to_string_flags_, tab_count, tab_size));
@@ -2063,7 +2063,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_IsTemporaryMonoSupported(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -2086,7 +2086,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_GetRestrictToOutput(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]ppRestrictToOutput", to_string_flags_, tab_count, tab_size, HandleIdToString(ppRestrictToOutput));
         }
@@ -2110,7 +2110,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_SetBackgroundColor(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pColor", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pColor, to_string_flags_, tab_count, tab_size));
         }
@@ -2134,7 +2134,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_GetBackgroundColor(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pColor", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pColor, to_string_flags_, tab_count, tab_size));
         }
@@ -2158,7 +2158,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_SetRotation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Rotation", to_string_flags_, tab_count, tab_size, '"' + ToString(Rotation, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -2182,7 +2182,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain1_GetRotation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pRotation", to_string_flags_, tab_count, tab_size, EnumPointerDecoderToString(pRotation));
         }
@@ -2205,7 +2205,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_IsWindowedStereoEnabled(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -2233,7 +2233,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_CreateSwapChainForHwnd(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "hWnd", to_string_flags_, tab_count, tab_size, HandleIdToString(hWnd));
@@ -2266,7 +2266,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_CreateSwapChainForCoreWindow(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "pWindow", to_string_flags_, tab_count, tab_size, HandleIdToString(pWindow));
@@ -2295,7 +2295,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_GetSharedResourceAdapterLuid(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hResource", to_string_flags_, tab_count, tab_size, HandleIdToString(hResource));
             FieldToString(str_strm, false, "[out]pLuid", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pLuid, to_string_flags_, tab_count, tab_size));
@@ -2322,7 +2322,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_RegisterStereoStatusWindow(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "WindowHandle", to_string_flags_, tab_count, tab_size, HandleIdToString(WindowHandle));
             FieldToString(str_strm, false, "wMsg", to_string_flags_, tab_count, tab_size, ToString(wMsg, to_string_flags_, tab_count, tab_size));
@@ -2349,7 +2349,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_RegisterStereoStatusEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hEvent", to_string_flags_, tab_count, tab_size, HandleIdToString(hEvent));
             FieldToString(str_strm, false, "[out]pdwCookie", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pdwCookie, to_string_flags_, tab_count, tab_size));
@@ -2373,7 +2373,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_UnregisterStereoStatus(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "dwCookie", to_string_flags_, tab_count, tab_size, ToString(dwCookie, to_string_flags_, tab_count, tab_size));
         }
@@ -2399,7 +2399,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_RegisterOcclusionStatusWindow(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "WindowHandle", to_string_flags_, tab_count, tab_size, HandleIdToString(WindowHandle));
             FieldToString(str_strm, false, "wMsg", to_string_flags_, tab_count, tab_size, ToString(wMsg, to_string_flags_, tab_count, tab_size));
@@ -2426,7 +2426,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_RegisterOcclusionStatusEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hEvent", to_string_flags_, tab_count, tab_size, HandleIdToString(hEvent));
             FieldToString(str_strm, false, "[out]pdwCookie", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pdwCookie, to_string_flags_, tab_count, tab_size));
@@ -2450,7 +2450,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_UnregisterOcclusionStatus(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "dwCookie", to_string_flags_, tab_count, tab_size, ToString(dwCookie, to_string_flags_, tab_count, tab_size));
         }
@@ -2477,7 +2477,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory2_CreateSwapChainForComposition(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -2504,7 +2504,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter2_GetDesc2(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -2531,7 +2531,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput1_GetDisplayModeList1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "EnumFormat", to_string_flags_, tab_count, tab_size, '"' + ToString(EnumFormat, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "Flags", to_string_flags_, tab_count, tab_size, ToString(Flags, to_string_flags_, tab_count, tab_size));
@@ -2560,7 +2560,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput1_FindClosestMatchingMode1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pModeToMatch", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pModeToMatch, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pClosestMatch", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pClosestMatch, to_string_flags_, tab_count, tab_size));
@@ -2586,7 +2586,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput1_GetDisplaySurfaceData1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDestination", to_string_flags_, tab_count, tab_size, HandleIdToString(pDestination));
         }
@@ -2611,7 +2611,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput1_DuplicateOutput(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "[out]ppOutputDuplication", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppOutputDuplication));
@@ -2641,7 +2641,7 @@ void Dx12AsciiConsumer::Process_CreateDXGIFactory2(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Flags", to_string_flags_, tab_count, tab_size, ToString(Flags, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -2668,7 +2668,7 @@ void Dx12AsciiConsumer::Process_DXGIGetDebugInterface1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Flags", to_string_flags_, tab_count, tab_size, ToString(Flags, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -2692,7 +2692,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice3_Trim(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -2716,7 +2716,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain2_SetSourceSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Width", to_string_flags_, tab_count, tab_size, ToString(Width, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Height", to_string_flags_, tab_count, tab_size, ToString(Height, to_string_flags_, tab_count, tab_size));
@@ -2742,7 +2742,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain2_GetSourceSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pWidth", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pWidth, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pHeight", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pHeight, to_string_flags_, tab_count, tab_size));
@@ -2767,7 +2767,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain2_SetMaximumFrameLatency(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "MaxLatency", to_string_flags_, tab_count, tab_size, ToString(MaxLatency, to_string_flags_, tab_count, tab_size));
         }
@@ -2791,7 +2791,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain2_GetMaximumFrameLatency(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pMaxLatency", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pMaxLatency, to_string_flags_, tab_count, tab_size));
         }
@@ -2814,7 +2814,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain2_GetFrameLatencyWaitableObject(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -2837,7 +2837,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain2_SetMatrixTransform(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pMatrix", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pMatrix, to_string_flags_, tab_count, tab_size));
         }
@@ -2861,7 +2861,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain2_GetMatrixTransform(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pMatrix", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pMatrix, to_string_flags_, tab_count, tab_size));
         }
@@ -2884,7 +2884,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput2_SupportsOverlays(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -2906,7 +2906,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory3_GetCreationFlags(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -2931,7 +2931,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_PresentBuffer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "BufferToPresent", to_string_flags_, tab_count, tab_size, ToString(BufferToPresent, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SyncInterval", to_string_flags_, tab_count, tab_size, ToString(SyncInterval, to_string_flags_, tab_count, tab_size));
@@ -2957,7 +2957,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_SetSourceRect(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pRect", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pRect, to_string_flags_, tab_count, tab_size));
         }
@@ -2981,7 +2981,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_SetTargetRect(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pRect", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pRect, to_string_flags_, tab_count, tab_size));
         }
@@ -3006,7 +3006,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_SetDestSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Width", to_string_flags_, tab_count, tab_size, ToString(Width, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Height", to_string_flags_, tab_count, tab_size, ToString(Height, to_string_flags_, tab_count, tab_size));
@@ -3031,7 +3031,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_GetSourceRect(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pRect", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pRect, to_string_flags_, tab_count, tab_size));
         }
@@ -3055,7 +3055,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_GetTargetRect(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pRect", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pRect, to_string_flags_, tab_count, tab_size));
         }
@@ -3080,7 +3080,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_GetDestSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pWidth", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pWidth, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pHeight", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pHeight, to_string_flags_, tab_count, tab_size));
@@ -3105,7 +3105,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_SetColorSpace(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ColorSpace", to_string_flags_, tab_count, tab_size, '"' + ToString(ColorSpace, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -3128,7 +3128,7 @@ void Dx12AsciiConsumer::Process_IDXGIDecodeSwapChain_GetColorSpace(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -3155,7 +3155,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactoryMedia_CreateSwapChainForCompositionS
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "hSurface", to_string_flags_, tab_count, tab_size, HandleIdToString(hSurface));
@@ -3188,7 +3188,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactoryMedia_CreateDecodeSwapChainForCompos
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "hSurface", to_string_flags_, tab_count, tab_size, HandleIdToString(hSurface));
@@ -3217,7 +3217,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChainMedia_GetFrameStatisticsMedia(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pStats", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pStats, to_string_flags_, tab_count, tab_size));
         }
@@ -3241,7 +3241,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChainMedia_SetPresentDuration(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Duration", to_string_flags_, tab_count, tab_size, ToString(Duration, to_string_flags_, tab_count, tab_size));
         }
@@ -3267,7 +3267,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChainMedia_CheckPresentDurationSupport(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "DesiredPresentDuration", to_string_flags_, tab_count, tab_size, ToString(DesiredPresentDuration, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pClosestSmallerPresentDuration", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pClosestSmallerPresentDuration, to_string_flags_, tab_count, tab_size));
@@ -3295,7 +3295,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput3_CheckOverlaySupport(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "EnumFormat", to_string_flags_, tab_count, tab_size, '"' + ToString(EnumFormat, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "pConcernedDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pConcernedDevice));
@@ -3324,7 +3324,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain3_GetCurrentBackBufferIndex(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -3348,7 +3348,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain3_CheckColorSpaceSupport(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ColorSpace", to_string_flags_, tab_count, tab_size, '"' + ToString(ColorSpace, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "[out]pColorSpaceSupport", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pColorSpaceSupport, to_string_flags_, tab_count, tab_size));
@@ -3373,7 +3373,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain3_SetColorSpace1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ColorSpace", to_string_flags_, tab_count, tab_size, '"' + ToString(ColorSpace, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -3403,7 +3403,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain3_ResizeBuffers1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "BufferCount", to_string_flags_, tab_count, tab_size, ToString(BufferCount, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Width", to_string_flags_, tab_count, tab_size, ToString(Width, to_string_flags_, tab_count, tab_size));
@@ -3436,7 +3436,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput4_CheckOverlayColorSpaceSupport(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Format", to_string_flags_, tab_count, tab_size, '"' + ToString(Format, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "ColorSpace", to_string_flags_, tab_count, tab_size, '"' + ToString(ColorSpace, to_string_flags_, tab_count, tab_size) + '"');
@@ -3465,7 +3465,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory4_EnumAdapterByLuid(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "AdapterLuid", to_string_flags_, tab_count, tab_size, ToString(*AdapterLuid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -3492,7 +3492,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory4_EnumWarpAdapter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppvAdapter", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppvAdapter));
@@ -3518,7 +3518,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter3_RegisterHardwareContentProtectionT
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hEvent", to_string_flags_, tab_count, tab_size, HandleIdToString(hEvent));
             FieldToString(str_strm, false, "[out]pdwCookie", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pdwCookie, to_string_flags_, tab_count, tab_size));
@@ -3542,7 +3542,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter3_UnregisterHardwareContentProtectio
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "dwCookie", to_string_flags_, tab_count, tab_size, ToString(dwCookie, to_string_flags_, tab_count, tab_size));
         }
@@ -3568,7 +3568,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter3_QueryVideoMemoryInfo(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NodeIndex", to_string_flags_, tab_count, tab_size, ToString(NodeIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "MemorySegmentGroup", to_string_flags_, tab_count, tab_size, '"' + ToString(MemorySegmentGroup, to_string_flags_, tab_count, tab_size) + '"');
@@ -3596,7 +3596,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter3_SetVideoMemoryReservation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NodeIndex", to_string_flags_, tab_count, tab_size, ToString(NodeIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "MemorySegmentGroup", to_string_flags_, tab_count, tab_size, '"' + ToString(MemorySegmentGroup, to_string_flags_, tab_count, tab_size) + '"');
@@ -3623,7 +3623,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNot
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hEvent", to_string_flags_, tab_count, tab_size, HandleIdToString(hEvent));
             FieldToString(str_strm, false, "[out]pdwCookie", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pdwCookie, to_string_flags_, tab_count, tab_size));
@@ -3647,7 +3647,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter3_UnregisterVideoMemoryBudgetChangeN
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "dwCookie", to_string_flags_, tab_count, tab_size, ToString(dwCookie, to_string_flags_, tab_count, tab_size));
         }
@@ -3679,7 +3679,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput5_DuplicateOutput1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDevice", to_string_flags_, tab_count, tab_size, HandleIdToString(pDevice));
             FieldToString(str_strm, false, "Flags", to_string_flags_, tab_count, tab_size, ToString(Flags, to_string_flags_, tab_count, tab_size));
@@ -3709,7 +3709,7 @@ void Dx12AsciiConsumer::Process_IDXGISwapChain4_SetHDRMetaData(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "Size", to_string_flags_, tab_count, tab_size, ToString(Size, to_string_flags_, tab_count, tab_size));
@@ -3738,7 +3738,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice4_OfferResources1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumResources", to_string_flags_, tab_count, tab_size, ToString(NumResources, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppResources", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumResources, ppResources, to_string_flags_, tab_count, tab_size));
@@ -3767,7 +3767,7 @@ void Dx12AsciiConsumer::Process_IDXGIDevice4_ReclaimResources1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumResources", to_string_flags_, tab_count, tab_size, ToString(NumResources, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppResources", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumResources, ppResources, to_string_flags_, tab_count, tab_size));
@@ -3795,7 +3795,7 @@ void Dx12AsciiConsumer::Process_DXGIDeclareAdapterRemovalSupport(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -3818,7 +3818,7 @@ void Dx12AsciiConsumer::Process_IDXGIAdapter4_GetDesc3(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -3842,7 +3842,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput6_GetDesc1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -3866,7 +3866,7 @@ void Dx12AsciiConsumer::Process_IDXGIOutput6_CheckHardwareCompositionSupport(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pFlags", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pFlags, to_string_flags_, tab_count, tab_size));
         }
@@ -3893,7 +3893,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory6_EnumAdapterByGpuPreference(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Adapter", to_string_flags_, tab_count, tab_size, ToString(Adapter, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "GpuPreference", to_string_flags_, tab_count, tab_size, '"' + ToString(GpuPreference, to_string_flags_, tab_count, tab_size) + '"');
@@ -3921,7 +3921,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory7_RegisterAdaptersChangedEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hEvent", to_string_flags_, tab_count, tab_size, HandleIdToString(hEvent));
             FieldToString(str_strm, false, "[out]pdwCookie", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pdwCookie, to_string_flags_, tab_count, tab_size));
@@ -3946,7 +3946,7 @@ void Dx12AsciiConsumer::Process_IDXGIFactory7_UnregisterAdaptersChangedEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "dwCookie", to_string_flags_, tab_count, tab_size, ToString(dwCookie, to_string_flags_, tab_count, tab_size));
         }
@@ -3976,7 +3976,7 @@ void Dx12AsciiConsumer::Process_D3D12SerializeRootSignature(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pRootSignature", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pRootSignature, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Version", to_string_flags_, tab_count, tab_size, '"' + ToString(Version, to_string_flags_, tab_count, tab_size) + '"');
@@ -4004,7 +4004,7 @@ void Dx12AsciiConsumer::Process_D3D12SerializeVersionedRootSignature(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pRootSignature", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pRootSignature, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppBlob", to_string_flags_, tab_count, tab_size, HandleIdToString(ppBlob));
@@ -4032,7 +4032,7 @@ void Dx12AsciiConsumer::Process_D3D12CreateVersionedRootSignatureDeserializer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pSrcData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(SrcDataSizeInBytes, pSrcData, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SrcDataSizeInBytes", to_string_flags_, tab_count, tab_size, ToString(SrcDataSizeInBytes, to_string_flags_, tab_count, tab_size));
@@ -4061,7 +4061,7 @@ void Dx12AsciiConsumer::Process_D3D12CreateDevice(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pAdapter", to_string_flags_, tab_count, tab_size, HandleIdToString(pAdapter));
             FieldToString(str_strm, false, "MinimumFeatureLevel", to_string_flags_, tab_count, tab_size, '"' + ToString(MinimumFeatureLevel, to_string_flags_, tab_count, tab_size) + '"');
@@ -4088,7 +4088,7 @@ void Dx12AsciiConsumer::Process_D3D12GetDebugInterface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppvDebug", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppvDebug));
@@ -4115,7 +4115,7 @@ void Dx12AsciiConsumer::Process_D3D12EnableExperimentalFeatures(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumFeatures", to_string_flags_, tab_count, tab_size, ToString(NumFeatures, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pIIDs", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumFeatures, pIIDs, to_string_flags_, tab_count, tab_size));
@@ -4143,7 +4143,7 @@ void Dx12AsciiConsumer::Process_D3D12GetInterface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "rclsid", to_string_flags_, tab_count, tab_size, ToString(*rclsid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -4171,7 +4171,7 @@ void Dx12AsciiConsumer::Process_ID3D12Object_GetPrivateData(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "guid", to_string_flags_, tab_count, tab_size, ToString(*guid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pDataSize", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pDataSize, to_string_flags_, tab_count, tab_size));
@@ -4199,7 +4199,7 @@ void Dx12AsciiConsumer::Process_ID3D12Object_SetPrivateData(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "guid", to_string_flags_, tab_count, tab_size, ToString(*guid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DataSize", to_string_flags_, tab_count, tab_size, ToString(DataSize, to_string_flags_, tab_count, tab_size));
@@ -4226,7 +4226,7 @@ void Dx12AsciiConsumer::Process_ID3D12Object_SetPrivateDataInterface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "guid", to_string_flags_, tab_count, tab_size, ToString(*guid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, HandleIdToString(pData));
@@ -4251,7 +4251,7 @@ void Dx12AsciiConsumer::Process_ID3D12Object_SetName(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Name", to_string_flags_, tab_count, tab_size, StringDecoderToString(Name));
         }
@@ -4276,7 +4276,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceChild_GetDevice(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppvDevice", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppvDevice));
@@ -4302,7 +4302,7 @@ void Dx12AsciiConsumer::Process_ID3D12VersionedRootSignatureDeserializer_GetRoot
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "convertToVersion", to_string_flags_, tab_count, tab_size, '"' + ToString(convertToVersion, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "[out]ppDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(ppDesc, to_string_flags_, tab_count, tab_size));
@@ -4329,7 +4329,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource_Map(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pReadRange", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pReadRange, to_string_flags_, tab_count, tab_size));
@@ -4355,7 +4355,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource_Unmap(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pWrittenRange", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pWrittenRange, to_string_flags_, tab_count, tab_size));
@@ -4379,7 +4379,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource_GetGPUVirtualAddress(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -4406,7 +4406,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource_ReadFromSubresource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pDstData", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstData));
             FieldToString(str_strm, false, "DstRowPitch", to_string_flags_, tab_count, tab_size, ToString(DstRowPitch, to_string_flags_, tab_count, tab_size));
@@ -4435,7 +4435,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource_GetHeapProperties(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pHeapProperties", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pHeapProperties, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pHeapFlags", to_string_flags_, tab_count, tab_size, EnumPointerDecoderToString(pHeapFlags));
@@ -4459,7 +4459,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandAllocator_Reset(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -4481,7 +4481,7 @@ void Dx12AsciiConsumer::Process_ID3D12Fence_GetCompletedValue(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -4505,7 +4505,7 @@ void Dx12AsciiConsumer::Process_ID3D12Fence_SetEventOnCompletion(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Value", to_string_flags_, tab_count, tab_size, ToString(Value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "hEvent", to_string_flags_, tab_count, tab_size, HandleIdToString(hEvent));
@@ -4530,7 +4530,7 @@ void Dx12AsciiConsumer::Process_ID3D12Fence_Signal(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Value", to_string_flags_, tab_count, tab_size, ToString(Value, to_string_flags_, tab_count, tab_size));
         }
@@ -4553,7 +4553,7 @@ void Dx12AsciiConsumer::Process_ID3D12Fence1_GetCreationFlags(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -4576,7 +4576,7 @@ void Dx12AsciiConsumer::Process_ID3D12PipelineState_GetCachedBlob(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]ppBlob", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppBlob));
         }
@@ -4599,7 +4599,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_Close(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -4623,7 +4623,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_Reset(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pAllocator", to_string_flags_, tab_count, tab_size, HandleIdToString(pAllocator));
             FieldToString(str_strm, false, "pInitialState", to_string_flags_, tab_count, tab_size, HandleIdToString(pInitialState));
@@ -4647,7 +4647,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ClearState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pPipelineState", to_string_flags_, tab_count, tab_size, HandleIdToString(pPipelineState));
         }
@@ -4673,7 +4673,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_DrawInstanced(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "VertexCountPerInstance", to_string_flags_, tab_count, tab_size, ToString(VertexCountPerInstance, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "InstanceCount", to_string_flags_, tab_count, tab_size, ToString(InstanceCount, to_string_flags_, tab_count, tab_size));
@@ -4703,7 +4703,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_DrawIndexedInstanced(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "IndexCountPerInstance", to_string_flags_, tab_count, tab_size, ToString(IndexCountPerInstance, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "InstanceCount", to_string_flags_, tab_count, tab_size, ToString(InstanceCount, to_string_flags_, tab_count, tab_size));
@@ -4732,7 +4732,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_Dispatch(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ThreadGroupCountX", to_string_flags_, tab_count, tab_size, ToString(ThreadGroupCountX, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ThreadGroupCountY", to_string_flags_, tab_count, tab_size, ToString(ThreadGroupCountY, to_string_flags_, tab_count, tab_size));
@@ -4761,7 +4761,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_CopyBufferRegion(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDstBuffer", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstBuffer));
             FieldToString(str_strm, false, "DstOffset", to_string_flags_, tab_count, tab_size, ToString(DstOffset, to_string_flags_, tab_count, tab_size));
@@ -4793,7 +4793,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_CopyTextureRegion(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDst", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDst, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DstX", to_string_flags_, tab_count, tab_size, ToString(DstX, to_string_flags_, tab_count, tab_size));
@@ -4822,7 +4822,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_CopyResource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDstResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstResource));
             FieldToString(str_strm, false, "pSrcResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pSrcResource));
@@ -4851,7 +4851,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_CopyTiles(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pTiledResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pTiledResource));
             FieldToString(str_strm, false, "pTileRegionStartCoordinate", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pTileRegionStartCoordinate, to_string_flags_, tab_count, tab_size));
@@ -4883,7 +4883,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ResolveSubresource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDstResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstResource));
             FieldToString(str_strm, false, "DstSubresource", to_string_flags_, tab_count, tab_size, ToString(DstSubresource, to_string_flags_, tab_count, tab_size));
@@ -4910,7 +4910,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_IASetPrimitiveTopology
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "PrimitiveTopology", to_string_flags_, tab_count, tab_size, '"' + ToString(PrimitiveTopology, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -4934,7 +4934,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_RSSetViewports(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumViewports", to_string_flags_, tab_count, tab_size, ToString(NumViewports, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pViewports", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumViewports, pViewports, to_string_flags_, tab_count, tab_size));
@@ -4959,7 +4959,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_RSSetScissorRects(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumRects", to_string_flags_, tab_count, tab_size, ToString(NumRects, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pRects", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumRects, pRects, to_string_flags_, tab_count, tab_size));
@@ -4983,7 +4983,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_OMSetBlendFactor(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "BlendFactor", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(4, BlendFactor, to_string_flags_, tab_count, tab_size));
         }
@@ -5006,7 +5006,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_OMSetStencilRef(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "StencilRef", to_string_flags_, tab_count, tab_size, ToString(StencilRef, to_string_flags_, tab_count, tab_size));
         }
@@ -5029,7 +5029,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetPipelineState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pPipelineState", to_string_flags_, tab_count, tab_size, HandleIdToString(pPipelineState));
         }
@@ -5052,7 +5052,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ExecuteBundle(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pCommandList", to_string_flags_, tab_count, tab_size, HandleIdToString(pCommandList));
         }
@@ -5076,7 +5076,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetDescriptorHeaps(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumDescriptorHeaps", to_string_flags_, tab_count, tab_size, ToString(NumDescriptorHeaps, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppDescriptorHeaps", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumDescriptorHeaps, ppDescriptorHeaps, to_string_flags_, tab_count, tab_size));
@@ -5100,7 +5100,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootSignatur
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pRootSignature", to_string_flags_, tab_count, tab_size, HandleIdToString(pRootSignature));
         }
@@ -5123,7 +5123,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootSignatu
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pRootSignature", to_string_flags_, tab_count, tab_size, HandleIdToString(pRootSignature));
         }
@@ -5147,7 +5147,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootDescript
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BaseDescriptor", to_string_flags_, tab_count, tab_size, ToString(*BaseDescriptor.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -5172,7 +5172,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootDescrip
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BaseDescriptor", to_string_flags_, tab_count, tab_size, ToString(*BaseDescriptor.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -5198,7 +5198,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetComputeRoot32BitCon
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SrcData", to_string_flags_, tab_count, tab_size, ToString(SrcData, to_string_flags_, tab_count, tab_size));
@@ -5225,7 +5225,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRoot32BitCo
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SrcData", to_string_flags_, tab_count, tab_size, ToString(SrcData, to_string_flags_, tab_count, tab_size));
@@ -5253,7 +5253,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetComputeRoot32BitCon
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Num32BitValuesToSet", to_string_flags_, tab_count, tab_size, ToString(Num32BitValuesToSet, to_string_flags_, tab_count, tab_size));
@@ -5282,7 +5282,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRoot32BitCo
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Num32BitValuesToSet", to_string_flags_, tab_count, tab_size, ToString(Num32BitValuesToSet, to_string_flags_, tab_count, tab_size));
@@ -5309,7 +5309,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootConstant
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BufferLocation", to_string_flags_, tab_count, tab_size, ToString(BufferLocation, to_string_flags_, tab_count, tab_size));
@@ -5334,7 +5334,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootConstan
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BufferLocation", to_string_flags_, tab_count, tab_size, ToString(BufferLocation, to_string_flags_, tab_count, tab_size));
@@ -5359,7 +5359,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootShaderRe
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BufferLocation", to_string_flags_, tab_count, tab_size, ToString(BufferLocation, to_string_flags_, tab_count, tab_size));
@@ -5384,7 +5384,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootShaderR
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BufferLocation", to_string_flags_, tab_count, tab_size, ToString(BufferLocation, to_string_flags_, tab_count, tab_size));
@@ -5409,7 +5409,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootUnordere
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BufferLocation", to_string_flags_, tab_count, tab_size, ToString(BufferLocation, to_string_flags_, tab_count, tab_size));
@@ -5434,7 +5434,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootUnorder
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RootParameterIndex", to_string_flags_, tab_count, tab_size, ToString(RootParameterIndex, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BufferLocation", to_string_flags_, tab_count, tab_size, ToString(BufferLocation, to_string_flags_, tab_count, tab_size));
@@ -5458,7 +5458,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_IASetIndexBuffer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pView", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pView, to_string_flags_, tab_count, tab_size));
         }
@@ -5483,7 +5483,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_IASetVertexBuffers(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "StartSlot", to_string_flags_, tab_count, tab_size, ToString(StartSlot, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NumViews", to_string_flags_, tab_count, tab_size, ToString(NumViews, to_string_flags_, tab_count, tab_size));
@@ -5510,7 +5510,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SOSetTargets(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "StartSlot", to_string_flags_, tab_count, tab_size, ToString(StartSlot, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NumViews", to_string_flags_, tab_count, tab_size, ToString(NumViews, to_string_flags_, tab_count, tab_size));
@@ -5538,7 +5538,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_OMSetRenderTargets(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumRenderTargetDescriptors", to_string_flags_, tab_count, tab_size, ToString(NumRenderTargetDescriptors, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pRenderTargetDescriptors", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString((NumRenderTargetDescriptors ? (RTsSingleHandleToDescriptorRange ? 1 : NumRenderTargetDescriptors) : 0), pRenderTargetDescriptors, to_string_flags_, tab_count, tab_size));
@@ -5569,7 +5569,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ClearDepthStencilView(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "DepthStencilView", to_string_flags_, tab_count, tab_size, ToString(*DepthStencilView.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ClearFlags", to_string_flags_, tab_count, tab_size, '"' + ToString(ClearFlags, to_string_flags_, tab_count, tab_size) + '"');
@@ -5600,7 +5600,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ClearRenderTargetView(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "RenderTargetView", to_string_flags_, tab_count, tab_size, ToString(*RenderTargetView.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ColorRGBA", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(4, ColorRGBA, to_string_flags_, tab_count, tab_size));
@@ -5631,7 +5631,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ClearUnorderedAccessVi
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ViewGPUHandleInCurrentHeap", to_string_flags_, tab_count, tab_size, ToString(*ViewGPUHandleInCurrentHeap.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ViewCPUHandle", to_string_flags_, tab_count, tab_size, ToString(*ViewCPUHandle.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -5664,7 +5664,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ClearUnorderedAccessVi
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ViewGPUHandleInCurrentHeap", to_string_flags_, tab_count, tab_size, ToString(*ViewGPUHandleInCurrentHeap.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ViewCPUHandle", to_string_flags_, tab_count, tab_size, ToString(*ViewCPUHandle.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -5693,7 +5693,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_DiscardResource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "pRegion", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pRegion, to_string_flags_, tab_count, tab_size));
@@ -5719,7 +5719,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_BeginQuery(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pQueryHeap", to_string_flags_, tab_count, tab_size, HandleIdToString(pQueryHeap));
             FieldToString(str_strm, false, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
@@ -5746,7 +5746,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_EndQuery(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pQueryHeap", to_string_flags_, tab_count, tab_size, HandleIdToString(pQueryHeap));
             FieldToString(str_strm, false, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
@@ -5776,7 +5776,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ResolveQueryData(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pQueryHeap", to_string_flags_, tab_count, tab_size, HandleIdToString(pQueryHeap));
             FieldToString(str_strm, false, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
@@ -5806,7 +5806,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetPredication(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pBuffer", to_string_flags_, tab_count, tab_size, HandleIdToString(pBuffer));
             FieldToString(str_strm, false, "AlignedBufferOffset", to_string_flags_, tab_count, tab_size, ToString(AlignedBufferOffset, to_string_flags_, tab_count, tab_size));
@@ -5833,7 +5833,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_SetMarker(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Metadata", to_string_flags_, tab_count, tab_size, ToString(Metadata, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(Size, pData, to_string_flags_, tab_count, tab_size));
@@ -5860,7 +5860,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_BeginEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Metadata", to_string_flags_, tab_count, tab_size, ToString(Metadata, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(Size, pData, to_string_flags_, tab_count, tab_size));
@@ -5884,7 +5884,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_EndEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -5911,7 +5911,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList_ExecuteIndirect(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pCommandSignature", to_string_flags_, tab_count, tab_size, HandleIdToString(pCommandSignature));
             FieldToString(str_strm, false, "MaxCommandCount", to_string_flags_, tab_count, tab_size, ToString(MaxCommandCount, to_string_flags_, tab_count, tab_size));
@@ -5945,7 +5945,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDstBuffer", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstBuffer));
             FieldToString(str_strm, false, "DstOffset", to_string_flags_, tab_count, tab_size, ToString(DstOffset, to_string_flags_, tab_count, tab_size));
@@ -5980,7 +5980,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT6
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDstBuffer", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstBuffer));
             FieldToString(str_strm, false, "DstOffset", to_string_flags_, tab_count, tab_size, ToString(DstOffset, to_string_flags_, tab_count, tab_size));
@@ -6010,7 +6010,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList1_OMSetDepthBounds(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Min", to_string_flags_, tab_count, tab_size, ToString(Min, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Max", to_string_flags_, tab_count, tab_size, ToString(Max, to_string_flags_, tab_count, tab_size));
@@ -6036,7 +6036,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList1_SetSamplePositions(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumSamplesPerPixel", to_string_flags_, tab_count, tab_size, ToString(NumSamplesPerPixel, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NumPixels", to_string_flags_, tab_count, tab_size, ToString(NumPixels, to_string_flags_, tab_count, tab_size));
@@ -6069,7 +6069,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList1_ResolveSubresourceReg
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDstResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstResource));
             FieldToString(str_strm, false, "DstSubresource", to_string_flags_, tab_count, tab_size, ToString(DstSubresource, to_string_flags_, tab_count, tab_size));
@@ -6100,7 +6100,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList1_SetViewInstanceMask(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Mask", to_string_flags_, tab_count, tab_size, ToString(Mask, to_string_flags_, tab_count, tab_size));
         }
@@ -6125,7 +6125,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList2_WriteBufferImmediate(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Count", to_string_flags_, tab_count, tab_size, ToString(Count, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pParams", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(Count, pParams, to_string_flags_, tab_count, tab_size));
@@ -6159,7 +6159,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_UpdateTileMappings(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "NumResourceRegions", to_string_flags_, tab_count, tab_size, ToString(NumResourceRegions, to_string_flags_, tab_count, tab_size));
@@ -6196,7 +6196,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_CopyTileMappings(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDstResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pDstResource));
             FieldToString(str_strm, false, "pDstRegionStartCoordinate", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDstRegionStartCoordinate, to_string_flags_, tab_count, tab_size));
@@ -6225,7 +6225,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_ExecuteCommandLists(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumCommandLists", to_string_flags_, tab_count, tab_size, ToString(NumCommandLists, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppCommandLists", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumCommandLists, ppCommandLists, to_string_flags_, tab_count, tab_size));
@@ -6251,7 +6251,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_SetMarker(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Metadata", to_string_flags_, tab_count, tab_size, ToString(Metadata, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(Size, pData, to_string_flags_, tab_count, tab_size));
@@ -6278,7 +6278,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_BeginEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Metadata", to_string_flags_, tab_count, tab_size, ToString(Metadata, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(Size, pData, to_string_flags_, tab_count, tab_size));
@@ -6302,7 +6302,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_EndEvent(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -6326,7 +6326,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_Signal(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFence", to_string_flags_, tab_count, tab_size, HandleIdToString(pFence));
             FieldToString(str_strm, false, "Value", to_string_flags_, tab_count, tab_size, ToString(Value, to_string_flags_, tab_count, tab_size));
@@ -6352,7 +6352,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_Wait(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFence", to_string_flags_, tab_count, tab_size, HandleIdToString(pFence));
             FieldToString(str_strm, false, "Value", to_string_flags_, tab_count, tab_size, ToString(Value, to_string_flags_, tab_count, tab_size));
@@ -6377,7 +6377,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_GetTimestampFrequency(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pFrequency", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pFrequency, to_string_flags_, tab_count, tab_size));
         }
@@ -6402,7 +6402,7 @@ void Dx12AsciiConsumer::Process_ID3D12CommandQueue_GetClockCalibration(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pGpuTimestamp", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pGpuTimestamp, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pCpuTimestamp", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pCpuTimestamp, to_string_flags_, tab_count, tab_size));
@@ -6426,7 +6426,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetNodeCount(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -6451,7 +6451,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateCommandQueue(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6479,7 +6479,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateCommandAllocator(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "type", to_string_flags_, tab_count, tab_size, '"' + ToString(type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6507,7 +6507,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateGraphicsPipelineState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6535,7 +6535,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateComputePipelineState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6566,7 +6566,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateCommandList(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "nodeMask", to_string_flags_, tab_count, tab_size, ToString(nodeMask, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "type", to_string_flags_, tab_count, tab_size, '"' + ToString(type, to_string_flags_, tab_count, tab_size) + '"');
@@ -6597,7 +6597,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateDescriptorHeap(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDescriptorHeapDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDescriptorHeapDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6623,7 +6623,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetDescriptorHandleIncrementSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "DescriptorHeapType", to_string_flags_, tab_count, tab_size, '"' + ToString(DescriptorHeapType, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -6647,7 +6647,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateConstantBufferView(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DestDescriptor", to_string_flags_, tab_count, tab_size, ToString(*DestDescriptor.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6673,7 +6673,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateShaderResourceView(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -6701,7 +6701,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateUnorderedAccessView(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "pCounterResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pCounterResource));
@@ -6729,7 +6729,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateRenderTargetView(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -6756,7 +6756,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateDepthStencilView(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -6782,7 +6782,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateSampler(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DestDescriptor", to_string_flags_, tab_count, tab_size, ToString(*DestDescriptor.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6812,7 +6812,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CopyDescriptors(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumDestDescriptorRanges", to_string_flags_, tab_count, tab_size, ToString(NumDestDescriptorRanges, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pDestDescriptorRangeStarts", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumDestDescriptorRanges, pDestDescriptorRangeStarts, to_string_flags_, tab_count, tab_size));
@@ -6844,7 +6844,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CopyDescriptorsSimple(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumDescriptors", to_string_flags_, tab_count, tab_size, ToString(NumDescriptors, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DestDescriptorRangeStart", to_string_flags_, tab_count, tab_size, ToString(*DestDescriptorRangeStart.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6877,7 +6877,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateCommittedResource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pHeapProperties", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pHeapProperties, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "HeapFlags", to_string_flags_, tab_count, tab_size, '"' + ToString(HeapFlags, to_string_flags_, tab_count, tab_size) + '"');
@@ -6909,7 +6909,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateHeap(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -6941,7 +6941,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreatePlacedResource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pHeap", to_string_flags_, tab_count, tab_size, HandleIdToString(pHeap));
             FieldToString(str_strm, false, "HeapOffset", to_string_flags_, tab_count, tab_size, ToString(HeapOffset, to_string_flags_, tab_count, tab_size));
@@ -6975,7 +6975,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateReservedResource(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "InitialState", to_string_flags_, tab_count, tab_size, '"' + ToString(InitialState, to_string_flags_, tab_count, tab_size) + '"');
@@ -7007,7 +7007,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateSharedHandle(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pObject", to_string_flags_, tab_count, tab_size, HandleIdToString(pObject));
             FieldToString(str_strm, false, "pAttributes", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pAttributes, to_string_flags_, tab_count, tab_size));
@@ -7037,7 +7037,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_OpenSharedHandle(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NTHandle", to_string_flags_, tab_count, tab_size, HandleIdToString(NTHandle));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -7065,7 +7065,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_OpenSharedHandleByName(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Name", to_string_flags_, tab_count, tab_size, StringDecoderToString(Name));
             FieldToString(str_strm, false, "Access", to_string_flags_, tab_count, tab_size, ToString(Access, to_string_flags_, tab_count, tab_size));
@@ -7092,7 +7092,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_MakeResident(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumObjects", to_string_flags_, tab_count, tab_size, ToString(NumObjects, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppObjects", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumObjects, ppObjects, to_string_flags_, tab_count, tab_size));
@@ -7118,7 +7118,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_Evict(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumObjects", to_string_flags_, tab_count, tab_size, ToString(NumObjects, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppObjects", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumObjects, ppObjects, to_string_flags_, tab_count, tab_size));
@@ -7146,7 +7146,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateFence(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "InitialValue", to_string_flags_, tab_count, tab_size, ToString(InitialValue, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Flags", to_string_flags_, tab_count, tab_size, '"' + ToString(Flags, to_string_flags_, tab_count, tab_size) + '"');
@@ -7172,7 +7172,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetDeviceRemovedReason(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -7201,7 +7201,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetCopyableFootprints(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResourceDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pResourceDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "FirstSubresource", to_string_flags_, tab_count, tab_size, ToString(FirstSubresource, to_string_flags_, tab_count, tab_size));
@@ -7234,7 +7234,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateQueryHeap(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -7260,7 +7260,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_SetStablePowerState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enable", to_string_flags_, tab_count, tab_size, ToString(Enable, to_string_flags_, tab_count, tab_size));
         }
@@ -7287,7 +7287,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_CreateCommandSignature(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pRootSignature", to_string_flags_, tab_count, tab_size, HandleIdToString(pRootSignature));
@@ -7319,7 +7319,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device_GetResourceTiling(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pTiledResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pTiledResource));
             FieldToString(str_strm, false, "[out]pNumTilesForEntireResource", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pNumTilesForEntireResource, to_string_flags_, tab_count, tab_size));
@@ -7350,7 +7350,7 @@ void Dx12AsciiConsumer::Process_ID3D12PipelineLibrary_StorePipeline(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pName", to_string_flags_, tab_count, tab_size, StringDecoderToString(pName));
             FieldToString(str_strm, false, "pPipeline", to_string_flags_, tab_count, tab_size, HandleIdToString(pPipeline));
@@ -7378,7 +7378,7 @@ void Dx12AsciiConsumer::Process_ID3D12PipelineLibrary_LoadGraphicsPipeline(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pName", to_string_flags_, tab_count, tab_size, StringDecoderToString(pName));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -7408,7 +7408,7 @@ void Dx12AsciiConsumer::Process_ID3D12PipelineLibrary_LoadComputePipeline(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pName", to_string_flags_, tab_count, tab_size, StringDecoderToString(pName));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -7434,7 +7434,7 @@ void Dx12AsciiConsumer::Process_ID3D12PipelineLibrary_GetSerializedSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -7458,7 +7458,7 @@ void Dx12AsciiConsumer::Process_ID3D12PipelineLibrary_Serialize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSizeInBytes, pData, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DataSizeInBytes", to_string_flags_, tab_count, tab_size, ToString(DataSizeInBytes, to_string_flags_, tab_count, tab_size));
@@ -7486,7 +7486,7 @@ void Dx12AsciiConsumer::Process_ID3D12PipelineLibrary1_LoadPipeline(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pName", to_string_flags_, tab_count, tab_size, StringDecoderToString(pName));
             FieldToString(str_strm, false, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
@@ -7517,7 +7517,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device1_SetEventOnMultipleFenceCompletion(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ppFences", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumFences, ppFences, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pFenceValues", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumFences, pFenceValues, to_string_flags_, tab_count, tab_size));
@@ -7547,7 +7547,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device1_SetResidencyPriority(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumObjects", to_string_flags_, tab_count, tab_size, ToString(NumObjects, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ppObjects", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(NumObjects, ppObjects, to_string_flags_, tab_count, tab_size));
@@ -7575,7 +7575,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device2_CreatePipelineState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -7603,7 +7603,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device3_OpenExistingHeapFromAddress(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pAddress", to_string_flags_, tab_count, tab_size, HandleIdToString(pAddress));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -7631,7 +7631,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device3_OpenExistingHeapFromFileMapping(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "hFileMapping", to_string_flags_, tab_count, tab_size, HandleIdToString(hFileMapping));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -7661,7 +7661,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device3_EnqueueMakeResident(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Flags", to_string_flags_, tab_count, tab_size, '"' + ToString(Flags, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "NumObjects", to_string_flags_, tab_count, tab_size, ToString(NumObjects, to_string_flags_, tab_count, tab_size));
@@ -7690,7 +7690,7 @@ void Dx12AsciiConsumer::Process_ID3D12ProtectedSession_GetStatusFence(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppFence", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppFence));
@@ -7714,7 +7714,7 @@ void Dx12AsciiConsumer::Process_ID3D12ProtectedSession_GetSessionStatus(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -7741,7 +7741,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device4_CreateCommandList1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "nodeMask", to_string_flags_, tab_count, tab_size, ToString(nodeMask, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "type", to_string_flags_, tab_count, tab_size, '"' + ToString(type, to_string_flags_, tab_count, tab_size) + '"');
@@ -7771,7 +7771,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device4_CreateProtectedResourceSession(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -7804,7 +7804,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device4_CreateCommittedResource1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pHeapProperties", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pHeapProperties, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "HeapFlags", to_string_flags_, tab_count, tab_size, '"' + ToString(HeapFlags, to_string_flags_, tab_count, tab_size) + '"');
@@ -7838,7 +7838,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device4_CreateHeap1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pProtectedSession", to_string_flags_, tab_count, tab_size, HandleIdToString(pProtectedSession));
@@ -7870,7 +7870,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device4_CreateReservedResource1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "InitialState", to_string_flags_, tab_count, tab_size, '"' + ToString(InitialState, to_string_flags_, tab_count, tab_size) + '"');
@@ -7898,7 +7898,7 @@ void Dx12AsciiConsumer::Process_ID3D12LifetimeOwner_LifetimeStateUpdated(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NewState", to_string_flags_, tab_count, tab_size, '"' + ToString(NewState, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -7921,7 +7921,7 @@ void Dx12AsciiConsumer::Process_ID3D12SwapChainAssistant_GetLUID(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -7945,7 +7945,7 @@ void Dx12AsciiConsumer::Process_ID3D12SwapChainAssistant_GetSwapChainObject(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppv", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppv));
@@ -7973,7 +7973,7 @@ void Dx12AsciiConsumer::Process_ID3D12SwapChainAssistant_GetCurrentResourceAndCo
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riidResource", to_string_flags_, tab_count, tab_size, ToString(*riidResource.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppvResource", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppvResource));
@@ -7999,7 +7999,7 @@ void Dx12AsciiConsumer::Process_ID3D12SwapChainAssistant_InsertImplicitSync(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -8022,7 +8022,7 @@ void Dx12AsciiConsumer::Process_ID3D12LifetimeTracker_DestroyOwnedObject(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pObject", to_string_flags_, tab_count, tab_size, HandleIdToString(pObject));
         }
@@ -8046,7 +8046,7 @@ void Dx12AsciiConsumer::Process_ID3D12StateObjectProperties_GetShaderIdentifier(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pExportName", to_string_flags_, tab_count, tab_size, StringDecoderToString(pExportName));
         }
@@ -8070,7 +8070,7 @@ void Dx12AsciiConsumer::Process_ID3D12StateObjectProperties_GetShaderStackSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pExportName", to_string_flags_, tab_count, tab_size, StringDecoderToString(pExportName));
         }
@@ -8093,7 +8093,7 @@ void Dx12AsciiConsumer::Process_ID3D12StateObjectProperties_GetPipelineStackSize
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -8115,7 +8115,7 @@ void Dx12AsciiConsumer::Process_ID3D12StateObjectProperties_SetPipelineStackSize
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "PipelineStackSizeInBytes", to_string_flags_, tab_count, tab_size, ToString(PipelineStackSizeInBytes, to_string_flags_, tab_count, tab_size));
         }
@@ -8141,7 +8141,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_CreateLifetimeTracker(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pOwner", to_string_flags_, tab_count, tab_size, HandleIdToString(pOwner));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -8165,7 +8165,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_RemoveDevice(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -8189,7 +8189,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_EnumerateMetaCommands(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pNumMetaCommands", to_string_flags_, tab_count, tab_size, PointerDecoderToString(pNumMetaCommands, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pDescs", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(pNumMetaCommands, pDescs, to_string_flags_, tab_count, tab_size));
@@ -8218,7 +8218,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_EnumerateMetaCommandParameters(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "CommandId", to_string_flags_, tab_count, tab_size, ToString(*CommandId.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Stage", to_string_flags_, tab_count, tab_size, '"' + ToString(Stage, to_string_flags_, tab_count, tab_size) + '"');
@@ -8251,7 +8251,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_CreateMetaCommand(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "CommandId", to_string_flags_, tab_count, tab_size, ToString(*CommandId.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NodeMask", to_string_flags_, tab_count, tab_size, ToString(NodeMask, to_string_flags_, tab_count, tab_size));
@@ -8282,7 +8282,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_CreateStateObject(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -8308,7 +8308,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_GetRaytracingAccelerationStructure
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]pInfo", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pInfo, to_string_flags_, tab_count, tab_size));
@@ -8334,7 +8334,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device5_CheckDriverMatchingIdentifier(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "SerializedDataType", to_string_flags_, tab_count, tab_size, '"' + ToString(SerializedDataType, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "pIdentifierToCheck", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pIdentifierToCheck, to_string_flags_, tab_count, tab_size));
@@ -8358,7 +8358,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings_SetAutoB
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enablement", to_string_flags_, tab_count, tab_size, '"' + ToString(Enablement, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -8381,7 +8381,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings_SetPageF
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enablement", to_string_flags_, tab_count, tab_size, '"' + ToString(Enablement, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -8404,7 +8404,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings_SetWatso
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enablement", to_string_flags_, tab_count, tab_size, '"' + ToString(Enablement, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -8427,7 +8427,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings1_SetBrea
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enablement", to_string_flags_, tab_count, tab_size, '"' + ToString(Enablement, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -8450,7 +8450,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings2_UseMark
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "MarkersOnly", to_string_flags_, tab_count, tab_size, ToString(MarkersOnly, to_string_flags_, tab_count, tab_size));
         }
@@ -8474,7 +8474,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedData_GetAutoBreadcrum
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pOutput", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pOutput, to_string_flags_, tab_count, tab_size));
         }
@@ -8498,7 +8498,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedData_GetPageFaultAllo
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pOutput", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pOutput, to_string_flags_, tab_count, tab_size));
         }
@@ -8522,7 +8522,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedData1_GetAutoBreadcru
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pOutput", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pOutput, to_string_flags_, tab_count, tab_size));
         }
@@ -8546,7 +8546,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedData1_GetPageFaultAll
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pOutput", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pOutput, to_string_flags_, tab_count, tab_size));
         }
@@ -8570,7 +8570,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedData2_GetPageFaultAll
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pOutput", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pOutput, to_string_flags_, tab_count, tab_size));
         }
@@ -8593,7 +8593,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceRemovedExtendedData2_GetDeviceState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -8619,7 +8619,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device6_SetBackgroundProcessingMode(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Mode", to_string_flags_, tab_count, tab_size, '"' + ToString(Mode, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "MeasurementsAction", to_string_flags_, tab_count, tab_size, '"' + ToString(MeasurementsAction, to_string_flags_, tab_count, tab_size) + '"');
@@ -8645,7 +8645,7 @@ void Dx12AsciiConsumer::Process_ID3D12ProtectedResourceSession1_GetDesc1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -8671,7 +8671,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device7_AddToStateObject(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pAddition", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pAddition, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pStateObjectToGrowFrom", to_string_flags_, tab_count, tab_size, HandleIdToString(pStateObjectToGrowFrom));
@@ -8700,7 +8700,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device7_CreateProtectedResourceSession1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -8729,7 +8729,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device8_GetResourceAllocationInfo2(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "visibleMask", to_string_flags_, tab_count, tab_size, ToString(visibleMask, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "numResourceDescs", to_string_flags_, tab_count, tab_size, ToString(numResourceDescs, to_string_flags_, tab_count, tab_size));
@@ -8763,7 +8763,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device8_CreateCommittedResource2(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pHeapProperties", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pHeapProperties, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "HeapFlags", to_string_flags_, tab_count, tab_size, '"' + ToString(HeapFlags, to_string_flags_, tab_count, tab_size) + '"');
@@ -8800,7 +8800,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device8_CreatePlacedResource1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pHeap", to_string_flags_, tab_count, tab_size, HandleIdToString(pHeap));
             FieldToString(str_strm, false, "HeapOffset", to_string_flags_, tab_count, tab_size, ToString(HeapOffset, to_string_flags_, tab_count, tab_size));
@@ -8831,7 +8831,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device8_CreateSamplerFeedbackUnorderedAcce
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pTargetedResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pTargetedResource));
             FieldToString(str_strm, false, "pFeedbackResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pFeedbackResource));
@@ -8863,7 +8863,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device8_GetCopyableFootprints1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResourceDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pResourceDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "FirstSubresource", to_string_flags_, tab_count, tab_size, ToString(FirstSubresource, to_string_flags_, tab_count, tab_size));
@@ -8895,7 +8895,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource1_GetProtectedResourceSession(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppProtectedSession", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppProtectedSession));
@@ -8919,7 +8919,7 @@ void Dx12AsciiConsumer::Process_ID3D12Resource2_GetDesc1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -8943,7 +8943,7 @@ void Dx12AsciiConsumer::Process_ID3D12Heap1_GetProtectedResourceSession(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppProtectedSession", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppProtectedSession));
@@ -8967,7 +8967,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList3_SetProtectedResourceS
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pProtectedResourceSession", to_string_flags_, tab_count, tab_size, HandleIdToString(pProtectedResourceSession));
         }
@@ -8992,7 +8992,7 @@ void Dx12AsciiConsumer::Process_ID3D12MetaCommand_GetRequiredParameterResourceSi
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Stage", to_string_flags_, tab_count, tab_size, '"' + ToString(Stage, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "ParameterIndex", to_string_flags_, tab_count, tab_size, ToString(ParameterIndex, to_string_flags_, tab_count, tab_size));
@@ -9019,7 +9019,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_BeginRenderPass(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumRenderTargets", to_string_flags_, tab_count, tab_size, ToString(NumRenderTargets, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pRenderTargets", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumRenderTargets, pRenderTargets, to_string_flags_, tab_count, tab_size));
@@ -9044,7 +9044,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_EndRenderPass(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9068,7 +9068,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_InitializeMetaCommand
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pMetaCommand", to_string_flags_, tab_count, tab_size, HandleIdToString(pMetaCommand));
             FieldToString(str_strm, false, "pInitializationParametersData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(InitializationParametersDataSizeInBytes, pInitializationParametersData, to_string_flags_, tab_count, tab_size));
@@ -9095,7 +9095,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_ExecuteMetaCommand(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pMetaCommand", to_string_flags_, tab_count, tab_size, HandleIdToString(pMetaCommand));
             FieldToString(str_strm, false, "pExecutionParametersData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(ExecutionParametersDataSizeInBytes, pExecutionParametersData, to_string_flags_, tab_count, tab_size));
@@ -9122,7 +9122,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_BuildRaytracingAccele
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NumPostbuildInfoDescs", to_string_flags_, tab_count, tab_size, ToString(NumPostbuildInfoDescs, to_string_flags_, tab_count, tab_size));
@@ -9149,7 +9149,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_EmitRaytracingAcceler
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NumSourceAccelerationStructures", to_string_flags_, tab_count, tab_size, ToString(NumSourceAccelerationStructures, to_string_flags_, tab_count, tab_size));
@@ -9176,7 +9176,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_CopyRaytracingAcceler
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "DestAccelerationStructureData", to_string_flags_, tab_count, tab_size, ToString(DestAccelerationStructureData, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SourceAccelerationStructureData", to_string_flags_, tab_count, tab_size, ToString(SourceAccelerationStructureData, to_string_flags_, tab_count, tab_size));
@@ -9201,7 +9201,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_SetPipelineState1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pStateObject", to_string_flags_, tab_count, tab_size, HandleIdToString(pStateObject));
         }
@@ -9224,7 +9224,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList4_DispatchRays(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
         }
@@ -9251,7 +9251,7 @@ void Dx12AsciiConsumer::Process_ID3D12ShaderCacheSession_FindValue(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pKey", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(KeySize, pKey, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "KeySize", to_string_flags_, tab_count, tab_size, ToString(KeySize, to_string_flags_, tab_count, tab_size));
@@ -9281,7 +9281,7 @@ void Dx12AsciiConsumer::Process_ID3D12ShaderCacheSession_StoreValue(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pKey", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(KeySize, pKey, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "KeySize", to_string_flags_, tab_count, tab_size, ToString(KeySize, to_string_flags_, tab_count, tab_size));
@@ -9306,7 +9306,7 @@ void Dx12AsciiConsumer::Process_ID3D12ShaderCacheSession_SetDeleteOnDestroy(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9328,7 +9328,7 @@ void Dx12AsciiConsumer::Process_ID3D12ShaderCacheSession_GetDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9353,7 +9353,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device9_CreateShaderCacheSession(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -9380,7 +9380,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device9_ShaderCacheControl(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Kinds", to_string_flags_, tab_count, tab_size, '"' + ToString(Kinds, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "Control", to_string_flags_, tab_count, tab_size, '"' + ToString(Control, to_string_flags_, tab_count, tab_size) + '"');
@@ -9408,7 +9408,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device9_CreateCommandQueue1(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "CreatorID", to_string_flags_, tab_count, tab_size, ToString(*CreatorID.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -9444,7 +9444,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device10_CreateCommittedResource3(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pHeapProperties", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pHeapProperties, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "HeapFlags", to_string_flags_, tab_count, tab_size, '"' + ToString(HeapFlags, to_string_flags_, tab_count, tab_size) + '"');
@@ -9485,7 +9485,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device10_CreatePlacedResource2(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pHeap", to_string_flags_, tab_count, tab_size, HandleIdToString(pHeap));
             FieldToString(str_strm, false, "HeapOffset", to_string_flags_, tab_count, tab_size, ToString(HeapOffset, to_string_flags_, tab_count, tab_size));
@@ -9524,7 +9524,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device10_CreateReservedResource2(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "InitialLayout", to_string_flags_, tab_count, tab_size, '"' + ToString(InitialLayout, to_string_flags_, tab_count, tab_size) + '"');
@@ -9555,7 +9555,7 @@ void Dx12AsciiConsumer::Process_ID3D12Device11_CreateSampler2(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "DestDescriptor", to_string_flags_, tab_count, tab_size, ToString(*DestDescriptor.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -9581,7 +9581,7 @@ void Dx12AsciiConsumer::Process_ID3D12VirtualizationGuestDevice_ShareWithHost(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pObject", to_string_flags_, tab_count, tab_size, HandleIdToString(pObject));
             FieldToString(str_strm, false, "[out]pHandle", to_string_flags_, tab_count, tab_size, HandleIdToString(pHandle));
@@ -9608,7 +9608,7 @@ void Dx12AsciiConsumer::Process_ID3D12VirtualizationGuestDevice_CreateFenceFd(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFence", to_string_flags_, tab_count, tab_size, HandleIdToString(pFence));
             FieldToString(str_strm, false, "FenceValue", to_string_flags_, tab_count, tab_size, ToString(FenceValue, to_string_flags_, tab_count, tab_size));
@@ -9633,7 +9633,7 @@ void Dx12AsciiConsumer::Process_ID3D12Tools_EnableShaderInstrumentation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "bEnable", to_string_flags_, tab_count, tab_size, ToString(bEnable, to_string_flags_, tab_count, tab_size));
         }
@@ -9656,7 +9656,7 @@ void Dx12AsciiConsumer::Process_ID3D12Tools_ShaderInstrumentationEnabled(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9680,7 +9680,7 @@ void Dx12AsciiConsumer::Process_ID3D12SDKConfiguration_SetSDKVersion(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "SDKVersion", to_string_flags_, tab_count, tab_size, ToString(SDKVersion, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SDKPath", to_string_flags_, tab_count, tab_size, StringDecoderToString(SDKPath));
@@ -9708,7 +9708,7 @@ void Dx12AsciiConsumer::Process_ID3D12SDKConfiguration1_CreateDeviceFactory(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "SDKVersion", to_string_flags_, tab_count, tab_size, ToString(SDKVersion, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "SDKPath", to_string_flags_, tab_count, tab_size, StringDecoderToString(SDKPath));
@@ -9733,7 +9733,7 @@ void Dx12AsciiConsumer::Process_ID3D12SDKConfiguration1_FreeUnusedSDKs(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9755,7 +9755,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceFactory_InitializeFromGlobalState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9777,7 +9777,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceFactory_ApplyToGlobalState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9800,7 +9800,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceFactory_SetFlags(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "flags", to_string_flags_, tab_count, tab_size, '"' + ToString(flags, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -9823,7 +9823,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceFactory_GetFlags(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9848,7 +9848,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceFactory_GetConfigurationInterface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "clsid", to_string_flags_, tab_count, tab_size, ToString(*clsid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "iid", to_string_flags_, tab_count, tab_size, ToString(*iid.decoded_value, to_string_flags_, tab_count, tab_size));
@@ -9877,7 +9877,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceFactory_EnableExperimentalFeatures(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumFeatures", to_string_flags_, tab_count, tab_size, ToString(NumFeatures, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pIIDs", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumFeatures, pIIDs, to_string_flags_, tab_count, tab_size));
@@ -9907,7 +9907,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceFactory_CreateDevice(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "adapter", to_string_flags_, tab_count, tab_size, HandleIdToString(adapter));
             FieldToString(str_strm, false, "FeatureLevel", to_string_flags_, tab_count, tab_size, '"' + ToString(FeatureLevel, to_string_flags_, tab_count, tab_size) + '"');
@@ -9933,7 +9933,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceConfiguration_GetDesc(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -9957,7 +9957,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceConfiguration_GetEnabledExperimental
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "[out]pGuids", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumGuids, pGuids, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "NumGuids", to_string_flags_, tab_count, tab_size, ToString(NumGuids, to_string_flags_, tab_count, tab_size));
@@ -9984,7 +9984,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceConfiguration_SerializeVersionedRoot
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pDesc", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pDesc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppResult", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppResult));
@@ -10013,7 +10013,7 @@ void Dx12AsciiConsumer::Process_ID3D12DeviceConfiguration_CreateVersionedRootSig
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pBlob", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(Size, pBlob, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "Size", to_string_flags_, tab_count, tab_size, ToString(Size, to_string_flags_, tab_count, tab_size));
@@ -10040,7 +10040,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList5_RSSetShadingRate(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "baseShadingRate", to_string_flags_, tab_count, tab_size, '"' + ToString(baseShadingRate, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "combiners", to_string_flags_, tab_count, tab_size, EnumPointerDecoderArrayToString(D3D12_RS_SET_SHADING_RATE_COMBINER_COUNT, combiners, to_string_flags_, tab_count, tab_size));
@@ -10064,7 +10064,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList5_RSSetShadingRateImage
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "shadingRateImage", to_string_flags_, tab_count, tab_size, HandleIdToString(shadingRateImage));
         }
@@ -10089,7 +10089,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList6_DispatchMesh(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ThreadGroupCountX", to_string_flags_, tab_count, tab_size, ToString(ThreadGroupCountX, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "ThreadGroupCountY", to_string_flags_, tab_count, tab_size, ToString(ThreadGroupCountY, to_string_flags_, tab_count, tab_size));
@@ -10115,7 +10115,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList7_Barrier(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "NumBarrierGroups", to_string_flags_, tab_count, tab_size, ToString(NumBarrierGroups, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pBarrierGroups", to_string_flags_, tab_count, tab_size, StructPointerDecoderArrayToString(NumBarrierGroups, pBarrierGroups, to_string_flags_, tab_count, tab_size));
@@ -10140,7 +10140,7 @@ void Dx12AsciiConsumer::Process_ID3D12GraphicsCommandList8_OMSetFrontAndBackSten
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "FrontStencilRef", to_string_flags_, tab_count, tab_size, ToString(FrontStencilRef, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "BackStencilRef", to_string_flags_, tab_count, tab_size, ToString(BackStencilRef, to_string_flags_, tab_count, tab_size));
@@ -10168,7 +10168,7 @@ void Dx12AsciiConsumer::Process_ID3D10Blob_GetBufferPointer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -10190,7 +10190,7 @@ void Dx12AsciiConsumer::Process_ID3D10Blob_GetBufferSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -10215,7 +10215,7 @@ void Dx12AsciiConsumer::Process_ID3DDestructionNotifier_RegisterDestructionCallb
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "callbackFn", to_string_flags_, tab_count, tab_size, ToString(callbackFn, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, HandleIdToString(pData));
@@ -10241,7 +10241,7 @@ void Dx12AsciiConsumer::Process_ID3DDestructionNotifier_UnregisterDestructionCal
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "callbackID", to_string_flags_, tab_count, tab_size, ToString(callbackID, to_string_flags_, tab_count, tab_size));
         }
@@ -10267,7 +10267,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug_EnableDebugLayer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -10288,7 +10288,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug1_EnableDebugLayer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -10310,7 +10310,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug1_SetEnableGPUBasedValidation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enable", to_string_flags_, tab_count, tab_size, ToString(Enable, to_string_flags_, tab_count, tab_size));
         }
@@ -10333,7 +10333,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug1_SetEnableSynchronizedCommandQueueVa
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enable", to_string_flags_, tab_count, tab_size, ToString(Enable, to_string_flags_, tab_count, tab_size));
         }
@@ -10356,7 +10356,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug2_SetGPUBasedValidationFlags(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Flags", to_string_flags_, tab_count, tab_size, '"' + ToString(Flags, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -10379,7 +10379,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug3_SetEnableGPUBasedValidation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enable", to_string_flags_, tab_count, tab_size, ToString(Enable, to_string_flags_, tab_count, tab_size));
         }
@@ -10402,7 +10402,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug3_SetEnableSynchronizedCommandQueueVa
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enable", to_string_flags_, tab_count, tab_size, ToString(Enable, to_string_flags_, tab_count, tab_size));
         }
@@ -10425,7 +10425,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug3_SetGPUBasedValidationFlags(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Flags", to_string_flags_, tab_count, tab_size, '"' + ToString(Flags, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -10447,7 +10447,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug4_DisableDebugLayer(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -10469,7 +10469,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug5_SetEnableAutoName(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enable", to_string_flags_, tab_count, tab_size, ToString(Enable, to_string_flags_, tab_count, tab_size));
         }
@@ -10492,7 +10492,7 @@ void Dx12AsciiConsumer::Process_ID3D12Debug6_SetForceLegacyBarrierValidation(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Enable", to_string_flags_, tab_count, tab_size, ToString(Enable, to_string_flags_, tab_count, tab_size));
         }
@@ -10518,7 +10518,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice1_SetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -10546,7 +10546,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice1_GetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "[out]pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -10572,7 +10572,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice1_ReportLiveDeviceObjects(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Flags", to_string_flags_, tab_count, tab_size, '"' + ToString(Flags, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -10596,7 +10596,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice_SetFeatureMask(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Mask", to_string_flags_, tab_count, tab_size, '"' + ToString(Mask, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -10619,7 +10619,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice_GetFeatureMask(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -10642,7 +10642,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice_ReportLiveDeviceObjects(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Flags", to_string_flags_, tab_count, tab_size, '"' + ToString(Flags, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -10668,7 +10668,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice2_SetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -10696,7 +10696,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugDevice2_GetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "[out]pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -10724,7 +10724,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandQueue_AssertResourceState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -10751,7 +10751,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandQueue1_AssertResourceAccess(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -10778,7 +10778,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandQueue1_AssertTextureLayout(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -10806,7 +10806,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList1_AssertResourceState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -10834,7 +10834,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList1_SetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -10862,7 +10862,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList1_GetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "[out]pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -10890,7 +10890,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList_AssertResourceState(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -10916,7 +10916,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList_SetFeatureMask(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Mask", to_string_flags_, tab_count, tab_size, '"' + ToString(Mask, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -10939,7 +10939,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList_GetFeatureMask(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -10964,7 +10964,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList2_SetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -10992,7 +10992,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList2_GetDebugParameter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Type", to_string_flags_, tab_count, tab_size, '"' + ToString(Type, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "[out]pData", to_string_flags_, tab_count, tab_size, PointerDecoderArrayToString(DataSize, pData, to_string_flags_, tab_count, tab_size));
@@ -11019,7 +11019,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList3_AssertResourceAccess(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -11046,7 +11046,7 @@ void Dx12AsciiConsumer::Process_ID3D12DebugCommandList3_AssertTextureLayout(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -11073,7 +11073,7 @@ void Dx12AsciiConsumer::Process_ID3D12SharingContract_Present(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pResource", to_string_flags_, tab_count, tab_size, HandleIdToString(pResource));
             FieldToString(str_strm, false, "Subresource", to_string_flags_, tab_count, tab_size, ToString(Subresource, to_string_flags_, tab_count, tab_size));
@@ -11099,7 +11099,7 @@ void Dx12AsciiConsumer::Process_ID3D12SharingContract_SharedFenceSignal(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFence", to_string_flags_, tab_count, tab_size, HandleIdToString(pFence));
             FieldToString(str_strm, false, "FenceValue", to_string_flags_, tab_count, tab_size, ToString(FenceValue, to_string_flags_, tab_count, tab_size));
@@ -11123,7 +11123,7 @@ void Dx12AsciiConsumer::Process_ID3D12SharingContract_BeginCapturableWork(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "guid", to_string_flags_, tab_count, tab_size, ToString(*guid.decoded_value, to_string_flags_, tab_count, tab_size));
         }
@@ -11146,7 +11146,7 @@ void Dx12AsciiConsumer::Process_ID3D12SharingContract_EndCapturableWork(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "guid", to_string_flags_, tab_count, tab_size, ToString(*guid.decoded_value, to_string_flags_, tab_count, tab_size));
         }
@@ -11170,7 +11170,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_SetMessageCountLimit(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "MessageCountLimit", to_string_flags_, tab_count, tab_size, ToString(MessageCountLimit, to_string_flags_, tab_count, tab_size));
         }
@@ -11192,7 +11192,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_ClearStoredMessages(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11214,7 +11214,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetNumMessagesAllowedByStorageFi
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11236,7 +11236,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetNumMessagesDeniedByStorageFil
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11258,7 +11258,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetNumStoredMessages(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11280,7 +11280,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetNumStoredMessagesAllowedByRet
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11302,7 +11302,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetNumMessagesDiscardedByMessage
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11324,7 +11324,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetMessageCountLimit(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11347,7 +11347,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_AddStorageFilterEntries(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFilter", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pFilter, to_string_flags_, tab_count, tab_size));
         }
@@ -11369,7 +11369,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_ClearStorageFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11391,7 +11391,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PushEmptyStorageFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11413,7 +11413,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PushCopyOfStorageFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11436,7 +11436,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PushStorageFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFilter", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pFilter, to_string_flags_, tab_count, tab_size));
         }
@@ -11458,7 +11458,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PopStorageFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11480,7 +11480,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetStorageFilterStackSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11503,7 +11503,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_AddRetrievalFilterEntries(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFilter", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pFilter, to_string_flags_, tab_count, tab_size));
         }
@@ -11525,7 +11525,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_ClearRetrievalFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11547,7 +11547,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PushEmptyRetrievalFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11569,7 +11569,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PushCopyOfRetrievalFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11592,7 +11592,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PushRetrievalFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "pFilter", to_string_flags_, tab_count, tab_size, StructPointerDecoderToString(pFilter, to_string_flags_, tab_count, tab_size));
         }
@@ -11614,7 +11614,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_PopRetrievalFilter(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11636,7 +11636,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetRetrievalFilterStackSize(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11662,7 +11662,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_AddMessage(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Category", to_string_flags_, tab_count, tab_size, '"' + ToString(Category, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "Severity", to_string_flags_, tab_count, tab_size, '"' + ToString(Severity, to_string_flags_, tab_count, tab_size) + '"');
@@ -11690,7 +11690,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_AddApplicationMessage(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Severity", to_string_flags_, tab_count, tab_size, '"' + ToString(Severity, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "pDescription", to_string_flags_, tab_count, tab_size, StringDecoderToString(pDescription));
@@ -11716,7 +11716,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_SetBreakOnCategory(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Category", to_string_flags_, tab_count, tab_size, '"' + ToString(Category, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "bEnable", to_string_flags_, tab_count, tab_size, ToString(bEnable, to_string_flags_, tab_count, tab_size));
@@ -11742,7 +11742,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_SetBreakOnSeverity(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Severity", to_string_flags_, tab_count, tab_size, '"' + ToString(Severity, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "bEnable", to_string_flags_, tab_count, tab_size, ToString(bEnable, to_string_flags_, tab_count, tab_size));
@@ -11768,7 +11768,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_SetBreakOnID(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ID", to_string_flags_, tab_count, tab_size, '"' + ToString(ID, to_string_flags_, tab_count, tab_size) + '"');
             FieldToString(str_strm, false, "bEnable", to_string_flags_, tab_count, tab_size, ToString(bEnable, to_string_flags_, tab_count, tab_size));
@@ -11793,7 +11793,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetBreakOnCategory(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Category", to_string_flags_, tab_count, tab_size, '"' + ToString(Category, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -11817,7 +11817,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetBreakOnSeverity(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "Severity", to_string_flags_, tab_count, tab_size, '"' + ToString(Severity, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -11841,7 +11841,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetBreakOnID(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "ID", to_string_flags_, tab_count, tab_size, '"' + ToString(ID, to_string_flags_, tab_count, tab_size) + '"');
         }
@@ -11864,7 +11864,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_SetMuteDebugOutput(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "bMute", to_string_flags_, tab_count, tab_size, ToString(bMute, to_string_flags_, tab_count, tab_size));
         }
@@ -11887,7 +11887,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue_GetMuteDebugOutput(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -11913,7 +11913,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue1_RegisterMessageCallback(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "CallbackFunc", to_string_flags_, tab_count, tab_size, ToString(CallbackFunc, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "CallbackFilterFlags", to_string_flags_, tab_count, tab_size, '"' + ToString(CallbackFilterFlags, to_string_flags_, tab_count, tab_size) + '"');
@@ -11940,7 +11940,7 @@ void Dx12AsciiConsumer::Process_ID3D12InfoQueue1_UnregisterMessageCallback(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "CallbackCookie", to_string_flags_, tab_count, tab_size, ToString(CallbackCookie, to_string_flags_, tab_count, tab_size));
         }
@@ -11969,7 +11969,7 @@ void Dx12AsciiConsumer::Process_IUnknown_QueryInterface(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
             FieldToString(str_strm, true, "riid", to_string_flags_, tab_count, tab_size, ToString(*riid.decoded_value, to_string_flags_, tab_count, tab_size));
             FieldToString(str_strm, false, "[out]ppvObject", to_string_flags_, tab_count, tab_size, OutPtrDecoderToString(ppvObject));
@@ -11993,7 +11993,7 @@ void Dx12AsciiConsumer::Process_IUnknown_AddRef(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );
@@ -12015,7 +12015,7 @@ void Dx12AsciiConsumer::Process_IUnknown_Release(
     writeApiCallToFileInfo.pReturnValue = !returnValue.empty() ? returnValue.c_str() : nullptr;
     WriteApiCallToFile(
         writeApiCallToFileInfo, tab_count, tab_size,
-        [&](std::stringstream& str_strm)
+        [&](std::ostringstream& str_strm)
         {
         }
     );

--- a/framework/generated/generated_dx12_struct_to_string.cpp
+++ b/framework/generated/generated_dx12_struct_to_string.cpp
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(util)
 template <> std::string ToString<DXGI_FRAME_STATISTICS>(const DXGI_FRAME_STATISTICS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "PresentCount", toStringFlags, tabCount, tabSize, ToString(obj.PresentCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "PresentRefreshCount", toStringFlags, tabCount, tabSize, ToString(obj.PresentRefreshCount, toStringFlags, tabCount, tabSize));
@@ -50,7 +50,7 @@ template <> std::string ToString<DXGI_FRAME_STATISTICS>(const DXGI_FRAME_STATIST
 template <> std::string ToString<DXGI_MAPPED_RECT>(const DXGI_MAPPED_RECT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Pitch", toStringFlags, tabCount, tabSize, ToString(obj.Pitch, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBits", toStringFlags, tabCount, tabSize, (obj.pBits ? ToString(*obj.pBits, toStringFlags, tabCount, tabSize) : "null"));
@@ -61,7 +61,7 @@ template <> std::string ToString<DXGI_MAPPED_RECT>(const DXGI_MAPPED_RECT& obj, 
 template <> std::string ToString<LUID>(const LUID& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "LowPart", toStringFlags, tabCount, tabSize, ToString(obj.LowPart, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "HighPart", toStringFlags, tabCount, tabSize, ToString(obj.HighPart, toStringFlags, tabCount, tabSize));
@@ -72,7 +72,7 @@ template <> std::string ToString<LUID>(const LUID& obj, ToStringFlags toStringFl
 template <> std::string ToString<DXGI_ADAPTER_DESC>(const DXGI_ADAPTER_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Description", toStringFlags, tabCount, tabSize, '"' + WCharArrayToString(obj.Description) + '"');
             FieldToString(strStrm, false, "VendorId", toStringFlags, tabCount, tabSize, ToString(obj.VendorId, toStringFlags, tabCount, tabSize));
@@ -90,7 +90,7 @@ template <> std::string ToString<DXGI_ADAPTER_DESC>(const DXGI_ADAPTER_DESC& obj
 template <> std::string ToString<DXGI_OUTPUT_DESC>(const DXGI_OUTPUT_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DeviceName", toStringFlags, tabCount, tabSize, '"' + WCharArrayToString(obj.DeviceName) + '"');
             FieldToString(strStrm, false, "DesktopCoordinates", toStringFlags, tabCount, tabSize, ToString(obj.DesktopCoordinates, toStringFlags, tabCount, tabSize));
@@ -104,7 +104,7 @@ template <> std::string ToString<DXGI_OUTPUT_DESC>(const DXGI_OUTPUT_DESC& obj, 
 template <> std::string ToString<DXGI_SHARED_RESOURCE>(const DXGI_SHARED_RESOURCE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Handle", toStringFlags, tabCount, tabSize, HandleIdToString(obj.Handle));
         }
@@ -114,7 +114,7 @@ template <> std::string ToString<DXGI_SHARED_RESOURCE>(const DXGI_SHARED_RESOURC
 template <> std::string ToString<DXGI_SURFACE_DESC>(const DXGI_SURFACE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Width", toStringFlags, tabCount, tabSize, ToString(obj.Width, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Height", toStringFlags, tabCount, tabSize, ToString(obj.Height, toStringFlags, tabCount, tabSize));
@@ -127,7 +127,7 @@ template <> std::string ToString<DXGI_SURFACE_DESC>(const DXGI_SURFACE_DESC& obj
 template <> std::string ToString<DXGI_SWAP_CHAIN_DESC>(const DXGI_SWAP_CHAIN_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "BufferDesc", toStringFlags, tabCount, tabSize, ToString(obj.BufferDesc, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SampleDesc", toStringFlags, tabCount, tabSize, ToString(obj.SampleDesc, toStringFlags, tabCount, tabSize));
@@ -144,7 +144,7 @@ template <> std::string ToString<DXGI_SWAP_CHAIN_DESC>(const DXGI_SWAP_CHAIN_DES
 template <> std::string ToString<DXGI_ADAPTER_DESC1>(const DXGI_ADAPTER_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Description", toStringFlags, tabCount, tabSize, '"' + WCharArrayToString(obj.Description) + '"');
             FieldToString(strStrm, false, "VendorId", toStringFlags, tabCount, tabSize, ToString(obj.VendorId, toStringFlags, tabCount, tabSize));
@@ -163,7 +163,7 @@ template <> std::string ToString<DXGI_ADAPTER_DESC1>(const DXGI_ADAPTER_DESC1& o
 template <> std::string ToString<DXGI_OUTDUPL_MOVE_RECT>(const DXGI_OUTDUPL_MOVE_RECT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SourcePoint", toStringFlags, tabCount, tabSize, ToString(obj.SourcePoint, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DestinationRect", toStringFlags, tabCount, tabSize, ToString(obj.DestinationRect, toStringFlags, tabCount, tabSize));
@@ -174,7 +174,7 @@ template <> std::string ToString<DXGI_OUTDUPL_MOVE_RECT>(const DXGI_OUTDUPL_MOVE
 template <> std::string ToString<DXGI_OUTDUPL_DESC>(const DXGI_OUTDUPL_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ModeDesc", toStringFlags, tabCount, tabSize, ToString(obj.ModeDesc, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Rotation", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Rotation, toStringFlags, tabCount, tabSize) + '"');
@@ -186,7 +186,7 @@ template <> std::string ToString<DXGI_OUTDUPL_DESC>(const DXGI_OUTDUPL_DESC& obj
 template <> std::string ToString<DXGI_OUTDUPL_POINTER_POSITION>(const DXGI_OUTDUPL_POINTER_POSITION& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Position", toStringFlags, tabCount, tabSize, ToString(obj.Position, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Visible", toStringFlags, tabCount, tabSize, ToString(obj.Visible, toStringFlags, tabCount, tabSize));
@@ -197,7 +197,7 @@ template <> std::string ToString<DXGI_OUTDUPL_POINTER_POSITION>(const DXGI_OUTDU
 template <> std::string ToString<DXGI_OUTDUPL_POINTER_SHAPE_INFO>(const DXGI_OUTDUPL_POINTER_SHAPE_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, ToString(obj.Type, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Width", toStringFlags, tabCount, tabSize, ToString(obj.Width, toStringFlags, tabCount, tabSize));
@@ -211,7 +211,7 @@ template <> std::string ToString<DXGI_OUTDUPL_POINTER_SHAPE_INFO>(const DXGI_OUT
 template <> std::string ToString<DXGI_OUTDUPL_FRAME_INFO>(const DXGI_OUTDUPL_FRAME_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "LastPresentTime", toStringFlags, tabCount, tabSize, ToString(obj.LastPresentTime, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "LastMouseUpdateTime", toStringFlags, tabCount, tabSize, ToString(obj.LastMouseUpdateTime, toStringFlags, tabCount, tabSize));
@@ -228,7 +228,7 @@ template <> std::string ToString<DXGI_OUTDUPL_FRAME_INFO>(const DXGI_OUTDUPL_FRA
 template <> std::string ToString<DXGI_MODE_DESC1>(const DXGI_MODE_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Width", toStringFlags, tabCount, tabSize, ToString(obj.Width, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Height", toStringFlags, tabCount, tabSize, ToString(obj.Height, toStringFlags, tabCount, tabSize));
@@ -244,7 +244,7 @@ template <> std::string ToString<DXGI_MODE_DESC1>(const DXGI_MODE_DESC1& obj, To
 template <> std::string ToString<DXGI_SWAP_CHAIN_DESC1>(const DXGI_SWAP_CHAIN_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Width", toStringFlags, tabCount, tabSize, ToString(obj.Width, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Height", toStringFlags, tabCount, tabSize, ToString(obj.Height, toStringFlags, tabCount, tabSize));
@@ -264,7 +264,7 @@ template <> std::string ToString<DXGI_SWAP_CHAIN_DESC1>(const DXGI_SWAP_CHAIN_DE
 template <> std::string ToString<DXGI_SWAP_CHAIN_FULLSCREEN_DESC>(const DXGI_SWAP_CHAIN_FULLSCREEN_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "RefreshRate", toStringFlags, tabCount, tabSize, ToString(obj.RefreshRate, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ScanlineOrdering", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ScanlineOrdering, toStringFlags, tabCount, tabSize) + '"');
@@ -277,7 +277,7 @@ template <> std::string ToString<DXGI_SWAP_CHAIN_FULLSCREEN_DESC>(const DXGI_SWA
 template <> std::string ToString<DXGI_PRESENT_PARAMETERS>(const DXGI_PRESENT_PARAMETERS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DirtyRectsCount", toStringFlags, tabCount, tabSize, ToString(obj.DirtyRectsCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDirtyRects", toStringFlags, tabCount, tabSize, ArrayToString(obj.DirtyRectsCount, obj.pDirtyRects, toStringFlags, tabCount, tabSize));
@@ -290,7 +290,7 @@ template <> std::string ToString<DXGI_PRESENT_PARAMETERS>(const DXGI_PRESENT_PAR
 template <> std::string ToString<DXGI_ADAPTER_DESC2>(const DXGI_ADAPTER_DESC2& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Description", toStringFlags, tabCount, tabSize, '"' + WCharArrayToString(obj.Description) + '"');
             FieldToString(strStrm, false, "VendorId", toStringFlags, tabCount, tabSize, ToString(obj.VendorId, toStringFlags, tabCount, tabSize));
@@ -311,7 +311,7 @@ template <> std::string ToString<DXGI_ADAPTER_DESC2>(const DXGI_ADAPTER_DESC2& o
 template <> std::string ToString<DXGI_MATRIX_3X2_F>(const DXGI_MATRIX_3X2_F& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "_11", toStringFlags, tabCount, tabSize, ToString(obj._11, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "_12", toStringFlags, tabCount, tabSize, ToString(obj._12, toStringFlags, tabCount, tabSize));
@@ -326,7 +326,7 @@ template <> std::string ToString<DXGI_MATRIX_3X2_F>(const DXGI_MATRIX_3X2_F& obj
 template <> std::string ToString<DXGI_DECODE_SWAP_CHAIN_DESC>(const DXGI_DECODE_SWAP_CHAIN_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Flags", toStringFlags, tabCount, tabSize, ToString(obj.Flags, toStringFlags, tabCount, tabSize));
         }
@@ -336,7 +336,7 @@ template <> std::string ToString<DXGI_DECODE_SWAP_CHAIN_DESC>(const DXGI_DECODE_
 template <> std::string ToString<DXGI_FRAME_STATISTICS_MEDIA>(const DXGI_FRAME_STATISTICS_MEDIA& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "PresentCount", toStringFlags, tabCount, tabSize, ToString(obj.PresentCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "PresentRefreshCount", toStringFlags, tabCount, tabSize, ToString(obj.PresentRefreshCount, toStringFlags, tabCount, tabSize));
@@ -352,7 +352,7 @@ template <> std::string ToString<DXGI_FRAME_STATISTICS_MEDIA>(const DXGI_FRAME_S
 template <> std::string ToString<DXGI_QUERY_VIDEO_MEMORY_INFO>(const DXGI_QUERY_VIDEO_MEMORY_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Budget", toStringFlags, tabCount, tabSize, ToString(obj.Budget, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "CurrentUsage", toStringFlags, tabCount, tabSize, ToString(obj.CurrentUsage, toStringFlags, tabCount, tabSize));
@@ -365,7 +365,7 @@ template <> std::string ToString<DXGI_QUERY_VIDEO_MEMORY_INFO>(const DXGI_QUERY_
 template <> std::string ToString<DXGI_HDR_METADATA_HDR10>(const DXGI_HDR_METADATA_HDR10& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "RedPrimary", toStringFlags, tabCount, tabSize, ArrayToString(2, obj.RedPrimary, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "GreenPrimary", toStringFlags, tabCount, tabSize, ArrayToString(2, obj.GreenPrimary, toStringFlags, tabCount, tabSize));
@@ -382,7 +382,7 @@ template <> std::string ToString<DXGI_HDR_METADATA_HDR10>(const DXGI_HDR_METADAT
 template <> std::string ToString<DXGI_HDR_METADATA_HDR10PLUS>(const DXGI_HDR_METADATA_HDR10PLUS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Data", toStringFlags, tabCount, tabSize, ArrayToString(72, obj.Data, toStringFlags, tabCount, tabSize));
         }
@@ -392,7 +392,7 @@ template <> std::string ToString<DXGI_HDR_METADATA_HDR10PLUS>(const DXGI_HDR_MET
 template <> std::string ToString<DXGI_ADAPTER_DESC3>(const DXGI_ADAPTER_DESC3& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Description", toStringFlags, tabCount, tabSize, '"' + WCharArrayToString(obj.Description) + '"');
             FieldToString(strStrm, false, "VendorId", toStringFlags, tabCount, tabSize, ToString(obj.VendorId, toStringFlags, tabCount, tabSize));
@@ -413,7 +413,7 @@ template <> std::string ToString<DXGI_ADAPTER_DESC3>(const DXGI_ADAPTER_DESC3& o
 template <> std::string ToString<DXGI_OUTPUT_DESC1>(const DXGI_OUTPUT_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DeviceName", toStringFlags, tabCount, tabSize, '"' + WCharArrayToString(obj.DeviceName) + '"');
             FieldToString(strStrm, false, "DesktopCoordinates", toStringFlags, tabCount, tabSize, ToString(obj.DesktopCoordinates, toStringFlags, tabCount, tabSize));
@@ -436,7 +436,7 @@ template <> std::string ToString<DXGI_OUTPUT_DESC1>(const DXGI_OUTPUT_DESC1& obj
 template <> std::string ToString<DXGI_RATIONAL>(const DXGI_RATIONAL& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Numerator", toStringFlags, tabCount, tabSize, ToString(obj.Numerator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Denominator", toStringFlags, tabCount, tabSize, ToString(obj.Denominator, toStringFlags, tabCount, tabSize));
@@ -447,7 +447,7 @@ template <> std::string ToString<DXGI_RATIONAL>(const DXGI_RATIONAL& obj, ToStri
 template <> std::string ToString<DXGI_SAMPLE_DESC>(const DXGI_SAMPLE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Count", toStringFlags, tabCount, tabSize, ToString(obj.Count, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Quality", toStringFlags, tabCount, tabSize, ToString(obj.Quality, toStringFlags, tabCount, tabSize));
@@ -458,7 +458,7 @@ template <> std::string ToString<DXGI_SAMPLE_DESC>(const DXGI_SAMPLE_DESC& obj, 
 template <> std::string ToString<DXGI_RGB>(const DXGI_RGB& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Red", toStringFlags, tabCount, tabSize, ToString(obj.Red, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Green", toStringFlags, tabCount, tabSize, ToString(obj.Green, toStringFlags, tabCount, tabSize));
@@ -470,7 +470,7 @@ template <> std::string ToString<DXGI_RGB>(const DXGI_RGB& obj, ToStringFlags to
 template <> std::string ToString<D3DCOLORVALUE>(const D3DCOLORVALUE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "r", toStringFlags, tabCount, tabSize, ToString(obj.r, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "g", toStringFlags, tabCount, tabSize, ToString(obj.g, toStringFlags, tabCount, tabSize));
@@ -483,7 +483,7 @@ template <> std::string ToString<D3DCOLORVALUE>(const D3DCOLORVALUE& obj, ToStri
 template <> std::string ToString<DXGI_GAMMA_CONTROL>(const DXGI_GAMMA_CONTROL& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Scale", toStringFlags, tabCount, tabSize, ToString(obj.Scale, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Offset", toStringFlags, tabCount, tabSize, ToString(obj.Offset, toStringFlags, tabCount, tabSize));
@@ -495,7 +495,7 @@ template <> std::string ToString<DXGI_GAMMA_CONTROL>(const DXGI_GAMMA_CONTROL& o
 template <> std::string ToString<DXGI_GAMMA_CONTROL_CAPABILITIES>(const DXGI_GAMMA_CONTROL_CAPABILITIES& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ScaleAndOffsetSupported", toStringFlags, tabCount, tabSize, ToString(obj.ScaleAndOffsetSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MaxConvertedValue", toStringFlags, tabCount, tabSize, ToString(obj.MaxConvertedValue, toStringFlags, tabCount, tabSize));
@@ -509,7 +509,7 @@ template <> std::string ToString<DXGI_GAMMA_CONTROL_CAPABILITIES>(const DXGI_GAM
 template <> std::string ToString<DXGI_MODE_DESC>(const DXGI_MODE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Width", toStringFlags, tabCount, tabSize, ToString(obj.Width, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Height", toStringFlags, tabCount, tabSize, ToString(obj.Height, toStringFlags, tabCount, tabSize));
@@ -524,7 +524,7 @@ template <> std::string ToString<DXGI_MODE_DESC>(const DXGI_MODE_DESC& obj, ToSt
 template <> std::string ToString<DXGI_JPEG_DC_HUFFMAN_TABLE>(const DXGI_JPEG_DC_HUFFMAN_TABLE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "CodeCounts", toStringFlags, tabCount, tabSize, ArrayToString(12, obj.CodeCounts, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "CodeValues", toStringFlags, tabCount, tabSize, ArrayToString(12, obj.CodeValues, toStringFlags, tabCount, tabSize));
@@ -535,7 +535,7 @@ template <> std::string ToString<DXGI_JPEG_DC_HUFFMAN_TABLE>(const DXGI_JPEG_DC_
 template <> std::string ToString<DXGI_JPEG_AC_HUFFMAN_TABLE>(const DXGI_JPEG_AC_HUFFMAN_TABLE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "CodeCounts", toStringFlags, tabCount, tabSize, ArrayToString(16, obj.CodeCounts, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "CodeValues", toStringFlags, tabCount, tabSize, ArrayToString(162, obj.CodeValues, toStringFlags, tabCount, tabSize));
@@ -546,7 +546,7 @@ template <> std::string ToString<DXGI_JPEG_AC_HUFFMAN_TABLE>(const DXGI_JPEG_AC_
 template <> std::string ToString<DXGI_JPEG_QUANTIZATION_TABLE>(const DXGI_JPEG_QUANTIZATION_TABLE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Elements", toStringFlags, tabCount, tabSize, ArrayToString(64, obj.Elements, toStringFlags, tabCount, tabSize));
         }
@@ -556,7 +556,7 @@ template <> std::string ToString<DXGI_JPEG_QUANTIZATION_TABLE>(const DXGI_JPEG_Q
 template <> std::string ToString<D3D12_COMMAND_QUEUE_DESC>(const D3D12_COMMAND_QUEUE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Priority", toStringFlags, tabCount, tabSize, ToString(obj.Priority, toStringFlags, tabCount, tabSize));
@@ -569,7 +569,7 @@ template <> std::string ToString<D3D12_COMMAND_QUEUE_DESC>(const D3D12_COMMAND_Q
 template <> std::string ToString<D3D12_INPUT_ELEMENT_DESC>(const D3D12_INPUT_ELEMENT_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SemanticName", toStringFlags, tabCount, tabSize, (obj.SemanticName ? ToString(*obj.SemanticName, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "SemanticIndex", toStringFlags, tabCount, tabSize, ToString(obj.SemanticIndex, toStringFlags, tabCount, tabSize));
@@ -585,7 +585,7 @@ template <> std::string ToString<D3D12_INPUT_ELEMENT_DESC>(const D3D12_INPUT_ELE
 template <> std::string ToString<D3D12_SO_DECLARATION_ENTRY>(const D3D12_SO_DECLARATION_ENTRY& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Stream", toStringFlags, tabCount, tabSize, ToString(obj.Stream, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SemanticName", toStringFlags, tabCount, tabSize, (obj.SemanticName ? ToString(*obj.SemanticName, toStringFlags, tabCount, tabSize) : "null"));
@@ -600,7 +600,7 @@ template <> std::string ToString<D3D12_SO_DECLARATION_ENTRY>(const D3D12_SO_DECL
 template <> std::string ToString<D3D12_VIEWPORT>(const D3D12_VIEWPORT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "TopLeftX", toStringFlags, tabCount, tabSize, ToString(obj.TopLeftX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "TopLeftY", toStringFlags, tabCount, tabSize, ToString(obj.TopLeftY, toStringFlags, tabCount, tabSize));
@@ -615,7 +615,7 @@ template <> std::string ToString<D3D12_VIEWPORT>(const D3D12_VIEWPORT& obj, ToSt
 template <> std::string ToString<D3D12_BOX>(const D3D12_BOX& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "left", toStringFlags, tabCount, tabSize, ToString(obj.left, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "top", toStringFlags, tabCount, tabSize, ToString(obj.top, toStringFlags, tabCount, tabSize));
@@ -630,7 +630,7 @@ template <> std::string ToString<D3D12_BOX>(const D3D12_BOX& obj, ToStringFlags 
 template <> std::string ToString<D3D12_DEPTH_STENCILOP_DESC>(const D3D12_DEPTH_STENCILOP_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "StencilFailOp", toStringFlags, tabCount, tabSize, '"' + ToString(obj.StencilFailOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "StencilDepthFailOp", toStringFlags, tabCount, tabSize, '"' + ToString(obj.StencilDepthFailOp, toStringFlags, tabCount, tabSize) + '"');
@@ -643,7 +643,7 @@ template <> std::string ToString<D3D12_DEPTH_STENCILOP_DESC>(const D3D12_DEPTH_S
 template <> std::string ToString<D3D12_DEPTH_STENCIL_DESC>(const D3D12_DEPTH_STENCIL_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DepthEnable", toStringFlags, tabCount, tabSize, ToString(obj.DepthEnable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DepthWriteMask", toStringFlags, tabCount, tabSize, '"' + ToString(obj.DepthWriteMask, toStringFlags, tabCount, tabSize) + '"');
@@ -660,7 +660,7 @@ template <> std::string ToString<D3D12_DEPTH_STENCIL_DESC>(const D3D12_DEPTH_STE
 template <> std::string ToString<D3D12_DEPTH_STENCIL_DESC1>(const D3D12_DEPTH_STENCIL_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DepthEnable", toStringFlags, tabCount, tabSize, ToString(obj.DepthEnable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DepthWriteMask", toStringFlags, tabCount, tabSize, '"' + ToString(obj.DepthWriteMask, toStringFlags, tabCount, tabSize) + '"');
@@ -678,7 +678,7 @@ template <> std::string ToString<D3D12_DEPTH_STENCIL_DESC1>(const D3D12_DEPTH_ST
 template <> std::string ToString<D3D12_DEPTH_STENCILOP_DESC1>(const D3D12_DEPTH_STENCILOP_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "StencilFailOp", toStringFlags, tabCount, tabSize, '"' + ToString(obj.StencilFailOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "StencilDepthFailOp", toStringFlags, tabCount, tabSize, '"' + ToString(obj.StencilDepthFailOp, toStringFlags, tabCount, tabSize) + '"');
@@ -693,7 +693,7 @@ template <> std::string ToString<D3D12_DEPTH_STENCILOP_DESC1>(const D3D12_DEPTH_
 template <> std::string ToString<D3D12_DEPTH_STENCIL_DESC2>(const D3D12_DEPTH_STENCIL_DESC2& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DepthEnable", toStringFlags, tabCount, tabSize, ToString(obj.DepthEnable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DepthWriteMask", toStringFlags, tabCount, tabSize, '"' + ToString(obj.DepthWriteMask, toStringFlags, tabCount, tabSize) + '"');
@@ -709,7 +709,7 @@ template <> std::string ToString<D3D12_DEPTH_STENCIL_DESC2>(const D3D12_DEPTH_ST
 template <> std::string ToString<D3D12_RENDER_TARGET_BLEND_DESC>(const D3D12_RENDER_TARGET_BLEND_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "BlendEnable", toStringFlags, tabCount, tabSize, ToString(obj.BlendEnable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "LogicOpEnable", toStringFlags, tabCount, tabSize, ToString(obj.LogicOpEnable, toStringFlags, tabCount, tabSize));
@@ -728,7 +728,7 @@ template <> std::string ToString<D3D12_RENDER_TARGET_BLEND_DESC>(const D3D12_REN
 template <> std::string ToString<D3D12_BLEND_DESC>(const D3D12_BLEND_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "AlphaToCoverageEnable", toStringFlags, tabCount, tabSize, ToString(obj.AlphaToCoverageEnable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "IndependentBlendEnable", toStringFlags, tabCount, tabSize, ToString(obj.IndependentBlendEnable, toStringFlags, tabCount, tabSize));
@@ -740,7 +740,7 @@ template <> std::string ToString<D3D12_BLEND_DESC>(const D3D12_BLEND_DESC& obj, 
 template <> std::string ToString<D3D12_RASTERIZER_DESC>(const D3D12_RASTERIZER_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FillMode", toStringFlags, tabCount, tabSize, '"' + ToString(obj.FillMode, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "CullMode", toStringFlags, tabCount, tabSize, '"' + ToString(obj.CullMode, toStringFlags, tabCount, tabSize) + '"');
@@ -760,7 +760,7 @@ template <> std::string ToString<D3D12_RASTERIZER_DESC>(const D3D12_RASTERIZER_D
 template <> std::string ToString<D3D12_SHADER_BYTECODE>(const D3D12_SHADER_BYTECODE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pShaderBytecode", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pShaderBytecode));
             FieldToString(strStrm, false, "BytecodeLength", toStringFlags, tabCount, tabSize, ToString(obj.BytecodeLength, toStringFlags, tabCount, tabSize));
@@ -771,7 +771,7 @@ template <> std::string ToString<D3D12_SHADER_BYTECODE>(const D3D12_SHADER_BYTEC
 template <> std::string ToString<D3D12_STREAM_OUTPUT_DESC>(const D3D12_STREAM_OUTPUT_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pSODeclaration", toStringFlags, tabCount, tabSize, ArrayToString(obj.NumEntries, obj.pSODeclaration, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumEntries", toStringFlags, tabCount, tabSize, ToString(obj.NumEntries, toStringFlags, tabCount, tabSize));
@@ -785,7 +785,7 @@ template <> std::string ToString<D3D12_STREAM_OUTPUT_DESC>(const D3D12_STREAM_OU
 template <> std::string ToString<D3D12_INPUT_LAYOUT_DESC>(const D3D12_INPUT_LAYOUT_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pInputElementDescs", toStringFlags, tabCount, tabSize, ArrayToString(obj.NumElements, obj.pInputElementDescs, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumElements", toStringFlags, tabCount, tabSize, ToString(obj.NumElements, toStringFlags, tabCount, tabSize));
@@ -796,7 +796,7 @@ template <> std::string ToString<D3D12_INPUT_LAYOUT_DESC>(const D3D12_INPUT_LAYO
 template <> std::string ToString<D3D12_CACHED_PIPELINE_STATE>(const D3D12_CACHED_PIPELINE_STATE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pCachedBlob", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pCachedBlob));
             FieldToString(strStrm, false, "CachedBlobSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.CachedBlobSizeInBytes, toStringFlags, tabCount, tabSize));
@@ -807,7 +807,7 @@ template <> std::string ToString<D3D12_CACHED_PIPELINE_STATE>(const D3D12_CACHED
 template <> std::string ToString<D3D12_GRAPHICS_PIPELINE_STATE_DESC>(const D3D12_GRAPHICS_PIPELINE_STATE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pRootSignature", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pRootSignature));
             FieldToString(strStrm, false, "VS", toStringFlags, tabCount, tabSize, ToString(obj.VS, toStringFlags, tabCount, tabSize));
@@ -837,7 +837,7 @@ template <> std::string ToString<D3D12_GRAPHICS_PIPELINE_STATE_DESC>(const D3D12
 template <> std::string ToString<D3D12_COMPUTE_PIPELINE_STATE_DESC>(const D3D12_COMPUTE_PIPELINE_STATE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pRootSignature", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pRootSignature));
             FieldToString(strStrm, false, "CS", toStringFlags, tabCount, tabSize, ToString(obj.CS, toStringFlags, tabCount, tabSize));
@@ -851,7 +851,7 @@ template <> std::string ToString<D3D12_COMPUTE_PIPELINE_STATE_DESC>(const D3D12_
 template <> std::string ToString<D3D12_RT_FORMAT_ARRAY>(const D3D12_RT_FORMAT_ARRAY& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "RTFormats", toStringFlags, tabCount, tabSize, EnumArrayToString(8, obj.RTFormats, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumRenderTargets", toStringFlags, tabCount, tabSize, ToString(obj.NumRenderTargets, toStringFlags, tabCount, tabSize));
@@ -862,7 +862,7 @@ template <> std::string ToString<D3D12_RT_FORMAT_ARRAY>(const D3D12_RT_FORMAT_AR
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS>(const D3D12_FEATURE_DATA_D3D12_OPTIONS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DoublePrecisionFloatShaderOps", toStringFlags, tabCount, tabSize, ToString(obj.DoublePrecisionFloatShaderOps, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "OutputMergerLogicOp", toStringFlags, tabCount, tabSize, ToString(obj.OutputMergerLogicOp, toStringFlags, tabCount, tabSize));
@@ -886,7 +886,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS>(const D3D12_F
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS1>(const D3D12_FEATURE_DATA_D3D12_OPTIONS1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "WaveOps", toStringFlags, tabCount, tabSize, ToString(obj.WaveOps, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "WaveLaneCountMin", toStringFlags, tabCount, tabSize, ToString(obj.WaveLaneCountMin, toStringFlags, tabCount, tabSize));
@@ -901,7 +901,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS1>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS2>(const D3D12_FEATURE_DATA_D3D12_OPTIONS2& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DepthBoundsTestSupported", toStringFlags, tabCount, tabSize, ToString(obj.DepthBoundsTestSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ProgrammableSamplePositionsTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ProgrammableSamplePositionsTier, toStringFlags, tabCount, tabSize) + '"');
@@ -912,7 +912,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS2>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_ROOT_SIGNATURE>(const D3D12_FEATURE_DATA_ROOT_SIGNATURE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "HighestVersion", toStringFlags, tabCount, tabSize, '"' + ToString(obj.HighestVersion, toStringFlags, tabCount, tabSize) + '"');
         }
@@ -922,7 +922,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_ROOT_SIGNATURE>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_ARCHITECTURE>(const D3D12_FEATURE_DATA_ARCHITECTURE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeIndex", toStringFlags, tabCount, tabSize, ToString(obj.NodeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "TileBasedRenderer", toStringFlags, tabCount, tabSize, ToString(obj.TileBasedRenderer, toStringFlags, tabCount, tabSize));
@@ -935,7 +935,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_ARCHITECTURE>(const D3D12_FE
 template <> std::string ToString<D3D12_FEATURE_DATA_ARCHITECTURE1>(const D3D12_FEATURE_DATA_ARCHITECTURE1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeIndex", toStringFlags, tabCount, tabSize, ToString(obj.NodeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "TileBasedRenderer", toStringFlags, tabCount, tabSize, ToString(obj.TileBasedRenderer, toStringFlags, tabCount, tabSize));
@@ -949,7 +949,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_ARCHITECTURE1>(const D3D12_F
 template <> std::string ToString<D3D12_FEATURE_DATA_FEATURE_LEVELS>(const D3D12_FEATURE_DATA_FEATURE_LEVELS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumFeatureLevels", toStringFlags, tabCount, tabSize, ToString(obj.NumFeatureLevels, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pFeatureLevelsRequested", toStringFlags, tabCount, tabSize, EnumArrayToString(obj.NumFeatureLevels, obj.pFeatureLevelsRequested, toStringFlags, tabCount, tabSize));
@@ -961,7 +961,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_FEATURE_LEVELS>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_SHADER_MODEL>(const D3D12_FEATURE_DATA_SHADER_MODEL& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "HighestShaderModel", toStringFlags, tabCount, tabSize, '"' + ToString(obj.HighestShaderModel, toStringFlags, tabCount, tabSize) + '"');
         }
@@ -971,7 +971,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_SHADER_MODEL>(const D3D12_FE
 template <> std::string ToString<D3D12_FEATURE_DATA_FORMAT_SUPPORT>(const D3D12_FEATURE_DATA_FORMAT_SUPPORT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Support1", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Support1, toStringFlags, tabCount, tabSize) + '"');
@@ -983,7 +983,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_FORMAT_SUPPORT>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS>(const D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "SampleCount", toStringFlags, tabCount, tabSize, ToString(obj.SampleCount, toStringFlags, tabCount, tabSize));
@@ -996,7 +996,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS>(
 template <> std::string ToString<D3D12_FEATURE_DATA_FORMAT_INFO>(const D3D12_FEATURE_DATA_FORMAT_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "PlaneCount", toStringFlags, tabCount, tabSize, ToString(obj.PlaneCount, toStringFlags, tabCount, tabSize));
@@ -1007,7 +1007,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_FORMAT_INFO>(const D3D12_FEA
 template <> std::string ToString<D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT>(const D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MaxGPUVirtualAddressBitsPerResource", toStringFlags, tabCount, tabSize, ToString(obj.MaxGPUVirtualAddressBitsPerResource, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MaxGPUVirtualAddressBitsPerProcess", toStringFlags, tabCount, tabSize, ToString(obj.MaxGPUVirtualAddressBitsPerProcess, toStringFlags, tabCount, tabSize));
@@ -1018,7 +1018,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT>
 template <> std::string ToString<D3D12_FEATURE_DATA_SHADER_CACHE>(const D3D12_FEATURE_DATA_SHADER_CACHE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SupportFlags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SupportFlags, toStringFlags, tabCount, tabSize) + '"');
         }
@@ -1028,7 +1028,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_SHADER_CACHE>(const D3D12_FE
 template <> std::string ToString<D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY>(const D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "CommandListType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.CommandListType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Priority", toStringFlags, tabCount, tabSize, ToString(obj.Priority, toStringFlags, tabCount, tabSize));
@@ -1040,7 +1040,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY>(cons
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS3>(const D3D12_FEATURE_DATA_D3D12_OPTIONS3& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "CopyQueueTimestampQueriesSupported", toStringFlags, tabCount, tabSize, ToString(obj.CopyQueueTimestampQueriesSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "CastingFullyTypedFormatSupported", toStringFlags, tabCount, tabSize, ToString(obj.CastingFullyTypedFormatSupported, toStringFlags, tabCount, tabSize));
@@ -1054,7 +1054,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS3>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_EXISTING_HEAPS>(const D3D12_FEATURE_DATA_EXISTING_HEAPS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Supported", toStringFlags, tabCount, tabSize, ToString(obj.Supported, toStringFlags, tabCount, tabSize));
         }
@@ -1064,7 +1064,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_EXISTING_HEAPS>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_DISPLAYABLE>(const D3D12_FEATURE_DATA_DISPLAYABLE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DisplayableTexture", toStringFlags, tabCount, tabSize, ToString(obj.DisplayableTexture, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SharedResourceCompatibilityTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SharedResourceCompatibilityTier, toStringFlags, tabCount, tabSize) + '"');
@@ -1075,7 +1075,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_DISPLAYABLE>(const D3D12_FEA
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS4>(const D3D12_FEATURE_DATA_D3D12_OPTIONS4& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MSAA64KBAlignedTextureSupported", toStringFlags, tabCount, tabSize, ToString(obj.MSAA64KBAlignedTextureSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SharedResourceCompatibilityTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SharedResourceCompatibilityTier, toStringFlags, tabCount, tabSize) + '"');
@@ -1087,7 +1087,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS4>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_SERIALIZATION>(const D3D12_FEATURE_DATA_SERIALIZATION& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeIndex", toStringFlags, tabCount, tabSize, ToString(obj.NodeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "HeapSerializationTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.HeapSerializationTier, toStringFlags, tabCount, tabSize) + '"');
@@ -1098,7 +1098,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_SERIALIZATION>(const D3D12_F
 template <> std::string ToString<D3D12_FEATURE_DATA_CROSS_NODE>(const D3D12_FEATURE_DATA_CROSS_NODE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SharingTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SharingTier, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "AtomicShaderInstructions", toStringFlags, tabCount, tabSize, ToString(obj.AtomicShaderInstructions, toStringFlags, tabCount, tabSize));
@@ -1109,7 +1109,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_CROSS_NODE>(const D3D12_FEAT
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS5>(const D3D12_FEATURE_DATA_D3D12_OPTIONS5& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SRVOnlyTiledResourceTier3", toStringFlags, tabCount, tabSize, ToString(obj.SRVOnlyTiledResourceTier3, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "RenderPassesTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.RenderPassesTier, toStringFlags, tabCount, tabSize) + '"');
@@ -1121,7 +1121,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS5>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS6>(const D3D12_FEATURE_DATA_D3D12_OPTIONS6& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "AdditionalShadingRatesSupported", toStringFlags, tabCount, tabSize, ToString(obj.AdditionalShadingRatesSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "PerPrimitiveShadingRateSupportedWithViewportIndexing", toStringFlags, tabCount, tabSize, ToString(obj.PerPrimitiveShadingRateSupportedWithViewportIndexing, toStringFlags, tabCount, tabSize));
@@ -1135,7 +1135,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS6>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS7>(const D3D12_FEATURE_DATA_D3D12_OPTIONS7& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MeshShaderTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.MeshShaderTier, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "SamplerFeedbackTier", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SamplerFeedbackTier, toStringFlags, tabCount, tabSize) + '"');
@@ -1146,7 +1146,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS7>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_QUERY_META_COMMAND>(const D3D12_FEATURE_DATA_QUERY_META_COMMAND& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "CommandId", toStringFlags, tabCount, tabSize, ToString(obj.CommandId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NodeMask", toStringFlags, tabCount, tabSize, ToString(obj.NodeMask, toStringFlags, tabCount, tabSize));
@@ -1161,7 +1161,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_QUERY_META_COMMAND>(const D3
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS8>(const D3D12_FEATURE_DATA_D3D12_OPTIONS8& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "UnalignedBlockTexturesSupported", toStringFlags, tabCount, tabSize, ToString(obj.UnalignedBlockTexturesSupported, toStringFlags, tabCount, tabSize));
         }
@@ -1171,7 +1171,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS8>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS9>(const D3D12_FEATURE_DATA_D3D12_OPTIONS9& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MeshShaderPipelineStatsSupported", toStringFlags, tabCount, tabSize, ToString(obj.MeshShaderPipelineStatsSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MeshShaderSupportsFullRangeRenderTargetArrayIndex", toStringFlags, tabCount, tabSize, ToString(obj.MeshShaderSupportsFullRangeRenderTargetArrayIndex, toStringFlags, tabCount, tabSize));
@@ -1186,7 +1186,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS9>(const D3D12_
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS10>(const D3D12_FEATURE_DATA_D3D12_OPTIONS10& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "VariableRateShadingSumCombinerSupported", toStringFlags, tabCount, tabSize, ToString(obj.VariableRateShadingSumCombinerSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MeshShaderPerPrimitiveShadingRateSupported", toStringFlags, tabCount, tabSize, ToString(obj.MeshShaderPerPrimitiveShadingRateSupported, toStringFlags, tabCount, tabSize));
@@ -1197,7 +1197,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS10>(const D3D12
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS11>(const D3D12_FEATURE_DATA_D3D12_OPTIONS11& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "AtomicInt64OnDescriptorHeapResourceSupported", toStringFlags, tabCount, tabSize, ToString(obj.AtomicInt64OnDescriptorHeapResourceSupported, toStringFlags, tabCount, tabSize));
         }
@@ -1207,7 +1207,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS11>(const D3D12
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS12>(const D3D12_FEATURE_DATA_D3D12_OPTIONS12& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MSPrimitivesPipelineStatisticIncludesCulledPrimitives", toStringFlags, tabCount, tabSize, '"' + ToString(obj.MSPrimitivesPipelineStatisticIncludesCulledPrimitives, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "EnhancedBarriersSupported", toStringFlags, tabCount, tabSize, ToString(obj.EnhancedBarriersSupported, toStringFlags, tabCount, tabSize));
@@ -1219,7 +1219,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS12>(const D3D12
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS13>(const D3D12_FEATURE_DATA_D3D12_OPTIONS13& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "UnrestrictedBufferTextureCopyPitchSupported", toStringFlags, tabCount, tabSize, ToString(obj.UnrestrictedBufferTextureCopyPitchSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "UnrestrictedVertexElementAlignmentSupported", toStringFlags, tabCount, tabSize, ToString(obj.UnrestrictedVertexElementAlignmentSupported, toStringFlags, tabCount, tabSize));
@@ -1234,7 +1234,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS13>(const D3D12
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS14>(const D3D12_FEATURE_DATA_D3D12_OPTIONS14& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "AdvancedTextureOpsSupported", toStringFlags, tabCount, tabSize, ToString(obj.AdvancedTextureOpsSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "WriteableMSAATexturesSupported", toStringFlags, tabCount, tabSize, ToString(obj.WriteableMSAATexturesSupported, toStringFlags, tabCount, tabSize));
@@ -1246,7 +1246,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS14>(const D3D12
 template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS15>(const D3D12_FEATURE_DATA_D3D12_OPTIONS15& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "TriangleFanSupported", toStringFlags, tabCount, tabSize, ToString(obj.TriangleFanSupported, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DynamicIndexBufferStripCutSupported", toStringFlags, tabCount, tabSize, ToString(obj.DynamicIndexBufferStripCutSupported, toStringFlags, tabCount, tabSize));
@@ -1257,7 +1257,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_D3D12_OPTIONS15>(const D3D12
 template <> std::string ToString<D3D12_RESOURCE_ALLOCATION_INFO>(const D3D12_RESOURCE_ALLOCATION_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Alignment", toStringFlags, tabCount, tabSize, ToString(obj.Alignment, toStringFlags, tabCount, tabSize));
@@ -1268,7 +1268,7 @@ template <> std::string ToString<D3D12_RESOURCE_ALLOCATION_INFO>(const D3D12_RES
 template <> std::string ToString<D3D12_RESOURCE_ALLOCATION_INFO1>(const D3D12_RESOURCE_ALLOCATION_INFO1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Offset", toStringFlags, tabCount, tabSize, ToString(obj.Offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Alignment", toStringFlags, tabCount, tabSize, ToString(obj.Alignment, toStringFlags, tabCount, tabSize));
@@ -1280,7 +1280,7 @@ template <> std::string ToString<D3D12_RESOURCE_ALLOCATION_INFO1>(const D3D12_RE
 template <> std::string ToString<D3D12_HEAP_PROPERTIES>(const D3D12_HEAP_PROPERTIES& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "CPUPageProperty", toStringFlags, tabCount, tabSize, '"' + ToString(obj.CPUPageProperty, toStringFlags, tabCount, tabSize) + '"');
@@ -1294,7 +1294,7 @@ template <> std::string ToString<D3D12_HEAP_PROPERTIES>(const D3D12_HEAP_PROPERT
 template <> std::string ToString<D3D12_HEAP_DESC>(const D3D12_HEAP_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Properties", toStringFlags, tabCount, tabSize, ToString(obj.Properties, toStringFlags, tabCount, tabSize));
@@ -1307,7 +1307,7 @@ template <> std::string ToString<D3D12_HEAP_DESC>(const D3D12_HEAP_DESC& obj, To
 template <> std::string ToString<D3D12_MIP_REGION>(const D3D12_MIP_REGION& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Width", toStringFlags, tabCount, tabSize, ToString(obj.Width, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Height", toStringFlags, tabCount, tabSize, ToString(obj.Height, toStringFlags, tabCount, tabSize));
@@ -1319,7 +1319,7 @@ template <> std::string ToString<D3D12_MIP_REGION>(const D3D12_MIP_REGION& obj, 
 template <> std::string ToString<D3D12_RESOURCE_DESC>(const D3D12_RESOURCE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Dimension", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Dimension, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Alignment", toStringFlags, tabCount, tabSize, ToString(obj.Alignment, toStringFlags, tabCount, tabSize));
@@ -1338,7 +1338,7 @@ template <> std::string ToString<D3D12_RESOURCE_DESC>(const D3D12_RESOURCE_DESC&
 template <> std::string ToString<D3D12_RESOURCE_DESC1>(const D3D12_RESOURCE_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Dimension", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Dimension, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Alignment", toStringFlags, tabCount, tabSize, ToString(obj.Alignment, toStringFlags, tabCount, tabSize));
@@ -1358,7 +1358,7 @@ template <> std::string ToString<D3D12_RESOURCE_DESC1>(const D3D12_RESOURCE_DESC
 template <> std::string ToString<D3D12_DEPTH_STENCIL_VALUE>(const D3D12_DEPTH_STENCIL_VALUE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Depth", toStringFlags, tabCount, tabSize, ToString(obj.Depth, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Stencil", toStringFlags, tabCount, tabSize, ToString(obj.Stencil, toStringFlags, tabCount, tabSize));
@@ -1369,7 +1369,7 @@ template <> std::string ToString<D3D12_DEPTH_STENCIL_VALUE>(const D3D12_DEPTH_ST
 template <> std::string ToString<D3D12_RANGE>(const D3D12_RANGE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Begin", toStringFlags, tabCount, tabSize, ToString(obj.Begin, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "End", toStringFlags, tabCount, tabSize, ToString(obj.End, toStringFlags, tabCount, tabSize));
@@ -1380,7 +1380,7 @@ template <> std::string ToString<D3D12_RANGE>(const D3D12_RANGE& obj, ToStringFl
 template <> std::string ToString<D3D12_RANGE_UINT64>(const D3D12_RANGE_UINT64& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Begin", toStringFlags, tabCount, tabSize, ToString(obj.Begin, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "End", toStringFlags, tabCount, tabSize, ToString(obj.End, toStringFlags, tabCount, tabSize));
@@ -1391,7 +1391,7 @@ template <> std::string ToString<D3D12_RANGE_UINT64>(const D3D12_RANGE_UINT64& o
 template <> std::string ToString<D3D12_SUBRESOURCE_RANGE_UINT64>(const D3D12_SUBRESOURCE_RANGE_UINT64& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Subresource", toStringFlags, tabCount, tabSize, ToString(obj.Subresource, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Range", toStringFlags, tabCount, tabSize, ToString(obj.Range, toStringFlags, tabCount, tabSize));
@@ -1402,7 +1402,7 @@ template <> std::string ToString<D3D12_SUBRESOURCE_RANGE_UINT64>(const D3D12_SUB
 template <> std::string ToString<D3D12_SUBRESOURCE_INFO>(const D3D12_SUBRESOURCE_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Offset", toStringFlags, tabCount, tabSize, ToString(obj.Offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "RowPitch", toStringFlags, tabCount, tabSize, ToString(obj.RowPitch, toStringFlags, tabCount, tabSize));
@@ -1414,7 +1414,7 @@ template <> std::string ToString<D3D12_SUBRESOURCE_INFO>(const D3D12_SUBRESOURCE
 template <> std::string ToString<D3D12_TILED_RESOURCE_COORDINATE>(const D3D12_TILED_RESOURCE_COORDINATE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "X", toStringFlags, tabCount, tabSize, ToString(obj.X, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Y", toStringFlags, tabCount, tabSize, ToString(obj.Y, toStringFlags, tabCount, tabSize));
@@ -1427,7 +1427,7 @@ template <> std::string ToString<D3D12_TILED_RESOURCE_COORDINATE>(const D3D12_TI
 template <> std::string ToString<D3D12_TILE_REGION_SIZE>(const D3D12_TILE_REGION_SIZE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumTiles", toStringFlags, tabCount, tabSize, ToString(obj.NumTiles, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "UseBox", toStringFlags, tabCount, tabSize, ToString(obj.UseBox, toStringFlags, tabCount, tabSize));
@@ -1441,7 +1441,7 @@ template <> std::string ToString<D3D12_TILE_REGION_SIZE>(const D3D12_TILE_REGION
 template <> std::string ToString<D3D12_SUBRESOURCE_TILING>(const D3D12_SUBRESOURCE_TILING& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "WidthInTiles", toStringFlags, tabCount, tabSize, ToString(obj.WidthInTiles, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "HeightInTiles", toStringFlags, tabCount, tabSize, ToString(obj.HeightInTiles, toStringFlags, tabCount, tabSize));
@@ -1454,7 +1454,7 @@ template <> std::string ToString<D3D12_SUBRESOURCE_TILING>(const D3D12_SUBRESOUR
 template <> std::string ToString<D3D12_TILE_SHAPE>(const D3D12_TILE_SHAPE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "WidthInTexels", toStringFlags, tabCount, tabSize, ToString(obj.WidthInTexels, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "HeightInTexels", toStringFlags, tabCount, tabSize, ToString(obj.HeightInTexels, toStringFlags, tabCount, tabSize));
@@ -1466,7 +1466,7 @@ template <> std::string ToString<D3D12_TILE_SHAPE>(const D3D12_TILE_SHAPE& obj, 
 template <> std::string ToString<D3D12_PACKED_MIP_INFO>(const D3D12_PACKED_MIP_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumStandardMips", toStringFlags, tabCount, tabSize, ToString(obj.NumStandardMips, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumPackedMips", toStringFlags, tabCount, tabSize, ToString(obj.NumPackedMips, toStringFlags, tabCount, tabSize));
@@ -1479,7 +1479,7 @@ template <> std::string ToString<D3D12_PACKED_MIP_INFO>(const D3D12_PACKED_MIP_I
 template <> std::string ToString<D3D12_RESOURCE_TRANSITION_BARRIER>(const D3D12_RESOURCE_TRANSITION_BARRIER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pResource", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pResource));
             FieldToString(strStrm, false, "Subresource", toStringFlags, tabCount, tabSize, ToString(obj.Subresource, toStringFlags, tabCount, tabSize));
@@ -1492,7 +1492,7 @@ template <> std::string ToString<D3D12_RESOURCE_TRANSITION_BARRIER>(const D3D12_
 template <> std::string ToString<D3D12_RESOURCE_ALIASING_BARRIER>(const D3D12_RESOURCE_ALIASING_BARRIER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pResourceBefore", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pResourceBefore));
             FieldToString(strStrm, false, "pResourceAfter", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pResourceAfter));
@@ -1503,7 +1503,7 @@ template <> std::string ToString<D3D12_RESOURCE_ALIASING_BARRIER>(const D3D12_RE
 template <> std::string ToString<D3D12_RESOURCE_UAV_BARRIER>(const D3D12_RESOURCE_UAV_BARRIER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pResource", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pResource));
         }
@@ -1513,7 +1513,7 @@ template <> std::string ToString<D3D12_RESOURCE_UAV_BARRIER>(const D3D12_RESOURC
 template <> std::string ToString<D3D12_SUBRESOURCE_FOOTPRINT>(const D3D12_SUBRESOURCE_FOOTPRINT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Format", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Width", toStringFlags, tabCount, tabSize, ToString(obj.Width, toStringFlags, tabCount, tabSize));
@@ -1527,7 +1527,7 @@ template <> std::string ToString<D3D12_SUBRESOURCE_FOOTPRINT>(const D3D12_SUBRES
 template <> std::string ToString<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>(const D3D12_PLACED_SUBRESOURCE_FOOTPRINT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Offset", toStringFlags, tabCount, tabSize, ToString(obj.Offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Footprint", toStringFlags, tabCount, tabSize, ToString(obj.Footprint, toStringFlags, tabCount, tabSize));
@@ -1538,7 +1538,7 @@ template <> std::string ToString<D3D12_PLACED_SUBRESOURCE_FOOTPRINT>(const D3D12
 template <> std::string ToString<D3D12_SAMPLE_POSITION>(const D3D12_SAMPLE_POSITION& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "X", toStringFlags, tabCount, tabSize, ToString(obj.X, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Y", toStringFlags, tabCount, tabSize, ToString(obj.Y, toStringFlags, tabCount, tabSize));
@@ -1549,7 +1549,7 @@ template <> std::string ToString<D3D12_SAMPLE_POSITION>(const D3D12_SAMPLE_POSIT
 template <> std::string ToString<D3D12_VIEW_INSTANCE_LOCATION>(const D3D12_VIEW_INSTANCE_LOCATION& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ViewportArrayIndex", toStringFlags, tabCount, tabSize, ToString(obj.ViewportArrayIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "RenderTargetArrayIndex", toStringFlags, tabCount, tabSize, ToString(obj.RenderTargetArrayIndex, toStringFlags, tabCount, tabSize));
@@ -1560,7 +1560,7 @@ template <> std::string ToString<D3D12_VIEW_INSTANCE_LOCATION>(const D3D12_VIEW_
 template <> std::string ToString<D3D12_VIEW_INSTANCING_DESC>(const D3D12_VIEW_INSTANCING_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ViewInstanceCount", toStringFlags, tabCount, tabSize, ToString(obj.ViewInstanceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pViewInstanceLocations", toStringFlags, tabCount, tabSize, ArrayToString(obj.ViewInstanceCount, obj.pViewInstanceLocations, toStringFlags, tabCount, tabSize));
@@ -1572,7 +1572,7 @@ template <> std::string ToString<D3D12_VIEW_INSTANCING_DESC>(const D3D12_VIEW_IN
 template <> std::string ToString<D3D12_BUFFER_SRV>(const D3D12_BUFFER_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FirstElement", toStringFlags, tabCount, tabSize, ToString(obj.FirstElement, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumElements", toStringFlags, tabCount, tabSize, ToString(obj.NumElements, toStringFlags, tabCount, tabSize));
@@ -1585,7 +1585,7 @@ template <> std::string ToString<D3D12_BUFFER_SRV>(const D3D12_BUFFER_SRV& obj, 
 template <> std::string ToString<D3D12_TEX1D_SRV>(const D3D12_TEX1D_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MostDetailedMip", toStringFlags, tabCount, tabSize, ToString(obj.MostDetailedMip, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MipLevels", toStringFlags, tabCount, tabSize, ToString(obj.MipLevels, toStringFlags, tabCount, tabSize));
@@ -1597,7 +1597,7 @@ template <> std::string ToString<D3D12_TEX1D_SRV>(const D3D12_TEX1D_SRV& obj, To
 template <> std::string ToString<D3D12_TEX1D_ARRAY_SRV>(const D3D12_TEX1D_ARRAY_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MostDetailedMip", toStringFlags, tabCount, tabSize, ToString(obj.MostDetailedMip, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MipLevels", toStringFlags, tabCount, tabSize, ToString(obj.MipLevels, toStringFlags, tabCount, tabSize));
@@ -1611,7 +1611,7 @@ template <> std::string ToString<D3D12_TEX1D_ARRAY_SRV>(const D3D12_TEX1D_ARRAY_
 template <> std::string ToString<D3D12_TEX2D_SRV>(const D3D12_TEX2D_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MostDetailedMip", toStringFlags, tabCount, tabSize, ToString(obj.MostDetailedMip, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MipLevels", toStringFlags, tabCount, tabSize, ToString(obj.MipLevels, toStringFlags, tabCount, tabSize));
@@ -1624,7 +1624,7 @@ template <> std::string ToString<D3D12_TEX2D_SRV>(const D3D12_TEX2D_SRV& obj, To
 template <> std::string ToString<D3D12_TEX2D_ARRAY_SRV>(const D3D12_TEX2D_ARRAY_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MostDetailedMip", toStringFlags, tabCount, tabSize, ToString(obj.MostDetailedMip, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MipLevels", toStringFlags, tabCount, tabSize, ToString(obj.MipLevels, toStringFlags, tabCount, tabSize));
@@ -1639,7 +1639,7 @@ template <> std::string ToString<D3D12_TEX2D_ARRAY_SRV>(const D3D12_TEX2D_ARRAY_
 template <> std::string ToString<D3D12_TEX3D_SRV>(const D3D12_TEX3D_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MostDetailedMip", toStringFlags, tabCount, tabSize, ToString(obj.MostDetailedMip, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MipLevels", toStringFlags, tabCount, tabSize, ToString(obj.MipLevels, toStringFlags, tabCount, tabSize));
@@ -1651,7 +1651,7 @@ template <> std::string ToString<D3D12_TEX3D_SRV>(const D3D12_TEX3D_SRV& obj, To
 template <> std::string ToString<D3D12_TEXCUBE_SRV>(const D3D12_TEXCUBE_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MostDetailedMip", toStringFlags, tabCount, tabSize, ToString(obj.MostDetailedMip, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MipLevels", toStringFlags, tabCount, tabSize, ToString(obj.MipLevels, toStringFlags, tabCount, tabSize));
@@ -1663,7 +1663,7 @@ template <> std::string ToString<D3D12_TEXCUBE_SRV>(const D3D12_TEXCUBE_SRV& obj
 template <> std::string ToString<D3D12_TEXCUBE_ARRAY_SRV>(const D3D12_TEXCUBE_ARRAY_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MostDetailedMip", toStringFlags, tabCount, tabSize, ToString(obj.MostDetailedMip, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MipLevels", toStringFlags, tabCount, tabSize, ToString(obj.MipLevels, toStringFlags, tabCount, tabSize));
@@ -1677,7 +1677,7 @@ template <> std::string ToString<D3D12_TEXCUBE_ARRAY_SRV>(const D3D12_TEXCUBE_AR
 template <> std::string ToString<D3D12_TEX2DMS_SRV>(const D3D12_TEX2DMS_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "UnusedField_NothingToDefine", toStringFlags, tabCount, tabSize, ToString(obj.UnusedField_NothingToDefine, toStringFlags, tabCount, tabSize));
         }
@@ -1687,7 +1687,7 @@ template <> std::string ToString<D3D12_TEX2DMS_SRV>(const D3D12_TEX2DMS_SRV& obj
 template <> std::string ToString<D3D12_TEX2DMS_ARRAY_SRV>(const D3D12_TEX2DMS_ARRAY_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ArraySize", toStringFlags, tabCount, tabSize, ToString(obj.ArraySize, toStringFlags, tabCount, tabSize));
@@ -1698,7 +1698,7 @@ template <> std::string ToString<D3D12_TEX2DMS_ARRAY_SRV>(const D3D12_TEX2DMS_AR
 template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV>(const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Location", toStringFlags, tabCount, tabSize, ToString(obj.Location, toStringFlags, tabCount, tabSize));
         }
@@ -1708,7 +1708,7 @@ template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV>(co
 template <> std::string ToString<D3D12_CONSTANT_BUFFER_VIEW_DESC>(const D3D12_CONSTANT_BUFFER_VIEW_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "BufferLocation", toStringFlags, tabCount, tabSize, ToString(obj.BufferLocation, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
@@ -1719,7 +1719,7 @@ template <> std::string ToString<D3D12_CONSTANT_BUFFER_VIEW_DESC>(const D3D12_CO
 template <> std::string ToString<D3D12_SAMPLER_DESC>(const D3D12_SAMPLER_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Filter", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Filter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "AddressU", toStringFlags, tabCount, tabSize, '"' + ToString(obj.AddressU, toStringFlags, tabCount, tabSize) + '"');
@@ -1738,7 +1738,7 @@ template <> std::string ToString<D3D12_SAMPLER_DESC>(const D3D12_SAMPLER_DESC& o
 template <> std::string ToString<D3D12_BUFFER_UAV>(const D3D12_BUFFER_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FirstElement", toStringFlags, tabCount, tabSize, ToString(obj.FirstElement, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumElements", toStringFlags, tabCount, tabSize, ToString(obj.NumElements, toStringFlags, tabCount, tabSize));
@@ -1752,7 +1752,7 @@ template <> std::string ToString<D3D12_BUFFER_UAV>(const D3D12_BUFFER_UAV& obj, 
 template <> std::string ToString<D3D12_TEX1D_UAV>(const D3D12_TEX1D_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
         }
@@ -1762,7 +1762,7 @@ template <> std::string ToString<D3D12_TEX1D_UAV>(const D3D12_TEX1D_UAV& obj, To
 template <> std::string ToString<D3D12_TEX1D_ARRAY_UAV>(const D3D12_TEX1D_ARRAY_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
@@ -1774,7 +1774,7 @@ template <> std::string ToString<D3D12_TEX1D_ARRAY_UAV>(const D3D12_TEX1D_ARRAY_
 template <> std::string ToString<D3D12_TEX2D_UAV>(const D3D12_TEX2D_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "PlaneSlice", toStringFlags, tabCount, tabSize, ToString(obj.PlaneSlice, toStringFlags, tabCount, tabSize));
@@ -1785,7 +1785,7 @@ template <> std::string ToString<D3D12_TEX2D_UAV>(const D3D12_TEX2D_UAV& obj, To
 template <> std::string ToString<D3D12_TEX2D_ARRAY_UAV>(const D3D12_TEX2D_ARRAY_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
@@ -1798,7 +1798,7 @@ template <> std::string ToString<D3D12_TEX2D_ARRAY_UAV>(const D3D12_TEX2D_ARRAY_
 template <> std::string ToString<D3D12_TEX2DMS_UAV>(const D3D12_TEX2DMS_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "UnusedField_NothingToDefine", toStringFlags, tabCount, tabSize, ToString(obj.UnusedField_NothingToDefine, toStringFlags, tabCount, tabSize));
         }
@@ -1808,7 +1808,7 @@ template <> std::string ToString<D3D12_TEX2DMS_UAV>(const D3D12_TEX2DMS_UAV& obj
 template <> std::string ToString<D3D12_TEX2DMS_ARRAY_UAV>(const D3D12_TEX2DMS_ARRAY_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ArraySize", toStringFlags, tabCount, tabSize, ToString(obj.ArraySize, toStringFlags, tabCount, tabSize));
@@ -1819,7 +1819,7 @@ template <> std::string ToString<D3D12_TEX2DMS_ARRAY_UAV>(const D3D12_TEX2DMS_AR
 template <> std::string ToString<D3D12_TEX3D_UAV>(const D3D12_TEX3D_UAV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstWSlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstWSlice, toStringFlags, tabCount, tabSize));
@@ -1831,7 +1831,7 @@ template <> std::string ToString<D3D12_TEX3D_UAV>(const D3D12_TEX3D_UAV& obj, To
 template <> std::string ToString<D3D12_BUFFER_RTV>(const D3D12_BUFFER_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FirstElement", toStringFlags, tabCount, tabSize, ToString(obj.FirstElement, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumElements", toStringFlags, tabCount, tabSize, ToString(obj.NumElements, toStringFlags, tabCount, tabSize));
@@ -1842,7 +1842,7 @@ template <> std::string ToString<D3D12_BUFFER_RTV>(const D3D12_BUFFER_RTV& obj, 
 template <> std::string ToString<D3D12_TEX1D_RTV>(const D3D12_TEX1D_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
         }
@@ -1852,7 +1852,7 @@ template <> std::string ToString<D3D12_TEX1D_RTV>(const D3D12_TEX1D_RTV& obj, To
 template <> std::string ToString<D3D12_TEX1D_ARRAY_RTV>(const D3D12_TEX1D_ARRAY_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
@@ -1864,7 +1864,7 @@ template <> std::string ToString<D3D12_TEX1D_ARRAY_RTV>(const D3D12_TEX1D_ARRAY_
 template <> std::string ToString<D3D12_TEX2D_RTV>(const D3D12_TEX2D_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "PlaneSlice", toStringFlags, tabCount, tabSize, ToString(obj.PlaneSlice, toStringFlags, tabCount, tabSize));
@@ -1875,7 +1875,7 @@ template <> std::string ToString<D3D12_TEX2D_RTV>(const D3D12_TEX2D_RTV& obj, To
 template <> std::string ToString<D3D12_TEX2DMS_RTV>(const D3D12_TEX2DMS_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "UnusedField_NothingToDefine", toStringFlags, tabCount, tabSize, ToString(obj.UnusedField_NothingToDefine, toStringFlags, tabCount, tabSize));
         }
@@ -1885,7 +1885,7 @@ template <> std::string ToString<D3D12_TEX2DMS_RTV>(const D3D12_TEX2DMS_RTV& obj
 template <> std::string ToString<D3D12_TEX2D_ARRAY_RTV>(const D3D12_TEX2D_ARRAY_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
@@ -1898,7 +1898,7 @@ template <> std::string ToString<D3D12_TEX2D_ARRAY_RTV>(const D3D12_TEX2D_ARRAY_
 template <> std::string ToString<D3D12_TEX2DMS_ARRAY_RTV>(const D3D12_TEX2DMS_ARRAY_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ArraySize", toStringFlags, tabCount, tabSize, ToString(obj.ArraySize, toStringFlags, tabCount, tabSize));
@@ -1909,7 +1909,7 @@ template <> std::string ToString<D3D12_TEX2DMS_ARRAY_RTV>(const D3D12_TEX2DMS_AR
 template <> std::string ToString<D3D12_TEX3D_RTV>(const D3D12_TEX3D_RTV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstWSlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstWSlice, toStringFlags, tabCount, tabSize));
@@ -1921,7 +1921,7 @@ template <> std::string ToString<D3D12_TEX3D_RTV>(const D3D12_TEX3D_RTV& obj, To
 template <> std::string ToString<D3D12_TEX1D_DSV>(const D3D12_TEX1D_DSV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
         }
@@ -1931,7 +1931,7 @@ template <> std::string ToString<D3D12_TEX1D_DSV>(const D3D12_TEX1D_DSV& obj, To
 template <> std::string ToString<D3D12_TEX1D_ARRAY_DSV>(const D3D12_TEX1D_ARRAY_DSV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
@@ -1943,7 +1943,7 @@ template <> std::string ToString<D3D12_TEX1D_ARRAY_DSV>(const D3D12_TEX1D_ARRAY_
 template <> std::string ToString<D3D12_TEX2D_DSV>(const D3D12_TEX2D_DSV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
         }
@@ -1953,7 +1953,7 @@ template <> std::string ToString<D3D12_TEX2D_DSV>(const D3D12_TEX2D_DSV& obj, To
 template <> std::string ToString<D3D12_TEX2D_ARRAY_DSV>(const D3D12_TEX2D_ARRAY_DSV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MipSlice", toStringFlags, tabCount, tabSize, ToString(obj.MipSlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
@@ -1965,7 +1965,7 @@ template <> std::string ToString<D3D12_TEX2D_ARRAY_DSV>(const D3D12_TEX2D_ARRAY_
 template <> std::string ToString<D3D12_TEX2DMS_DSV>(const D3D12_TEX2DMS_DSV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "UnusedField_NothingToDefine", toStringFlags, tabCount, tabSize, ToString(obj.UnusedField_NothingToDefine, toStringFlags, tabCount, tabSize));
         }
@@ -1975,7 +1975,7 @@ template <> std::string ToString<D3D12_TEX2DMS_DSV>(const D3D12_TEX2DMS_DSV& obj
 template <> std::string ToString<D3D12_TEX2DMS_ARRAY_DSV>(const D3D12_TEX2DMS_ARRAY_DSV& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "FirstArraySlice", toStringFlags, tabCount, tabSize, ToString(obj.FirstArraySlice, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ArraySize", toStringFlags, tabCount, tabSize, ToString(obj.ArraySize, toStringFlags, tabCount, tabSize));
@@ -1986,7 +1986,7 @@ template <> std::string ToString<D3D12_TEX2DMS_ARRAY_DSV>(const D3D12_TEX2DMS_AR
 template <> std::string ToString<D3D12_DESCRIPTOR_HEAP_DESC>(const D3D12_DESCRIPTOR_HEAP_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "NumDescriptors", toStringFlags, tabCount, tabSize, ToString(obj.NumDescriptors, toStringFlags, tabCount, tabSize));
@@ -1999,7 +1999,7 @@ template <> std::string ToString<D3D12_DESCRIPTOR_HEAP_DESC>(const D3D12_DESCRIP
 template <> std::string ToString<D3D12_DESCRIPTOR_RANGE>(const D3D12_DESCRIPTOR_RANGE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "RangeType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.RangeType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "NumDescriptors", toStringFlags, tabCount, tabSize, ToString(obj.NumDescriptors, toStringFlags, tabCount, tabSize));
@@ -2013,7 +2013,7 @@ template <> std::string ToString<D3D12_DESCRIPTOR_RANGE>(const D3D12_DESCRIPTOR_
 template <> std::string ToString<D3D12_ROOT_DESCRIPTOR_TABLE>(const D3D12_ROOT_DESCRIPTOR_TABLE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumDescriptorRanges", toStringFlags, tabCount, tabSize, ToString(obj.NumDescriptorRanges, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorRanges", toStringFlags, tabCount, tabSize, ArrayToString(obj.NumDescriptorRanges, obj.pDescriptorRanges, toStringFlags, tabCount, tabSize));
@@ -2024,7 +2024,7 @@ template <> std::string ToString<D3D12_ROOT_DESCRIPTOR_TABLE>(const D3D12_ROOT_D
 template <> std::string ToString<D3D12_ROOT_CONSTANTS>(const D3D12_ROOT_CONSTANTS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ShaderRegister", toStringFlags, tabCount, tabSize, ToString(obj.ShaderRegister, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "RegisterSpace", toStringFlags, tabCount, tabSize, ToString(obj.RegisterSpace, toStringFlags, tabCount, tabSize));
@@ -2036,7 +2036,7 @@ template <> std::string ToString<D3D12_ROOT_CONSTANTS>(const D3D12_ROOT_CONSTANT
 template <> std::string ToString<D3D12_ROOT_DESCRIPTOR>(const D3D12_ROOT_DESCRIPTOR& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ShaderRegister", toStringFlags, tabCount, tabSize, ToString(obj.ShaderRegister, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "RegisterSpace", toStringFlags, tabCount, tabSize, ToString(obj.RegisterSpace, toStringFlags, tabCount, tabSize));
@@ -2047,7 +2047,7 @@ template <> std::string ToString<D3D12_ROOT_DESCRIPTOR>(const D3D12_ROOT_DESCRIP
 template <> std::string ToString<D3D12_STATIC_SAMPLER_DESC>(const D3D12_STATIC_SAMPLER_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Filter", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Filter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "AddressU", toStringFlags, tabCount, tabSize, '"' + ToString(obj.AddressU, toStringFlags, tabCount, tabSize) + '"');
@@ -2069,7 +2069,7 @@ template <> std::string ToString<D3D12_STATIC_SAMPLER_DESC>(const D3D12_STATIC_S
 template <> std::string ToString<D3D12_ROOT_SIGNATURE_DESC>(const D3D12_ROOT_SIGNATURE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumParameters", toStringFlags, tabCount, tabSize, ToString(obj.NumParameters, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pParameters", toStringFlags, tabCount, tabSize, ArrayToString(obj.NumParameters, obj.pParameters, toStringFlags, tabCount, tabSize));
@@ -2083,7 +2083,7 @@ template <> std::string ToString<D3D12_ROOT_SIGNATURE_DESC>(const D3D12_ROOT_SIG
 template <> std::string ToString<D3D12_DESCRIPTOR_RANGE1>(const D3D12_DESCRIPTOR_RANGE1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "RangeType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.RangeType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "NumDescriptors", toStringFlags, tabCount, tabSize, ToString(obj.NumDescriptors, toStringFlags, tabCount, tabSize));
@@ -2098,7 +2098,7 @@ template <> std::string ToString<D3D12_DESCRIPTOR_RANGE1>(const D3D12_DESCRIPTOR
 template <> std::string ToString<D3D12_ROOT_DESCRIPTOR_TABLE1>(const D3D12_ROOT_DESCRIPTOR_TABLE1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumDescriptorRanges", toStringFlags, tabCount, tabSize, ToString(obj.NumDescriptorRanges, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorRanges", toStringFlags, tabCount, tabSize, ArrayToString(obj.NumDescriptorRanges, obj.pDescriptorRanges, toStringFlags, tabCount, tabSize));
@@ -2109,7 +2109,7 @@ template <> std::string ToString<D3D12_ROOT_DESCRIPTOR_TABLE1>(const D3D12_ROOT_
 template <> std::string ToString<D3D12_ROOT_DESCRIPTOR1>(const D3D12_ROOT_DESCRIPTOR1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ShaderRegister", toStringFlags, tabCount, tabSize, ToString(obj.ShaderRegister, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "RegisterSpace", toStringFlags, tabCount, tabSize, ToString(obj.RegisterSpace, toStringFlags, tabCount, tabSize));
@@ -2121,7 +2121,7 @@ template <> std::string ToString<D3D12_ROOT_DESCRIPTOR1>(const D3D12_ROOT_DESCRI
 template <> std::string ToString<D3D12_ROOT_SIGNATURE_DESC1>(const D3D12_ROOT_SIGNATURE_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumParameters", toStringFlags, tabCount, tabSize, ToString(obj.NumParameters, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pParameters", toStringFlags, tabCount, tabSize, ArrayToString(obj.NumParameters, obj.pParameters, toStringFlags, tabCount, tabSize));
@@ -2135,7 +2135,7 @@ template <> std::string ToString<D3D12_ROOT_SIGNATURE_DESC1>(const D3D12_ROOT_SI
 template <> std::string ToString<D3D12_DISCARD_REGION>(const D3D12_DISCARD_REGION& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumRects", toStringFlags, tabCount, tabSize, ToString(obj.NumRects, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRects", toStringFlags, tabCount, tabSize, ArrayToString(obj.NumRects, obj.pRects, toStringFlags, tabCount, tabSize));
@@ -2148,7 +2148,7 @@ template <> std::string ToString<D3D12_DISCARD_REGION>(const D3D12_DISCARD_REGIO
 template <> std::string ToString<D3D12_QUERY_HEAP_DESC>(const D3D12_QUERY_HEAP_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Count", toStringFlags, tabCount, tabSize, ToString(obj.Count, toStringFlags, tabCount, tabSize));
@@ -2160,7 +2160,7 @@ template <> std::string ToString<D3D12_QUERY_HEAP_DESC>(const D3D12_QUERY_HEAP_D
 template <> std::string ToString<D3D12_QUERY_DATA_PIPELINE_STATISTICS>(const D3D12_QUERY_DATA_PIPELINE_STATISTICS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "IAVertices", toStringFlags, tabCount, tabSize, ToString(obj.IAVertices, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "IAPrimitives", toStringFlags, tabCount, tabSize, ToString(obj.IAPrimitives, toStringFlags, tabCount, tabSize));
@@ -2180,7 +2180,7 @@ template <> std::string ToString<D3D12_QUERY_DATA_PIPELINE_STATISTICS>(const D3D
 template <> std::string ToString<D3D12_QUERY_DATA_PIPELINE_STATISTICS1>(const D3D12_QUERY_DATA_PIPELINE_STATISTICS1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "IAVertices", toStringFlags, tabCount, tabSize, ToString(obj.IAVertices, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "IAPrimitives", toStringFlags, tabCount, tabSize, ToString(obj.IAPrimitives, toStringFlags, tabCount, tabSize));
@@ -2203,7 +2203,7 @@ template <> std::string ToString<D3D12_QUERY_DATA_PIPELINE_STATISTICS1>(const D3
 template <> std::string ToString<D3D12_QUERY_DATA_SO_STATISTICS>(const D3D12_QUERY_DATA_SO_STATISTICS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumPrimitivesWritten", toStringFlags, tabCount, tabSize, ToString(obj.NumPrimitivesWritten, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "PrimitivesStorageNeeded", toStringFlags, tabCount, tabSize, ToString(obj.PrimitivesStorageNeeded, toStringFlags, tabCount, tabSize));
@@ -2214,7 +2214,7 @@ template <> std::string ToString<D3D12_QUERY_DATA_SO_STATISTICS>(const D3D12_QUE
 template <> std::string ToString<D3D12_STREAM_OUTPUT_BUFFER_VIEW>(const D3D12_STREAM_OUTPUT_BUFFER_VIEW& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "BufferLocation", toStringFlags, tabCount, tabSize, ToString(obj.BufferLocation, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
@@ -2226,7 +2226,7 @@ template <> std::string ToString<D3D12_STREAM_OUTPUT_BUFFER_VIEW>(const D3D12_ST
 template <> std::string ToString<D3D12_DRAW_ARGUMENTS>(const D3D12_DRAW_ARGUMENTS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "VertexCountPerInstance", toStringFlags, tabCount, tabSize, ToString(obj.VertexCountPerInstance, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "InstanceCount", toStringFlags, tabCount, tabSize, ToString(obj.InstanceCount, toStringFlags, tabCount, tabSize));
@@ -2239,7 +2239,7 @@ template <> std::string ToString<D3D12_DRAW_ARGUMENTS>(const D3D12_DRAW_ARGUMENT
 template <> std::string ToString<D3D12_DRAW_INDEXED_ARGUMENTS>(const D3D12_DRAW_INDEXED_ARGUMENTS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "IndexCountPerInstance", toStringFlags, tabCount, tabSize, ToString(obj.IndexCountPerInstance, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "InstanceCount", toStringFlags, tabCount, tabSize, ToString(obj.InstanceCount, toStringFlags, tabCount, tabSize));
@@ -2253,7 +2253,7 @@ template <> std::string ToString<D3D12_DRAW_INDEXED_ARGUMENTS>(const D3D12_DRAW_
 template <> std::string ToString<D3D12_DISPATCH_ARGUMENTS>(const D3D12_DISPATCH_ARGUMENTS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ThreadGroupCountX", toStringFlags, tabCount, tabSize, ToString(obj.ThreadGroupCountX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ThreadGroupCountY", toStringFlags, tabCount, tabSize, ToString(obj.ThreadGroupCountY, toStringFlags, tabCount, tabSize));
@@ -2265,7 +2265,7 @@ template <> std::string ToString<D3D12_DISPATCH_ARGUMENTS>(const D3D12_DISPATCH_
 template <> std::string ToString<D3D12_VERTEX_BUFFER_VIEW>(const D3D12_VERTEX_BUFFER_VIEW& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "BufferLocation", toStringFlags, tabCount, tabSize, ToString(obj.BufferLocation, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
@@ -2277,7 +2277,7 @@ template <> std::string ToString<D3D12_VERTEX_BUFFER_VIEW>(const D3D12_VERTEX_BU
 template <> std::string ToString<D3D12_INDEX_BUFFER_VIEW>(const D3D12_INDEX_BUFFER_VIEW& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "BufferLocation", toStringFlags, tabCount, tabSize, ToString(obj.BufferLocation, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
@@ -2289,7 +2289,7 @@ template <> std::string ToString<D3D12_INDEX_BUFFER_VIEW>(const D3D12_INDEX_BUFF
 template <> std::string ToString<D3D12_COMMAND_SIGNATURE_DESC>(const D3D12_COMMAND_SIGNATURE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ByteStride", toStringFlags, tabCount, tabSize, ToString(obj.ByteStride, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumArgumentDescs", toStringFlags, tabCount, tabSize, ToString(obj.NumArgumentDescs, toStringFlags, tabCount, tabSize));
@@ -2302,7 +2302,7 @@ template <> std::string ToString<D3D12_COMMAND_SIGNATURE_DESC>(const D3D12_COMMA
 template <> std::string ToString<D3D12_WRITEBUFFERIMMEDIATE_PARAMETER>(const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Dest", toStringFlags, tabCount, tabSize, ToString(obj.Dest, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Value", toStringFlags, tabCount, tabSize, ToString(obj.Value, toStringFlags, tabCount, tabSize));
@@ -2313,7 +2313,7 @@ template <> std::string ToString<D3D12_WRITEBUFFERIMMEDIATE_PARAMETER>(const D3D
 template <> std::string ToString<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT>(const D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeIndex", toStringFlags, tabCount, tabSize, ToString(obj.NodeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Support", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Support, toStringFlags, tabCount, tabSize) + '"');
@@ -2324,7 +2324,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_S
 template <> std::string ToString<D3D12_PROTECTED_RESOURCE_SESSION_DESC>(const D3D12_PROTECTED_RESOURCE_SESSION_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeMask", toStringFlags, tabCount, tabSize, ToString(obj.NodeMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
@@ -2335,7 +2335,7 @@ template <> std::string ToString<D3D12_PROTECTED_RESOURCE_SESSION_DESC>(const D3
 template <> std::string ToString<D3D12_META_COMMAND_PARAMETER_DESC>(const D3D12_META_COMMAND_PARAMETER_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Name", toStringFlags, tabCount, tabSize, (obj.Name ? ToString(*obj.Name, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
@@ -2349,7 +2349,7 @@ template <> std::string ToString<D3D12_META_COMMAND_PARAMETER_DESC>(const D3D12_
 template <> std::string ToString<D3D12_META_COMMAND_DESC>(const D3D12_META_COMMAND_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Id", toStringFlags, tabCount, tabSize, ToString(obj.Id, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Name", toStringFlags, tabCount, tabSize, (obj.Name ? ToString(*obj.Name, toStringFlags, tabCount, tabSize) : "null"));
@@ -2362,7 +2362,7 @@ template <> std::string ToString<D3D12_META_COMMAND_DESC>(const D3D12_META_COMMA
 template <> std::string ToString<D3D12_STATE_OBJECT_CONFIG>(const D3D12_STATE_OBJECT_CONFIG& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
         }
@@ -2372,7 +2372,7 @@ template <> std::string ToString<D3D12_STATE_OBJECT_CONFIG>(const D3D12_STATE_OB
 template <> std::string ToString<D3D12_GLOBAL_ROOT_SIGNATURE>(const D3D12_GLOBAL_ROOT_SIGNATURE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pGlobalRootSignature", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pGlobalRootSignature));
         }
@@ -2382,7 +2382,7 @@ template <> std::string ToString<D3D12_GLOBAL_ROOT_SIGNATURE>(const D3D12_GLOBAL
 template <> std::string ToString<D3D12_LOCAL_ROOT_SIGNATURE>(const D3D12_LOCAL_ROOT_SIGNATURE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pLocalRootSignature", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pLocalRootSignature));
         }
@@ -2392,7 +2392,7 @@ template <> std::string ToString<D3D12_LOCAL_ROOT_SIGNATURE>(const D3D12_LOCAL_R
 template <> std::string ToString<D3D12_NODE_MASK>(const D3D12_NODE_MASK& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeMask", toStringFlags, tabCount, tabSize, ToString(obj.NodeMask, toStringFlags, tabCount, tabSize));
         }
@@ -2402,7 +2402,7 @@ template <> std::string ToString<D3D12_NODE_MASK>(const D3D12_NODE_MASK& obj, To
 template <> std::string ToString<D3D12_EXPORT_DESC>(const D3D12_EXPORT_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Name", toStringFlags, tabCount, tabSize, (obj.Name ? ToString(*obj.Name, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "ExportToRename", toStringFlags, tabCount, tabSize, (obj.ExportToRename ? ToString(*obj.ExportToRename, toStringFlags, tabCount, tabSize) : "null"));
@@ -2414,7 +2414,7 @@ template <> std::string ToString<D3D12_EXPORT_DESC>(const D3D12_EXPORT_DESC& obj
 template <> std::string ToString<D3D12_DXIL_LIBRARY_DESC>(const D3D12_DXIL_LIBRARY_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DXILLibrary", toStringFlags, tabCount, tabSize, ToString(obj.DXILLibrary, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumExports", toStringFlags, tabCount, tabSize, ToString(obj.NumExports, toStringFlags, tabCount, tabSize));
@@ -2426,7 +2426,7 @@ template <> std::string ToString<D3D12_DXIL_LIBRARY_DESC>(const D3D12_DXIL_LIBRA
 template <> std::string ToString<D3D12_EXISTING_COLLECTION_DESC>(const D3D12_EXISTING_COLLECTION_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pExistingCollection", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pExistingCollection));
             FieldToString(strStrm, false, "NumExports", toStringFlags, tabCount, tabSize, ToString(obj.NumExports, toStringFlags, tabCount, tabSize));
@@ -2438,7 +2438,7 @@ template <> std::string ToString<D3D12_EXISTING_COLLECTION_DESC>(const D3D12_EXI
 template <> std::string ToString<D3D12_HIT_GROUP_DESC>(const D3D12_HIT_GROUP_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "HitGroupExport", toStringFlags, tabCount, tabSize, (obj.HitGroupExport ? ToString(*obj.HitGroupExport, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
@@ -2452,7 +2452,7 @@ template <> std::string ToString<D3D12_HIT_GROUP_DESC>(const D3D12_HIT_GROUP_DES
 template <> std::string ToString<D3D12_RAYTRACING_SHADER_CONFIG>(const D3D12_RAYTRACING_SHADER_CONFIG& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MaxPayloadSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.MaxPayloadSizeInBytes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MaxAttributeSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.MaxAttributeSizeInBytes, toStringFlags, tabCount, tabSize));
@@ -2463,7 +2463,7 @@ template <> std::string ToString<D3D12_RAYTRACING_SHADER_CONFIG>(const D3D12_RAY
 template <> std::string ToString<D3D12_RAYTRACING_PIPELINE_CONFIG>(const D3D12_RAYTRACING_PIPELINE_CONFIG& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MaxTraceRecursionDepth", toStringFlags, tabCount, tabSize, ToString(obj.MaxTraceRecursionDepth, toStringFlags, tabCount, tabSize));
         }
@@ -2473,7 +2473,7 @@ template <> std::string ToString<D3D12_RAYTRACING_PIPELINE_CONFIG>(const D3D12_R
 template <> std::string ToString<D3D12_RAYTRACING_PIPELINE_CONFIG1>(const D3D12_RAYTRACING_PIPELINE_CONFIG1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MaxTraceRecursionDepth", toStringFlags, tabCount, tabSize, ToString(obj.MaxTraceRecursionDepth, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
@@ -2484,7 +2484,7 @@ template <> std::string ToString<D3D12_RAYTRACING_PIPELINE_CONFIG1>(const D3D12_
 template <> std::string ToString<D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE>(const D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "StartAddress", toStringFlags, tabCount, tabSize, ToString(obj.StartAddress, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "StrideInBytes", toStringFlags, tabCount, tabSize, ToString(obj.StrideInBytes, toStringFlags, tabCount, tabSize));
@@ -2495,7 +2495,7 @@ template <> std::string ToString<D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE>(const D3D
 template <> std::string ToString<D3D12_GPU_VIRTUAL_ADDRESS_RANGE>(const D3D12_GPU_VIRTUAL_ADDRESS_RANGE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "StartAddress", toStringFlags, tabCount, tabSize, ToString(obj.StartAddress, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
@@ -2506,7 +2506,7 @@ template <> std::string ToString<D3D12_GPU_VIRTUAL_ADDRESS_RANGE>(const D3D12_GP
 template <> std::string ToString<D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE>(const D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "StartAddress", toStringFlags, tabCount, tabSize, ToString(obj.StartAddress, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SizeInBytes, toStringFlags, tabCount, tabSize));
@@ -2518,7 +2518,7 @@ template <> std::string ToString<D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE>(con
 template <> std::string ToString<D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC>(const D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Transform3x4", toStringFlags, tabCount, tabSize, ToString(obj.Transform3x4, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "IndexFormat", toStringFlags, tabCount, tabSize, '"' + ToString(obj.IndexFormat, toStringFlags, tabCount, tabSize) + '"');
@@ -2534,7 +2534,7 @@ template <> std::string ToString<D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC>(const
 template <> std::string ToString<D3D12_RAYTRACING_AABB>(const D3D12_RAYTRACING_AABB& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MinX", toStringFlags, tabCount, tabSize, ToString(obj.MinX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MinY", toStringFlags, tabCount, tabSize, ToString(obj.MinY, toStringFlags, tabCount, tabSize));
@@ -2549,7 +2549,7 @@ template <> std::string ToString<D3D12_RAYTRACING_AABB>(const D3D12_RAYTRACING_A
 template <> std::string ToString<D3D12_RAYTRACING_GEOMETRY_AABBS_DESC>(const D3D12_RAYTRACING_GEOMETRY_AABBS_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "AABBCount", toStringFlags, tabCount, tabSize, ToString(obj.AABBCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "AABBs", toStringFlags, tabCount, tabSize, ToString(obj.AABBs, toStringFlags, tabCount, tabSize));
@@ -2560,7 +2560,7 @@ template <> std::string ToString<D3D12_RAYTRACING_GEOMETRY_AABBS_DESC>(const D3D
 template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC>(const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DestBuffer", toStringFlags, tabCount, tabSize, ToString(obj.DestBuffer, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "InfoType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.InfoType, toStringFlags, tabCount, tabSize) + '"');
@@ -2571,7 +2571,7 @@ template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUI
 template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC>(const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "CompactedSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.CompactedSizeInBytes, toStringFlags, tabCount, tabSize));
         }
@@ -2581,7 +2581,7 @@ template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUI
 template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESC>(const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DecodedSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.DecodedSizeInBytes, toStringFlags, tabCount, tabSize));
         }
@@ -2591,7 +2591,7 @@ template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUI
 template <> std::string ToString<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADER>(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Type", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "NumDescs", toStringFlags, tabCount, tabSize, ToString(obj.NumDescs, toStringFlags, tabCount, tabSize));
@@ -2602,7 +2602,7 @@ template <> std::string ToString<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_T
 template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESC>(const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SerializedSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.SerializedSizeInBytes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumBottomLevelAccelerationStructurePointers", toStringFlags, tabCount, tabSize, ToString(obj.NumBottomLevelAccelerationStructurePointers, toStringFlags, tabCount, tabSize));
@@ -2613,7 +2613,7 @@ template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUI
 template <> std::string ToString<D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER>(const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DriverOpaqueGUID", toStringFlags, tabCount, tabSize, ToString(obj.DriverOpaqueGUID, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DriverOpaqueVersioningData", toStringFlags, tabCount, tabSize, ArrayToString(16, obj.DriverOpaqueVersioningData, toStringFlags, tabCount, tabSize));
@@ -2624,7 +2624,7 @@ template <> std::string ToString<D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIE
 template <> std::string ToString<D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER>(const D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DriverMatchingIdentifier", toStringFlags, tabCount, tabSize, ToString(obj.DriverMatchingIdentifier, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "SerializedSizeInBytesIncludingHeader", toStringFlags, tabCount, tabSize, ToString(obj.SerializedSizeInBytesIncludingHeader, toStringFlags, tabCount, tabSize));
@@ -2637,7 +2637,7 @@ template <> std::string ToString<D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCT
 template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC>(const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "CurrentSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.CurrentSizeInBytes, toStringFlags, tabCount, tabSize));
         }
@@ -2647,7 +2647,7 @@ template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUI
 template <> std::string ToString<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC>(const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DestAccelerationStructureData", toStringFlags, tabCount, tabSize, ToString(obj.DestAccelerationStructureData, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Inputs", toStringFlags, tabCount, tabSize, ToString(obj.Inputs, toStringFlags, tabCount, tabSize));
@@ -2660,7 +2660,7 @@ template <> std::string ToString<D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_D
 template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO>(const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ResultDataMaxSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.ResultDataMaxSizeInBytes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ScratchDataSizeInBytes", toStringFlags, tabCount, tabSize, ToString(obj.ScratchDataSizeInBytes, toStringFlags, tabCount, tabSize));
@@ -2672,7 +2672,7 @@ template <> std::string ToString<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUIL
 template <> std::string ToString<D3D12_AUTO_BREADCRUMB_NODE>(const D3D12_AUTO_BREADCRUMB_NODE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pCommandListDebugNameA", toStringFlags, tabCount, tabSize, (obj.pCommandListDebugNameA ? ToString(*obj.pCommandListDebugNameA, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "pCommandListDebugNameW", toStringFlags, tabCount, tabSize, (obj.pCommandListDebugNameW ? ToString(*obj.pCommandListDebugNameW, toStringFlags, tabCount, tabSize) : "null"));
@@ -2691,7 +2691,7 @@ template <> std::string ToString<D3D12_AUTO_BREADCRUMB_NODE>(const D3D12_AUTO_BR
 template <> std::string ToString<D3D12_DRED_BREADCRUMB_CONTEXT>(const D3D12_DRED_BREADCRUMB_CONTEXT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "BreadcrumbIndex", toStringFlags, tabCount, tabSize, ToString(obj.BreadcrumbIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pContextString", toStringFlags, tabCount, tabSize, (obj.pContextString ? ToString(*obj.pContextString, toStringFlags, tabCount, tabSize) : "null"));
@@ -2702,7 +2702,7 @@ template <> std::string ToString<D3D12_DRED_BREADCRUMB_CONTEXT>(const D3D12_DRED
 template <> std::string ToString<D3D12_AUTO_BREADCRUMB_NODE1>(const D3D12_AUTO_BREADCRUMB_NODE1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pCommandListDebugNameA", toStringFlags, tabCount, tabSize, (obj.pCommandListDebugNameA ? ToString(*obj.pCommandListDebugNameA, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "pCommandListDebugNameW", toStringFlags, tabCount, tabSize, (obj.pCommandListDebugNameW ? ToString(*obj.pCommandListDebugNameW, toStringFlags, tabCount, tabSize) : "null"));
@@ -2723,7 +2723,7 @@ template <> std::string ToString<D3D12_AUTO_BREADCRUMB_NODE1>(const D3D12_AUTO_B
 template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA>(const D3D12_DEVICE_REMOVED_EXTENDED_DATA& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pHeadAutoBreadcrumbNode", toStringFlags, tabCount, tabSize, (obj.pHeadAutoBreadcrumbNode ? ToString(*obj.pHeadAutoBreadcrumbNode, toStringFlags, tabCount, tabSize) : "null"));
@@ -2734,7 +2734,7 @@ template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA>(const D3D12
 template <> std::string ToString<D3D12_DRED_ALLOCATION_NODE>(const D3D12_DRED_ALLOCATION_NODE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ObjectNameA", toStringFlags, tabCount, tabSize, (obj.ObjectNameA ? ToString(*obj.ObjectNameA, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "ObjectNameW", toStringFlags, tabCount, tabSize, (obj.ObjectNameW ? ToString(*obj.ObjectNameW, toStringFlags, tabCount, tabSize) : "null"));
@@ -2747,7 +2747,7 @@ template <> std::string ToString<D3D12_DRED_ALLOCATION_NODE>(const D3D12_DRED_AL
 template <> std::string ToString<D3D12_DRED_ALLOCATION_NODE1>(const D3D12_DRED_ALLOCATION_NODE1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ObjectNameA", toStringFlags, tabCount, tabSize, (obj.ObjectNameA ? ToString(*obj.ObjectNameA, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "ObjectNameW", toStringFlags, tabCount, tabSize, (obj.ObjectNameW ? ToString(*obj.ObjectNameW, toStringFlags, tabCount, tabSize) : "null"));
@@ -2761,7 +2761,7 @@ template <> std::string ToString<D3D12_DRED_ALLOCATION_NODE1>(const D3D12_DRED_A
 template <> std::string ToString<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT>(const D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pHeadAutoBreadcrumbNode", toStringFlags, tabCount, tabSize, (obj.pHeadAutoBreadcrumbNode ? ToString(*obj.pHeadAutoBreadcrumbNode, toStringFlags, tabCount, tabSize) : "null"));
         }
@@ -2771,7 +2771,7 @@ template <> std::string ToString<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT>(const D3D12
 template <> std::string ToString<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1>(const D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pHeadAutoBreadcrumbNode", toStringFlags, tabCount, tabSize, (obj.pHeadAutoBreadcrumbNode ? ToString(*obj.pHeadAutoBreadcrumbNode, toStringFlags, tabCount, tabSize) : "null"));
         }
@@ -2781,7 +2781,7 @@ template <> std::string ToString<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1>(const D3D1
 template <> std::string ToString<D3D12_DRED_PAGE_FAULT_OUTPUT>(const D3D12_DRED_PAGE_FAULT_OUTPUT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "PageFaultVA", toStringFlags, tabCount, tabSize, ToString(obj.PageFaultVA, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pHeadExistingAllocationNode", toStringFlags, tabCount, tabSize, (obj.pHeadExistingAllocationNode ? ToString(*obj.pHeadExistingAllocationNode, toStringFlags, tabCount, tabSize) : "null"));
@@ -2793,7 +2793,7 @@ template <> std::string ToString<D3D12_DRED_PAGE_FAULT_OUTPUT>(const D3D12_DRED_
 template <> std::string ToString<D3D12_DRED_PAGE_FAULT_OUTPUT1>(const D3D12_DRED_PAGE_FAULT_OUTPUT1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "PageFaultVA", toStringFlags, tabCount, tabSize, ToString(obj.PageFaultVA, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pHeadExistingAllocationNode", toStringFlags, tabCount, tabSize, (obj.pHeadExistingAllocationNode ? ToString(*obj.pHeadExistingAllocationNode, toStringFlags, tabCount, tabSize) : "null"));
@@ -2805,7 +2805,7 @@ template <> std::string ToString<D3D12_DRED_PAGE_FAULT_OUTPUT1>(const D3D12_DRED
 template <> std::string ToString<D3D12_DRED_PAGE_FAULT_OUTPUT2>(const D3D12_DRED_PAGE_FAULT_OUTPUT2& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "PageFaultVA", toStringFlags, tabCount, tabSize, ToString(obj.PageFaultVA, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pHeadExistingAllocationNode", toStringFlags, tabCount, tabSize, (obj.pHeadExistingAllocationNode ? ToString(*obj.pHeadExistingAllocationNode, toStringFlags, tabCount, tabSize) : "null"));
@@ -2818,7 +2818,7 @@ template <> std::string ToString<D3D12_DRED_PAGE_FAULT_OUTPUT2>(const D3D12_DRED
 template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA1>(const D3D12_DEVICE_REMOVED_EXTENDED_DATA1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DeviceRemovedReason", toStringFlags, tabCount, tabSize, ToString(obj.DeviceRemovedReason, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "AutoBreadcrumbsOutput", toStringFlags, tabCount, tabSize, ToString(obj.AutoBreadcrumbsOutput, toStringFlags, tabCount, tabSize));
@@ -2830,7 +2830,7 @@ template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA1>(const D3D1
 template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA2>(const D3D12_DEVICE_REMOVED_EXTENDED_DATA2& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DeviceRemovedReason", toStringFlags, tabCount, tabSize, ToString(obj.DeviceRemovedReason, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "AutoBreadcrumbsOutput", toStringFlags, tabCount, tabSize, ToString(obj.AutoBreadcrumbsOutput, toStringFlags, tabCount, tabSize));
@@ -2842,7 +2842,7 @@ template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA2>(const D3D1
 template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA3>(const D3D12_DEVICE_REMOVED_EXTENDED_DATA3& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "DeviceRemovedReason", toStringFlags, tabCount, tabSize, ToString(obj.DeviceRemovedReason, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "AutoBreadcrumbsOutput", toStringFlags, tabCount, tabSize, ToString(obj.AutoBreadcrumbsOutput, toStringFlags, tabCount, tabSize));
@@ -2855,7 +2855,7 @@ template <> std::string ToString<D3D12_DEVICE_REMOVED_EXTENDED_DATA3>(const D3D1
 template <> std::string ToString<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT>(const D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeIndex", toStringFlags, tabCount, tabSize, ToString(obj.NodeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Count", toStringFlags, tabCount, tabSize, ToString(obj.Count, toStringFlags, tabCount, tabSize));
@@ -2866,7 +2866,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_T
 template <> std::string ToString<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES>(const D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeIndex", toStringFlags, tabCount, tabSize, ToString(obj.NodeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Count", toStringFlags, tabCount, tabSize, ToString(obj.Count, toStringFlags, tabCount, tabSize));
@@ -2878,7 +2878,7 @@ template <> std::string ToString<D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_T
 template <> std::string ToString<D3D12_PROTECTED_RESOURCE_SESSION_DESC1>(const D3D12_PROTECTED_RESOURCE_SESSION_DESC1& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NodeMask", toStringFlags, tabCount, tabSize, ToString(obj.NodeMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
@@ -2890,7 +2890,7 @@ template <> std::string ToString<D3D12_PROTECTED_RESOURCE_SESSION_DESC1>(const D
 template <> std::string ToString<D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS>(const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ClearValue", toStringFlags, tabCount, tabSize, ToString(obj.ClearValue, toStringFlags, tabCount, tabSize));
         }
@@ -2900,7 +2900,7 @@ template <> std::string ToString<D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAME
 template <> std::string ToString<D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS>(const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SrcSubresource", toStringFlags, tabCount, tabSize, ToString(obj.SrcSubresource, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DstSubresource", toStringFlags, tabCount, tabSize, ToString(obj.DstSubresource, toStringFlags, tabCount, tabSize));
@@ -2914,7 +2914,7 @@ template <> std::string ToString<D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESO
 template <> std::string ToString<D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS>(const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pSrcResource", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pSrcResource));
             FieldToString(strStrm, false, "pDstResource", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pDstResource));
@@ -2930,7 +2930,7 @@ template <> std::string ToString<D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMET
 template <> std::string ToString<D3D12_RENDER_PASS_RENDER_TARGET_DESC>(const D3D12_RENDER_PASS_RENDER_TARGET_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "cpuDescriptor", toStringFlags, tabCount, tabSize, ToString(obj.cpuDescriptor, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "BeginningAccess", toStringFlags, tabCount, tabSize, ToString(obj.BeginningAccess, toStringFlags, tabCount, tabSize));
@@ -2942,7 +2942,7 @@ template <> std::string ToString<D3D12_RENDER_PASS_RENDER_TARGET_DESC>(const D3D
 template <> std::string ToString<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>(const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "cpuDescriptor", toStringFlags, tabCount, tabSize, ToString(obj.cpuDescriptor, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DepthBeginningAccess", toStringFlags, tabCount, tabSize, ToString(obj.DepthBeginningAccess, toStringFlags, tabCount, tabSize));
@@ -2956,7 +2956,7 @@ template <> std::string ToString<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>(const D3D
 template <> std::string ToString<D3D12_DISPATCH_RAYS_DESC>(const D3D12_DISPATCH_RAYS_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "RayGenerationShaderRecord", toStringFlags, tabCount, tabSize, ToString(obj.RayGenerationShaderRecord, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "MissShaderTable", toStringFlags, tabCount, tabSize, ToString(obj.MissShaderTable, toStringFlags, tabCount, tabSize));
@@ -2972,7 +2972,7 @@ template <> std::string ToString<D3D12_DISPATCH_RAYS_DESC>(const D3D12_DISPATCH_
 template <> std::string ToString<D3D12_SHADER_CACHE_SESSION_DESC>(const D3D12_SHADER_CACHE_SESSION_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Identifier", toStringFlags, tabCount, tabSize, ToString(obj.Identifier, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "Mode", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Mode, toStringFlags, tabCount, tabSize) + '"');
@@ -2988,7 +2988,7 @@ template <> std::string ToString<D3D12_SHADER_CACHE_SESSION_DESC>(const D3D12_SH
 template <> std::string ToString<D3D12_BARRIER_SUBRESOURCE_RANGE>(const D3D12_BARRIER_SUBRESOURCE_RANGE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "IndexOrFirstMipLevel", toStringFlags, tabCount, tabSize, ToString(obj.IndexOrFirstMipLevel, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "NumMipLevels", toStringFlags, tabCount, tabSize, ToString(obj.NumMipLevels, toStringFlags, tabCount, tabSize));
@@ -3003,7 +3003,7 @@ template <> std::string ToString<D3D12_BARRIER_SUBRESOURCE_RANGE>(const D3D12_BA
 template <> std::string ToString<D3D12_GLOBAL_BARRIER>(const D3D12_GLOBAL_BARRIER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SyncBefore", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SyncBefore, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "SyncAfter", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SyncAfter, toStringFlags, tabCount, tabSize) + '"');
@@ -3016,7 +3016,7 @@ template <> std::string ToString<D3D12_GLOBAL_BARRIER>(const D3D12_GLOBAL_BARRIE
 template <> std::string ToString<D3D12_TEXTURE_BARRIER>(const D3D12_TEXTURE_BARRIER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SyncBefore", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SyncBefore, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "SyncAfter", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SyncAfter, toStringFlags, tabCount, tabSize) + '"');
@@ -3034,7 +3034,7 @@ template <> std::string ToString<D3D12_TEXTURE_BARRIER>(const D3D12_TEXTURE_BARR
 template <> std::string ToString<D3D12_BUFFER_BARRIER>(const D3D12_BUFFER_BARRIER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SyncBefore", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SyncBefore, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "SyncAfter", toStringFlags, tabCount, tabSize, '"' + ToString(obj.SyncAfter, toStringFlags, tabCount, tabSize) + '"');
@@ -3050,7 +3050,7 @@ template <> std::string ToString<D3D12_BUFFER_BARRIER>(const D3D12_BUFFER_BARRIE
 template <> std::string ToString<D3D12_SUBRESOURCE_DATA>(const D3D12_SUBRESOURCE_DATA& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pData", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pData));
             FieldToString(strStrm, false, "RowPitch", toStringFlags, tabCount, tabSize, ToString(obj.RowPitch, toStringFlags, tabCount, tabSize));
@@ -3062,7 +3062,7 @@ template <> std::string ToString<D3D12_SUBRESOURCE_DATA>(const D3D12_SUBRESOURCE
 template <> std::string ToString<D3D12_MEMCPY_DEST>(const D3D12_MEMCPY_DEST& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "pData", toStringFlags, tabCount, tabSize, HandleIdToString(obj.pData));
             FieldToString(strStrm, false, "RowPitch", toStringFlags, tabCount, tabSize, ToString(obj.RowPitch, toStringFlags, tabCount, tabSize));
@@ -3074,7 +3074,7 @@ template <> std::string ToString<D3D12_MEMCPY_DEST>(const D3D12_MEMCPY_DEST& obj
 template <> std::string ToString<D3D12_DEVICE_CONFIGURATION_DESC>(const D3D12_DEVICE_CONFIGURATION_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Flags", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Flags, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "GpuBasedValidationFlags", toStringFlags, tabCount, tabSize, ToString(obj.GpuBasedValidationFlags, toStringFlags, tabCount, tabSize));
@@ -3087,7 +3087,7 @@ template <> std::string ToString<D3D12_DEVICE_CONFIGURATION_DESC>(const D3D12_DE
 template <> std::string ToString<D3D12_DISPATCH_MESH_ARGUMENTS>(const D3D12_DISPATCH_MESH_ARGUMENTS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ThreadGroupCountX", toStringFlags, tabCount, tabSize, ToString(obj.ThreadGroupCountX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "ThreadGroupCountY", toStringFlags, tabCount, tabSize, ToString(obj.ThreadGroupCountY, toStringFlags, tabCount, tabSize));
@@ -3099,7 +3099,7 @@ template <> std::string ToString<D3D12_DISPATCH_MESH_ARGUMENTS>(const D3D12_DISP
 template <> std::string ToString<D3D_SHADER_MACRO>(const D3D_SHADER_MACRO& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Name", toStringFlags, tabCount, tabSize, (obj.Name ? ToString(*obj.Name, toStringFlags, tabCount, tabSize) : "null"));
             FieldToString(strStrm, false, "Definition", toStringFlags, tabCount, tabSize, (obj.Definition ? ToString(*obj.Definition, toStringFlags, tabCount, tabSize) : "null"));
@@ -3110,7 +3110,7 @@ template <> std::string ToString<D3D_SHADER_MACRO>(const D3D_SHADER_MACRO& obj, 
 template <> std::string ToString<D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGS>(const D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "MaxMessagesPerCommandList", toStringFlags, tabCount, tabSize, ToString(obj.MaxMessagesPerCommandList, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DefaultShaderPatchMode", toStringFlags, tabCount, tabSize, '"' + ToString(obj.DefaultShaderPatchMode, toStringFlags, tabCount, tabSize) + '"');
@@ -3122,7 +3122,7 @@ template <> std::string ToString<D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTING
 template <> std::string ToString<D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR>(const D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "SlowdownFactor", toStringFlags, tabCount, tabSize, ToString(obj.SlowdownFactor, toStringFlags, tabCount, tabSize));
         }
@@ -3132,7 +3132,7 @@ template <> std::string ToString<D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FAC
 template <> std::string ToString<D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS>(const D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "ShaderPatchMode", toStringFlags, tabCount, tabSize, '"' + ToString(obj.ShaderPatchMode, toStringFlags, tabCount, tabSize) + '"');
         }
@@ -3142,7 +3142,7 @@ template <> std::string ToString<D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_S
 template <> std::string ToString<D3D12_MESSAGE>(const D3D12_MESSAGE& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "Category", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Category, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "Severity", toStringFlags, tabCount, tabSize, '"' + ToString(obj.Severity, toStringFlags, tabCount, tabSize) + '"');
@@ -3156,7 +3156,7 @@ template <> std::string ToString<D3D12_MESSAGE>(const D3D12_MESSAGE& obj, ToStri
 template <> std::string ToString<D3D12_INFO_QUEUE_FILTER_DESC>(const D3D12_INFO_QUEUE_FILTER_DESC& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "NumCategories", toStringFlags, tabCount, tabSize, ToString(obj.NumCategories, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCategoryList", toStringFlags, tabCount, tabSize, EnumArrayToString(obj.NumCategories, obj.pCategoryList, toStringFlags, tabCount, tabSize));
@@ -3171,7 +3171,7 @@ template <> std::string ToString<D3D12_INFO_QUEUE_FILTER_DESC>(const D3D12_INFO_
 template <> std::string ToString<D3D12_INFO_QUEUE_FILTER>(const D3D12_INFO_QUEUE_FILTER& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "AllowList", toStringFlags, tabCount, tabSize, ToString(obj.AllowList, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "DenyList", toStringFlags, tabCount, tabSize, ToString(obj.DenyList, toStringFlags, tabCount, tabSize));
@@ -3182,7 +3182,7 @@ template <> std::string ToString<D3D12_INFO_QUEUE_FILTER>(const D3D12_INFO_QUEUE
 template <> std::string ToString<tagRECT>(const tagRECT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "left", toStringFlags, tabCount, tabSize, ToString(obj.left, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "top", toStringFlags, tabCount, tabSize, ToString(obj.top, toStringFlags, tabCount, tabSize));
@@ -3195,7 +3195,7 @@ template <> std::string ToString<tagRECT>(const tagRECT& obj, ToStringFlags toSt
 template <> std::string ToString<tagPOINT>(const tagPOINT& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "x", toStringFlags, tabCount, tabSize, ToString(obj.x, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "y", toStringFlags, tabCount, tabSize, ToString(obj.y, toStringFlags, tabCount, tabSize));

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -130,7 +130,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
     uint32_t option_index = 0;
     if (!options.empty())
     {
-        std::stringstream option_strstr(options);
+        std::istringstream option_strstr(options);
         while (option_strstr.good())
         {
             std::getline(option_strstr, sub_string, ',');
@@ -140,7 +140,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
             // of the values to point to the same option flag.
             if (sub_string.find('|') != std::string::npos)
             {
-                std::stringstream option_strstr_2(sub_string);
+                std::istringstream option_strstr_2(sub_string);
                 while (option_strstr_2.good())
                 {
                     std::getline(option_strstr_2, sub_string2, '|');
@@ -160,7 +160,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
     uint32_t argument_index = 0;
     if (!arguments.empty())
     {
-        std::stringstream arguments_strstr(arguments);
+        std::istringstream arguments_strstr(arguments);
         while (arguments_strstr.good())
         {
             std::getline(arguments_strstr, sub_string, ',');
@@ -170,7 +170,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
             // of the values to point to the same argument.
             if (sub_string.find('|') != std::string::npos)
             {
-                std::stringstream arguments_strstr_2(sub_string);
+                std::istringstream arguments_strstr_2(sub_string);
                 while (arguments_strstr_2.good())
                 {
                     std::getline(arguments_strstr_2, sub_string2, '|');

--- a/framework/util/custom_common_to_string.cpp
+++ b/framework/util/custom_common_to_string.cpp
@@ -33,7 +33,7 @@ template <>
 std::string ToString<SECURITY_ATTRIBUTES>(const SECURITY_ATTRIBUTES& obj, ToStringFlags toStringFlags, uint32_t tabCount, uint32_t tabSize)
 {
     return ObjectToString(toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
+        [&](std::ostringstream& strStrm)
         {
             FieldToString(strStrm, true, "nLength", toStringFlags, tabCount, tabSize, ToString(obj.nLength, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "lpSecurityDescriptor", toStringFlags, tabCount, tabSize, Quote(PtrToString(obj.lpSecurityDescriptor)));

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -191,8 +191,8 @@ template <typename ToStringFunctionType>
 inline std::string
 ObjectToString(ToStringFlags toStringFlags, uint32_t& tabCount, uint32_t tabSize, ToStringFunctionType toStringFunction)
 {
-    std::stringstream strStrm;
-    const auto        nl = GetNewlineString(toStringFlags);
+    std::ostringstream strStrm;
+    const auto         nl = GetNewlineString(toStringFlags);
     strStrm << '{';
     strStrm << nl;
     ++tabCount;
@@ -204,13 +204,13 @@ ObjectToString(ToStringFlags toStringFlags, uint32_t& tabCount, uint32_t tabSize
     return strStrm.str();
 }
 
-inline void FieldToString(std::stringstream& strStrm,
-                          bool               firstField,
-                          const char*        fieldName,
-                          ToStringFlags      toStringFlags,
-                          uint32_t           tabCount,
-                          uint32_t           tabSize,
-                          const std::string& fieldString)
+inline void FieldToString(std::ostringstream& strStrm,
+                          bool                firstField,
+                          const char*         fieldName,
+                          ToStringFlags       toStringFlags,
+                          uint32_t            tabCount,
+                          uint32_t            tabSize,
+                          const std::string&  fieldString)
 {
     if (!firstField)
     {

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -86,7 +86,7 @@ inline std::string ToString(uint32_t      apiFlags,
 template <typename HandleIdType>
 inline std::string HandleIdToString(HandleIdType handleId)
 {
-    std::stringstream strStrm;
+    std::ostringstream strStrm;
     if (handleId)
     {
         strStrm << "\"0x" << reinterpret_cast<const void*>(handleId) << "\"";
@@ -159,7 +159,7 @@ inline std::string BitmaskToString(FlagsType flags)
 template <typename PtrType>
 inline std::string PtrToString(PtrType* ptr)
 {
-    std::stringstream strStrm;
+    std::ostringstream strStrm;
     strStrm << "0x" << std::hex << reinterpret_cast<uintptr_t>(ptr);
     return strStrm.str();
 }
@@ -167,7 +167,7 @@ inline std::string PtrToString(PtrType* ptr)
 template <typename PtrType>
 inline std::string PtrToString(PtrType ptr)
 {
-    std::stringstream strStrm;
+    std::ostringstream strStrm;
     strStrm << "0x" << std::hex << ptr;
     return strStrm.str();
 }
@@ -236,7 +236,7 @@ inline std::string ArrayToString(size_t                    count,
         return "null";
     }
 
-    std::stringstream strStrm;
+    std::ostringstream strStrm;
     strStrm << '[';
     strStrm << GetNewlineString(toStringFlags);
     for (uint32_t i = 0; i < count; ++i)

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -135,7 +135,7 @@ static gfxrecon::decode::JsonFormat GetOutputFormat(const gfxrecon::util::Argume
 
 std::string FormatFrameNumber(uint32_t frame_number)
 {
-    std::stringstream stream;
+    std::ostringstream stream;
     stream << std::setfill('0') << std::setw(5) << frame_number;
     return stream.str();
 }


### PR DESCRIPTION
We use temporary input/output `std::stringstream`s when all we want is to either input from them (split string type applications) or output into them (formatting into a string) but never both.

The class `std:stringstream` uses _virtual_ multiple inheritance.

![Multiple](https://upload.cppreference.com/mwiki/images/7/70/std-basic_stringstream-inheritance.svg)

The classes `std:ostringstream` `std:istringstream` only use single inheritance, with hopefully faster function dispatch and a simpler internal layout to each object.

![Single](https://upload.cppreference.com/mwiki/images/a/ac/std-basic_ostringstream-inheritance.svg)

This PR uses the simplest option we can get away with in each case.

Fixes #810.