### PR TITLE
Fix raytracing trim error in state tracking

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -241,53 +241,43 @@ void D3D12CaptureManager::ResizeSwapChainImages(IDXGISwapChain_Wrapper* wrapper,
     }
 }
 
-// There are several types of resource creation API functions which use different types of resource desc
-// struct like D3D12_RESOURCE_DESC, D3D12_RESOURCE_DESC1..., so here template is used to handle it.
-template <class T>
-void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*   device_wrapper,
-                                                       ID3D12Resource_Wrapper* resource_wrapper,
-                                                       T                       desc,
-                                                       UINT64                  size,
-                                                       D3D12_HEAP_TYPE         heap_type,
-                                                       D3D12_CPU_PAGE_PROPERTY page_property,
-                                                       D3D12_MEMORY_POOL       memory_pool,
-                                                       D3D12_RESOURCE_STATES   initial_state,
-                                                       bool                    has_write_watch)
+void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    device_wrapper,
+                                                       ID3D12Resource_Wrapper*  resource_wrapper,
+                                                       D3D12_RESOURCE_DIMENSION dimension,
+                                                       D3D12_TEXTURE_LAYOUT     layout,
+                                                       UINT64                   width,
+                                                       UINT64                   size,
+                                                       D3D12_HEAP_TYPE          heap_type,
+                                                       D3D12_CPU_PAGE_PROPERTY  page_property,
+                                                       D3D12_MEMORY_POOL        memory_pool,
+                                                       D3D12_RESOURCE_STATES    initial_state,
+                                                       bool                     has_write_watch)
 {
     assert(resource_wrapper != nullptr);
 
     auto info = resource_wrapper->GetObjectInfo();
     assert((info != nullptr) && (device_wrapper != nullptr));
 
-    info->device_wrapper        = device_wrapper;
-    info->heap_type             = heap_type;
-    info->page_property         = page_property;
-    info->memory_pool           = memory_pool;
-    info->has_write_watch       = has_write_watch;
-    info->size_in_bytes         = size;
-    info->desc.Dimension        = desc->Dimension;
-    info->desc.Alignment        = desc->Alignment;
-    info->desc.Width            = desc->Width;
-    info->desc.Height           = desc->Height;
-    info->desc.DepthOrArraySize = desc->DepthOrArraySize;
-    info->desc.MipLevels        = desc->MipLevels;
-    info->desc.Format           = desc->Format;
-    info->desc.SampleDesc       = desc->SampleDesc;
-    info->desc.Layout           = desc->Layout;
-    info->desc.Flags            = desc->Flags;
+    info->device_wrapper  = device_wrapper;
+    info->heap_type       = heap_type;
+    info->page_property   = page_property;
+    info->memory_pool     = memory_pool;
+    info->has_write_watch = has_write_watch;
+    info->size_in_bytes   = size;
+    info->dimension       = dimension;
+    info->layout          = layout;
 
-    if (info->desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+    if (dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
         info->num_subresources     = 1;
         info->mapped_subresources  = std::make_unique<MappedSubresource[]>(info->num_subresources);
         info->subresource_sizes    = std::make_unique<uint64_t[]>(info->num_subresources);
-        info->subresource_sizes[0] = info->desc.Width;
+        info->subresource_sizes[0] = width;
     }
     else
     {
-        assert((info->desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D) ||
-               (info->desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) ||
-               (info->desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D));
+        assert((dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D) || (dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) ||
+               (dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D));
 
         uint32_t plane_count = 1;
         auto     device      = device_wrapper->GetWrappedObjectAs<ID3D12Device>();
@@ -306,8 +296,7 @@ void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*   d
 
         auto num_subresources = full_desc.MipLevels * plane_count;
 
-        if ((info->desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) ||
-            (info->desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D))
+        if ((dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D) || (dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D))
         {
             num_subresources *= full_desc.DepthOrArraySize;
         }
@@ -769,10 +758,12 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateCommittedResource(
 
         uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
 
-        InitializeID3D12ResourceInfo<const D3D12_RESOURCE_DESC*>(
+        InitializeID3D12ResourceInfo(
             wrapper,
             resource_wrapper,
-            desc,
+            desc->Dimension,
+            desc->Layout,
+            desc->Width,
             total_size_in_bytes,
             heap_properties->Type,
             heap_properties->CPUPageProperty,
@@ -808,15 +799,17 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreatePlacedResource(ID3D12De
 
         uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
 
-        InitializeID3D12ResourceInfo<const D3D12_RESOURCE_DESC*>(wrapper,
-                                                                 resource_wrapper,
-                                                                 desc,
-                                                                 total_size_in_bytes,
-                                                                 heap_info->heap_type,
-                                                                 heap_info->page_property,
-                                                                 heap_info->memory_pool,
-                                                                 initial_state,
-                                                                 heap_info->has_write_watch);
+        InitializeID3D12ResourceInfo(wrapper,
+                                     resource_wrapper,
+                                     desc->Dimension,
+                                     desc->Layout,
+                                     desc->Width,
+                                     total_size_in_bytes,
+                                     heap_info->heap_type,
+                                     heap_info->page_property,
+                                     heap_info->memory_pool,
+                                     initial_state,
+                                     heap_info->has_write_watch);
     }
 }
 
@@ -839,15 +832,17 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateReservedResource(
 
         uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
 
-        InitializeID3D12ResourceInfo<const D3D12_RESOURCE_DESC*>(wrapper,
-                                                                 resource_wrapper,
-                                                                 desc,
-                                                                 total_size_in_bytes,
-                                                                 D3D12_HEAP_TYPE_DEFAULT,
-                                                                 D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-                                                                 D3D12_MEMORY_POOL_UNKNOWN,
-                                                                 initial_state,
-                                                                 false);
+        InitializeID3D12ResourceInfo(wrapper,
+                                     resource_wrapper,
+                                     desc->Dimension,
+                                     desc->Layout,
+                                     desc->Width,
+                                     total_size_in_bytes,
+                                     D3D12_HEAP_TYPE_DEFAULT,
+                                     D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+                                     D3D12_MEMORY_POOL_UNKNOWN,
+                                     initial_state,
+                                     false);
     }
 }
 
@@ -872,15 +867,17 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateReservedResource1(
 
         uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
 
-        InitializeID3D12ResourceInfo<const D3D12_RESOURCE_DESC*>(wrapper,
-                                                                 resource_wrapper,
-                                                                 desc,
-                                                                 total_size_in_bytes,
-                                                                 D3D12_HEAP_TYPE_DEFAULT,
-                                                                 D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-                                                                 D3D12_MEMORY_POOL_UNKNOWN,
-                                                                 initial_state,
-                                                                 false);
+        InitializeID3D12ResourceInfo(wrapper,
+                                     resource_wrapper,
+                                     desc->Dimension,
+                                     desc->Layout,
+                                     desc->Width,
+                                     total_size_in_bytes,
+                                     D3D12_HEAP_TYPE_DEFAULT,
+                                     D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+                                     D3D12_MEMORY_POOL_UNKNOWN,
+                                     initial_state,
+                                     false);
     }
 }
 
@@ -974,10 +971,12 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateCommittedResource1(
 
         uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
 
-        InitializeID3D12ResourceInfo<const D3D12_RESOURCE_DESC*>(
+        InitializeID3D12ResourceInfo(
             wrapper,
             resource_wrapper,
-            desc,
+            desc->Dimension,
+            desc->Layout,
+            desc->Width,
             total_size_in_bytes,
             heap_properties->Type,
             heap_properties->CPUPageProperty,
@@ -1012,10 +1011,12 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreateCommittedResource2(
 
         uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
 
-        InitializeID3D12ResourceInfo<const D3D12_RESOURCE_DESC1*>(
+        InitializeID3D12ResourceInfo(
             wrapper,
             resource_wrapper,
-            desc,
+            desc->Dimension,
+            desc->Layout,
+            desc->Width,
             total_size_in_bytes,
             heap_properties->Type,
             heap_properties->CPUPageProperty,
@@ -1052,15 +1053,17 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreatePlacedResource1(
 
         uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
 
-        InitializeID3D12ResourceInfo<const D3D12_RESOURCE_DESC1*>(wrapper,
-                                                                  resource_wrapper,
-                                                                  desc,
-                                                                  total_size_in_bytes,
-                                                                  heap_info->heap_type,
-                                                                  heap_info->page_property,
-                                                                  heap_info->memory_pool,
-                                                                  initial_state,
-                                                                  heap_info->has_write_watch);
+        InitializeID3D12ResourceInfo(wrapper,
+                                     resource_wrapper,
+                                     desc->Dimension,
+                                     desc->Layout,
+                                     desc->Width,
+                                     total_size_in_bytes,
+                                     heap_info->heap_type,
+                                     heap_info->page_property,
+                                     heap_info->memory_pool,
+                                     initial_state,
+                                     heap_info->has_write_watch);
     }
 }
 

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -364,10 +364,9 @@ void D3D12CaptureManager::InitializeID3D12DeviceInfo(IUnknown* adapter, void** d
     }
 }
 
-bool D3D12CaptureManager::IsAccelerationStructureResouce(format::HandleId id)
+bool D3D12CaptureManager::IsAccelerationStructureResource(format::HandleId id)
 {
-    GFXRECON_ASSERT(state_tracker_ != nullptr);
-    return state_tracker_->IsAccelerationStructureResouce(id);
+    return state_tracker_->IsAccelerationStructureResource(id);
 }
 
 void D3D12CaptureManager::CheckWriteWatchIgnored(D3D12_HEAP_FLAGS flags, format::HandleId id)

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -364,6 +364,13 @@ void D3D12CaptureManager::InitializeID3D12DeviceInfo(IUnknown* adapter, void** d
     }
 }
 
+bool D3D12CaptureManager::IsResourceForRaytracingAccelerationStructure(format::HandleId id)
+{
+    assert(state_tracker_ != nullptr);
+    bool result = state_tracker_->IsResourceForRaytracingAccelerationStructure(id);
+    return result;
+}
+
 void D3D12CaptureManager::CheckWriteWatchIgnored(D3D12_HEAP_FLAGS flags, format::HandleId id)
 {
     // Report that write watch was ignored because the application enabled it.

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -375,10 +375,10 @@ void D3D12CaptureManager::InitializeID3D12DeviceInfo(IUnknown* adapter, void** d
     }
 }
 
-bool D3D12CaptureManager::IsResourceForRaytracingAccelerationStructure(format::HandleId id)
+bool D3D12CaptureManager::IsAccelerationStructureResouce(format::HandleId id)
 {
     assert(state_tracker_ != nullptr);
-    bool result = state_tracker_->IsResourceForRaytracingAccelerationStructure(id);
+    bool result = state_tracker_->IsAccelerationStructureResouce(id);
     return result;
 }
 

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -366,9 +366,8 @@ void D3D12CaptureManager::InitializeID3D12DeviceInfo(IUnknown* adapter, void** d
 
 bool D3D12CaptureManager::IsAccelerationStructureResouce(format::HandleId id)
 {
-    assert(state_tracker_ != nullptr);
-    bool result = state_tracker_->IsAccelerationStructureResouce(id);
-    return result;
+    GFXRECON_ASSERT(state_tracker_ != nullptr);
+    return state_tracker_->IsAccelerationStructureResouce(id);
 }
 
 void D3D12CaptureManager::CheckWriteWatchIgnored(D3D12_HEAP_FLAGS flags, format::HandleId id)

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -639,7 +639,7 @@ class D3D12CaptureManager : public CaptureManager
 
     void WriteDxgiAdapterInfo();
 
-    bool IsAccelerationStructureResouce(format::HandleId id);
+    bool IsAccelerationStructureResource(format::HandleId id);
 
   protected:
     D3D12CaptureManager();

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -639,6 +639,8 @@ class D3D12CaptureManager : public CaptureManager
 
     void WriteDxgiAdapterInfo();
 
+    bool IsResourceForRaytracingAccelerationStructure(format::HandleId id);
+
   protected:
     D3D12CaptureManager();
 

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -639,7 +639,7 @@ class D3D12CaptureManager : public CaptureManager
 
     void WriteDxgiAdapterInfo();
 
-    bool IsResourceForRaytracingAccelerationStructure(format::HandleId id);
+    bool IsAccelerationStructureResouce(format::HandleId id);
 
   protected:
     D3D12CaptureManager();

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -661,17 +661,16 @@ class D3D12CaptureManager : public CaptureManager
 
     void ResizeSwapChainImages(IDXGISwapChain_Wrapper* wrapper, HRESULT result, UINT buffer_count);
 
-    void InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    device_wrapper,
-                                      ID3D12Resource_Wrapper*  resource_wrapper,
-                                      D3D12_RESOURCE_DIMENSION dimension,
-                                      D3D12_TEXTURE_LAYOUT     layout,
-                                      UINT64                   width,
-                                      UINT64                   size,
-                                      D3D12_HEAP_TYPE          heap_type,
-                                      D3D12_CPU_PAGE_PROPERTY  page_property,
-                                      D3D12_MEMORY_POOL        memory_pool,
-                                      D3D12_RESOURCE_STATES    initial_state,
-                                      bool                     has_write_watch);
+    template <class T>
+    void InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*   device_wrapper,
+                                      ID3D12Resource_Wrapper* resource_wrapper,
+                                      T                       desc,
+                                      UINT64                  size,
+                                      D3D12_HEAP_TYPE         heap_type,
+                                      D3D12_CPU_PAGE_PROPERTY page_property,
+                                      D3D12_MEMORY_POOL       memory_pool,
+                                      D3D12_RESOURCE_STATES   initial_state,
+                                      bool                    has_write_watch);
 
     void InitializeSwapChainBufferResourceInfo(ID3D12Resource_Wrapper* resource_wrapper,
                                                D3D12_RESOURCE_STATES   initial_state);

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -661,16 +661,17 @@ class D3D12CaptureManager : public CaptureManager
 
     void ResizeSwapChainImages(IDXGISwapChain_Wrapper* wrapper, HRESULT result, UINT buffer_count);
 
-    template <class T>
-    void InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*   device_wrapper,
-                                      ID3D12Resource_Wrapper* resource_wrapper,
-                                      T                       desc,
-                                      UINT64                  size,
-                                      D3D12_HEAP_TYPE         heap_type,
-                                      D3D12_CPU_PAGE_PROPERTY page_property,
-                                      D3D12_MEMORY_POOL       memory_pool,
-                                      D3D12_RESOURCE_STATES   initial_state,
-                                      bool                    has_write_watch);
+    void InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    device_wrapper,
+                                      ID3D12Resource_Wrapper*  resource_wrapper,
+                                      D3D12_RESOURCE_DIMENSION dimension,
+                                      D3D12_TEXTURE_LAYOUT     layout,
+                                      UINT64                   width,
+                                      UINT64                   size,
+                                      D3D12_HEAP_TYPE          heap_type,
+                                      D3D12_CPU_PAGE_PROPERTY  page_property,
+                                      D3D12_MEMORY_POOL        memory_pool,
+                                      D3D12_RESOURCE_STATES    initial_state,
+                                      bool                     has_write_watch);
 
     void InitializeSwapChainBufferResourceInfo(ID3D12Resource_Wrapper* resource_wrapper,
                                                D3D12_RESOURCE_STATES   initial_state);

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -367,7 +367,8 @@ struct ID3D12ResourceInfo : public DxWrapperInfo
     D3D12_CPU_PAGE_PROPERTY              page_property{};
     D3D12_MEMORY_POOL                    memory_pool{};
     uint64_t                             size_in_bytes{ 0 };
-    D3D12_RESOURCE_DESC                  desc{};
+    D3D12_RESOURCE_DIMENSION             dimension{ D3D12_RESOURCE_DIMENSION_UNKNOWN };
+    D3D12_TEXTURE_LAYOUT                 layout{ D3D12_TEXTURE_LAYOUT_UNKNOWN };
     //// State tracking data:
 
     // Most recent transitions for each subresource.

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -367,8 +367,7 @@ struct ID3D12ResourceInfo : public DxWrapperInfo
     D3D12_CPU_PAGE_PROPERTY              page_property{};
     D3D12_MEMORY_POOL                    memory_pool{};
     uint64_t                             size_in_bytes{ 0 };
-    D3D12_RESOURCE_DIMENSION             dimension{ D3D12_RESOURCE_DIMENSION_UNKNOWN };
-    D3D12_TEXTURE_LAYOUT                 layout{ D3D12_TEXTURE_LAYOUT_UNKNOWN };
+    D3D12_RESOURCE_DESC                  desc{};
     //// State tracking data:
 
     // Most recent transitions for each subresource.

--- a/framework/encode/dx12_state_table_base.h
+++ b/framework/encode/dx12_state_table_base.h
@@ -48,10 +48,9 @@ class Dx12StateTableBase
     }
 
     // Returns the handle ID for the resource that contains the GPU VA address or kNullHandleId if no match is found.
-    format::HandleId
-    GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                                         address,
-                        uint64_t                                                          minimum_end_address,
-                        graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr)
+    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                            address,
+                                         uint64_t                                             minimum_end_address,
+                                         graphics::IsAccelerationStructureResourceFunctionPtr func = nullptr)
     {
         bool             found  = false;
         format::HandleId result = format::kNullHandleId;

--- a/framework/encode/dx12_state_table_base.h
+++ b/framework/encode/dx12_state_table_base.h
@@ -26,6 +26,7 @@
 
 #include "format/format.h"
 #include "generated/generated_dx12_wrappers.h"
+#include "graphics/dx12_gpu_va_map.h"
 #include "util/defines.h"
 
 #include <functional>
@@ -52,6 +53,17 @@ class Dx12StateTableBase
         bool             found  = false;
         format::HandleId result = format::kNullHandleId;
         gpu_va_map_.Map(address, &result, &found, minimum_end_address);
+        return result;
+    }
+
+    format::HandleId GetAccelerationStructureResourceForGpuVa(
+        D3D12_GPU_VIRTUAL_ADDRESS                                         address,
+        uint64_t                                                          minimum_end_address,
+        graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr)
+    {
+        bool             found  = false;
+        format::HandleId result = format::kNullHandleId;
+        gpu_va_map_.Map(address, &result, &found, minimum_end_address, func);
         return result;
     }
 

