### PR TITLE
Add list of Vulkan extensions to info output

### DIFF
--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -269,6 +269,22 @@ void PrintVulkanStats(const gfxrecon::decode::VulkanStatsConsumer& vulkan_stats_
         GFXRECON_WRITE_CONSOLE("\tEngine version: %u", vulkan_stats_consumer.GetEngineVersion());
         GFXRECON_WRITE_CONSOLE("\tTarget API version: %u (%s)", api_version, GetVersionString(api_version).c_str());
 
+        GFXRECON_WRITE_CONSOLE("\nExtension info:");
+
+        GFXRECON_WRITE_CONSOLE("\tInstance extensions: ");
+        auto instance_extensions = vulkan_stats_consumer.GetInstanceExtensions();
+        for (auto extension : instance_extensions)
+        {
+            GFXRECON_WRITE_CONSOLE("\t\t%s", extension.c_str());
+        }
+
+        GFXRECON_WRITE_CONSOLE("\tDevice extensions: ");
+        auto device_extensions = vulkan_stats_consumer.GetDeviceExtensions();
+        for (auto extension : device_extensions)
+        {
+            GFXRECON_WRITE_CONSOLE("\t\t%s", extension.c_str());
+        }
+
         // Properties for physical devices used to create logical devices.
         std::vector<const VkPhysicalDeviceProperties*> used_device_properties;
         auto                                           used_devices = vulkan_stats_consumer.GetInstantiatedDevices();


### PR DESCRIPTION
Currently, in order to get information about which Vulkan extensions are requested in a capture, the primary workflow is to use the `gfxrecon-convert` utility to obtain the JSON output, and then separately inspect each instance/device CreateInfo structure. This can become quite inconvenient, especially for larger capture files.

This PR resolves the issue by having the `gfxrecon-info` tool perform this collection automatically and include the list of requested Vulkan extensions as part of its normal output.

An example of the additional `gfxrecon-info` output:
```
...
	Target API version:

Extension info:
        Instance extensions:
                VK_KHR_get_physical_device_properties2
                VK_KHR_surface
                VK_KHR_win32_surface
                VK_KHR_portability_enumeration
        Device extensions:
                VK_KHR_portability_subset
                VK_KHR_swapchain

Physical device info:
...
```

