### PR TITLE
docs: Link to HOWTO_android.md in other docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -445,3 +445,9 @@ gfxreconstruct/android/tools/replay/src/main/jniLibs/
 3. Rebuild and deploy `gfxrecon-replay`
 
 The [Android Vulkan Validation Guide](https://developer.android.com/ndk/guides/graphics/validation-layer) has further instructions for advanced validation layer usage on Android
+
+
+#### Android Detailed Examples
+
+For more information and detailed examples on building and using GFXReconstruct
+on Android can be found in the [HOWTO_android.md](./HOWTO_android.md) document.

--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -40,6 +40,8 @@ to one of these other documents:
     5. [Key Controls](#key-controls)
     6. [Limitations of Replay On Android](#limitations-of-replay-on-android)
     7. [Troubleshooting Replay of Applications](#troubleshooting-replay-of-applications)
+4. [Android Detailed Examples](#android-detailed-examples)
+
 
 ## Behavior on Android
 
@@ -911,3 +913,9 @@ setup.
 If the user wants to bypass the feature and use the captured indices to present
 directly on the swapchain of the replay implementation, they should add the
 `--use-captured-swapchain-indices` option when invoking `gfxrecon-replay`.
+
+
+## Android Detailed Examples
+
+For more information and detailed examples on using GFXReconstruct on Android
+can be found in the [HOWTO_android.md](./HOWTO_android.md) document.


### PR DESCRIPTION
Link to the new HOWTO_android.md doc from inside the BUILD.md and USAGE_android.md docs so that people can know of the existence of this new document.