--- a/framework/encode/dx12_state_table_base.h
+++ b/framework/encode/dx12_state_table_base.h
@@ -48,13 +48,13 @@ class Dx12StateTableBase
     }
 
     // Returns the handle ID for the resource that contains the GPU VA address or kNullHandleId if no match is found.
-    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                            address,
-                                         uint64_t                                             minimum_end_address,
-                                         graphics::IsAccelerationStructureResourceFunctionPtr func = nullptr)
+    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS          address,
+                                         uint64_t                           minimum_end_address,
+                                         graphics::ResourceMatchFunctionPtr resource_match_func = nullptr)
     {
         bool             found  = false;
         format::HandleId result = format::kNullHandleId;
-        gpu_va_map_.Map(address, &result, &found, minimum_end_address, func);
+        gpu_va_map_.Map(address, &result, &found, minimum_end_address, resource_match_func);
         return result;
     }
 

--- a/framework/encode/dx12_state_table_base.h
+++ b/framework/encode/dx12_state_table_base.h
@@ -46,10 +46,11 @@ class Dx12StateTableBase
     }
 
     // Returns the handle ID for the resource that contains the GPU VA address or kNullHandleId if no match is found.
-    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address)
+    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address, uint64_t minimum_end_address = 0Ui64)
     {
+        bool             found  = false;
         format::HandleId result = format::kNullHandleId;
-        gpu_va_map_.Map(address, &result);
+        gpu_va_map_.Map(address, &result, &found, minimum_end_address);
         return result;
     }
 

