### PR TITLE
Fix capture-time validation errors when creating descriptor heaps

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -696,7 +696,15 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateDescriptorHeap(
 
         size_t offset    = 0;
         auto   cpu_start = descriptor_heap->GetCPUDescriptorHandleForHeapStart();
-        auto   gpu_start = descriptor_heap->GetGPUDescriptorHandleForHeapStart();
+        auto   gpu_start = cpu_start;
+
+        // D3D12 validation layer states GetGPUDescriptorHandleForHeapStart() should only be used for heaps
+        // with D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE flag set.
+        // If the flag is not set, then we should call GetCPUDescriptorHandleForHeapStart()
+        if (desc->Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+        {
+            gpu_start.ptr = descriptor_heap->GetGPUDescriptorHandleForHeapStart().ptr;
+        }
 
         for (uint32_t i = 0; i < num_descriptors; ++i)
         {


### PR DESCRIPTION
**Problem**
The D3D12 validation layer outputs errors during capture:

`D3D12 ERROR: ID3D12DescriptorHeap::GetGPUDescriptorHandleForHeapStart: GetGPUDescriptorHandleForHeapStart is invalid to call on a descriptor heap that does not have DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE set. If the heap is not supposed to be shader visible, then GetCPUDescriptorHandleForHeapStart would be the appropriate method to call. That call is valid both for shader visible and non shader visible descriptor heaps. [ STATE_GETTING ERROR #1315: DESCRIPTOR_HEAP_NOT_SHADER_VISIBLE]`

**Solution**
Only use `GetGPUDescriptorHandleForHeapStart` if `DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE` flag is set during creation of descriptor heaps.

**Testing**
D3D12 validation layer is clear of errors when capturing apps.