--- a/framework/encode/dx12_state_table_base.h
+++ b/framework/encode/dx12_state_table_base.h
@@ -48,18 +48,10 @@ class Dx12StateTableBase
     }
 
     // Returns the handle ID for the resource that contains the GPU VA address or kNullHandleId if no match is found.
-    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address, uint64_t minimum_end_address)
-    {
-        bool             found  = false;
-        format::HandleId result = format::kNullHandleId;
-        gpu_va_map_.Map(address, &result, &found, minimum_end_address);
-        return result;
-    }
-
-    format::HandleId GetAccelerationStructureResourceForGpuVa(
-        D3D12_GPU_VIRTUAL_ADDRESS                                         address,
-        uint64_t                                                          minimum_end_address,
-        graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr)
+    format::HandleId
+    GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                                         address,
+                        uint64_t                                                          minimum_end_address,
+                        graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr)
     {
         bool             found  = false;
         format::HandleId result = format::kNullHandleId;

--- a/framework/encode/dx12_state_table_base.h
+++ b/framework/encode/dx12_state_table_base.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to
@@ -46,7 +47,7 @@ class Dx12StateTableBase
     }
 
     // Returns the handle ID for the resource that contains the GPU VA address or kNullHandleId if no match is found.
-    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address, uint64_t minimum_end_address = 0Ui64)
+    format::HandleId GetResourceForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address, uint64_t minimum_end_address)
     {
         bool             found  = false;
         format::HandleId result = format::kNullHandleId;

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -931,12 +931,13 @@ bool Dx12StateTracker::IsAccelerationStructureResouce(format::HandleId id)
     return result;
 }
 
-ID3D12Resource_Wrapper* Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va,
-                                                                     uint64_t                  minimum_end_address,
-                                                                     graphics::ResourceMatchFunctionPtr func)
+ID3D12Resource_Wrapper*
+Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS          gpu_va,
+                                             uint64_t                           minimum_end_address,
+                                             graphics::ResourceMatchFunctionPtr resource_match_func)
 {
-    ID3D12Resource_Wrapper* result      = nullptr;
-    auto                    resource_id = state_table_.GetResourceForGpuVa(gpu_va, minimum_end_address, func);
+    ID3D12Resource_Wrapper* result = nullptr;
+    auto resource_id               = state_table_.GetResourceForGpuVa(gpu_va, minimum_end_address, resource_match_func);
 
     if (resource_id != format::kNullHandleId)
     {

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -564,7 +564,7 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
         resource_wrapper =
             GetResourceWrapperForGpuVa(desc->DestAccelerationStructureData,
                                        desc->DestAccelerationStructureData + prebuild_info.ResultDataMaxSizeInBytes,
-                                       IsResourceUsedForRaytracingAccelerationStructure);
+                                       IsResourceUsedForAccelerationStructure);
     }
 
     if (resource_wrapper)
@@ -661,7 +661,7 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
                     src_resource_wrapper =
                         GetResourceWrapperForGpuVa(*curr_entry_iter->desc_gpu_va,
                                                    *curr_entry_iter->desc_gpu_va + curr_entry_iter->size,
-                                                   IsResourceUsedForRaytracingAccelerationStructure);
+                                                   IsResourceUsedForAccelerationStructure);
                 }
 
                 if (src_resource_wrapper == nullptr)
@@ -786,10 +786,10 @@ void Dx12StateTracker::TrackCopyRaytracingAccelerationStructure(
         std::unique_lock<std::mutex> lock(state_table_mutex_);
         // TODO: find and use the data size of acceleration structure to replace 0
         //       for function GetResourceWrapperForGpuVa.
-        dest_resource_wrapper = GetResourceWrapperForGpuVa(
-            dest_acceleration_structure_data, 0, IsResourceUsedForRaytracingAccelerationStructure);
-        source_resource_wrapper = GetResourceWrapperForGpuVa(
-            source_acceleration_structure_data, 0, IsResourceUsedForRaytracingAccelerationStructure);
+        dest_resource_wrapper =
+            GetResourceWrapperForGpuVa(dest_acceleration_structure_data, 0, IsResourceUsedForAccelerationStructure);
+        source_resource_wrapper =
+            GetResourceWrapperForGpuVa(source_acceleration_structure_data, 0, IsResourceUsedForAccelerationStructure);
     }
 
     if (dest_resource_wrapper && source_resource_wrapper)
@@ -898,7 +898,7 @@ void Dx12StateTracker::TrackGetShaderIdentifier(ID3D12StateObjectProperties_Wrap
         std::make_shared<util::MemoryOutputStream>(parameter_buffer->GetData(), parameter_buffer->GetDataSize());
 }
 
-bool Dx12StateTracker::IsResourceForRaytracingAccelerationStructure(format::HandleId id)
+bool Dx12StateTracker::IsAccelerationStructureResouce(format::HandleId id)
 {
     ID3D12Resource_Wrapper* resource_wrapper = nullptr;
     bool                    result           = false;
@@ -1012,9 +1012,9 @@ Dx12StateTracker::CommitAccelerationStructureCopyInfo(DxAccelerationStructureCop
 // D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE. Such handling is for
 // keeping headfile organized without having to add too much change to headfile
 // structure.
-bool IsResourceUsedForRaytracingAccelerationStructure(format::HandleId id)
+bool IsResourceUsedForAccelerationStructure(format::HandleId id)
 {
-    return D3D12CaptureManager::Get()->IsResourceForRaytracingAccelerationStructure(id);
+    return D3D12CaptureManager::Get()->IsAccelerationStructureResouce(id);
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -922,9 +922,9 @@ bool Dx12StateTracker::IsAccelerationStructureResouce(format::HandleId id)
 }
 
 ID3D12Resource_Wrapper*
-Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va,
-                                             uint64_t                  minimum_end_address,
-                                             graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func)
+Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                            gpu_va,
+                                             uint64_t                                             minimum_end_address,
+                                             graphics::IsAccelerationStructureResourceFunctionPtr func)
 {
     ID3D12Resource_Wrapper* result      = nullptr;
     auto                    resource_id = state_table_.GetResourceForGpuVa(gpu_va, minimum_end_address, func);

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 // structure.
 bool IsResourceUsedForAccelerationStructure(format::HandleId id)
 {
-    return D3D12CaptureManager::Get()->IsAccelerationStructureResouce(id);
+    return D3D12CaptureManager::Get()->IsAccelerationStructureResource(id);
 }
 
 #define GFXRECON_ACCEL_STRUCT_TRIM_BARRIER 0
@@ -668,10 +668,8 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
                 ID3D12Resource_Wrapper* src_resource_wrapper = nullptr;
                 {
                     std::unique_lock<std::mutex> lock(state_table_mutex_);
-                    src_resource_wrapper =
-                        GetResourceWrapperForGpuVa(*curr_entry_iter->desc_gpu_va,
-                                                   *curr_entry_iter->desc_gpu_va + curr_entry_iter->size,
-                                                   IsResourceUsedForAccelerationStructure);
+                    src_resource_wrapper = GetResourceWrapperForGpuVa(
+                        *curr_entry_iter->desc_gpu_va, *curr_entry_iter->desc_gpu_va + curr_entry_iter->size);
                 }
 
                 if (src_resource_wrapper == nullptr)
@@ -908,7 +906,7 @@ void Dx12StateTracker::TrackGetShaderIdentifier(ID3D12StateObjectProperties_Wrap
         std::make_shared<util::MemoryOutputStream>(parameter_buffer->GetData(), parameter_buffer->GetDataSize());
 }
 
-bool Dx12StateTracker::IsAccelerationStructureResouce(format::HandleId id)
+bool Dx12StateTracker::IsAccelerationStructureResource(format::HandleId id)
 {
     ID3D12Resource_Wrapper* resource_wrapper = nullptr;
     bool                    result           = false;

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -911,7 +911,7 @@ bool Dx12StateTracker::IsAccelerationStructureResouce(format::HandleId id)
         {
             auto object_info = resource_wrapper->GetObjectInfo();
 
-            if ((object_info->desc.Flags & D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE) != 0)
+            if ((object_info->initial_state & D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE) != 0)
             {
                 result = true;
             }

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -653,7 +653,8 @@ void Dx12StateTracker::TrackBuildRaytracingAccelerationStructure(
                 ID3D12Resource_Wrapper* src_resource_wrapper = nullptr;
                 {
                     std::unique_lock<std::mutex> lock(state_table_mutex_);
-                    src_resource_wrapper = GetResourceWrapperForGpuVa(*curr_entry_iter->desc_gpu_va);
+                    src_resource_wrapper = GetResourceWrapperForGpuVa(
+                        *curr_entry_iter->desc_gpu_va, *curr_entry_iter->desc_gpu_va + curr_entry_iter->size);
                 }
 
                 if (src_resource_wrapper == nullptr)
@@ -886,10 +887,11 @@ void Dx12StateTracker::TrackGetShaderIdentifier(ID3D12StateObjectProperties_Wrap
         std::make_shared<util::MemoryOutputStream>(parameter_buffer->GetData(), parameter_buffer->GetDataSize());
 }
 
-ID3D12Resource_Wrapper* Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va)
+ID3D12Resource_Wrapper* Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va,
+                                                                     uint64_t                  minimum_end_address)
 {
     ID3D12Resource_Wrapper* result      = nullptr;
-    auto                    resource_id = state_table_.GetResourceForGpuVa(gpu_va);
+    auto                    resource_id = state_table_.GetResourceForGpuVa(gpu_va, minimum_end_address);
     if (resource_id != format::kNullHandleId)
     {
         result = state_table_.GetID3D12Resource_Wrapper(resource_id);

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -29,6 +29,16 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
+// The function is used as function pointer parameter for GPUVA map functions
+// in dx12_gpu_va_map.cpp for searching resource which has flag
+// D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE. Such handling is for
+// keeping headfile organized without having to add too much change to headfile
+// structure.
+bool IsResourceUsedForAccelerationStructure(format::HandleId id)
+{
+    return D3D12CaptureManager::Get()->IsAccelerationStructureResouce(id);
+}
+
 #define GFXRECON_ACCEL_STRUCT_TRIM_BARRIER 0
 
 Dx12StateTracker::Dx12StateTracker() : accel_struct_id_(1) {}
@@ -921,10 +931,9 @@ bool Dx12StateTracker::IsAccelerationStructureResouce(format::HandleId id)
     return result;
 }
 
-ID3D12Resource_Wrapper*
-Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                            gpu_va,
-                                             uint64_t                                             minimum_end_address,
-                                             graphics::IsAccelerationStructureResourceFunctionPtr func)
+ID3D12Resource_Wrapper* Dx12StateTracker::GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va,
+                                                                     uint64_t                  minimum_end_address,
+                                                                     graphics::ResourceMatchFunctionPtr func)
 {
     ID3D12Resource_Wrapper* result      = nullptr;
     auto                    resource_id = state_table_.GetResourceForGpuVa(gpu_va, minimum_end_address, func);
@@ -1005,16 +1014,6 @@ Dx12StateTracker::CommitAccelerationStructureCopyInfo(DxAccelerationStructureCop
     inputs_data_resource = dest_build_info.input_data_resource;
 
     return CommitAccelerationStructureBuildInfo(dest_build_info);
-}
-
-// The function is used as function pointer parameter for GPUVA map functions
-// in dx12_gpu_va_map.cpp for searching resource which has flag
-// D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE. Such handling is for
-// keeping headfile organized without having to add too much change to headfile
-// structure.
-bool IsResourceUsedForAccelerationStructure(format::HandleId id)
-{
-    return D3D12CaptureManager::Get()->IsAccelerationStructureResouce(id);
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -216,7 +216,7 @@ class Dx12StateTracker
                                   LPCWSTR                              export_name,
                                   const util::MemoryOutputStream*      parameter_buffer);
 
-    bool IsResourceForRaytracingAccelerationStructure(format::HandleId id);
+    bool IsAccelerationStructureResouce(format::HandleId id);
 
   private:
     template <typename Wrapper>
@@ -256,7 +256,7 @@ class Dx12StateTracker
     std::atomic_uint64_t accel_struct_id_;
 };
 
-bool IsResourceUsedForRaytracingAccelerationStructure(format::HandleId id);
+bool IsResourceUsedForAccelerationStructure(format::HandleId id);
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -235,7 +235,8 @@ class Dx12StateTracker
                                format::ApiCallId               call_id,
                                const util::MemoryOutputStream* parameter_buffer);
 
-    ID3D12Resource_Wrapper* GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va);
+    ID3D12Resource_Wrapper* GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va,
+                                                       uint64_t                  minimum_end_address = 0Ui64);
 
     uint64_t CommitAccelerationStructureBuildInfo(DxAccelerationStructureBuildInfo& accel_struct_build);
 

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -239,9 +239,9 @@ class Dx12StateTracker
                                const util::MemoryOutputStream* parameter_buffer);
 
     ID3D12Resource_Wrapper*
-    GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                                         gpu_va,
-                               uint64_t                                                          minimum_end_address,
-                               graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr);
+    GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                            gpu_va,
+                               uint64_t                                             minimum_end_address,
+                               graphics::IsAccelerationStructureResourceFunctionPtr func = nullptr);
 
     uint64_t CommitAccelerationStructureBuildInfo(DxAccelerationStructureBuildInfo& accel_struct_build);
 

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -235,8 +236,7 @@ class Dx12StateTracker
                                format::ApiCallId               call_id,
                                const util::MemoryOutputStream* parameter_buffer);
 
-    ID3D12Resource_Wrapper* GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va,
-                                                       uint64_t                  minimum_end_address = 0Ui64);
+    ID3D12Resource_Wrapper* GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va, uint64_t minimum_end_address);
 
     uint64_t CommitAccelerationStructureBuildInfo(DxAccelerationStructureBuildInfo& accel_struct_build);
 

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -216,7 +216,7 @@ class Dx12StateTracker
                                   LPCWSTR                              export_name,
                                   const util::MemoryOutputStream*      parameter_buffer);
 
-    bool IsAccelerationStructureResouce(format::HandleId id);
+    bool IsAccelerationStructureResource(format::HandleId id);
 
   private:
     template <typename Wrapper>

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -216,6 +216,8 @@ class Dx12StateTracker
                                   LPCWSTR                              export_name,
                                   const util::MemoryOutputStream*      parameter_buffer);
 
+    bool IsResourceForRaytracingAccelerationStructure(format::HandleId id);
+
   private:
     template <typename Wrapper>
     void DestroyState(Wrapper* wrapper)
@@ -238,6 +240,11 @@ class Dx12StateTracker
 
     ID3D12Resource_Wrapper* GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va, uint64_t minimum_end_address);
 
+    ID3D12Resource_Wrapper* GetAccelerationStructureResourceWrapperForGpuVa(
+        D3D12_GPU_VIRTUAL_ADDRESS                                         gpu_va,
+        uint64_t                                                          minimum_end_address,
+        graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr);
+
     uint64_t CommitAccelerationStructureBuildInfo(DxAccelerationStructureBuildInfo& accel_struct_build);
 
     uint64_t CommitAccelerationStructureCopyInfo(DxAccelerationStructureCopyInfo&      accel_struct_copy,
@@ -251,6 +258,7 @@ class Dx12StateTracker
     std::atomic_uint64_t accel_struct_id_;
 };
 
+bool IsResourceUsedForRaytracingAccelerationStructure(format::HandleId id);
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -238,12 +238,10 @@ class Dx12StateTracker
                                format::ApiCallId               call_id,
                                const util::MemoryOutputStream* parameter_buffer);
 
-    ID3D12Resource_Wrapper* GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS gpu_va, uint64_t minimum_end_address);
-
-    ID3D12Resource_Wrapper* GetAccelerationStructureResourceWrapperForGpuVa(
-        D3D12_GPU_VIRTUAL_ADDRESS                                         gpu_va,
-        uint64_t                                                          minimum_end_address,
-        graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr);
+    ID3D12Resource_Wrapper*
+    GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                                         gpu_va,
+                               uint64_t                                                          minimum_end_address,
+                               graphics::IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr);
 
     uint64_t CommitAccelerationStructureBuildInfo(DxAccelerationStructureBuildInfo& accel_struct_build);
 

--- a/framework/encode/dx12_state_tracker.h
+++ b/framework/encode/dx12_state_tracker.h
@@ -239,9 +239,9 @@ class Dx12StateTracker
                                const util::MemoryOutputStream* parameter_buffer);
 
     ID3D12Resource_Wrapper*
-    GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS                            gpu_va,
-                               uint64_t                                             minimum_end_address,
-                               graphics::IsAccelerationStructureResourceFunctionPtr func = nullptr);
+    GetResourceWrapperForGpuVa(D3D12_GPU_VIRTUAL_ADDRESS          gpu_va,
+                               uint64_t                           minimum_end_address,
+                               graphics::ResourceMatchFunctionPtr resource_match_func = nullptr);
 
     uint64_t CommitAccelerationStructureBuildInfo(DxAccelerationStructureBuildInfo& accel_struct_build);
 
@@ -256,7 +256,6 @@ class Dx12StateTracker
     std::atomic_uint64_t accel_struct_id_;
 };
 
-bool IsResourceUsedForAccelerationStructure(format::HandleId id);
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1299,7 +1299,7 @@ bool Dx12StateWriter::CheckGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address)
     if (address != 0)
     {
         bool found = false;
-        gpu_va_map_.Map(address, nullptr, &found, 0);
+        gpu_va_map_.Map(address, nullptr, &found);
         return found;
     }
     return true;

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -630,7 +630,7 @@ void Dx12StateWriter::WriteResourceCreationState(
         uint8_t* result_ptr        = nullptr;
         auto     resource_info     = map_info.resource_wrapper->GetObjectInfo();
         bool     unknown_layout_mapping =
-            graphics::dx12::IsTextureWithUnknownLayout(resource_info->dimension, resource_info->layout);
+            graphics::dx12::IsTextureWithUnknownLayout(resource_info->desc.Dimension, resource_info->desc.Layout);
 
         graphics::dx12::MapSubresource(
             mappable_resource, map_info.subresource, &graphics::dx12::kZeroRange, result_ptr, unknown_layout_mapping);
@@ -769,7 +769,8 @@ void Dx12StateWriter::WriteResourceSnapshots(
                 const double max_cpu_mem_usage = 7.0 / 8.0;
 
                 const bool is_uma = device_wrapper->GetObjectInfo()->is_uma;
-                if (!graphics::dx12::IsMemoryAvailable(size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage, is_uma))
+                if (!graphics::dx12::IsMemoryAvailable(
+                        size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage, is_uma))
                 {
                     // If neither system memory or GPU memory are able to accommodate next resource,
                     // execute the existing Copy() calls and release temp buffer to free memory
@@ -801,7 +802,7 @@ void Dx12StateWriter::WriteResourceSnapshots(
                            format::ApiCall_ID3D12Device4_CreateReservedResource1)));
 
                 bool target_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(
-                    resource_info.get()->dimension, resource_info.get()->layout);
+                    resource_info.get()->desc.Dimension, resource_info.get()->desc.Layout);
 
                 if ((is_cpu_accessible == false) || (is_cpu_accessible && target_texture_with_unknown_layout))
                 {

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -630,7 +630,7 @@ void Dx12StateWriter::WriteResourceCreationState(
         uint8_t* result_ptr        = nullptr;
         auto     resource_info     = map_info.resource_wrapper->GetObjectInfo();
         bool     unknown_layout_mapping =
-            graphics::dx12::IsTextureWithUnknownLayout(resource_info->desc.Dimension, resource_info->desc.Layout);
+            graphics::dx12::IsTextureWithUnknownLayout(resource_info->dimension, resource_info->layout);
 
         graphics::dx12::MapSubresource(
             mappable_resource, map_info.subresource, &graphics::dx12::kZeroRange, result_ptr, unknown_layout_mapping);
@@ -802,7 +802,7 @@ void Dx12StateWriter::WriteResourceSnapshots(
                            format::ApiCall_ID3D12Device4_CreateReservedResource1)));
 
                 bool target_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(
-                    resource_info.get()->desc.Dimension, resource_info.get()->desc.Layout);
+                    resource_info.get()->dimension, resource_info.get()->layout);
 
                 if ((is_cpu_accessible == false) || (is_cpu_accessible && target_texture_with_unknown_layout))
                 {

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1298,7 +1298,7 @@ bool Dx12StateWriter::CheckGpuVa(D3D12_GPU_VIRTUAL_ADDRESS address)
     if (address != 0)
     {
         bool found = false;
-        gpu_va_map_.Map(address, nullptr, &found);
+        gpu_va_map_.Map(address, nullptr, &found, 0);
         return found;
     }
     return true;

--- a/framework/graphics/dx12_gpu_va_map.cpp
+++ b/framework/graphics/dx12_gpu_va_map.cpp
@@ -133,39 +133,33 @@ bool Dx12GpuVaMap::FindMatch(const AliasedResourceVaInfo&                       
         if (address < info.old_end_address && minimum_old_end_address <= info.old_end_address)
         {
             address = info.new_start_address + (address - old_start_address);
-            if (first_resource_id == format::kNullHandleId)
-            {
-                first_resource_id = resource_entry.first;
-            }
 
             // if func is valid, the caller need first return resource for RaytracingAccelerationStructure so we
             // continue to check if the resource flag match D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE
-            if (func != nullptr)
+            if (func == nullptr || (func != nullptr && (*func)(resource_entry.first) == true))
             {
-                if ((*func)(resource_entry.first))
+                if (resource_id != nullptr)
                 {
-                    first_resource_id = resource_entry.first;
-                    break;
+                    *resource_id = resource_entry.first;
                 }
+                return true;
             }
             else
             {
-                break;
+                if (first_resource_id == format::kNullHandleId)
+                {
+                    first_resource_id = resource_entry.first;
+                }
             }
         }
     }
 
-    if (first_resource_id != format::kNullHandleId)
+    if (resource_id != nullptr)
     {
-        if (resource_id != nullptr)
-        {
-            *resource_id = first_resource_id;
-        }
-
-        return true;
+        *resource_id = first_resource_id;
     }
 
-    return false;
+    return (first_resource_id != format::kNullHandleId);
 }
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/dx12_gpu_va_map.cpp
+++ b/framework/graphics/dx12_gpu_va_map.cpp
@@ -62,11 +62,11 @@ void Dx12GpuVaMap::Remove(format::HandleId resource_id, uint64_t old_start_addre
     }
 }
 
-uint64_t Dx12GpuVaMap::Map(uint64_t                                                address,
-                           format::HandleId*                                       resource_id,
-                           bool*                                                   found,
-                           uint64_t                                                minimum_old_end_address,
-                           IsResourceForRaytracingAccelerationStructureFunctionPtr func) const
+uint64_t Dx12GpuVaMap::Map(uint64_t                                   address,
+                           format::HandleId*                          resource_id,
+                           bool*                                      found,
+                           uint64_t                                   minimum_old_end_address,
+                           IsAccelerationStructureResourceFunctionPtr func) const
 {
     bool local_found = false;
 
@@ -114,12 +114,12 @@ uint64_t Dx12GpuVaMap::Map(uint64_t                                             
 
 // If func is valid, the function return matched resource which is used for RaytracingAccelerationStructure,
 // if func is nullptr, it return first resource which match old_start_address and minimum_old_end_address.
-bool Dx12GpuVaMap::FindMatch(const AliasedResourceVaInfo&                            resource_info,
-                             uint64_t                                                old_start_address,
-                             uint64_t&                                               address,
-                             format::HandleId*                                       resource_id,
-                             uint64_t                                                minimum_old_end_address,
-                             IsResourceForRaytracingAccelerationStructureFunctionPtr func) const
+bool Dx12GpuVaMap::FindMatch(const AliasedResourceVaInfo&               resource_info,
+                             uint64_t                                   old_start_address,
+                             uint64_t&                                  address,
+                             format::HandleId*                          resource_id,
+                             uint64_t                                   minimum_old_end_address,
+                             IsAccelerationStructureResourceFunctionPtr func) const
 {
     // Check for a match in the aliased resource list.
     for (const auto& resource_entry : resource_info)

--- a/framework/graphics/dx12_gpu_va_map.h
+++ b/framework/graphics/dx12_gpu_va_map.h
@@ -33,6 +33,8 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
+typedef bool (*IsResourceForRaytracingAccelerationStructureFunctionPtr)(format::HandleId id);
+
 class Dx12GpuVaMap
 {
   public:
@@ -40,10 +42,11 @@ class Dx12GpuVaMap
 
     void Remove(format::HandleId resource_id, uint64_t old_start_address);
 
-    uint64_t Map(uint64_t          old_address,
-                 format::HandleId* resource_id             = nullptr,
-                 bool*             found                   = nullptr,
-                 uint64_t          minimum_old_end_address = 0) const;
+    uint64_t Map(uint64_t                                                old_address,
+                 format::HandleId*                                       resource_id             = nullptr,
+                 bool*                                                   found                   = nullptr,
+                 uint64_t                                                minimum_old_end_address = 0,
+                 IsResourceForRaytracingAccelerationStructureFunctionPtr func                    = nullptr) const;
 
   private:
     struct GpuVaInfo
@@ -56,11 +59,12 @@ class Dx12GpuVaMap
     typedef std::map<uint64_t, AliasedResourceVaInfo, std::greater<uint64_t>> GpuVaMap;
 
   private:
-    bool FindMatch(const AliasedResourceVaInfo& resource_info,
-                   uint64_t                     old_start_address,
-                   uint64_t&                    address,
-                   format::HandleId*            resource_id,
-                   uint64_t                     minimum_old_end_address) const;
+    bool FindMatch(const AliasedResourceVaInfo&                            resource_info,
+                   uint64_t                                                old_start_address,
+                   uint64_t&                                               address,
+                   format::HandleId*                                       resource_id,
+                   uint64_t                                                minimum_old_end_address,
+                   IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr) const;
 
   private:
     GpuVaMap gpu_va_map_;

--- a/framework/graphics/dx12_gpu_va_map.h
+++ b/framework/graphics/dx12_gpu_va_map.h
@@ -33,7 +33,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
-typedef bool (*IsResourceForRaytracingAccelerationStructureFunctionPtr)(format::HandleId id);
+typedef bool (*IsAccelerationStructureResourceFunctionPtr)(format::HandleId id);
 
 class Dx12GpuVaMap
 {
@@ -42,11 +42,11 @@ class Dx12GpuVaMap
 
     void Remove(format::HandleId resource_id, uint64_t old_start_address);
 
-    uint64_t Map(uint64_t                                                old_address,
-                 format::HandleId*                                       resource_id             = nullptr,
-                 bool*                                                   found                   = nullptr,
-                 uint64_t                                                minimum_old_end_address = 0,
-                 IsResourceForRaytracingAccelerationStructureFunctionPtr func                    = nullptr) const;
+    uint64_t Map(uint64_t                                   old_address,
+                 format::HandleId*                          resource_id             = nullptr,
+                 bool*                                      found                   = nullptr,
+                 uint64_t                                   minimum_old_end_address = 0,
+                 IsAccelerationStructureResourceFunctionPtr func                    = nullptr) const;
 
   private:
     struct GpuVaInfo
@@ -59,12 +59,12 @@ class Dx12GpuVaMap
     typedef std::map<uint64_t, AliasedResourceVaInfo, std::greater<uint64_t>> GpuVaMap;
 
   private:
-    bool FindMatch(const AliasedResourceVaInfo&                            resource_info,
-                   uint64_t                                                old_start_address,
-                   uint64_t&                                               address,
-                   format::HandleId*                                       resource_id,
-                   uint64_t                                                minimum_old_end_address,
-                   IsResourceForRaytracingAccelerationStructureFunctionPtr func = nullptr) const;
+    bool FindMatch(const AliasedResourceVaInfo&               resource_info,
+                   uint64_t                                   old_start_address,
+                   uint64_t&                                  address,
+                   format::HandleId*                          resource_id,
+                   uint64_t                                   minimum_old_end_address,
+                   IsAccelerationStructureResourceFunctionPtr func = nullptr) const;
 
   private:
     GpuVaMap gpu_va_map_;

--- a/framework/graphics/dx12_gpu_va_map.h
+++ b/framework/graphics/dx12_gpu_va_map.h
@@ -33,7 +33,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
-typedef bool (*IsAccelerationStructureResourceFunctionPtr)(format::HandleId id);
+typedef bool (*ResourceMatchFunctionPtr)(format::HandleId id);
 
 class Dx12GpuVaMap
 {
@@ -42,11 +42,11 @@ class Dx12GpuVaMap
 
     void Remove(format::HandleId resource_id, uint64_t old_start_address);
 
-    uint64_t Map(uint64_t                                   old_address,
-                 format::HandleId*                          resource_id             = nullptr,
-                 bool*                                      found                   = nullptr,
-                 uint64_t                                   minimum_old_end_address = 0,
-                 IsAccelerationStructureResourceFunctionPtr func                    = nullptr) const;
+    uint64_t Map(uint64_t                 old_address,
+                 format::HandleId*        resource_id             = nullptr,
+                 bool*                    found                   = nullptr,
+                 uint64_t                 minimum_old_end_address = 0,
+                 ResourceMatchFunctionPtr resource_match_func     = nullptr) const;
 
   private:
     struct GpuVaInfo
@@ -59,12 +59,12 @@ class Dx12GpuVaMap
     typedef std::map<uint64_t, AliasedResourceVaInfo, std::greater<uint64_t>> GpuVaMap;
 
   private:
-    bool FindMatch(const AliasedResourceVaInfo&               resource_info,
-                   uint64_t                                   old_start_address,
-                   uint64_t&                                  address,
-                   format::HandleId*                          resource_id,
-                   uint64_t                                   minimum_old_end_address,
-                   IsAccelerationStructureResourceFunctionPtr func = nullptr) const;
+    bool FindMatch(const AliasedResourceVaInfo& resource_info,
+                   uint64_t                     old_start_address,
+                   uint64_t&                    address,
+                   format::HandleId*            resource_id,
+                   uint64_t                     minimum_old_end_address,
+                   ResourceMatchFunctionPtr     resource_match_func = nullptr) const;
 
   private:
     GpuVaMap gpu_va_map_;


### PR DESCRIPTION
**The problem**
   
During trim state tracking of BuildRaytracingAccelerationStructure, GetResourceWrapperForGpuVa returns wrong resource for aliased resources and trigger GPU crash later.

**The solution**

When searching resource in GPU virtual address map for trim handling of BuildRaytracingAccelerationStructure, make sure the search condition includes and use end GPU address.

**Result**

Tested target title with the pull request, the result show the commit fix the issue.