### PR TITLE
Update VulkanMemoryAllocator to 3.1.0

### DIFF
--- a/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
+++ b/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
@@ -25,7 +25,7 @@
 
 /** \mainpage Vulkan Memory Allocator
 
-<b>Version 3.0.1 (2022-05-26)</b>
+<b>Version 3.1.0-development</b>
 
 Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved. \n
 License: MIT
@@ -117,113 +117,109 @@ for user-defined purpose without allocating any real GPU memory.
 
 \defgroup group_stats Statistics
 
-\brief API elements that query current status of the allocator, from memory usage, budget, to full dump of the internal
-state in JSON format. See documentation chapter: \ref statistics.
+\brief API elements that query current status of the allocator, from memory usage, budget, to full dump of the internal state in JSON format.
+See documentation chapter: \ref statistics.
 */
 
+
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 #ifndef VULKAN_H_
-#include <vulkan/vulkan.h>
+    #include <vulkan/vulkan.h>
 #endif
 
-// Define this macro to declare maximum supported Vulkan version in format AAABBBCCC,
-// where AAA = major, BBB = minor, CCC = patch.
-// If you want to use version > 1.0, it still needs to be enabled via VmaAllocatorCreateInfo::vulkanApiVersion.
 #if !defined(VMA_VULKAN_VERSION)
-#if defined(VK_VERSION_1_3)
-#define VMA_VULKAN_VERSION 1003000
-#elif defined(VK_VERSION_1_2)
-#define VMA_VULKAN_VERSION 1002000
-#elif defined(VK_VERSION_1_1)
-#define VMA_VULKAN_VERSION 1001000
-#else
-#define VMA_VULKAN_VERSION 1000000
-#endif
+    #if defined(VK_VERSION_1_3)
+        #define VMA_VULKAN_VERSION 1003000
+    #elif defined(VK_VERSION_1_2)
+        #define VMA_VULKAN_VERSION 1002000
+    #elif defined(VK_VERSION_1_1)
+        #define VMA_VULKAN_VERSION 1001000
+    #else
+        #define VMA_VULKAN_VERSION 1000000
+    #endif
 #endif
 
 #if defined(__ANDROID__) && defined(VK_NO_PROTOTYPES) && VMA_STATIC_VULKAN_FUNCTIONS
-    extern PFN_vkGetInstanceProcAddr               vkGetInstanceProcAddr;
-    extern PFN_vkGetDeviceProcAddr                 vkGetDeviceProcAddr;
-    extern PFN_vkGetPhysicalDeviceProperties       vkGetPhysicalDeviceProperties;
+    extern PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
+    extern PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr;
+    extern PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties;
     extern PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties;
-    extern PFN_vkAllocateMemory                    vkAllocateMemory;
-    extern PFN_vkFreeMemory                        vkFreeMemory;
-    extern PFN_vkMapMemory                         vkMapMemory;
-    extern PFN_vkUnmapMemory                       vkUnmapMemory;
-    extern PFN_vkFlushMappedMemoryRanges           vkFlushMappedMemoryRanges;
-    extern PFN_vkInvalidateMappedMemoryRanges      vkInvalidateMappedMemoryRanges;
-    extern PFN_vkBindBufferMemory                  vkBindBufferMemory;
-    extern PFN_vkBindImageMemory                   vkBindImageMemory;
-    extern PFN_vkGetBufferMemoryRequirements       vkGetBufferMemoryRequirements;
-    extern PFN_vkGetImageMemoryRequirements        vkGetImageMemoryRequirements;
-    extern PFN_vkCreateBuffer                      vkCreateBuffer;
-    extern PFN_vkDestroyBuffer                     vkDestroyBuffer;
-    extern PFN_vkCreateImage                       vkCreateImage;
-    extern PFN_vkDestroyImage                      vkDestroyImage;
-    extern PFN_vkCmdCopyBuffer                     vkCmdCopyBuffer;
-#if VMA_VULKAN_VERSION >= 1001000
-    extern PFN_vkGetBufferMemoryRequirements2       vkGetBufferMemoryRequirements2;
-    extern PFN_vkGetImageMemoryRequirements2        vkGetImageMemoryRequirements2;
-    extern PFN_vkBindBufferMemory2                  vkBindBufferMemory2;
-    extern PFN_vkBindImageMemory2                   vkBindImageMemory2;
-    extern PFN_vkGetPhysicalDeviceMemoryProperties2 vkGetPhysicalDeviceMemoryProperties2;
-#endif // #if VMA_VULKAN_VERSION >= 1001000
+    extern PFN_vkAllocateMemory vkAllocateMemory;
+    extern PFN_vkFreeMemory vkFreeMemory;
+    extern PFN_vkMapMemory vkMapMemory;
+    extern PFN_vkUnmapMemory vkUnmapMemory;
+    extern PFN_vkFlushMappedMemoryRanges vkFlushMappedMemoryRanges;
+    extern PFN_vkInvalidateMappedMemoryRanges vkInvalidateMappedMemoryRanges;
+    extern PFN_vkBindBufferMemory vkBindBufferMemory;
+    extern PFN_vkBindImageMemory vkBindImageMemory;
+    extern PFN_vkGetBufferMemoryRequirements vkGetBufferMemoryRequirements;
+    extern PFN_vkGetImageMemoryRequirements vkGetImageMemoryRequirements;
+    extern PFN_vkCreateBuffer vkCreateBuffer;
+    extern PFN_vkDestroyBuffer vkDestroyBuffer;
+    extern PFN_vkCreateImage vkCreateImage;
+    extern PFN_vkDestroyImage vkDestroyImage;
+    extern PFN_vkCmdCopyBuffer vkCmdCopyBuffer;
+    #if VMA_VULKAN_VERSION >= 1001000
+        extern PFN_vkGetBufferMemoryRequirements2 vkGetBufferMemoryRequirements2;
+        extern PFN_vkGetImageMemoryRequirements2 vkGetImageMemoryRequirements2;
+        extern PFN_vkBindBufferMemory2 vkBindBufferMemory2;
+        extern PFN_vkBindImageMemory2 vkBindImageMemory2;
+        extern PFN_vkGetPhysicalDeviceMemoryProperties2 vkGetPhysicalDeviceMemoryProperties2;
+    #endif // #if VMA_VULKAN_VERSION >= 1001000
 #endif // #if defined(__ANDROID__) && VMA_STATIC_VULKAN_FUNCTIONS && VK_NO_PROTOTYPES
 
 #if !defined(VMA_DEDICATED_ALLOCATION)
-#if VK_KHR_get_memory_requirements2 && VK_KHR_dedicated_allocation
-#define VMA_DEDICATED_ALLOCATION 1
-#else
-#define VMA_DEDICATED_ALLOCATION 0
-#endif
+    #if VK_KHR_get_memory_requirements2 && VK_KHR_dedicated_allocation
+        #define VMA_DEDICATED_ALLOCATION 1
+    #else
+        #define VMA_DEDICATED_ALLOCATION 0
+    #endif
 #endif
 
 #if !defined(VMA_BIND_MEMORY2)
-#if VK_KHR_bind_memory2
-#define VMA_BIND_MEMORY2 1
-#else
-#define VMA_BIND_MEMORY2 0
-#endif
+    #if VK_KHR_bind_memory2
+        #define VMA_BIND_MEMORY2 1
+    #else
+        #define VMA_BIND_MEMORY2 0
+    #endif
 #endif
 
 #if !defined(VMA_MEMORY_BUDGET)
-#if VK_EXT_memory_budget && (VK_KHR_get_physical_device_properties2 || VMA_VULKAN_VERSION >= 1001000)
-#define VMA_MEMORY_BUDGET 1
-#else
-#define VMA_MEMORY_BUDGET 0
-#endif
+    #if VK_EXT_memory_budget && (VK_KHR_get_physical_device_properties2 || VMA_VULKAN_VERSION >= 1001000)
+        #define VMA_MEMORY_BUDGET 1
+    #else
+        #define VMA_MEMORY_BUDGET 0
+    #endif
 #endif
 
-// Defined to 1 when VK_KHR_buffer_device_address device extension or equivalent core Vulkan 1.2 feature is defined in
-// its headers.
+// Defined to 1 when VK_KHR_buffer_device_address device extension or equivalent core Vulkan 1.2 feature is defined in its headers.
 #if !defined(VMA_BUFFER_DEVICE_ADDRESS)
-#if VK_KHR_buffer_device_address || VMA_VULKAN_VERSION >= 1002000
-#define VMA_BUFFER_DEVICE_ADDRESS 1
-#else
-#define VMA_BUFFER_DEVICE_ADDRESS 0
-#endif
+    #if VK_KHR_buffer_device_address || VMA_VULKAN_VERSION >= 1002000
+        #define VMA_BUFFER_DEVICE_ADDRESS 1
+    #else
+        #define VMA_BUFFER_DEVICE_ADDRESS 0
+    #endif
 #endif
 
 // Defined to 1 when VK_EXT_memory_priority device extension is defined in Vulkan headers.
 #if !defined(VMA_MEMORY_PRIORITY)
-#if VK_EXT_memory_priority
-#define VMA_MEMORY_PRIORITY 1
-#else
-#define VMA_MEMORY_PRIORITY 0
-#endif
+    #if VK_EXT_memory_priority
+        #define VMA_MEMORY_PRIORITY 1
+    #else
+        #define VMA_MEMORY_PRIORITY 0
+    #endif
 #endif
 
 // Defined to 1 when VK_KHR_external_memory device extension is defined in Vulkan headers.
 #if !defined(VMA_EXTERNAL_MEMORY)
-#if VK_KHR_external_memory
-#define VMA_EXTERNAL_MEMORY 1
-#else
-#define VMA_EXTERNAL_MEMORY 0
-#endif
+    #if VK_KHR_external_memory
+        #define VMA_EXTERNAL_MEMORY 1
+    #else
+        #define VMA_EXTERNAL_MEMORY 0
+    #endif
 #endif
 
 // Define these macros to decorate all public functions with additional code,
@@ -232,10 +228,10 @@ extern "C"
 // #define VMA_CALL_PRE  __declspec(dllexport)
 // #define VMA_CALL_POST __cdecl
 #ifndef VMA_CALL_PRE
-#define VMA_CALL_PRE
+    #define VMA_CALL_PRE
 #endif
 #ifndef VMA_CALL_POST
-#define VMA_CALL_POST
+    #define VMA_CALL_POST
 #endif
 
 // Define this macro to decorate pointers with an attribute specifying the
@@ -250,51 +246,49 @@ extern "C"
 //   this means the number of memory heaps available in the device associated
 //   with the VmaAllocator being dealt with.
 #ifndef VMA_LEN_IF_NOT_NULL
-#define VMA_LEN_IF_NOT_NULL(len)
+    #define VMA_LEN_IF_NOT_NULL(len)
 #endif
 
 // The VMA_NULLABLE macro is defined to be _Nullable when compiling with Clang.
 // see: https://clang.llvm.org/docs/AttributeReference.html#nullable
 #ifndef VMA_NULLABLE
-#ifdef __clang__
-#define VMA_NULLABLE _Nullable
-#else
-#define VMA_NULLABLE
-#endif
+    #ifdef __clang__
+        #define VMA_NULLABLE _Nullable
+    #else
+        #define VMA_NULLABLE
+    #endif
 #endif
 
 // The VMA_NOT_NULL macro is defined to be _Nonnull when compiling with Clang.
 // see: https://clang.llvm.org/docs/AttributeReference.html#nonnull
 #ifndef VMA_NOT_NULL
-#ifdef __clang__
-#define VMA_NOT_NULL _Nonnull
-#else
-#define VMA_NOT_NULL
-#endif
+    #ifdef __clang__
+        #define VMA_NOT_NULL _Nonnull
+    #else
+        #define VMA_NOT_NULL
+    #endif
 #endif
 
 // If non-dispatchable handles are represented as pointers then we can give
 // then nullability annotations
 #ifndef VMA_NOT_NULL_NON_DISPATCHABLE
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || \
-    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-#define VMA_NOT_NULL_NON_DISPATCHABLE VMA_NOT_NULL
-#else
-#define VMA_NOT_NULL_NON_DISPATCHABLE
-#endif
+    #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+        #define VMA_NOT_NULL_NON_DISPATCHABLE VMA_NOT_NULL
+    #else
+        #define VMA_NOT_NULL_NON_DISPATCHABLE
+    #endif
 #endif
 
 #ifndef VMA_NULLABLE_NON_DISPATCHABLE
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || \
-    defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-#define VMA_NULLABLE_NON_DISPATCHABLE VMA_NULLABLE
-#else
-#define VMA_NULLABLE_NON_DISPATCHABLE
-#endif
+    #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+        #define VMA_NULLABLE_NON_DISPATCHABLE VMA_NULLABLE
+    #else
+        #define VMA_NULLABLE_NON_DISPATCHABLE
+    #endif
 #endif
 
 #ifndef VMA_STATS_STRING_ENABLED
-#define VMA_STATS_STRING_ENABLED 1
+    #define VMA_STATS_STRING_ENABLED 1
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -305,2258 +299,2281 @@ extern "C"
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-// Sections for managing code placement in file, only for development purposes e.g. for convenient folding inside an
-// IDE.
+// Sections for managing code placement in file, only for development purposes e.g. for convenient folding inside an IDE.
 #ifndef _VMA_ENUM_DECLARATIONS
 
-    /**
-    \addtogroup group_init
-    @{
+/**
+\addtogroup group_init
+@{
+*/
+
+/// Flags for created #VmaAllocator.
+typedef enum VmaAllocatorCreateFlagBits
+{
+    /** \brief Allocator and all objects created from it will not be synchronized internally, so you must guarantee they are used from only one thread at a time or synchronized externally by you.
+
+    Using this flag may increase performance because internal mutexes are not used.
     */
+    VMA_ALLOCATOR_CREATE_EXTERNALLY_SYNCHRONIZED_BIT = 0x00000001,
+    /** \brief Enables usage of VK_KHR_dedicated_allocation extension.
 
-    /// Flags for created #VmaAllocator.
-    typedef enum VmaAllocatorCreateFlagBits
-    {
-        /** \brief Allocator and all objects created from it will not be synchronized internally, so you must guarantee
-        they are used from only one thread at a time or synchronized externally by you.
+    The flag works only if VmaAllocatorCreateInfo::vulkanApiVersion `== VK_API_VERSION_1_0`.
+    When it is `VK_API_VERSION_1_1`, the flag is ignored because the extension has been promoted to Vulkan 1.1.
 
-        Using this flag may increase performance because internal mutexes are not used.
-        */
-        VMA_ALLOCATOR_CREATE_EXTERNALLY_SYNCHRONIZED_BIT = 0x00000001,
-        /** \brief Enables usage of VK_KHR_dedicated_allocation extension.
+    Using this extension will automatically allocate dedicated blocks of memory for
+    some buffers and images instead of suballocating place for them out of bigger
+    memory blocks (as if you explicitly used #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT
+    flag) when it is recommended by the driver. It may improve performance on some
+    GPUs.
 
-        The flag works only if VmaAllocatorCreateInfo::vulkanApiVersion `== VK_API_VERSION_1_0`.
-        When it is `VK_API_VERSION_1_1`, the flag is ignored because the extension has been promoted to Vulkan 1.1.
+    You may set this flag only if you found out that following device extensions are
+    supported, you enabled them while creating Vulkan device passed as
+    VmaAllocatorCreateInfo::device, and you want them to be used internally by this
+    library:
 
-        Using this extension will automatically allocate dedicated blocks of memory for
-        some buffers and images instead of suballocating place for them out of bigger
-        memory blocks (as if you explicitly used #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT
-        flag) when it is recommended by the driver. It may improve performance on some
-        GPUs.
+    - VK_KHR_get_memory_requirements2 (device extension)
+    - VK_KHR_dedicated_allocation (device extension)
 
-        You may set this flag only if you found out that following device extensions are
-        supported, you enabled them while creating Vulkan device passed as
-        VmaAllocatorCreateInfo::device, and you want them to be used internally by this
-        library:
+    When this flag is set, you can experience following warnings reported by Vulkan
+    validation layer. You can ignore them.
 
-        - VK_KHR_get_memory_requirements2 (device extension)
-        - VK_KHR_dedicated_allocation (device extension)
-
-        When this flag is set, you can experience following warnings reported by Vulkan
-        validation layer. You can ignore them.
-
-        > vkBindBufferMemory(): Binding memory to buffer 0x2d but vkGetBufferMemoryRequirements() has not been called on
-        that buffer.
-        */
-        VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT = 0x00000002,
-        /**
-        Enables usage of VK_KHR_bind_memory2 extension.
-
-        The flag works only if VmaAllocatorCreateInfo::vulkanApiVersion `== VK_API_VERSION_1_0`.
-        When it is `VK_API_VERSION_1_1`, the flag is ignored because the extension has been promoted to Vulkan 1.1.
-
-        You may set this flag only if you found out that this device extension is supported,
-        you enabled it while creating Vulkan device passed as VmaAllocatorCreateInfo::device,
-        and you want it to be used internally by this library.
-
-        The extension provides functions `vkBindBufferMemory2KHR` and `vkBindImageMemory2KHR`,
-        which allow to pass a chain of `pNext` structures while binding.
-        This flag is required if you use `pNext` parameter in vmaBindBufferMemory2() or vmaBindImageMemory2().
-        */
-        VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT = 0x00000004,
-        /**
-        Enables usage of VK_EXT_memory_budget extension.
-
-        You may set this flag only if you found out that this device extension is supported,
-        you enabled it while creating Vulkan device passed as VmaAllocatorCreateInfo::device,
-        and you want it to be used internally by this library, along with another instance extension
-        VK_KHR_get_physical_device_properties2, which is required by it (or Vulkan 1.1, where this extension is
-        promoted).
-
-        The extension provides query for current memory usage and budget, which will probably
-        be more accurate than an estimation used by the library otherwise.
-        */
-        VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT = 0x00000008,
-        /**
-        Enables usage of VK_AMD_device_coherent_memory extension.
-
-        You may set this flag only if you:
-
-        - found out that this device extension is supported and enabled it while creating Vulkan device passed as
-        VmaAllocatorCreateInfo::device,
-        - checked that `VkPhysicalDeviceCoherentMemoryFeaturesAMD::deviceCoherentMemory` is true and set it while
-        creating the Vulkan device,
-        - want it to be used internally by this library.
-
-        The extension and accompanying device feature provide access to memory types with
-        `VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD` and `VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD` flags.
-        They are useful mostly for writing breadcrumb markers - a common method for debugging GPU crash/hang/TDR.
-
-        When the extension is not enabled, such memory types are still enumerated, but their usage is illegal.
-        To protect from this error, if you don't create the allocator with this flag, it will refuse to allocate any
-        memory or create a custom pool in such memory type, returning `VK_ERROR_FEATURE_NOT_PRESENT`.
-        */
-        VMA_ALLOCATOR_CREATE_AMD_DEVICE_COHERENT_MEMORY_BIT = 0x00000010,
-        /**
-        Enables usage of "buffer device address" feature, which allows you to use function
-        `vkGetBufferDeviceAddress*` to get raw GPU pointer to a buffer and pass it for usage inside a shader.
-
-        You may set this flag only if you:
-
-        1. (For Vulkan version < 1.2) Found as available and enabled device extension
-        VK_KHR_buffer_device_address.
-        This extension is promoted to core Vulkan 1.2.
-        2. Found as available and enabled device feature
-        `VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress`.
-
-        When this flag is set, you can create buffers with `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` using VMA.
-        The library automatically adds `VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT` to
-        allocated memory blocks wherever it might be needed.
-
-        For more information, see documentation chapter \ref enabling_buffer_device_address.
-        */
-        VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT = 0x00000020,
-        /**
-        Enables usage of VK_EXT_memory_priority extension in the library.
-
-        You may set this flag only if you found available and enabled this device extension,
-        along with `VkPhysicalDeviceMemoryPriorityFeaturesEXT::memoryPriority == VK_TRUE`,
-        while creating Vulkan device passed as VmaAllocatorCreateInfo::device.
-
-        When this flag is used, VmaAllocationCreateInfo::priority and VmaPoolCreateInfo::priority
-        are used to set priorities of allocated Vulkan memory. Without it, these variables are ignored.
-
-        A priority must be a floating-point value between 0 and 1, indicating the priority of the allocation relative to
-        other memory allocations. Larger values are higher priority. The granularity of the priorities is
-        implementation-dependent. It is automatically passed to every call to `vkAllocateMemory` done by the library
-        using structure `VkMemoryPriorityAllocateInfoEXT`. The value to be used for default priority is 0.5. For more
-        details, see the documentation of the VK_EXT_memory_priority extension.
-        */
-        VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT = 0x00000040,
-
-        VMA_ALLOCATOR_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
-    } VmaAllocatorCreateFlagBits;
-    /// See #VmaAllocatorCreateFlagBits.
-    typedef VkFlags VmaAllocatorCreateFlags;
-
-    /** @} */
-
-    /**
-    \addtogroup group_alloc
-    @{
+    > vkBindBufferMemory(): Binding memory to buffer 0x2d but vkGetBufferMemoryRequirements() has not been called on that buffer.
     */
-
-    /// \brief Intended usage of the allocated memory.
-    typedef enum VmaMemoryUsage
-    {
-        /** No intended memory usage specified.
-        Use other members of VmaAllocationCreateInfo to specify your requirements.
-        */
-        VMA_MEMORY_USAGE_UNKNOWN = 0,
-        /**
-        \deprecated Obsolete, preserved for backward compatibility.
-        Prefers `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`.
-        */
-        VMA_MEMORY_USAGE_GPU_ONLY = 1,
-        /**
-        \deprecated Obsolete, preserved for backward compatibility.
-        Guarantees `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT` and `VK_MEMORY_PROPERTY_HOST_COHERENT_BIT`.
-        */
-        VMA_MEMORY_USAGE_CPU_ONLY = 2,
-        /**
-        \deprecated Obsolete, preserved for backward compatibility.
-        Guarantees `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT`, prefers `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`.
-        */
-        VMA_MEMORY_USAGE_CPU_TO_GPU = 3,
-        /**
-        \deprecated Obsolete, preserved for backward compatibility.
-        Guarantees `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT`, prefers `VK_MEMORY_PROPERTY_HOST_CACHED_BIT`.
-        */
-        VMA_MEMORY_USAGE_GPU_TO_CPU = 4,
-        /**
-        \deprecated Obsolete, preserved for backward compatibility.
-        Prefers not `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`.
-        */
-        VMA_MEMORY_USAGE_CPU_COPY = 5,
-        /**
-        Lazily allocated GPU memory having `VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT`.
-        Exists mostly on mobile platforms. Using it on desktop PC or other GPUs with no such memory type present will
-        fail the allocation.
-
-        Usage: Memory for transient attachment images (color attachments, depth attachments etc.), created with
-        `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT`.
-
-        Allocations with this usage are always created as dedicated - it implies
-        #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
-        */
-        VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED = 6,
-        /**
-        Selects best memory type automatically.
-        This flag is recommended for most common use cases.
-
-        When using this flag, if you want to map the allocation (using vmaMapMemory() or
-        #VMA_ALLOCATION_CREATE_MAPPED_BIT), you must pass one of the flags:
-        #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT in
-        VmaAllocationCreateInfo::flags.
-
-        It can be used only with functions that let the library know `VkBufferCreateInfo` or `VkImageCreateInfo`, e.g.
-        vmaCreateBuffer(), vmaCreateImage(), vmaFindMemoryTypeIndexForBufferInfo(), vmaFindMemoryTypeIndexForImageInfo()
-        and not with generic memory allocation functions.
-        */
-        VMA_MEMORY_USAGE_AUTO = 7,
-        /**
-        Selects best memory type automatically with preference for GPU (device) memory.
-
-        When using this flag, if you want to map the allocation (using vmaMapMemory() or
-        #VMA_ALLOCATION_CREATE_MAPPED_BIT), you must pass one of the flags:
-        #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT in
-        VmaAllocationCreateInfo::flags.
-
-        It can be used only with functions that let the library know `VkBufferCreateInfo` or `VkImageCreateInfo`, e.g.
-        vmaCreateBuffer(), vmaCreateImage(), vmaFindMemoryTypeIndexForBufferInfo(), vmaFindMemoryTypeIndexForImageInfo()
-        and not with generic memory allocation functions.
-        */
-        VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE = 8,
-        /**
-        Selects best memory type automatically with preference for CPU (host) memory.
-
-        When using this flag, if you want to map the allocation (using vmaMapMemory() or
-        #VMA_ALLOCATION_CREATE_MAPPED_BIT), you must pass one of the flags:
-        #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT in
-        VmaAllocationCreateInfo::flags.
-
-        It can be used only with functions that let the library know `VkBufferCreateInfo` or `VkImageCreateInfo`, e.g.
-        vmaCreateBuffer(), vmaCreateImage(), vmaFindMemoryTypeIndexForBufferInfo(), vmaFindMemoryTypeIndexForImageInfo()
-        and not with generic memory allocation functions.
-        */
-        VMA_MEMORY_USAGE_AUTO_PREFER_HOST = 9,
-
-        VMA_MEMORY_USAGE_MAX_ENUM = 0x7FFFFFFF
-    } VmaMemoryUsage;
-
-    /// Flags to be passed as VmaAllocationCreateInfo::flags.
-    typedef enum VmaAllocationCreateFlagBits
-    {
-        /** \brief Set this flag if the allocation should have its own memory block.
-
-        Use it for special, big resources, like fullscreen images used as attachments.
-        */
-        VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT = 0x00000001,
-
-        /** \brief Set this flag to only try to allocate from existing `VkDeviceMemory` blocks and never create new such
-        block.
-
-        If new allocation cannot be placed in any of the existing blocks, allocation
-        fails with `VK_ERROR_OUT_OF_DEVICE_MEMORY` error.
-
-        You should not use #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT and
-        #VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT at the same time. It makes no sense.
-        */
-        VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT = 0x00000002,
-        /** \brief Set this flag to use a memory that will be persistently mapped and retrieve pointer to it.
-
-        Pointer to mapped memory will be returned through VmaAllocationInfo::pMappedData.
-
-        It is valid to use this flag for allocation made from memory type that is not
-        `HOST_VISIBLE`. This flag is then ignored and memory is not mapped. This is
-        useful if you need an allocation that is efficient to use on GPU
-        (`DEVICE_LOCAL`) and still want to map it directly if possible on platforms that
-        support it (e.g. Intel GPU).
-        */
-        VMA_ALLOCATION_CREATE_MAPPED_BIT = 0x00000004,
-        /** \deprecated Preserved for backward compatibility. Consider using vmaSetAllocationName() instead.
-
-        Set this flag to treat VmaAllocationCreateInfo::pUserData as pointer to a
-        null-terminated string. Instead of copying pointer value, a local copy of the
-        string is made and stored in allocation's `pName`. The string is automatically
-        freed together with the allocation. It is also used in vmaBuildStatsString().
-        */
-        VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT = 0x00000020,
-        /** Allocation will be created from upper stack in a double stack pool.
-
-        This flag is only allowed for custom pools created with #VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT flag.
-        */
-        VMA_ALLOCATION_CREATE_UPPER_ADDRESS_BIT = 0x00000040,
-        /** Create both buffer/image and allocation, but don't bind them together.
-        It is useful when you want to bind yourself to do some more advanced binding, e.g. using some extensions.
-        The flag is meaningful only with functions that bind by default: vmaCreateBuffer(), vmaCreateImage().
-        Otherwise it is ignored.
-
-        If you want to make sure the new buffer/image is not tied to the new memory allocation
-        through `VkMemoryDedicatedAllocateInfoKHR` structure in case the allocation ends up in its own memory block,
-        use also flag #VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT.
-        */
-        VMA_ALLOCATION_CREATE_DONT_BIND_BIT = 0x00000080,
-        /** Create allocation only if additional device memory required for it, if any, won't exceed
-        memory budget. Otherwise return `VK_ERROR_OUT_OF_DEVICE_MEMORY`.
-        */
-        VMA_ALLOCATION_CREATE_WITHIN_BUDGET_BIT = 0x00000100,
-        /** \brief Set this flag if the allocated memory will have aliasing resources.
-
-        Usage of this flag prevents supplying `VkMemoryDedicatedAllocateInfoKHR` when
-        #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT is specified. Otherwise created dedicated memory will not be
-        suitable for aliasing resources, resulting in Vulkan Validation Layer errors.
-        */
-        VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT = 0x00000200,
-        /**
-        Requests possibility to map the allocation (using vmaMapMemory() or #VMA_ALLOCATION_CREATE_MAPPED_BIT).
-
-        - If you use #VMA_MEMORY_USAGE_AUTO or other `VMA_MEMORY_USAGE_AUTO*` value,
-          you must use this flag to be able to map the allocation. Otherwise, mapping is incorrect.
-        - If you use other value of #VmaMemoryUsage, this flag is ignored and mapping is always possible in memory types
-        that are `HOST_VISIBLE`. This includes allocations created in \ref custom_memory_pools.
-
-        Declares that mapped memory will only be written sequentially, e.g. using `memcpy()` or a loop writing
-        number-by-number, never read or accessed randomly, so a memory type can be selected that is uncached and
-        write-combined.
-
-        \warning Violating this declaration may work correctly, but will likely be very slow.
-        Watch out for implicit reads introduced by doing e.g. `pMappedData[i] += x;`
-        Better prepare your data in a local variable and `memcpy()` it to the mapped pointer all at once.
-        */
-        VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT = 0x00000400,
-        /**
-        Requests possibility to map the allocation (using vmaMapMemory() or #VMA_ALLOCATION_CREATE_MAPPED_BIT).
-
-        - If you use #VMA_MEMORY_USAGE_AUTO or other `VMA_MEMORY_USAGE_AUTO*` value,
-          you must use this flag to be able to map the allocation. Otherwise, mapping is incorrect.
-        - If you use other value of #VmaMemoryUsage, this flag is ignored and mapping is always possible in memory types
-        that are `HOST_VISIBLE`. This includes allocations created in \ref custom_memory_pools.
-
-        Declares that mapped memory can be read, written, and accessed in random order,
-        so a `HOST_CACHED` memory type is required.
-        */
-        VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT = 0x00000800,
-        /**
-        Together with #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or
-        #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT, it says that despite request for host access, a
-        not-`HOST_VISIBLE` memory type can be selected if it may improve performance.
-
-        By using this flag, you declare that you will check if the allocation ended up in a `HOST_VISIBLE` memory type
-        (e.g. using vmaGetAllocationMemoryProperties()) and if not, you will create some "staging" buffer and
-        issue an explicit transfer to write/read your data.
-        To prepare for this possibility, don't forget to add appropriate flags like
-        `VK_BUFFER_USAGE_TRANSFER_DST_BIT`, `VK_BUFFER_USAGE_TRANSFER_SRC_BIT` to the parameters of created buffer or
-        image.
-        */
-        VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT = 0x00001000,
-        /** Allocation strategy that chooses smallest possible free range for the allocation
-        to minimize memory usage and fragmentation, possibly at the expense of allocation time.
-        */
-        VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT = 0x00010000,
-        /** Allocation strategy that chooses first suitable free range for the allocation -
-        not necessarily in terms of the smallest offset but the one that is easiest and fastest to find
-        to minimize allocation time, possibly at the expense of allocation quality.
-        */
-        VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT = 0x00020000,
-        /** Allocation strategy that chooses always the lowest offset in available space.
-        This is not the most efficient strategy but achieves highly packed data.
-        Used internally by defragmentation, not recomended in typical usage.
-        */
-        VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT = 0x00040000,
-        /** Alias to #VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT.
-         */
-        VMA_ALLOCATION_CREATE_STRATEGY_BEST_FIT_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT,
-        /** Alias to #VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT.
-         */
-        VMA_ALLOCATION_CREATE_STRATEGY_FIRST_FIT_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT,
-        /** A bit mask to extract only `STRATEGY` bits from entire set of flags.
-         */
-        VMA_ALLOCATION_CREATE_STRATEGY_MASK = VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT |
-                                              VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT |
-                                              VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
-
-        VMA_ALLOCATION_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
-    } VmaAllocationCreateFlagBits;
-    /// See #VmaAllocationCreateFlagBits.
-    typedef VkFlags VmaAllocationCreateFlags;
-
-    /// Flags to be passed as VmaPoolCreateInfo::flags.
-    typedef enum VmaPoolCreateFlagBits
-    {
-        /** \brief Use this flag if you always allocate only buffers and linear images or only optimal images out of
-        this pool and so Buffer-Image Granularity can be ignored.
-
-        This is an optional optimization flag.
-
-        If you always allocate using vmaCreateBuffer(), vmaCreateImage(),
-        vmaAllocateMemoryForBuffer(), then you don't need to use it because allocator
-        knows exact type of your allocations so it can handle Buffer-Image Granularity
-        in the optimal way.
-
-        If you also allocate using vmaAllocateMemoryForImage() or vmaAllocateMemory(),
-        exact type of such allocations is not known, so allocator must be conservative
-        in handling Buffer-Image Granularity, which can lead to suboptimal allocation
-        (wasted memory). In that case, if you can make sure you always allocate only
-        buffers and linear images or only optimal images out of this pool, use this flag
-        to make allocator disregard Buffer-Image Granularity and so make allocations
-        faster and more optimal.
-        */
-        VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT = 0x00000002,
-
-        /** \brief Enables alternative, linear allocation algorithm in this pool.
-
-        Specify this flag to enable linear allocation algorithm, which always creates
-        new allocations after last one and doesn't reuse space from allocations freed in
-        between. It trades memory consumption for simplified algorithm and data
-        structure, which has better performance and uses less memory for metadata.
-
-        By using this flag, you can achieve behavior of free-at-once, stack,
-        ring buffer, and double stack.
-        For details, see documentation chapter \ref linear_algorithm.
-        */
-        VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT = 0x00000004,
-
-        /** Bit mask to extract only `ALGORITHM` bits from entire set of flags.
-         */
-        VMA_POOL_CREATE_ALGORITHM_MASK = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT,
-
-        VMA_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
-    } VmaPoolCreateFlagBits;
-    /// Flags to be passed as VmaPoolCreateInfo::flags. See #VmaPoolCreateFlagBits.
-    typedef VkFlags VmaPoolCreateFlags;
-
-    /// Flags to be passed as VmaDefragmentationInfo::flags.
-    typedef enum VmaDefragmentationFlagBits
-    {
-        /* \brief Use simple but fast algorithm for defragmentation.
-        May not achieve best results but will require least time to compute and least allocations to copy.
-        */
-        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FAST_BIT = 0x1,
-        /* \brief Default defragmentation algorithm, applied also when no `ALGORITHM` flag is specified.
-        Offers a balance between defragmentation quality and the amount of allocations and bytes that need to be moved.
-        */
-        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT = 0x2,
-        /* \brief Perform full defragmentation of memory.
-        Can result in notably more time to compute and allocations to copy, but will achieve best memory packing.
-        */
-        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT = 0x4,
-        /** \brief Use the most roboust algorithm at the cost of time to compute and number of copies to make.
-        Only available when bufferImageGranularity is greater than 1, since it aims to reduce
-        alignment issues between different types of resources.
-        Otherwise falls back to same behavior as #VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT.
-        */
-        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT = 0x8,
-
-        /// A bit mask to extract only `ALGORITHM` bits from entire set of flags.
-        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_MASK =
-            VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FAST_BIT | VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT |
-            VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT | VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT,
-
-        VMA_DEFRAGMENTATION_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
-    } VmaDefragmentationFlagBits;
-    /// See #VmaDefragmentationFlagBits.
-    typedef VkFlags VmaDefragmentationFlags;
-
-    /// Operation performed on single defragmentation move. See structure #VmaDefragmentationMove.
-    typedef enum VmaDefragmentationMoveOperation
-    {
-        /// Buffer/image has been recreated at `dstTmpAllocation`, data has been copied, old buffer/image has been
-        /// destroyed. `srcAllocation` should be changed to point to the new place. This is the default value set by
-        /// vmaBeginDefragmentationPass().
-        VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY = 0,
-        /// Set this value if you cannot move the allocation. New place reserved at `dstTmpAllocation` will be freed.
-        /// `srcAllocation` will remain unchanged.
-        VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE = 1,
-        /// Set this value if you decide to abandon the allocation and you destroyed the buffer/image. New place
-        /// reserved at `dstTmpAllocation` will be freed, along with `srcAllocation`, which will be destroyed.
-        VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY = 2,
-    } VmaDefragmentationMoveOperation;
-
-    /** @} */
-
+    VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT = 0x00000002,
     /**
-    \addtogroup group_virtual
-    @{
+    Enables usage of VK_KHR_bind_memory2 extension.
+
+    The flag works only if VmaAllocatorCreateInfo::vulkanApiVersion `== VK_API_VERSION_1_0`.
+    When it is `VK_API_VERSION_1_1`, the flag is ignored because the extension has been promoted to Vulkan 1.1.
+
+    You may set this flag only if you found out that this device extension is supported,
+    you enabled it while creating Vulkan device passed as VmaAllocatorCreateInfo::device,
+    and you want it to be used internally by this library.
+
+    The extension provides functions `vkBindBufferMemory2KHR` and `vkBindImageMemory2KHR`,
+    which allow to pass a chain of `pNext` structures while binding.
+    This flag is required if you use `pNext` parameter in vmaBindBufferMemory2() or vmaBindImageMemory2().
     */
+    VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT = 0x00000004,
+    /**
+    Enables usage of VK_EXT_memory_budget extension.
 
-    /// Flags to be passed as VmaVirtualBlockCreateInfo::flags.
-    typedef enum VmaVirtualBlockCreateFlagBits
-    {
-        /** \brief Enables alternative, linear allocation algorithm in this virtual block.
+    You may set this flag only if you found out that this device extension is supported,
+    you enabled it while creating Vulkan device passed as VmaAllocatorCreateInfo::device,
+    and you want it to be used internally by this library, along with another instance extension
+    VK_KHR_get_physical_device_properties2, which is required by it (or Vulkan 1.1, where this extension is promoted).
 
-        Specify this flag to enable linear allocation algorithm, which always creates
-        new allocations after last one and doesn't reuse space from allocations freed in
-        between. It trades memory consumption for simplified algorithm and data
-        structure, which has better performance and uses less memory for metadata.
+    The extension provides query for current memory usage and budget, which will probably
+    be more accurate than an estimation used by the library otherwise.
+    */
+    VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT = 0x00000008,
+    /**
+    Enables usage of VK_AMD_device_coherent_memory extension.
 
-        By using this flag, you can achieve behavior of free-at-once, stack,
-        ring buffer, and double stack.
-        For details, see documentation chapter \ref linear_algorithm.
-        */
-        VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT = 0x00000001,
+    You may set this flag only if you:
 
-        /** \brief Bit mask to extract only `ALGORITHM` bits from entire set of flags.
-         */
-        VMA_VIRTUAL_BLOCK_CREATE_ALGORITHM_MASK = VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT,
+    - found out that this device extension is supported and enabled it while creating Vulkan device passed as VmaAllocatorCreateInfo::device,
+    - checked that `VkPhysicalDeviceCoherentMemoryFeaturesAMD::deviceCoherentMemory` is true and set it while creating the Vulkan device,
+    - want it to be used internally by this library.
 
-        VMA_VIRTUAL_BLOCK_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
-    } VmaVirtualBlockCreateFlagBits;
-    /// Flags to be passed as VmaVirtualBlockCreateInfo::flags. See #VmaVirtualBlockCreateFlagBits.
-    typedef VkFlags VmaVirtualBlockCreateFlags;
+    The extension and accompanying device feature provide access to memory types with
+    `VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD` and `VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD` flags.
+    They are useful mostly for writing breadcrumb markers - a common method for debugging GPU crash/hang/TDR.
 
-    /// Flags to be passed as VmaVirtualAllocationCreateInfo::flags.
-    typedef enum VmaVirtualAllocationCreateFlagBits
-    {
-        /** \brief Allocation will be created from upper stack in a double stack pool.
+    When the extension is not enabled, such memory types are still enumerated, but their usage is illegal.
+    To protect from this error, if you don't create the allocator with this flag, it will refuse to allocate any memory or create a custom pool in such memory type,
+    returning `VK_ERROR_FEATURE_NOT_PRESENT`.
+    */
+    VMA_ALLOCATOR_CREATE_AMD_DEVICE_COHERENT_MEMORY_BIT = 0x00000010,
+    /**
+    Enables usage of "buffer device address" feature, which allows you to use function
+    `vkGetBufferDeviceAddress*` to get raw GPU pointer to a buffer and pass it for usage inside a shader.
 
-        This flag is only allowed for virtual blocks created with #VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT flag.
-        */
-        VMA_VIRTUAL_ALLOCATION_CREATE_UPPER_ADDRESS_BIT = VMA_ALLOCATION_CREATE_UPPER_ADDRESS_BIT,
-        /** \brief Allocation strategy that tries to minimize memory usage.
-         */
-        VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT,
-        /** \brief Allocation strategy that tries to minimize allocation time.
-         */
-        VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT,
-        /** Allocation strategy that chooses always the lowest offset in available space.
-        This is not the most efficient strategy but achieves highly packed data.
-        */
-        VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
-        /** \brief A bit mask to extract only `STRATEGY` bits from entire set of flags.
+    You may set this flag only if you:
 
-        These strategy flags are binary compatible with equivalent flags in #VmaAllocationCreateFlagBits.
-        */
-        VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MASK = VMA_ALLOCATION_CREATE_STRATEGY_MASK,
+    1. (For Vulkan version < 1.2) Found as available and enabled device extension
+    VK_KHR_buffer_device_address.
+    This extension is promoted to core Vulkan 1.2.
+    2. Found as available and enabled device feature `VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress`.
 
-        VMA_VIRTUAL_ALLOCATION_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
-    } VmaVirtualAllocationCreateFlagBits;
-    /// Flags to be passed as VmaVirtualAllocationCreateInfo::flags. See #VmaVirtualAllocationCreateFlagBits.
-    typedef VkFlags VmaVirtualAllocationCreateFlags;
+    When this flag is set, you can create buffers with `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` using VMA.
+    The library automatically adds `VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT` to
+    allocated memory blocks wherever it might be needed.
 
-    /** @} */
+    For more information, see documentation chapter \ref enabling_buffer_device_address.
+    */
+    VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT = 0x00000020,
+    /**
+    Enables usage of VK_EXT_memory_priority extension in the library.
+
+    You may set this flag only if you found available and enabled this device extension,
+    along with `VkPhysicalDeviceMemoryPriorityFeaturesEXT::memoryPriority == VK_TRUE`,
+    while creating Vulkan device passed as VmaAllocatorCreateInfo::device.
+
+    When this flag is used, VmaAllocationCreateInfo::priority and VmaPoolCreateInfo::priority
+    are used to set priorities of allocated Vulkan memory. Without it, these variables are ignored.
+
+    A priority must be a floating-point value between 0 and 1, indicating the priority of the allocation relative to other memory allocations.
+    Larger values are higher priority. The granularity of the priorities is implementation-dependent.
+    It is automatically passed to every call to `vkAllocateMemory` done by the library using structure `VkMemoryPriorityAllocateInfoEXT`.
+    The value to be used for default priority is 0.5.
+    For more details, see the documentation of the VK_EXT_memory_priority extension.
+    */
+    VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT = 0x00000040,
+
+    VMA_ALLOCATOR_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
+} VmaAllocatorCreateFlagBits;
+/// See #VmaAllocatorCreateFlagBits.
+typedef VkFlags VmaAllocatorCreateFlags;
+
+/** @} */
+
+/**
+\addtogroup group_alloc
+@{
+*/
+
+/// \brief Intended usage of the allocated memory.
+typedef enum VmaMemoryUsage
+{
+    /** No intended memory usage specified.
+    Use other members of VmaAllocationCreateInfo to specify your requirements.
+    */
+    VMA_MEMORY_USAGE_UNKNOWN = 0,
+    /**
+    \deprecated Obsolete, preserved for backward compatibility.
+    Prefers `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`.
+    */
+    VMA_MEMORY_USAGE_GPU_ONLY = 1,
+    /**
+    \deprecated Obsolete, preserved for backward compatibility.
+    Guarantees `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT` and `VK_MEMORY_PROPERTY_HOST_COHERENT_BIT`.
+    */
+    VMA_MEMORY_USAGE_CPU_ONLY = 2,
+    /**
+    \deprecated Obsolete, preserved for backward compatibility.
+    Guarantees `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT`, prefers `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`.
+    */
+    VMA_MEMORY_USAGE_CPU_TO_GPU = 3,
+    /**
+    \deprecated Obsolete, preserved for backward compatibility.
+    Guarantees `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT`, prefers `VK_MEMORY_PROPERTY_HOST_CACHED_BIT`.
+    */
+    VMA_MEMORY_USAGE_GPU_TO_CPU = 4,
+    /**
+    \deprecated Obsolete, preserved for backward compatibility.
+    Prefers not `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`.
+    */
+    VMA_MEMORY_USAGE_CPU_COPY = 5,
+    /**
+    Lazily allocated GPU memory having `VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT`.
+    Exists mostly on mobile platforms. Using it on desktop PC or other GPUs with no such memory type present will fail the allocation.
+
+    Usage: Memory for transient attachment images (color attachments, depth attachments etc.), created with `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT`.
+
+    Allocations with this usage are always created as dedicated - it implies #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
+    */
+    VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED = 6,
+    /**
+    Selects best memory type automatically.
+    This flag is recommended for most common use cases.
+
+    When using this flag, if you want to map the allocation (using vmaMapMemory() or #VMA_ALLOCATION_CREATE_MAPPED_BIT),
+    you must pass one of the flags: #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT
+    in VmaAllocationCreateInfo::flags.
+
+    It can be used only with functions that let the library know `VkBufferCreateInfo` or `VkImageCreateInfo`, e.g.
+    vmaCreateBuffer(), vmaCreateImage(), vmaFindMemoryTypeIndexForBufferInfo(), vmaFindMemoryTypeIndexForImageInfo()
+    and not with generic memory allocation functions.
+    */
+    VMA_MEMORY_USAGE_AUTO = 7,
+    /**
+    Selects best memory type automatically with preference for GPU (device) memory.
+
+    When using this flag, if you want to map the allocation (using vmaMapMemory() or #VMA_ALLOCATION_CREATE_MAPPED_BIT),
+    you must pass one of the flags: #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT
+    in VmaAllocationCreateInfo::flags.
+
+    It can be used only with functions that let the library know `VkBufferCreateInfo` or `VkImageCreateInfo`, e.g.
+    vmaCreateBuffer(), vmaCreateImage(), vmaFindMemoryTypeIndexForBufferInfo(), vmaFindMemoryTypeIndexForImageInfo()
+    and not with generic memory allocation functions.
+    */
+    VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE = 8,
+    /**
+    Selects best memory type automatically with preference for CPU (host) memory.
+
+    When using this flag, if you want to map the allocation (using vmaMapMemory() or #VMA_ALLOCATION_CREATE_MAPPED_BIT),
+    you must pass one of the flags: #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT
+    in VmaAllocationCreateInfo::flags.
+
+    It can be used only with functions that let the library know `VkBufferCreateInfo` or `VkImageCreateInfo`, e.g.
+    vmaCreateBuffer(), vmaCreateImage(), vmaFindMemoryTypeIndexForBufferInfo(), vmaFindMemoryTypeIndexForImageInfo()
+    and not with generic memory allocation functions.
+    */
+    VMA_MEMORY_USAGE_AUTO_PREFER_HOST = 9,
+
+    VMA_MEMORY_USAGE_MAX_ENUM = 0x7FFFFFFF
+} VmaMemoryUsage;
+
+/// Flags to be passed as VmaAllocationCreateInfo::flags.
+typedef enum VmaAllocationCreateFlagBits
+{
+    /** \brief Set this flag if the allocation should have its own memory block.
+
+    Use it for special, big resources, like fullscreen images used as attachments.
+    */
+    VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT = 0x00000001,
+
+    /** \brief Set this flag to only try to allocate from existing `VkDeviceMemory` blocks and never create new such block.
+
+    If new allocation cannot be placed in any of the existing blocks, allocation
+    fails with `VK_ERROR_OUT_OF_DEVICE_MEMORY` error.
+
+    You should not use #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT and
+    #VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT at the same time. It makes no sense.
+    */
+    VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT = 0x00000002,
+    /** \brief Set this flag to use a memory that will be persistently mapped and retrieve pointer to it.
+
+    Pointer to mapped memory will be returned through VmaAllocationInfo::pMappedData.
+
+    It is valid to use this flag for allocation made from memory type that is not
+    `HOST_VISIBLE`. This flag is then ignored and memory is not mapped. This is
+    useful if you need an allocation that is efficient to use on GPU
+    (`DEVICE_LOCAL`) and still want to map it directly if possible on platforms that
+    support it (e.g. Intel GPU).
+    */
+    VMA_ALLOCATION_CREATE_MAPPED_BIT = 0x00000004,
+    /** \deprecated Preserved for backward compatibility. Consider using vmaSetAllocationName() instead.
+
+    Set this flag to treat VmaAllocationCreateInfo::pUserData as pointer to a
+    null-terminated string. Instead of copying pointer value, a local copy of the
+    string is made and stored in allocation's `pName`. The string is automatically
+    freed together with the allocation. It is also used in vmaBuildStatsString().
+    */
+    VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT = 0x00000020,
+    /** Allocation will be created from upper stack in a double stack pool.
+
+    This flag is only allowed for custom pools created with #VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT flag.
+    */
+    VMA_ALLOCATION_CREATE_UPPER_ADDRESS_BIT = 0x00000040,
+    /** Create both buffer/image and allocation, but don't bind them together.
+    It is useful when you want to bind yourself to do some more advanced binding, e.g. using some extensions.
+    The flag is meaningful only with functions that bind by default: vmaCreateBuffer(), vmaCreateImage().
+    Otherwise it is ignored.
+
+    If you want to make sure the new buffer/image is not tied to the new memory allocation
+    through `VkMemoryDedicatedAllocateInfoKHR` structure in case the allocation ends up in its own memory block,
+    use also flag #VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT.
+    */
+    VMA_ALLOCATION_CREATE_DONT_BIND_BIT = 0x00000080,
+    /** Create allocation only if additional device memory required for it, if any, won't exceed
+    memory budget. Otherwise return `VK_ERROR_OUT_OF_DEVICE_MEMORY`.
+    */
+    VMA_ALLOCATION_CREATE_WITHIN_BUDGET_BIT = 0x00000100,
+    /** \brief Set this flag if the allocated memory will have aliasing resources.
+
+    Usage of this flag prevents supplying `VkMemoryDedicatedAllocateInfoKHR` when #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT is specified.
+    Otherwise created dedicated memory will not be suitable for aliasing resources, resulting in Vulkan Validation Layer errors.
+    */
+    VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT = 0x00000200,
+    /**
+    Requests possibility to map the allocation (using vmaMapMemory() or #VMA_ALLOCATION_CREATE_MAPPED_BIT).
+
+    - If you use #VMA_MEMORY_USAGE_AUTO or other `VMA_MEMORY_USAGE_AUTO*` value,
+      you must use this flag to be able to map the allocation. Otherwise, mapping is incorrect.
+    - If you use other value of #VmaMemoryUsage, this flag is ignored and mapping is always possible in memory types that are `HOST_VISIBLE`.
+      This includes allocations created in \ref custom_memory_pools.
+
+    Declares that mapped memory will only be written sequentially, e.g. using `memcpy()` or a loop writing number-by-number,
+    never read or accessed randomly, so a memory type can be selected that is uncached and write-combined.
+
+    \warning Violating this declaration may work correctly, but will likely be very slow.
+    Watch out for implicit reads introduced by doing e.g. `pMappedData[i] += x;`
+    Better prepare your data in a local variable and `memcpy()` it to the mapped pointer all at once.
+    */
+    VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT = 0x00000400,
+    /**
+    Requests possibility to map the allocation (using vmaMapMemory() or #VMA_ALLOCATION_CREATE_MAPPED_BIT).
+
+    - If you use #VMA_MEMORY_USAGE_AUTO or other `VMA_MEMORY_USAGE_AUTO*` value,
+      you must use this flag to be able to map the allocation. Otherwise, mapping is incorrect.
+    - If you use other value of #VmaMemoryUsage, this flag is ignored and mapping is always possible in memory types that are `HOST_VISIBLE`.
+      This includes allocations created in \ref custom_memory_pools.
+
+    Declares that mapped memory can be read, written, and accessed in random order,
+    so a `HOST_CACHED` memory type is required.
+    */
+    VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT = 0x00000800,
+    /**
+    Together with #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT,
+    it says that despite request for host access, a not-`HOST_VISIBLE` memory type can be selected
+    if it may improve performance.
+
+    By using this flag, you declare that you will check if the allocation ended up in a `HOST_VISIBLE` memory type
+    (e.g. using vmaGetAllocationMemoryProperties()) and if not, you will create some "staging" buffer and
+    issue an explicit transfer to write/read your data.
+    To prepare for this possibility, don't forget to add appropriate flags like
+    `VK_BUFFER_USAGE_TRANSFER_DST_BIT`, `VK_BUFFER_USAGE_TRANSFER_SRC_BIT` to the parameters of created buffer or image.
+    */
+    VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT = 0x00001000,
+    /** Allocation strategy that chooses smallest possible free range for the allocation
+    to minimize memory usage and fragmentation, possibly at the expense of allocation time.
+    */
+    VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT = 0x00010000,
+    /** Allocation strategy that chooses first suitable free range for the allocation -
+    not necessarily in terms of the smallest offset but the one that is easiest and fastest to find
+    to minimize allocation time, possibly at the expense of allocation quality.
+    */
+    VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT = 0x00020000,
+    /** Allocation strategy that chooses always the lowest offset in available space.
+    This is not the most efficient strategy but achieves highly packed data.
+    Used internally by defragmentation, not recommended in typical usage.
+    */
+    VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT  = 0x00040000,
+    /** Alias to #VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT.
+    */
+    VMA_ALLOCATION_CREATE_STRATEGY_BEST_FIT_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT,
+    /** Alias to #VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT.
+    */
+    VMA_ALLOCATION_CREATE_STRATEGY_FIRST_FIT_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT,
+    /** A bit mask to extract only `STRATEGY` bits from entire set of flags.
+    */
+    VMA_ALLOCATION_CREATE_STRATEGY_MASK =
+        VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT |
+        VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT |
+        VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
+
+    VMA_ALLOCATION_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
+} VmaAllocationCreateFlagBits;
+/// See #VmaAllocationCreateFlagBits.
+typedef VkFlags VmaAllocationCreateFlags;
+
+/// Flags to be passed as VmaPoolCreateInfo::flags.
+typedef enum VmaPoolCreateFlagBits
+{
+    /** \brief Use this flag if you always allocate only buffers and linear images or only optimal images out of this pool and so Buffer-Image Granularity can be ignored.
+
+    This is an optional optimization flag.
+
+    If you always allocate using vmaCreateBuffer(), vmaCreateImage(),
+    vmaAllocateMemoryForBuffer(), then you don't need to use it because allocator
+    knows exact type of your allocations so it can handle Buffer-Image Granularity
+    in the optimal way.
+
+    If you also allocate using vmaAllocateMemoryForImage() or vmaAllocateMemory(),
+    exact type of such allocations is not known, so allocator must be conservative
+    in handling Buffer-Image Granularity, which can lead to suboptimal allocation
+    (wasted memory). In that case, if you can make sure you always allocate only
+    buffers and linear images or only optimal images out of this pool, use this flag
+    to make allocator disregard Buffer-Image Granularity and so make allocations
+    faster and more optimal.
+    */
+    VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT = 0x00000002,
+
+    /** \brief Enables alternative, linear allocation algorithm in this pool.
+
+    Specify this flag to enable linear allocation algorithm, which always creates
+    new allocations after last one and doesn't reuse space from allocations freed in
+    between. It trades memory consumption for simplified algorithm and data
+    structure, which has better performance and uses less memory for metadata.
+
+    By using this flag, you can achieve behavior of free-at-once, stack,
+    ring buffer, and double stack.
+    For details, see documentation chapter \ref linear_algorithm.
+    */
+    VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT = 0x00000004,
+
+    /** Bit mask to extract only `ALGORITHM` bits from entire set of flags.
+    */
+    VMA_POOL_CREATE_ALGORITHM_MASK =
+        VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT,
+
+    VMA_POOL_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
+} VmaPoolCreateFlagBits;
+/// Flags to be passed as VmaPoolCreateInfo::flags. See #VmaPoolCreateFlagBits.
+typedef VkFlags VmaPoolCreateFlags;
+
+/// Flags to be passed as VmaDefragmentationInfo::flags.
+typedef enum VmaDefragmentationFlagBits
+{
+    /* \brief Use simple but fast algorithm for defragmentation.
+    May not achieve best results but will require least time to compute and least allocations to copy.
+    */
+    VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FAST_BIT = 0x1,
+    /* \brief Default defragmentation algorithm, applied also when no `ALGORITHM` flag is specified.
+    Offers a balance between defragmentation quality and the amount of allocations and bytes that need to be moved.
+    */
+    VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT = 0x2,
+    /* \brief Perform full defragmentation of memory.
+    Can result in notably more time to compute and allocations to copy, but will achieve best memory packing.
+    */
+    VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT = 0x4,
+    /** \brief Use the most roboust algorithm at the cost of time to compute and number of copies to make.
+    Only available when bufferImageGranularity is greater than 1, since it aims to reduce
+    alignment issues between different types of resources.
+    Otherwise falls back to same behavior as #VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT.
+    */
+    VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT = 0x8,
+
+    /// A bit mask to extract only `ALGORITHM` bits from entire set of flags.
+    VMA_DEFRAGMENTATION_FLAG_ALGORITHM_MASK =
+        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FAST_BIT |
+        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT |
+        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT |
+        VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT,
+
+    VMA_DEFRAGMENTATION_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
+} VmaDefragmentationFlagBits;
+/// See #VmaDefragmentationFlagBits.
+typedef VkFlags VmaDefragmentationFlags;
+
+/// Operation performed on single defragmentation move. See structure #VmaDefragmentationMove.
+typedef enum VmaDefragmentationMoveOperation
+{
+    /// Buffer/image has been recreated at `dstTmpAllocation`, data has been copied, old buffer/image has been destroyed. `srcAllocation` should be changed to point to the new place. This is the default value set by vmaBeginDefragmentationPass().
+    VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY = 0,
+    /// Set this value if you cannot move the allocation. New place reserved at `dstTmpAllocation` will be freed. `srcAllocation` will remain unchanged.
+    VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE = 1,
+    /// Set this value if you decide to abandon the allocation and you destroyed the buffer/image. New place reserved at `dstTmpAllocation` will be freed, along with `srcAllocation`, which will be destroyed.
+    VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY = 2,
+} VmaDefragmentationMoveOperation;
+
+/** @} */
+
+/**
+\addtogroup group_virtual
+@{
+*/
+
+/// Flags to be passed as VmaVirtualBlockCreateInfo::flags.
+typedef enum VmaVirtualBlockCreateFlagBits
+{
+    /** \brief Enables alternative, linear allocation algorithm in this virtual block.
+
+    Specify this flag to enable linear allocation algorithm, which always creates
+    new allocations after last one and doesn't reuse space from allocations freed in
+    between. It trades memory consumption for simplified algorithm and data
+    structure, which has better performance and uses less memory for metadata.
+
+    By using this flag, you can achieve behavior of free-at-once, stack,
+    ring buffer, and double stack.
+    For details, see documentation chapter \ref linear_algorithm.
+    */
+    VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT = 0x00000001,
+
+    /** \brief Bit mask to extract only `ALGORITHM` bits from entire set of flags.
+    */
+    VMA_VIRTUAL_BLOCK_CREATE_ALGORITHM_MASK =
+        VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT,
+
+    VMA_VIRTUAL_BLOCK_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
+} VmaVirtualBlockCreateFlagBits;
+/// Flags to be passed as VmaVirtualBlockCreateInfo::flags. See #VmaVirtualBlockCreateFlagBits.
+typedef VkFlags VmaVirtualBlockCreateFlags;
+
+/// Flags to be passed as VmaVirtualAllocationCreateInfo::flags.
+typedef enum VmaVirtualAllocationCreateFlagBits
+{
+    /** \brief Allocation will be created from upper stack in a double stack pool.
+
+    This flag is only allowed for virtual blocks created with #VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT flag.
+    */
+    VMA_VIRTUAL_ALLOCATION_CREATE_UPPER_ADDRESS_BIT = VMA_ALLOCATION_CREATE_UPPER_ADDRESS_BIT,
+    /** \brief Allocation strategy that tries to minimize memory usage.
+    */
+    VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT,
+    /** \brief Allocation strategy that tries to minimize allocation time.
+    */
+    VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT,
+    /** Allocation strategy that chooses always the lowest offset in available space.
+    This is not the most efficient strategy but achieves highly packed data.
+    */
+    VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT = VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
+    /** \brief A bit mask to extract only `STRATEGY` bits from entire set of flags.
+
+    These strategy flags are binary compatible with equivalent flags in #VmaAllocationCreateFlagBits.
+    */
+    VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MASK = VMA_ALLOCATION_CREATE_STRATEGY_MASK,
+
+    VMA_VIRTUAL_ALLOCATION_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
+} VmaVirtualAllocationCreateFlagBits;
+/// Flags to be passed as VmaVirtualAllocationCreateInfo::flags. See #VmaVirtualAllocationCreateFlagBits.
+typedef VkFlags VmaVirtualAllocationCreateFlags;
+
+/** @} */
 
 #endif // _VMA_ENUM_DECLARATIONS
 
 #ifndef _VMA_DATA_TYPES_DECLARATIONS
 
-    /**
-    \addtogroup group_init
-    @{ */
+/**
+\addtogroup group_init
+@{ */
 
-    /** \struct VmaAllocator
-    \brief Represents main object of this library initialized.
+/** \struct VmaAllocator
+\brief Represents main object of this library initialized.
 
-    Fill structure #VmaAllocatorCreateInfo and call function vmaCreateAllocator() to create it.
-    Call function vmaDestroyAllocator() to destroy it.
+Fill structure #VmaAllocatorCreateInfo and call function vmaCreateAllocator() to create it.
+Call function vmaDestroyAllocator() to destroy it.
 
-    It is recommended to create just one object of this type per `VkDevice` object,
-    right after Vulkan is initialized and keep it alive until before Vulkan device is destroyed.
-    */
-    VK_DEFINE_HANDLE(VmaAllocator)
+It is recommended to create just one object of this type per `VkDevice` object,
+right after Vulkan is initialized and keep it alive until before Vulkan device is destroyed.
+*/
+VK_DEFINE_HANDLE(VmaAllocator)
 
-    /** @} */
+/** @} */
 
-    /**
-    \addtogroup group_alloc
-    @{
-    */
+/**
+\addtogroup group_alloc
+@{
+*/
 
-    /** \struct VmaPool
-    \brief Represents custom memory pool
+/** \struct VmaPool
+\brief Represents custom memory pool
 
-    Fill structure VmaPoolCreateInfo and call function vmaCreatePool() to create it.
-    Call function vmaDestroyPool() to destroy it.
+Fill structure VmaPoolCreateInfo and call function vmaCreatePool() to create it.
+Call function vmaDestroyPool() to destroy it.
 
-    For more information see [Custom memory pools](@ref choosing_memory_type_custom_memory_pools).
-    */
-    VK_DEFINE_HANDLE(VmaPool)
+For more information see [Custom memory pools](@ref choosing_memory_type_custom_memory_pools).
+*/
+VK_DEFINE_HANDLE(VmaPool)
 
-    /** \struct VmaAllocation
-    \brief Represents single memory allocation.
+/** \struct VmaAllocation
+\brief Represents single memory allocation.
 
-    It may be either dedicated block of `VkDeviceMemory` or a specific region of a bigger block of this type
-    plus unique offset.
+It may be either dedicated block of `VkDeviceMemory` or a specific region of a bigger block of this type
+plus unique offset.
 
-    There are multiple ways to create such object.
-    You need to fill structure VmaAllocationCreateInfo.
-    For more information see [Choosing memory type](@ref choosing_memory_type).
+There are multiple ways to create such object.
+You need to fill structure VmaAllocationCreateInfo.
+For more information see [Choosing memory type](@ref choosing_memory_type).
 
-    Although the library provides convenience functions that create Vulkan buffer or image,
-    allocate memory for it and bind them together,
-    binding of the allocation to a buffer or an image is out of scope of the allocation itself.
-    Allocation object can exist without buffer/image bound,
-    binding can be done manually by the user, and destruction of it can be done
-    independently of destruction of the allocation.
+Although the library provides convenience functions that create Vulkan buffer or image,
+allocate memory for it and bind them together,
+binding of the allocation to a buffer or an image is out of scope of the allocation itself.
+Allocation object can exist without buffer/image bound,
+binding can be done manually by the user, and destruction of it can be done
+independently of destruction of the allocation.
 
-    The object also remembers its size and some other information.
-    To retrieve this information, use function vmaGetAllocationInfo() and inspect
-    returned structure VmaAllocationInfo.
-    */
-    VK_DEFINE_HANDLE(VmaAllocation)
+The object also remembers its size and some other information.
+To retrieve this information, use function vmaGetAllocationInfo() and inspect
+returned structure VmaAllocationInfo.
+*/
+VK_DEFINE_HANDLE(VmaAllocation)
 
-    /** \struct VmaDefragmentationContext
-    \brief An opaque object that represents started defragmentation process.
+/** \struct VmaDefragmentationContext
+\brief An opaque object that represents started defragmentation process.
 
-    Fill structure #VmaDefragmentationInfo and call function vmaBeginDefragmentation() to create it.
-    Call function vmaEndDefragmentation() to destroy it.
-    */
-    VK_DEFINE_HANDLE(VmaDefragmentationContext)
+Fill structure #VmaDefragmentationInfo and call function vmaBeginDefragmentation() to create it.
+Call function vmaEndDefragmentation() to destroy it.
+*/
+VK_DEFINE_HANDLE(VmaDefragmentationContext)
 
-    /** @} */
+/** @} */
 
-    /**
-    \addtogroup group_virtual
-    @{
-    */
+/**
+\addtogroup group_virtual
+@{
+*/
 
-    /** \struct VmaVirtualAllocation
-    \brief Represents single memory allocation done inside VmaVirtualBlock.
+/** \struct VmaVirtualAllocation
+\brief Represents single memory allocation done inside VmaVirtualBlock.
 
-    Use it as a unique identifier to virtual allocation within the single block.
+Use it as a unique identifier to virtual allocation within the single block.
 
-    Use value `VK_NULL_HANDLE` to represent a null/invalid allocation.
-    */
-    VK_DEFINE_NON_DISPATCHABLE_HANDLE(VmaVirtualAllocation);
+Use value `VK_NULL_HANDLE` to represent a null/invalid allocation.
+*/
+VK_DEFINE_NON_DISPATCHABLE_HANDLE(VmaVirtualAllocation)
 
-    /** @} */
+/** @} */
 
-    /**
-    \addtogroup group_virtual
-    @{
-    */
+/**
+\addtogroup group_virtual
+@{
+*/
 
-    /** \struct VmaVirtualBlock
-    \brief Handle to a virtual block object that allows to use core allocation algorithm without allocating any real GPU
-    memory.
+/** \struct VmaVirtualBlock
+\brief Handle to a virtual block object that allows to use core allocation algorithm without allocating any real GPU memory.
 
-    Fill in #VmaVirtualBlockCreateInfo structure and use vmaCreateVirtualBlock() to create it. Use
-    vmaDestroyVirtualBlock() to destroy it. For more information, see documentation chapter \ref virtual_allocator.
+Fill in #VmaVirtualBlockCreateInfo structure and use vmaCreateVirtualBlock() to create it. Use vmaDestroyVirtualBlock() to destroy it.
+For more information, see documentation chapter \ref virtual_allocator.
 
-    This object is not thread-safe - should not be used from multiple threads simultaneously, must be synchronized
-    externally.
-    */
-    VK_DEFINE_HANDLE(VmaVirtualBlock)
+This object is not thread-safe - should not be used from multiple threads simultaneously, must be synchronized externally.
+*/
+VK_DEFINE_HANDLE(VmaVirtualBlock)
 
-    /** @} */
+/** @} */
 
-    /**
-    \addtogroup group_init
-    @{
-    */
+/**
+\addtogroup group_init
+@{
+*/
 
-    /// Callback function called after successful vkAllocateMemory.
-    typedef void(VKAPI_PTR* PFN_vmaAllocateDeviceMemoryFunction)(VmaAllocator VMA_NOT_NULL allocator,
-                                                                 uint32_t                  memoryType,
-                                                                 VkDeviceMemory VMA_NOT_NULL_NON_DISPATCHABLE memory,
-                                                                 VkDeviceSize                                 size,
-                                                                 void* VMA_NULLABLE pUserData);
+/// Callback function called after successful vkAllocateMemory.
+typedef void (VKAPI_PTR* PFN_vmaAllocateDeviceMemoryFunction)(
+    VmaAllocator VMA_NOT_NULL                    allocator,
+    uint32_t                                     memoryType,
+    VkDeviceMemory VMA_NOT_NULL_NON_DISPATCHABLE memory,
+    VkDeviceSize                                 size,
+    void* VMA_NULLABLE                           pUserData);
 
-    /// Callback function called before vkFreeMemory.
-    typedef void(VKAPI_PTR* PFN_vmaFreeDeviceMemoryFunction)(VmaAllocator VMA_NOT_NULL                    allocator,
-                                                             uint32_t                                     memoryType,
-                                                             VkDeviceMemory VMA_NOT_NULL_NON_DISPATCHABLE memory,
-                                                             VkDeviceSize                                 size,
-                                                             void* VMA_NULLABLE                           pUserData);
+/// Callback function called before vkFreeMemory.
+typedef void (VKAPI_PTR* PFN_vmaFreeDeviceMemoryFunction)(
+    VmaAllocator VMA_NOT_NULL                    allocator,
+    uint32_t                                     memoryType,
+    VkDeviceMemory VMA_NOT_NULL_NON_DISPATCHABLE memory,
+    VkDeviceSize                                 size,
+    void* VMA_NULLABLE                           pUserData);
 
-    /** \brief Set of callbacks that the library will call for `vkAllocateMemory` and `vkFreeMemory`.
+/** \brief Set of callbacks that the library will call for `vkAllocateMemory` and `vkFreeMemory`.
 
-    Provided for informative purpose, e.g. to gather statistics about number of
-    allocations or total amount of memory allocated in Vulkan.
+Provided for informative purpose, e.g. to gather statistics about number of
+allocations or total amount of memory allocated in Vulkan.
 
-    Used in VmaAllocatorCreateInfo::pDeviceMemoryCallbacks.
-    */
-    typedef struct VmaDeviceMemoryCallbacks
-    {
-        /// Optional, can be null.
-        PFN_vmaAllocateDeviceMemoryFunction VMA_NULLABLE pfnAllocate;
-        /// Optional, can be null.
-        PFN_vmaFreeDeviceMemoryFunction VMA_NULLABLE pfnFree;
-        /// Optional, can be null.
-        void* VMA_NULLABLE pUserData;
-    } VmaDeviceMemoryCallbacks;
+Used in VmaAllocatorCreateInfo::pDeviceMemoryCallbacks.
+*/
+typedef struct VmaDeviceMemoryCallbacks
+{
+    /// Optional, can be null.
+    PFN_vmaAllocateDeviceMemoryFunction VMA_NULLABLE pfnAllocate;
+    /// Optional, can be null.
+    PFN_vmaFreeDeviceMemoryFunction VMA_NULLABLE pfnFree;
+    /// Optional, can be null.
+    void* VMA_NULLABLE pUserData;
+} VmaDeviceMemoryCallbacks;
 
-    /** \brief Pointers to some Vulkan functions - a subset used by the library.
+/** \brief Pointers to some Vulkan functions - a subset used by the library.
 
-    Used in VmaAllocatorCreateInfo::pVulkanFunctions.
-    */
-    typedef struct VmaVulkanFunctions
-    {
-        /// Required when using VMA_DYNAMIC_VULKAN_FUNCTIONS.
-        PFN_vkGetInstanceProcAddr VMA_NULLABLE vkGetInstanceProcAddr;
-        /// Required when using VMA_DYNAMIC_VULKAN_FUNCTIONS.
-        PFN_vkGetDeviceProcAddr VMA_NULLABLE                 vkGetDeviceProcAddr;
-        PFN_vkGetPhysicalDeviceProperties VMA_NULLABLE       vkGetPhysicalDeviceProperties;
-        PFN_vkGetPhysicalDeviceMemoryProperties VMA_NULLABLE vkGetPhysicalDeviceMemoryProperties;
-        PFN_vkAllocateMemory VMA_NULLABLE                    vkAllocateMemory;
-        PFN_vkFreeMemory VMA_NULLABLE                        vkFreeMemory;
-        PFN_vkMapMemory VMA_NULLABLE                         vkMapMemory;
-        PFN_vkUnmapMemory VMA_NULLABLE                       vkUnmapMemory;
-        PFN_vkFlushMappedMemoryRanges VMA_NULLABLE           vkFlushMappedMemoryRanges;
-        PFN_vkInvalidateMappedMemoryRanges VMA_NULLABLE      vkInvalidateMappedMemoryRanges;
-        PFN_vkBindBufferMemory VMA_NULLABLE                  vkBindBufferMemory;
-        PFN_vkBindImageMemory VMA_NULLABLE                   vkBindImageMemory;
-        PFN_vkGetBufferMemoryRequirements VMA_NULLABLE       vkGetBufferMemoryRequirements;
-        PFN_vkGetImageMemoryRequirements VMA_NULLABLE        vkGetImageMemoryRequirements;
-        PFN_vkCreateBuffer VMA_NULLABLE                      vkCreateBuffer;
-        PFN_vkDestroyBuffer VMA_NULLABLE                     vkDestroyBuffer;
-        PFN_vkCreateImage VMA_NULLABLE                       vkCreateImage;
-        PFN_vkDestroyImage VMA_NULLABLE                      vkDestroyImage;
-        PFN_vkCmdCopyBuffer VMA_NULLABLE                     vkCmdCopyBuffer;
+Used in VmaAllocatorCreateInfo::pVulkanFunctions.
+*/
+typedef struct VmaVulkanFunctions
+{
+    /// Required when using VMA_DYNAMIC_VULKAN_FUNCTIONS.
+    PFN_vkGetInstanceProcAddr VMA_NULLABLE vkGetInstanceProcAddr;
+    /// Required when using VMA_DYNAMIC_VULKAN_FUNCTIONS.
+    PFN_vkGetDeviceProcAddr VMA_NULLABLE vkGetDeviceProcAddr;
+    PFN_vkGetPhysicalDeviceProperties VMA_NULLABLE vkGetPhysicalDeviceProperties;
+    PFN_vkGetPhysicalDeviceMemoryProperties VMA_NULLABLE vkGetPhysicalDeviceMemoryProperties;
+    PFN_vkAllocateMemory VMA_NULLABLE vkAllocateMemory;
+    PFN_vkFreeMemory VMA_NULLABLE vkFreeMemory;
+    PFN_vkMapMemory VMA_NULLABLE vkMapMemory;
+    PFN_vkUnmapMemory VMA_NULLABLE vkUnmapMemory;
+    PFN_vkFlushMappedMemoryRanges VMA_NULLABLE vkFlushMappedMemoryRanges;
+    PFN_vkInvalidateMappedMemoryRanges VMA_NULLABLE vkInvalidateMappedMemoryRanges;
+    PFN_vkBindBufferMemory VMA_NULLABLE vkBindBufferMemory;
+    PFN_vkBindImageMemory VMA_NULLABLE vkBindImageMemory;
+    PFN_vkGetBufferMemoryRequirements VMA_NULLABLE vkGetBufferMemoryRequirements;
+    PFN_vkGetImageMemoryRequirements VMA_NULLABLE vkGetImageMemoryRequirements;
+    PFN_vkCreateBuffer VMA_NULLABLE vkCreateBuffer;
+    PFN_vkDestroyBuffer VMA_NULLABLE vkDestroyBuffer;
+    PFN_vkCreateImage VMA_NULLABLE vkCreateImage;
+    PFN_vkDestroyImage VMA_NULLABLE vkDestroyImage;
+    PFN_vkCmdCopyBuffer VMA_NULLABLE vkCmdCopyBuffer;
 #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
-        /// Fetch "vkGetBufferMemoryRequirements2" on Vulkan >= 1.1, fetch "vkGetBufferMemoryRequirements2KHR" when
-        /// using VK_KHR_dedicated_allocation extension.
-        PFN_vkGetBufferMemoryRequirements2KHR VMA_NULLABLE vkGetBufferMemoryRequirements2KHR;
-        /// Fetch "vkGetImageMemoryRequirements2" on Vulkan >= 1.1, fetch "vkGetImageMemoryRequirements2KHR" when using
-        /// VK_KHR_dedicated_allocation extension.
-        PFN_vkGetImageMemoryRequirements2KHR VMA_NULLABLE vkGetImageMemoryRequirements2KHR;
+    /// Fetch "vkGetBufferMemoryRequirements2" on Vulkan >= 1.1, fetch "vkGetBufferMemoryRequirements2KHR" when using VK_KHR_dedicated_allocation extension.
+    PFN_vkGetBufferMemoryRequirements2KHR VMA_NULLABLE vkGetBufferMemoryRequirements2KHR;
+    /// Fetch "vkGetImageMemoryRequirements2" on Vulkan >= 1.1, fetch "vkGetImageMemoryRequirements2KHR" when using VK_KHR_dedicated_allocation extension.
+    PFN_vkGetImageMemoryRequirements2KHR VMA_NULLABLE vkGetImageMemoryRequirements2KHR;
 #endif
 #if VMA_BIND_MEMORY2 || VMA_VULKAN_VERSION >= 1001000
-        /// Fetch "vkBindBufferMemory2" on Vulkan >= 1.1, fetch "vkBindBufferMemory2KHR" when using VK_KHR_bind_memory2
-        /// extension.
-        PFN_vkBindBufferMemory2KHR VMA_NULLABLE vkBindBufferMemory2KHR;
-        /// Fetch "vkBindImageMemory2" on Vulkan >= 1.1, fetch "vkBindImageMemory2KHR" when using VK_KHR_bind_memory2
-        /// extension.
-        PFN_vkBindImageMemory2KHR VMA_NULLABLE vkBindImageMemory2KHR;
+    /// Fetch "vkBindBufferMemory2" on Vulkan >= 1.1, fetch "vkBindBufferMemory2KHR" when using VK_KHR_bind_memory2 extension.
+    PFN_vkBindBufferMemory2KHR VMA_NULLABLE vkBindBufferMemory2KHR;
+    /// Fetch "vkBindImageMemory2" on Vulkan >= 1.1, fetch "vkBindImageMemory2KHR" when using VK_KHR_bind_memory2 extension.
+    PFN_vkBindImageMemory2KHR VMA_NULLABLE vkBindImageMemory2KHR;
 #endif
 #if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
-        PFN_vkGetPhysicalDeviceMemoryProperties2KHR VMA_NULLABLE vkGetPhysicalDeviceMemoryProperties2KHR;
+    PFN_vkGetPhysicalDeviceMemoryProperties2KHR VMA_NULLABLE vkGetPhysicalDeviceMemoryProperties2KHR;
 #endif
 #if VMA_VULKAN_VERSION >= 1003000
-        /// Fetch from "vkGetDeviceBufferMemoryRequirements" on Vulkan >= 1.3, but you can also fetch it from
-        /// "vkGetDeviceBufferMemoryRequirementsKHR" if you enabled extension VK_KHR_maintenance4.
-        PFN_vkGetDeviceBufferMemoryRequirements VMA_NULLABLE vkGetDeviceBufferMemoryRequirements;
-        /// Fetch from "vkGetDeviceImageMemoryRequirements" on Vulkan >= 1.3, but you can also fetch it from
-        /// "vkGetDeviceImageMemoryRequirementsKHR" if you enabled extension VK_KHR_maintenance4.
-        PFN_vkGetDeviceImageMemoryRequirements VMA_NULLABLE vkGetDeviceImageMemoryRequirements;
+    /// Fetch from "vkGetDeviceBufferMemoryRequirements" on Vulkan >= 1.3, but you can also fetch it from "vkGetDeviceBufferMemoryRequirementsKHR" if you enabled extension VK_KHR_maintenance4.
+    PFN_vkGetDeviceBufferMemoryRequirements VMA_NULLABLE vkGetDeviceBufferMemoryRequirements;
+    /// Fetch from "vkGetDeviceImageMemoryRequirements" on Vulkan >= 1.3, but you can also fetch it from "vkGetDeviceImageMemoryRequirementsKHR" if you enabled extension VK_KHR_maintenance4.
+    PFN_vkGetDeviceImageMemoryRequirements VMA_NULLABLE vkGetDeviceImageMemoryRequirements;
 #endif
-    } VmaVulkanFunctions;
+} VmaVulkanFunctions;
 
-    /// Description of a Allocator to be created.
-    typedef struct VmaAllocatorCreateInfo
-    {
-        /// Flags for created allocator. Use #VmaAllocatorCreateFlagBits enum.
-        VmaAllocatorCreateFlags flags;
-        /// Vulkan physical device.
-        /** It must be valid throughout whole lifetime of created allocator. */
-        VkPhysicalDevice VMA_NOT_NULL physicalDevice;
-        /// Vulkan device.
-        /** It must be valid throughout whole lifetime of created allocator. */
-        VkDevice VMA_NOT_NULL device;
-        /// Preferred size of a single `VkDeviceMemory` block to be allocated from large heaps > 1 GiB. Optional.
-        /** Set to 0 to use default, which is currently 256 MiB. */
-        VkDeviceSize preferredLargeHeapBlockSize;
-        /// Custom CPU memory allocation callbacks. Optional.
-        /** Optional, can be null. When specified, will also be used for all CPU-side memory allocations. */
-        const VkAllocationCallbacks* VMA_NULLABLE pAllocationCallbacks;
-        /// Informative callbacks for `vkAllocateMemory`, `vkFreeMemory`. Optional.
-        /** Optional, can be null. */
-        const VmaDeviceMemoryCallbacks* VMA_NULLABLE pDeviceMemoryCallbacks;
-        /** \brief Either null or a pointer to an array of limits on maximum number of bytes that can be allocated out
-        of particular Vulkan memory heap.
+/// Description of a Allocator to be created.
+typedef struct VmaAllocatorCreateInfo
+{
+    /// Flags for created allocator. Use #VmaAllocatorCreateFlagBits enum.
+    VmaAllocatorCreateFlags flags;
+    /// Vulkan physical device.
+    /** It must be valid throughout whole lifetime of created allocator. */
+    VkPhysicalDevice VMA_NOT_NULL physicalDevice;
+    /// Vulkan device.
+    /** It must be valid throughout whole lifetime of created allocator. */
+    VkDevice VMA_NOT_NULL device;
+    /// Preferred size of a single `VkDeviceMemory` block to be allocated from large heaps > 1 GiB. Optional.
+    /** Set to 0 to use default, which is currently 256 MiB. */
+    VkDeviceSize preferredLargeHeapBlockSize;
+    /// Custom CPU memory allocation callbacks. Optional.
+    /** Optional, can be null. When specified, will also be used for all CPU-side memory allocations. */
+    const VkAllocationCallbacks* VMA_NULLABLE pAllocationCallbacks;
+    /// Informative callbacks for `vkAllocateMemory`, `vkFreeMemory`. Optional.
+    /** Optional, can be null. */
+    const VmaDeviceMemoryCallbacks* VMA_NULLABLE pDeviceMemoryCallbacks;
+    /** \brief Either null or a pointer to an array of limits on maximum number of bytes that can be allocated out of particular Vulkan memory heap.
 
-        If not NULL, it must be a pointer to an array of
-        `VkPhysicalDeviceMemoryProperties::memoryHeapCount` elements, defining limit on
-        maximum number of bytes that can be allocated out of particular Vulkan memory
-        heap.
+    If not NULL, it must be a pointer to an array of
+    `VkPhysicalDeviceMemoryProperties::memoryHeapCount` elements, defining limit on
+    maximum number of bytes that can be allocated out of particular Vulkan memory
+    heap.
 
-        Any of the elements may be equal to `VK_WHOLE_SIZE`, which means no limit on that
-        heap. This is also the default in case of `pHeapSizeLimit` = NULL.
+    Any of the elements may be equal to `VK_WHOLE_SIZE`, which means no limit on that
+    heap. This is also the default in case of `pHeapSizeLimit` = NULL.
 
-        If there is a limit defined for a heap:
+    If there is a limit defined for a heap:
 
-        - If user tries to allocate more memory from that heap using this allocator,
-          the allocation fails with `VK_ERROR_OUT_OF_DEVICE_MEMORY`.
-        - If the limit is smaller than heap size reported in `VkMemoryHeap::size`, the
-          value of this limit will be reported instead when using vmaGetMemoryProperties().
+    - If user tries to allocate more memory from that heap using this allocator,
+      the allocation fails with `VK_ERROR_OUT_OF_DEVICE_MEMORY`.
+    - If the limit is smaller than heap size reported in `VkMemoryHeap::size`, the
+      value of this limit will be reported instead when using vmaGetMemoryProperties().
 
-        Warning! Using this feature may not be equivalent to installing a GPU with
-        smaller amount of memory, because graphics driver doesn't necessary fail new
-        allocations with `VK_ERROR_OUT_OF_DEVICE_MEMORY` result when memory capacity is
-        exceeded. It may return success and just silently migrate some device memory
-        blocks to system RAM. This driver behavior can also be controlled using
-        VK_AMD_memory_overallocation_behavior extension.
-        */
-        const VkDeviceSize*
-            VMA_NULLABLE VMA_LEN_IF_NOT_NULL("VkPhysicalDeviceMemoryProperties::memoryHeapCount") pHeapSizeLimit;
+    Warning! Using this feature may not be equivalent to installing a GPU with
+    smaller amount of memory, because graphics driver doesn't necessary fail new
+    allocations with `VK_ERROR_OUT_OF_DEVICE_MEMORY` result when memory capacity is
+    exceeded. It may return success and just silently migrate some device memory
+    blocks to system RAM. This driver behavior can also be controlled using
+    VK_AMD_memory_overallocation_behavior extension.
+    */
+    const VkDeviceSize* VMA_NULLABLE VMA_LEN_IF_NOT_NULL("VkPhysicalDeviceMemoryProperties::memoryHeapCount") pHeapSizeLimit;
 
-        /** \brief Pointers to Vulkan functions. Can be null.
+    /** \brief Pointers to Vulkan functions. Can be null.
 
-        For details see [Pointers to Vulkan functions](@ref config_Vulkan_functions).
-        */
-        const VmaVulkanFunctions* VMA_NULLABLE pVulkanFunctions;
-        /** \brief Handle to Vulkan instance object.
+    For details see [Pointers to Vulkan functions](@ref config_Vulkan_functions).
+    */
+    const VmaVulkanFunctions* VMA_NULLABLE pVulkanFunctions;
+    /** \brief Handle to Vulkan instance object.
 
-        Starting from version 3.0.0 this member is no longer optional, it must be set!
-        */
-        VkInstance VMA_NOT_NULL instance;
-        /** \brief Optional. The highest version of Vulkan that the application is designed to use.
+    Starting from version 3.0.0 this member is no longer optional, it must be set!
+    */
+    VkInstance VMA_NOT_NULL instance;
+    /** \brief Optional. The highest version of Vulkan that the application is designed to use.
 
-        It must be a value in the format as created by macro `VK_MAKE_VERSION` or a constant like: `VK_API_VERSION_1_1`,
-        `VK_API_VERSION_1_0`. The patch version number specified is ignored. Only the major and minor versions are
-        considered. It must be less or equal (preferably equal) to value as passed to `vkCreateInstance` as
-        `VkApplicationInfo::apiVersion`. Only versions 1.0, 1.1, 1.2, 1.3 are supported by the current implementation.
-        Leaving it initialized to zero is equivalent to `VK_API_VERSION_1_0`.
-        */
-        uint32_t vulkanApiVersion;
+    It must be a value in the format as created by macro `VK_MAKE_VERSION` or a constant like: `VK_API_VERSION_1_1`, `VK_API_VERSION_1_0`.
+    The patch version number specified is ignored. Only the major and minor versions are considered.
+    It must be less or equal (preferably equal) to value as passed to `vkCreateInstance` as `VkApplicationInfo::apiVersion`.
+    Only versions 1.0, 1.1, 1.2, 1.3 are supported by the current implementation.
+    Leaving it initialized to zero is equivalent to `VK_API_VERSION_1_0`.
+    */
+    uint32_t vulkanApiVersion;
 #if VMA_EXTERNAL_MEMORY
-        /** \brief Either null or a pointer to an array of external memory handle types for each Vulkan memory type.
+    /** \brief Either null or a pointer to an array of external memory handle types for each Vulkan memory type.
 
-        If not NULL, it must be a pointer to an array of `VkPhysicalDeviceMemoryProperties::memoryTypeCount`
-        elements, defining external memory handle types of particular Vulkan memory type,
-        to be passed using `VkExportMemoryAllocateInfoKHR`.
+    If not NULL, it must be a pointer to an array of `VkPhysicalDeviceMemoryProperties::memoryTypeCount`
+    elements, defining external memory handle types of particular Vulkan memory type,
+    to be passed using `VkExportMemoryAllocateInfoKHR`.
 
-        Any of the elements may be equal to 0, which means not to use `VkExportMemoryAllocateInfoKHR` on this memory
-        type. This is also the default in case of `pTypeExternalMemoryHandleTypes` = NULL.
-        */
-        const VkExternalMemoryHandleTypeFlagsKHR* VMA_NULLABLE
-            VMA_LEN_IF_NOT_NULL("VkPhysicalDeviceMemoryProperties::memoryTypeCount") pTypeExternalMemoryHandleTypes;
+    Any of the elements may be equal to 0, which means not to use `VkExportMemoryAllocateInfoKHR` on this memory type.
+    This is also the default in case of `pTypeExternalMemoryHandleTypes` = NULL.
+    */
+    const VkExternalMemoryHandleTypeFlagsKHR* VMA_NULLABLE VMA_LEN_IF_NOT_NULL("VkPhysicalDeviceMemoryProperties::memoryTypeCount") pTypeExternalMemoryHandleTypes;
 #endif // #if VMA_EXTERNAL_MEMORY
-    } VmaAllocatorCreateInfo;
+} VmaAllocatorCreateInfo;
 
-    /// Information about existing #VmaAllocator object.
-    typedef struct VmaAllocatorInfo
-    {
-        /** \brief Handle to Vulkan instance object.
+/// Information about existing #VmaAllocator object.
+typedef struct VmaAllocatorInfo
+{
+    /** \brief Handle to Vulkan instance object.
 
-        This is the same value as has been passed through VmaAllocatorCreateInfo::instance.
-        */
-        VkInstance VMA_NOT_NULL instance;
-        /** \brief Handle to Vulkan physical device object.
-
-        This is the same value as has been passed through VmaAllocatorCreateInfo::physicalDevice.
-        */
-        VkPhysicalDevice VMA_NOT_NULL physicalDevice;
-        /** \brief Handle to Vulkan device object.
-
-        This is the same value as has been passed through VmaAllocatorCreateInfo::device.
-        */
-        VkDevice VMA_NOT_NULL device;
-    } VmaAllocatorInfo;
-
-    /** @} */
-
-    /**
-    \addtogroup group_stats
-    @{
+    This is the same value as has been passed through VmaAllocatorCreateInfo::instance.
     */
+    VkInstance VMA_NOT_NULL instance;
+    /** \brief Handle to Vulkan physical device object.
 
-    /** \brief Calculated statistics of memory usage e.g. in a specific memory type, heap, custom pool, or total.
-
-    These are fast to calculate.
-    See functions: vmaGetHeapBudgets(), vmaGetPoolStatistics().
+    This is the same value as has been passed through VmaAllocatorCreateInfo::physicalDevice.
     */
-    typedef struct VmaStatistics
-    {
-        /** \brief Number of `VkDeviceMemory` objects - Vulkan memory blocks allocated.
-         */
-        uint32_t blockCount;
-        /** \brief Number of #VmaAllocation objects allocated.
+    VkPhysicalDevice VMA_NOT_NULL physicalDevice;
+    /** \brief Handle to Vulkan device object.
 
-        Dedicated allocations have their own blocks, so each one adds 1 to `allocationCount` as well as `blockCount`.
-        */
-        uint32_t allocationCount;
-        /** \brief Number of bytes allocated in `VkDeviceMemory` blocks.
-
-        \note To avoid confusion, please be aware that what Vulkan calls an "allocation" - a whole `VkDeviceMemory`
-        object (e.g. as in `VkPhysicalDeviceLimits::maxMemoryAllocationCount`) is called a "block" in VMA, while VMA
-        calls "allocation" a #VmaAllocation object that represents a memory region sub-allocated from such block,
-        usually for a single buffer or image.
-        */
-        VkDeviceSize blockBytes;
-        /** \brief Total number of bytes occupied by all #VmaAllocation objects.
-
-        Always less or equal than `blockBytes`.
-        Difference `(blockBytes - allocationBytes)` is the amount of memory allocated from Vulkan
-        but unused by any #VmaAllocation.
-        */
-        VkDeviceSize allocationBytes;
-    } VmaStatistics;
-
-    /** \brief More detailed statistics than #VmaStatistics.
-
-    These are slower to calculate. Use for debugging purposes.
-    See functions: vmaCalculateStatistics(), vmaCalculatePoolStatistics().
-
-    Previous version of the statistics API provided averages, but they have been removed
-    because they can be easily calculated as:
-
-    \code
-    VkDeviceSize allocationSizeAvg = detailedStats.statistics.allocationBytes /
-    detailedStats.statistics.allocationCount; VkDeviceSize unusedBytes = detailedStats.statistics.blockBytes -
-    detailedStats.statistics.allocationBytes; VkDeviceSize unusedRangeSizeAvg = unusedBytes /
-    detailedStats.unusedRangeCount; \endcode
+    This is the same value as has been passed through VmaAllocatorCreateInfo::device.
     */
-    typedef struct VmaDetailedStatistics
-    {
-        /// Basic statistics.
-        VmaStatistics statistics;
-        /// Number of free ranges of memory between allocations.
-        uint32_t unusedRangeCount;
-        /// Smallest allocation size. `VK_WHOLE_SIZE` if there are 0 allocations.
-        VkDeviceSize allocationSizeMin;
-        /// Largest allocation size. 0 if there are 0 allocations.
-        VkDeviceSize allocationSizeMax;
-        /// Smallest empty range size. `VK_WHOLE_SIZE` if there are 0 empty ranges.
-        VkDeviceSize unusedRangeSizeMin;
-        /// Largest empty range size. 0 if there are 0 empty ranges.
-        VkDeviceSize unusedRangeSizeMax;
-    } VmaDetailedStatistics;
+    VkDevice VMA_NOT_NULL device;
+} VmaAllocatorInfo;
 
-    /** \brief  General statistics from current state of the Allocator -
-    total memory usage across all memory heaps and types.
+/** @} */
 
-    These are slower to calculate. Use for debugging purposes.
-    See function vmaCalculateStatistics().
+/**
+\addtogroup group_stats
+@{
+*/
+
+/** \brief Calculated statistics of memory usage e.g. in a specific memory type, heap, custom pool, or total.
+
+These are fast to calculate.
+See functions: vmaGetHeapBudgets(), vmaGetPoolStatistics().
+*/
+typedef struct VmaStatistics
+{
+    /** \brief Number of `VkDeviceMemory` objects - Vulkan memory blocks allocated.
     */
-    typedef struct VmaTotalStatistics
-    {
-        VmaDetailedStatistics memoryType[VK_MAX_MEMORY_TYPES];
-        VmaDetailedStatistics memoryHeap[VK_MAX_MEMORY_HEAPS];
-        VmaDetailedStatistics total;
-    } VmaTotalStatistics;
+    uint32_t blockCount;
+    /** \brief Number of #VmaAllocation objects allocated.
 
-    /** \brief Statistics of current memory usage and available budget for a specific memory heap.
-
-    These are fast to calculate.
-    See function vmaGetHeapBudgets().
+    Dedicated allocations have their own blocks, so each one adds 1 to `allocationCount` as well as `blockCount`.
     */
-    typedef struct VmaBudget
-    {
-        /** \brief Statistics fetched from the library.
-         */
-        VmaStatistics statistics;
-        /** \brief Estimated current memory usage of the program, in bytes.
+    uint32_t allocationCount;
+    /** \brief Number of bytes allocated in `VkDeviceMemory` blocks.
 
-        Fetched from system using VK_EXT_memory_budget extension if enabled.
-
-        It might be different than `statistics.blockBytes` (usually higher) due to additional implicit objects
-        also occupying the memory, like swapchain, pipelines, descriptor heaps, command buffers, or
-        `VkDeviceMemory` blocks allocated outside of this library, if any.
-        */
-        VkDeviceSize usage;
-        /** \brief Estimated amount of memory available to the program, in bytes.
-
-        Fetched from system using VK_EXT_memory_budget extension if enabled.
-
-        It might be different (most probably smaller) than `VkMemoryHeap::size[heapIndex]` due to factors
-        external to the program, decided by the operating system.
-        Difference `budget - usage` is the amount of additional memory that can probably
-        be allocated without problems. Exceeding the budget may result in various problems.
-        */
-        VkDeviceSize budget;
-    } VmaBudget;
-
-    /** @} */
-
-    /**
-    \addtogroup group_alloc
-    @{
+    \note To avoid confusion, please be aware that what Vulkan calls an "allocation" - a whole `VkDeviceMemory` object
+    (e.g. as in `VkPhysicalDeviceLimits::maxMemoryAllocationCount`) is called a "block" in VMA, while VMA calls
+    "allocation" a #VmaAllocation object that represents a memory region sub-allocated from such block, usually for a single buffer or image.
     */
+    VkDeviceSize blockBytes;
+    /** \brief Total number of bytes occupied by all #VmaAllocation objects.
 
-    /** \brief Parameters of new #VmaAllocation.
-
-    To be used with functions like vmaCreateBuffer(), vmaCreateImage(), and many others.
+    Always less or equal than `blockBytes`.
+    Difference `(blockBytes - allocationBytes)` is the amount of memory allocated from Vulkan
+    but unused by any #VmaAllocation.
     */
-    typedef struct VmaAllocationCreateInfo
-    {
-        /// Use #VmaAllocationCreateFlagBits enum.
-        VmaAllocationCreateFlags flags;
-        /** \brief Intended usage of memory.
+    VkDeviceSize allocationBytes;
+} VmaStatistics;
 
-        You can leave #VMA_MEMORY_USAGE_UNKNOWN if you specify memory requirements in other way. \n
-        If `pool` is not null, this member is ignored.
-        */
-        VmaMemoryUsage usage;
-        /** \brief Flags that must be set in a Memory Type chosen for an allocation.
+/** \brief More detailed statistics than #VmaStatistics.
 
-        Leave 0 if you specify memory requirements in other way. \n
-        If `pool` is not null, this member is ignored.*/
-        VkMemoryPropertyFlags requiredFlags;
-        /** \brief Flags that preferably should be set in a memory type chosen for an allocation.
+These are slower to calculate. Use for debugging purposes.
+See functions: vmaCalculateStatistics(), vmaCalculatePoolStatistics().
 
-        Set to 0 if no additional flags are preferred. \n
-        If `pool` is not null, this member is ignored. */
-        VkMemoryPropertyFlags preferredFlags;
-        /** \brief Bitmask containing one bit set for every memory type acceptable for this allocation.
+Previous version of the statistics API provided averages, but they have been removed
+because they can be easily calculated as:
 
-        Value 0 is equivalent to `UINT32_MAX` - it means any memory type is accepted if
-        it meets other requirements specified by this structure, with no further
-        restrictions on memory type index. \n
-        If `pool` is not null, this member is ignored.
-        */
-        uint32_t memoryTypeBits;
-        /** \brief Pool that this allocation should be created in.
+\code
+VkDeviceSize allocationSizeAvg = detailedStats.statistics.allocationBytes / detailedStats.statistics.allocationCount;
+VkDeviceSize unusedBytes = detailedStats.statistics.blockBytes - detailedStats.statistics.allocationBytes;
+VkDeviceSize unusedRangeSizeAvg = unusedBytes / detailedStats.unusedRangeCount;
+\endcode
+*/
+typedef struct VmaDetailedStatistics
+{
+    /// Basic statistics.
+    VmaStatistics statistics;
+    /// Number of free ranges of memory between allocations.
+    uint32_t unusedRangeCount;
+    /// Smallest allocation size. `VK_WHOLE_SIZE` if there are 0 allocations.
+    VkDeviceSize allocationSizeMin;
+    /// Largest allocation size. 0 if there are 0 allocations.
+    VkDeviceSize allocationSizeMax;
+    /// Smallest empty range size. `VK_WHOLE_SIZE` if there are 0 empty ranges.
+    VkDeviceSize unusedRangeSizeMin;
+    /// Largest empty range size. 0 if there are 0 empty ranges.
+    VkDeviceSize unusedRangeSizeMax;
+} VmaDetailedStatistics;
 
-        Leave `VK_NULL_HANDLE` to allocate from default pool. If not null, members:
-        `usage`, `requiredFlags`, `preferredFlags`, `memoryTypeBits` are ignored.
-        */
-        VmaPool VMA_NULLABLE pool;
-        /** \brief Custom general-purpose pointer that will be stored in #VmaAllocation, can be read as
-        VmaAllocationInfo::pUserData and changed using vmaSetAllocationUserData().
+/** \brief  General statistics from current state of the Allocator -
+total memory usage across all memory heaps and types.
 
-        If #VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT is used, it must be either
-        null or pointer to a null-terminated string. The string will be then copied to
-        internal buffer, so it doesn't need to be valid after allocation call.
-        */
-        void* VMA_NULLABLE pUserData;
-        /** \brief A floating-point value between 0 and 1, indicating the priority of the allocation relative to other
-        memory allocations.
+These are slower to calculate. Use for debugging purposes.
+See function vmaCalculateStatistics().
+*/
+typedef struct VmaTotalStatistics
+{
+    VmaDetailedStatistics memoryType[VK_MAX_MEMORY_TYPES];
+    VmaDetailedStatistics memoryHeap[VK_MAX_MEMORY_HEAPS];
+    VmaDetailedStatistics total;
+} VmaTotalStatistics;
 
-        It is used only when #VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT flag was used during creation of the
-        #VmaAllocator object and this allocation ends up as dedicated or is explicitly forced as dedicated using
-        #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT. Otherwise, it has the priority of a memory block where it is placed
-        and this variable is ignored.
-        */
-        float priority;
-    } VmaAllocationCreateInfo;
+/** \brief Statistics of current memory usage and available budget for a specific memory heap.
 
-    /// Describes parameter of created #VmaPool.
-    typedef struct VmaPoolCreateInfo
-    {
-        /** \brief Vulkan memory type index to allocate this pool from.
-         */
-        uint32_t memoryTypeIndex;
-        /** \brief Use combination of #VmaPoolCreateFlagBits.
-         */
-        VmaPoolCreateFlags flags;
-        /** \brief Size of a single `VkDeviceMemory` block to be allocated as part of this pool, in bytes. Optional.
-
-        Specify nonzero to set explicit, constant size of memory blocks used by this
-        pool.
-
-        Leave 0 to use default and let the library manage block sizes automatically.
-        Sizes of particular blocks may vary.
-        In this case, the pool will also support dedicated allocations.
-        */
-        VkDeviceSize blockSize;
-        /** \brief Minimum number of blocks to be always allocated in this pool, even if they stay empty.
-
-        Set to 0 to have no preallocated blocks and allow the pool be completely empty.
-        */
-        size_t minBlockCount;
-        /** \brief Maximum number of blocks that can be allocated in this pool. Optional.
-
-        Set to 0 to use default, which is `SIZE_MAX`, which means no limit.
-
-        Set to same value as VmaPoolCreateInfo::minBlockCount to have fixed amount of memory allocated
-        throughout whole lifetime of this pool.
-        */
-        size_t maxBlockCount;
-        /** \brief A floating-point value between 0 and 1, indicating the priority of the allocations in this pool
-        relative to other memory allocations.
-
-        It is used only when #VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT flag was used during creation of the
-        #VmaAllocator object. Otherwise, this variable is ignored.
-        */
-        float priority;
-        /** \brief Additional minimum alignment to be used for all allocations created from this pool. Can be 0.
-
-        Leave 0 (default) not to impose any additional alignment. If not 0, it must be a power of two.
-        It can be useful in cases where alignment returned by Vulkan by functions like `vkGetBufferMemoryRequirements`
-        is not enough, e.g. when doing interop with OpenGL.
-        */
-        VkDeviceSize minAllocationAlignment;
-        /** \brief Additional `pNext` chain to be attached to `VkMemoryAllocateInfo` used for every allocation made by
-        this pool. Optional.
-
-        Optional, can be null. If not null, it must point to a `pNext` chain of structures that can be attached to
-        `VkMemoryAllocateInfo`. It can be useful for special needs such as adding `VkExportMemoryAllocateInfoKHR`.
-        Structures pointed by this member must remain alive and unchanged for the whole lifetime of the custom pool.
-
-        Please note that some structures, e.g. `VkMemoryPriorityAllocateInfoEXT`, `VkMemoryDedicatedAllocateInfoKHR`,
-        can be attached automatically by this library when using other, more convenient of its features.
-        */
-        void* VMA_NULLABLE pMemoryAllocateNext;
-    } VmaPoolCreateInfo;
-
-    /** @} */
-
-    /**
-    \addtogroup group_alloc
-    @{
+These are fast to calculate.
+See function vmaGetHeapBudgets().
+*/
+typedef struct VmaBudget
+{
+    /** \brief Statistics fetched from the library.
     */
+    VmaStatistics statistics;
+    /** \brief Estimated current memory usage of the program, in bytes.
 
-    /// Parameters of #VmaAllocation objects, that can be retrieved using function vmaGetAllocationInfo().
-    typedef struct VmaAllocationInfo
-    {
-        /** \brief Memory type index that this allocation was allocated from.
+    Fetched from system using VK_EXT_memory_budget extension if enabled.
 
-        It never changes.
-        */
-        uint32_t memoryType;
-        /** \brief Handle to Vulkan memory object.
-
-        Same memory object can be shared by multiple allocations.
-
-        It can change after the allocation is moved during \ref defragmentation.
-        */
-        VkDeviceMemory VMA_NULLABLE_NON_DISPATCHABLE deviceMemory;
-        /** \brief Offset in `VkDeviceMemory` object to the beginning of this allocation, in bytes. `(deviceMemory,
-        offset)` pair is unique to this allocation.
-
-        You usually don't need to use this offset. If you create a buffer or an image together with the allocation using
-        e.g. function vmaCreateBuffer(), vmaCreateImage(), functions that operate on these resources refer to the
-        beginning of the buffer or image, not entire device memory block. Functions like vmaMapMemory(),
-        vmaBindBufferMemory() also refer to the beginning of the allocation and apply this offset automatically.
-
-        It can change after the allocation is moved during \ref defragmentation.
-        */
-        VkDeviceSize offset;
-        /** \brief Size of this allocation, in bytes.
-
-        It never changes.
-
-        \note Allocation size returned in this variable may be greater than the size
-        requested for the resource e.g. as `VkBufferCreateInfo::size`. Whole size of the
-        allocation is accessible for operations on memory e.g. using a pointer after
-        mapping with vmaMapMemory(), but operations on the resource e.g. using
-        `vkCmdCopyBuffer` must be limited to the size of the resource.
-        */
-        VkDeviceSize size;
-        /** \brief Pointer to the beginning of this allocation as mapped data.
-
-        If the allocation hasn't been mapped using vmaMapMemory() and hasn't been
-        created with #VMA_ALLOCATION_CREATE_MAPPED_BIT flag, this value is null.
-
-        It can change after call to vmaMapMemory(), vmaUnmapMemory().
-        It can also change after the allocation is moved during \ref defragmentation.
-        */
-        void* VMA_NULLABLE pMappedData;
-        /** \brief Custom general-purpose pointer that was passed as VmaAllocationCreateInfo::pUserData or set using
-        vmaSetAllocationUserData().
-
-        It can change after call to vmaSetAllocationUserData() for this allocation.
-        */
-        void* VMA_NULLABLE pUserData;
-        /** \brief Custom allocation name that was set with vmaSetAllocationName().
-
-        It can change after call to vmaSetAllocationName() for this allocation.
-
-        Another way to set custom name is to pass it in VmaAllocationCreateInfo::pUserData with
-        additional flag #VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT set [DEPRECATED].
-        */
-        const char* VMA_NULLABLE pName;
-    } VmaAllocationInfo;
-
-    /** \brief Parameters for defragmentation.
-
-    To be used with function vmaBeginDefragmentation().
+    It might be different than `statistics.blockBytes` (usually higher) due to additional implicit objects
+    also occupying the memory, like swapchain, pipelines, descriptor heaps, command buffers, or
+    `VkDeviceMemory` blocks allocated outside of this library, if any.
     */
-    typedef struct VmaDefragmentationInfo
-    {
-        /// \brief Use combination of #VmaDefragmentationFlagBits.
-        VmaDefragmentationFlags flags;
-        /** \brief Custom pool to be defragmented.
+    VkDeviceSize usage;
+    /** \brief Estimated amount of memory available to the program, in bytes.
 
-        If null then default pools will undergo defragmentation process.
-        */
-        VmaPool VMA_NULLABLE pool;
-        /** \brief Maximum numbers of bytes that can be copied during single pass, while moving allocations to different
-        places.
+    Fetched from system using VK_EXT_memory_budget extension if enabled.
 
-        `0` means no limit.
-        */
-        VkDeviceSize maxBytesPerPass;
-        /** \brief Maximum number of allocations that can be moved during single pass to a different place.
-
-        `0` means no limit.
-        */
-        uint32_t maxAllocationsPerPass;
-    } VmaDefragmentationInfo;
-
-    /// Single move of an allocation to be done for defragmentation.
-    typedef struct VmaDefragmentationMove
-    {
-        /// Operation to be performed on the allocation by vmaEndDefragmentationPass(). Default value is
-        /// #VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY. You can modify it.
-        VmaDefragmentationMoveOperation operation;
-        /// Allocation that should be moved.
-        VmaAllocation VMA_NOT_NULL srcAllocation;
-        /** \brief Temporary allocation pointing to destination memory that will replace `srcAllocation`.
-
-        \warning Do not store this allocation in your data structures! It exists only temporarily, for the duration of
-        the defragmentation pass, to be used for binding new buffer/image to the destination memory using e.g.
-        vmaBindBufferMemory(). vmaEndDefragmentationPass() will destroy it and make `srcAllocation` point to this
-        memory.
-        */
-        VmaAllocation VMA_NOT_NULL dstTmpAllocation;
-    } VmaDefragmentationMove;
-
-    /** \brief Parameters for incremental defragmentation steps.
-
-    To be used with function vmaBeginDefragmentationPass().
+    It might be different (most probably smaller) than `VkMemoryHeap::size[heapIndex]` due to factors
+    external to the program, decided by the operating system.
+    Difference `budget - usage` is the amount of additional memory that can probably
+    be allocated without problems. Exceeding the budget may result in various problems.
     */
-    typedef struct VmaDefragmentationPassMoveInfo
-    {
-        /// Number of elements in the `pMoves` array.
-        uint32_t moveCount;
-        /** \brief Array of moves to be performed by the user in the current defragmentation pass.
+    VkDeviceSize budget;
+} VmaBudget;
 
-        Pointer to an array of `moveCount` elements, owned by VMA, created in vmaBeginDefragmentationPass(), destroyed
-        in vmaEndDefragmentationPass().
+/** @} */
 
-        For each element, you should:
+/**
+\addtogroup group_alloc
+@{
+*/
 
-        1. Create a new buffer/image in the place pointed by VmaDefragmentationMove::dstMemory +
-        VmaDefragmentationMove::dstOffset.
-        2. Copy data from the VmaDefragmentationMove::srcAllocation e.g. using `vkCmdCopyBuffer`, `vkCmdCopyImage`.
-        3. Make sure these commands finished executing on the GPU.
-        4. Destroy the old buffer/image.
+/** \brief Parameters of new #VmaAllocation.
 
-        Only then you can finish defragmentation pass by calling vmaEndDefragmentationPass().
-        After this call, the allocation will point to the new place in memory.
+To be used with functions like vmaCreateBuffer(), vmaCreateImage(), and many others.
+*/
+typedef struct VmaAllocationCreateInfo
+{
+    /// Use #VmaAllocationCreateFlagBits enum.
+    VmaAllocationCreateFlags flags;
+    /** \brief Intended usage of memory.
 
-        Alternatively, if you cannot move specific allocation, you can set VmaDefragmentationMove::operation to
-        #VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE.
-
-        Alternatively, if you decide you want to completely remove the allocation:
-
-        1. Destroy its buffer/image.
-        2. Set VmaDefragmentationMove::operation to #VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY.
-
-        Then, after vmaEndDefragmentationPass() the allocation will be freed.
-        */
-        VmaDefragmentationMove* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(moveCount) pMoves;
-    } VmaDefragmentationPassMoveInfo;
-
-    /// Statistics returned for defragmentation process in function vmaEndDefragmentation().
-    typedef struct VmaDefragmentationStats
-    {
-        /// Total number of bytes that have been copied while moving allocations to different places.
-        VkDeviceSize bytesMoved;
-        /// Total number of bytes that have been released to the system by freeing empty `VkDeviceMemory` objects.
-        VkDeviceSize bytesFreed;
-        /// Number of allocations that have been moved to different places.
-        uint32_t allocationsMoved;
-        /// Number of empty `VkDeviceMemory` objects that have been released to the system.
-        uint32_t deviceMemoryBlocksFreed;
-    } VmaDefragmentationStats;
-
-    /** @} */
-
-    /**
-    \addtogroup group_virtual
-    @{
+    You can leave #VMA_MEMORY_USAGE_UNKNOWN if you specify memory requirements in other way. \n
+    If `pool` is not null, this member is ignored.
     */
+    VmaMemoryUsage usage;
+    /** \brief Flags that must be set in a Memory Type chosen for an allocation.
 
-    /// Parameters of created #VmaVirtualBlock object to be passed to vmaCreateVirtualBlock().
-    typedef struct VmaVirtualBlockCreateInfo
-    {
-        /** \brief Total size of the virtual block.
+    Leave 0 if you specify memory requirements in other way. \n
+    If `pool` is not null, this member is ignored.*/
+    VkMemoryPropertyFlags requiredFlags;
+    /** \brief Flags that preferably should be set in a memory type chosen for an allocation.
 
-        Sizes can be expressed in bytes or any units you want as long as you are consistent in using them.
-        For example, if you allocate from some array of structures, 1 can mean single instance of entire structure.
-        */
-        VkDeviceSize size;
+    Set to 0 if no additional flags are preferred. \n
+    If `pool` is not null, this member is ignored. */
+    VkMemoryPropertyFlags preferredFlags;
+    /** \brief Bitmask containing one bit set for every memory type acceptable for this allocation.
 
-        /** \brief Use combination of #VmaVirtualBlockCreateFlagBits.
-         */
-        VmaVirtualBlockCreateFlags flags;
+    Value 0 is equivalent to `UINT32_MAX` - it means any memory type is accepted if
+    it meets other requirements specified by this structure, with no further
+    restrictions on memory type index. \n
+    If `pool` is not null, this member is ignored.
+    */
+    uint32_t memoryTypeBits;
+    /** \brief Pool that this allocation should be created in.
 
-        /** \brief Custom CPU memory allocation callbacks. Optional.
+    Leave `VK_NULL_HANDLE` to allocate from default pool. If not null, members:
+    `usage`, `requiredFlags`, `preferredFlags`, `memoryTypeBits` are ignored.
+    */
+    VmaPool VMA_NULLABLE pool;
+    /** \brief Custom general-purpose pointer that will be stored in #VmaAllocation, can be read as VmaAllocationInfo::pUserData and changed using vmaSetAllocationUserData().
 
-        Optional, can be null. When specified, they will be used for all CPU-side memory allocations.
-        */
-        const VkAllocationCallbacks* VMA_NULLABLE pAllocationCallbacks;
-    } VmaVirtualBlockCreateInfo;
+    If #VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT is used, it must be either
+    null or pointer to a null-terminated string. The string will be then copied to
+    internal buffer, so it doesn't need to be valid after allocation call.
+    */
+    void* VMA_NULLABLE pUserData;
+    /** \brief A floating-point value between 0 and 1, indicating the priority of the allocation relative to other memory allocations.
 
-    /// Parameters of created virtual allocation to be passed to vmaVirtualAllocate().
-    typedef struct VmaVirtualAllocationCreateInfo
-    {
-        /** \brief Size of the allocation.
+    It is used only when #VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT flag was used during creation of the #VmaAllocator object
+    and this allocation ends up as dedicated or is explicitly forced as dedicated using #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
+    Otherwise, it has the priority of a memory block where it is placed and this variable is ignored.
+    */
+    float priority;
+} VmaAllocationCreateInfo;
 
-        Cannot be zero.
-        */
-        VkDeviceSize size;
-        /** \brief Required alignment of the allocation. Optional.
+/// Describes parameter of created #VmaPool.
+typedef struct VmaPoolCreateInfo
+{
+    /** \brief Vulkan memory type index to allocate this pool from.
+    */
+    uint32_t memoryTypeIndex;
+    /** \brief Use combination of #VmaPoolCreateFlagBits.
+    */
+    VmaPoolCreateFlags flags;
+    /** \brief Size of a single `VkDeviceMemory` block to be allocated as part of this pool, in bytes. Optional.
 
-        Must be power of two. Special value 0 has the same meaning as 1 - means no special alignment is required, so
-        allocation can start at any offset.
-        */
-        VkDeviceSize alignment;
-        /** \brief Use combination of #VmaVirtualAllocationCreateFlagBits.
-         */
-        VmaVirtualAllocationCreateFlags flags;
-        /** \brief Custom pointer to be associated with the allocation. Optional.
+    Specify nonzero to set explicit, constant size of memory blocks used by this
+    pool.
 
-        It can be any value and can be used for user-defined purposes. It can be fetched or changed later.
-        */
-        void* VMA_NULLABLE pUserData;
-    } VmaVirtualAllocationCreateInfo;
+    Leave 0 to use default and let the library manage block sizes automatically.
+    Sizes of particular blocks may vary.
+    In this case, the pool will also support dedicated allocations.
+    */
+    VkDeviceSize blockSize;
+    /** \brief Minimum number of blocks to be always allocated in this pool, even if they stay empty.
 
-    /// Parameters of an existing virtual allocation, returned by vmaGetVirtualAllocationInfo().
-    typedef struct VmaVirtualAllocationInfo
-    {
-        /** \brief Offset of the allocation.
+    Set to 0 to have no preallocated blocks and allow the pool be completely empty.
+    */
+    size_t minBlockCount;
+    /** \brief Maximum number of blocks that can be allocated in this pool. Optional.
 
-        Offset at which the allocation was made.
-        */
-        VkDeviceSize offset;
-        /** \brief Size of the allocation.
+    Set to 0 to use default, which is `SIZE_MAX`, which means no limit.
 
-        Same value as passed in VmaVirtualAllocationCreateInfo::size.
-        */
-        VkDeviceSize size;
-        /** \brief Custom pointer associated with the allocation.
+    Set to same value as VmaPoolCreateInfo::minBlockCount to have fixed amount of memory allocated
+    throughout whole lifetime of this pool.
+    */
+    size_t maxBlockCount;
+    /** \brief A floating-point value between 0 and 1, indicating the priority of the allocations in this pool relative to other memory allocations.
 
-        Same value as passed in VmaVirtualAllocationCreateInfo::pUserData or to vmaSetVirtualAllocationUserData().
-        */
-        void* VMA_NULLABLE pUserData;
-    } VmaVirtualAllocationInfo;
+    It is used only when #VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT flag was used during creation of the #VmaAllocator object.
+    Otherwise, this variable is ignored.
+    */
+    float priority;
+    /** \brief Additional minimum alignment to be used for all allocations created from this pool. Can be 0.
 
-    /** @} */
+    Leave 0 (default) not to impose any additional alignment. If not 0, it must be a power of two.
+    It can be useful in cases where alignment returned by Vulkan by functions like `vkGetBufferMemoryRequirements` is not enough,
+    e.g. when doing interop with OpenGL.
+    */
+    VkDeviceSize minAllocationAlignment;
+    /** \brief Additional `pNext` chain to be attached to `VkMemoryAllocateInfo` used for every allocation made by this pool. Optional.
+
+    Optional, can be null. If not null, it must point to a `pNext` chain of structures that can be attached to `VkMemoryAllocateInfo`.
+    It can be useful for special needs such as adding `VkExportMemoryAllocateInfoKHR`.
+    Structures pointed by this member must remain alive and unchanged for the whole lifetime of the custom pool.
+
+    Please note that some structures, e.g. `VkMemoryPriorityAllocateInfoEXT`, `VkMemoryDedicatedAllocateInfoKHR`,
+    can be attached automatically by this library when using other, more convenient of its features.
+    */
+    void* VMA_NULLABLE pMemoryAllocateNext;
+} VmaPoolCreateInfo;
+
+/** @} */
+
+/**
+\addtogroup group_alloc
+@{
+*/
+
+/// Parameters of #VmaAllocation objects, that can be retrieved using function vmaGetAllocationInfo().
+typedef struct VmaAllocationInfo
+{
+    /** \brief Memory type index that this allocation was allocated from.
+
+    It never changes.
+    */
+    uint32_t memoryType;
+    /** \brief Handle to Vulkan memory object.
+
+    Same memory object can be shared by multiple allocations.
+
+    It can change after the allocation is moved during \ref defragmentation.
+    */
+    VkDeviceMemory VMA_NULLABLE_NON_DISPATCHABLE deviceMemory;
+    /** \brief Offset in `VkDeviceMemory` object to the beginning of this allocation, in bytes. `(deviceMemory, offset)` pair is unique to this allocation.
+
+    You usually don't need to use this offset. If you create a buffer or an image together with the allocation using e.g. function
+    vmaCreateBuffer(), vmaCreateImage(), functions that operate on these resources refer to the beginning of the buffer or image,
+    not entire device memory block. Functions like vmaMapMemory(), vmaBindBufferMemory() also refer to the beginning of the allocation
+    and apply this offset automatically.
+
+    It can change after the allocation is moved during \ref defragmentation.
+    */
+    VkDeviceSize offset;
+    /** \brief Size of this allocation, in bytes.
+
+    It never changes.
+
+    \note Allocation size returned in this variable may be greater than the size
+    requested for the resource e.g. as `VkBufferCreateInfo::size`. Whole size of the
+    allocation is accessible for operations on memory e.g. using a pointer after
+    mapping with vmaMapMemory(), but operations on the resource e.g. using
+    `vkCmdCopyBuffer` must be limited to the size of the resource.
+    */
+    VkDeviceSize size;
+    /** \brief Pointer to the beginning of this allocation as mapped data.
+
+    If the allocation hasn't been mapped using vmaMapMemory() and hasn't been
+    created with #VMA_ALLOCATION_CREATE_MAPPED_BIT flag, this value is null.
+
+    It can change after call to vmaMapMemory(), vmaUnmapMemory().
+    It can also change after the allocation is moved during \ref defragmentation.
+    */
+    void* VMA_NULLABLE pMappedData;
+    /** \brief Custom general-purpose pointer that was passed as VmaAllocationCreateInfo::pUserData or set using vmaSetAllocationUserData().
+
+    It can change after call to vmaSetAllocationUserData() for this allocation.
+    */
+    void* VMA_NULLABLE pUserData;
+    /** \brief Custom allocation name that was set with vmaSetAllocationName().
+
+    It can change after call to vmaSetAllocationName() for this allocation.
+
+    Another way to set custom name is to pass it in VmaAllocationCreateInfo::pUserData with
+    additional flag #VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT set [DEPRECATED].
+    */
+    const char* VMA_NULLABLE pName;
+} VmaAllocationInfo;
+
+/** \brief Parameters for defragmentation.
+
+To be used with function vmaBeginDefragmentation().
+*/
+typedef struct VmaDefragmentationInfo
+{
+    /// \brief Use combination of #VmaDefragmentationFlagBits.
+    VmaDefragmentationFlags flags;
+    /** \brief Custom pool to be defragmented.
+
+    If null then default pools will undergo defragmentation process.
+    */
+    VmaPool VMA_NULLABLE pool;
+    /** \brief Maximum numbers of bytes that can be copied during single pass, while moving allocations to different places.
+
+    `0` means no limit.
+    */
+    VkDeviceSize maxBytesPerPass;
+    /** \brief Maximum number of allocations that can be moved during single pass to a different place.
+
+    `0` means no limit.
+    */
+    uint32_t maxAllocationsPerPass;
+} VmaDefragmentationInfo;
+
+/// Single move of an allocation to be done for defragmentation.
+typedef struct VmaDefragmentationMove
+{
+    /// Operation to be performed on the allocation by vmaEndDefragmentationPass(). Default value is #VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY. You can modify it.
+    VmaDefragmentationMoveOperation operation;
+    /// Allocation that should be moved.
+    VmaAllocation VMA_NOT_NULL srcAllocation;
+    /** \brief Temporary allocation pointing to destination memory that will replace `srcAllocation`.
+
+    \warning Do not store this allocation in your data structures! It exists only temporarily, for the duration of the defragmentation pass,
+    to be used for binding new buffer/image to the destination memory using e.g. vmaBindBufferMemory().
+    vmaEndDefragmentationPass() will destroy it and make `srcAllocation` point to this memory.
+    */
+    VmaAllocation VMA_NOT_NULL dstTmpAllocation;
+} VmaDefragmentationMove;
+
+/** \brief Parameters for incremental defragmentation steps.
+
+To be used with function vmaBeginDefragmentationPass().
+*/
+typedef struct VmaDefragmentationPassMoveInfo
+{
+    /// Number of elements in the `pMoves` array.
+    uint32_t moveCount;
+    /** \brief Array of moves to be performed by the user in the current defragmentation pass.
+
+    Pointer to an array of `moveCount` elements, owned by VMA, created in vmaBeginDefragmentationPass(), destroyed in vmaEndDefragmentationPass().
+
+    For each element, you should:
+
+    1. Create a new buffer/image in the place pointed by VmaDefragmentationMove::dstMemory + VmaDefragmentationMove::dstOffset.
+    2. Copy data from the VmaDefragmentationMove::srcAllocation e.g. using `vkCmdCopyBuffer`, `vkCmdCopyImage`.
+    3. Make sure these commands finished executing on the GPU.
+    4. Destroy the old buffer/image.
+
+    Only then you can finish defragmentation pass by calling vmaEndDefragmentationPass().
+    After this call, the allocation will point to the new place in memory.
+
+    Alternatively, if you cannot move specific allocation, you can set VmaDefragmentationMove::operation to #VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE.
+
+    Alternatively, if you decide you want to completely remove the allocation:
+
+    1. Destroy its buffer/image.
+    2. Set VmaDefragmentationMove::operation to #VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY.
+
+    Then, after vmaEndDefragmentationPass() the allocation will be freed.
+    */
+    VmaDefragmentationMove* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(moveCount) pMoves;
+} VmaDefragmentationPassMoveInfo;
+
+/// Statistics returned for defragmentation process in function vmaEndDefragmentation().
+typedef struct VmaDefragmentationStats
+{
+    /// Total number of bytes that have been copied while moving allocations to different places.
+    VkDeviceSize bytesMoved;
+    /// Total number of bytes that have been released to the system by freeing empty `VkDeviceMemory` objects.
+    VkDeviceSize bytesFreed;
+    /// Number of allocations that have been moved to different places.
+    uint32_t allocationsMoved;
+    /// Number of empty `VkDeviceMemory` objects that have been released to the system.
+    uint32_t deviceMemoryBlocksFreed;
+} VmaDefragmentationStats;
+
+/** @} */
+
+/**
+\addtogroup group_virtual
+@{
+*/
+
+/// Parameters of created #VmaVirtualBlock object to be passed to vmaCreateVirtualBlock().
+typedef struct VmaVirtualBlockCreateInfo
+{
+    /** \brief Total size of the virtual block.
+
+    Sizes can be expressed in bytes or any units you want as long as you are consistent in using them.
+    For example, if you allocate from some array of structures, 1 can mean single instance of entire structure.
+    */
+    VkDeviceSize size;
+
+    /** \brief Use combination of #VmaVirtualBlockCreateFlagBits.
+    */
+    VmaVirtualBlockCreateFlags flags;
+
+    /** \brief Custom CPU memory allocation callbacks. Optional.
+
+    Optional, can be null. When specified, they will be used for all CPU-side memory allocations.
+    */
+    const VkAllocationCallbacks* VMA_NULLABLE pAllocationCallbacks;
+} VmaVirtualBlockCreateInfo;
+
+/// Parameters of created virtual allocation to be passed to vmaVirtualAllocate().
+typedef struct VmaVirtualAllocationCreateInfo
+{
+    /** \brief Size of the allocation.
+
+    Cannot be zero.
+    */
+    VkDeviceSize size;
+    /** \brief Required alignment of the allocation. Optional.
+
+    Must be power of two. Special value 0 has the same meaning as 1 - means no special alignment is required, so allocation can start at any offset.
+    */
+    VkDeviceSize alignment;
+    /** \brief Use combination of #VmaVirtualAllocationCreateFlagBits.
+    */
+    VmaVirtualAllocationCreateFlags flags;
+    /** \brief Custom pointer to be associated with the allocation. Optional.
+
+    It can be any value and can be used for user-defined purposes. It can be fetched or changed later.
+    */
+    void* VMA_NULLABLE pUserData;
+} VmaVirtualAllocationCreateInfo;
+
+/// Parameters of an existing virtual allocation, returned by vmaGetVirtualAllocationInfo().
+typedef struct VmaVirtualAllocationInfo
+{
+    /** \brief Offset of the allocation.
+
+    Offset at which the allocation was made.
+    */
+    VkDeviceSize offset;
+    /** \brief Size of the allocation.
+
+    Same value as passed in VmaVirtualAllocationCreateInfo::size.
+    */
+    VkDeviceSize size;
+    /** \brief Custom pointer associated with the allocation.
+
+    Same value as passed in VmaVirtualAllocationCreateInfo::pUserData or to vmaSetVirtualAllocationUserData().
+    */
+    void* VMA_NULLABLE pUserData;
+} VmaVirtualAllocationInfo;
+
+/** @} */
 
 #endif // _VMA_DATA_TYPES_DECLARATIONS
 
 #ifndef _VMA_FUNCTION_HEADERS
 
-    /**
-    \addtogroup group_init
-    @{
-    */
-
-    /// Creates #VmaAllocator object.
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAllocator(const VmaAllocatorCreateInfo* VMA_NOT_NULL pCreateInfo,
-                                                           VmaAllocator VMA_NULLABLE* VMA_NOT_NULL pAllocator);
-
-    /// Destroys allocator object.
-    VMA_CALL_PRE void VMA_CALL_POST vmaDestroyAllocator(VmaAllocator VMA_NULLABLE allocator);
-
-    /** \brief Returns information about existing #VmaAllocator object - handle to Vulkan device etc.
-
-    It might be useful if you want to keep just the #VmaAllocator handle and fetch other required handles to
-    `VkPhysicalDevice`, `VkDevice` etc. every time using this function.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocatorInfo(VmaAllocator VMA_NOT_NULL      allocator,
-                                                        VmaAllocatorInfo* VMA_NOT_NULL pAllocatorInfo);
-
-    /**
-    PhysicalDeviceProperties are fetched from physicalDevice by the allocator.
-    You can access it here, without fetching it again on your own.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetPhysicalDeviceProperties(
-        VmaAllocator VMA_NOT_NULL         allocator,
-        const VkPhysicalDeviceProperties* VMA_NULLABLE* VMA_NOT_NULL ppPhysicalDeviceProperties);
-
-    /**
-    PhysicalDeviceMemoryProperties are fetched from physicalDevice by the allocator.
-    You can access it here, without fetching it again on your own.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryProperties(
-        VmaAllocator VMA_NOT_NULL               allocator,
-        const VkPhysicalDeviceMemoryProperties* VMA_NULLABLE* VMA_NOT_NULL ppPhysicalDeviceMemoryProperties);
-
-    /**
-    \brief Given Memory Type Index, returns Property Flags of this memory type.
-
-    This is just a convenience function. Same information can be obtained using
-    vmaGetMemoryProperties().
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryTypeProperties(VmaAllocator VMA_NOT_NULL           allocator,
-                                                               uint32_t                            memoryTypeIndex,
-                                                               VkMemoryPropertyFlags* VMA_NOT_NULL pFlags);
-
-    /** \brief Sets index of the current frame.
-     */
-    VMA_CALL_PRE void VMA_CALL_POST vmaSetCurrentFrameIndex(VmaAllocator VMA_NOT_NULL allocator, uint32_t frameIndex);
-
-    /** @} */
-
-    /**
-    \addtogroup group_stats
-    @{
-    */
-
-    /** \brief Retrieves statistics from current state of the Allocator.
-
-    This function is called "calculate" not "get" because it has to traverse all
-    internal data structures, so it may be quite slow. Use it for debugging purposes.
-    For faster but more brief statistics suitable to be called every frame or every allocation,
-    use vmaGetHeapBudgets().
-
-    Note that when using allocator from multiple threads, returned information may immediately
-    become outdated.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaCalculateStatistics(VmaAllocator VMA_NOT_NULL        allocator,
-                                                           VmaTotalStatistics* VMA_NOT_NULL pStats);
-
-    /** \brief Retrieves information about current memory usage and budget for all memory heaps.
-
-    \param allocator
-    \param[out] pBudgets Must point to array with number of elements at least equal to number of memory heaps in
-    physical device used.
-
-    This function is called "get" not "calculate" because it is very fast, suitable to be called
-    every frame or every allocation. For more detailed statistics use vmaCalculateStatistics().
-
-    Note that when using allocator from multiple threads, returned information may immediately
-    become outdated.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetHeapBudgets(
-        VmaAllocator VMA_NOT_NULL allocator,
-        VmaBudget* VMA_NOT_NULL   VMA_LEN_IF_NOT_NULL("VkPhysicalDeviceMemoryProperties::memoryHeapCount") pBudgets);
-
-    /** @} */
-
-    /**
-    \addtogroup group_alloc
-    @{
-    */
-
-    /**
-    \brief Helps to find memoryTypeIndex, given memoryTypeBits and VmaAllocationCreateInfo.
-
-    This algorithm tries to find a memory type that:
-
-    - Is allowed by memoryTypeBits.
-    - Contains all the flags from pAllocationCreateInfo->requiredFlags.
-    - Matches intended usage.
-    - Has as many flags from pAllocationCreateInfo->preferredFlags as possible.
-
-    \return Returns VK_ERROR_FEATURE_NOT_PRESENT if not found. Receiving such result
-    from this function or any other allocating function probably means that your
-    device doesn't support any memory type with requested features for the specific
-    type of resource you want to use it for. Please check parameters of your
-    resource, like image layout (OPTIMAL versus LINEAR) or mip level count.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaFindMemoryTypeIndex(VmaAllocator VMA_NOT_NULL                   allocator,
-                           uint32_t                                    memoryTypeBits,
-                           const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
-                           uint32_t* VMA_NOT_NULL                      pMemoryTypeIndex);
-
-    /**
-    \brief Helps to find memoryTypeIndex, given VkBufferCreateInfo and VmaAllocationCreateInfo.
-
-    It can be useful e.g. to determine value to be used as VmaPoolCreateInfo::memoryTypeIndex.
-    It internally creates a temporary, dummy buffer that never has memory bound.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaFindMemoryTypeIndexForBufferInfo(VmaAllocator VMA_NOT_NULL                   allocator,
-                                        const VkBufferCreateInfo* VMA_NOT_NULL      pBufferCreateInfo,
-                                        const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
-                                        uint32_t* VMA_NOT_NULL                      pMemoryTypeIndex);
-
-    /**
-    \brief Helps to find memoryTypeIndex, given VkImageCreateInfo and VmaAllocationCreateInfo.
-
-    It can be useful e.g. to determine value to be used as VmaPoolCreateInfo::memoryTypeIndex.
-    It internally creates a temporary, dummy image that never has memory bound.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaFindMemoryTypeIndexForImageInfo(VmaAllocator VMA_NOT_NULL                   allocator,
-                                       const VkImageCreateInfo* VMA_NOT_NULL       pImageCreateInfo,
-                                       const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
-                                       uint32_t* VMA_NOT_NULL                      pMemoryTypeIndex);
-
-    /** \brief Allocates Vulkan device memory and creates #VmaPool object.
-
-    \param allocator Allocator object.
-    \param pCreateInfo Parameters of pool to create.
-    \param[out] pPool Handle to created pool.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreatePool(VmaAllocator VMA_NOT_NULL             allocator,
-                                                      const VmaPoolCreateInfo* VMA_NOT_NULL pCreateInfo,
-                                                      VmaPool VMA_NULLABLE* VMA_NOT_NULL pPool);
-
-    /** \brief Destroys #VmaPool object and frees Vulkan device memory.
-     */
-    VMA_CALL_PRE void VMA_CALL_POST vmaDestroyPool(VmaAllocator VMA_NOT_NULL allocator, VmaPool VMA_NULLABLE pool);
-
-    /** @} */
-
-    /**
-    \addtogroup group_stats
-    @{
-    */
-
-    /** \brief Retrieves statistics of existing #VmaPool object.
-
-    \param allocator Allocator object.
-    \param pool Pool object.
-    \param[out] pPoolStats Statistics of specified pool.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolStatistics(VmaAllocator VMA_NOT_NULL   allocator,
-                                                         VmaPool VMA_NOT_NULL        pool,
-                                                         VmaStatistics* VMA_NOT_NULL pPoolStats);
-
-    /** \brief Retrieves detailed statistics of existing #VmaPool object.
-
-    \param allocator Allocator object.
-    \param pool Pool object.
-    \param[out] pPoolStats Statistics of specified pool.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaCalculatePoolStatistics(VmaAllocator VMA_NOT_NULL           allocator,
-                                                               VmaPool VMA_NOT_NULL                pool,
-                                                               VmaDetailedStatistics* VMA_NOT_NULL pPoolStats);
-
-    /** @} */
-
-    /**
-    \addtogroup group_alloc
-    @{
-    */
-
-    /** \brief Checks magic number in margins around all allocations in given memory pool in search for corruptions.
-
-    Corruption detection is enabled only when `VMA_DEBUG_DETECT_CORRUPTION` macro is defined to nonzero,
-    `VMA_DEBUG_MARGIN` is defined to nonzero and the pool is created in memory type that is
-    `HOST_VISIBLE` and `HOST_COHERENT`. For more information, see [Corruption detection](@ref
-    debugging_memory_usage_corruption_detection).
-
-    Possible return values:
-
-    - `VK_ERROR_FEATURE_NOT_PRESENT` - corruption detection is not enabled for specified pool.
-    - `VK_SUCCESS` - corruption detection has been performed and succeeded.
-    - `VK_ERROR_UNKNOWN` - corruption detection has been performed and found memory corruptions around one of the
-    allocations. `VMA_ASSERT` is also fired in that case.
-    - Other value: Error returned by Vulkan, e.g. memory mapping failure.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckPoolCorruption(VmaAllocator VMA_NOT_NULL allocator,
-                                                               VmaPool VMA_NOT_NULL      pool);
-
-    /** \brief Retrieves name of a custom pool.
-
-    After the call `ppName` is either null or points to an internally-owned null-terminated string
-    containing name of the pool that was previously set. The pointer becomes invalid when the pool is
-    destroyed or its name is changed using vmaSetPoolName().
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolName(VmaAllocator VMA_NOT_NULL allocator,
-                                                   VmaPool VMA_NOT_NULL      pool,
-                                                   const char* VMA_NULLABLE* VMA_NOT_NULL ppName);
-
-    /** \brief Sets name of a custom pool.
-
-    `pName` can be either null or pointer to a null-terminated string with new name for the pool.
-    Function makes internal copy of the string, so it can be changed or freed immediately after this call.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaSetPoolName(VmaAllocator VMA_NOT_NULL allocator,
-                                                   VmaPool VMA_NOT_NULL      pool,
-                                                   const char* VMA_NULLABLE  pName);
-
-    /** \brief General purpose memory allocation.
-
-    \param allocator
-    \param pVkMemoryRequirements
-    \param pCreateInfo
-    \param[out] pAllocation Handle to allocated memory.
-    \param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function
-    vmaGetAllocationInfo().
-
-    You should free the memory using vmaFreeMemory() or vmaFreeMemoryPages().
-
-    It is recommended to use vmaAllocateMemoryForBuffer(), vmaAllocateMemoryForImage(),
-    vmaCreateBuffer(), vmaCreateImage() instead whenever possible.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaAllocateMemory(VmaAllocator VMA_NOT_NULL                   allocator,
-                      const VkMemoryRequirements* VMA_NOT_NULL    pVkMemoryRequirements,
-                      const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                      VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                      VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
-
-    /** \brief General purpose memory allocation for multiple allocation objects at once.
-
-    \param allocator Allocator object.
-    \param pVkMemoryRequirements Memory requirements for each allocation.
-    \param pCreateInfo Creation parameters for each allocation.
-    \param allocationCount Number of allocations to make.
-    \param[out] pAllocations Pointer to array that will be filled with handles to created allocations.
-    \param[out] pAllocationInfo Optional. Pointer to array that will be filled with parameters of created allocations.
-
-    You should free the memory using vmaFreeMemory() or vmaFreeMemoryPages().
-
-    Word "pages" is just a suggestion to use this function to allocate pieces of memory needed for sparse binding.
-    It is just a general purpose allocation function able to make multiple allocations at once.
-    It may be internally optimized to be more efficient than calling vmaAllocateMemory() `allocationCount` times.
-
-    All allocations are made using same parameters. All of them are created out of the same memory pool and type.
-    If any allocation fails, all allocations already made within this function call are also freed, so that when
-    returned result is not `VK_SUCCESS`, `pAllocation` array is always entirely filled with `VK_NULL_HANDLE`.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryPages(
-        VmaAllocator VMA_NOT_NULL                   allocator,
-        const VkMemoryRequirements* VMA_NOT_NULL    VMA_LEN_IF_NOT_NULL(allocationCount) pVkMemoryRequirements,
-        const VmaAllocationCreateInfo* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pCreateInfo,
-        size_t                                      allocationCount,
-        VmaAllocation VMA_NULLABLE* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pAllocations,
-        VmaAllocationInfo* VMA_NULLABLE          VMA_LEN_IF_NOT_NULL(allocationCount) pAllocationInfo);
-
-    /** \brief Allocates memory suitable for given `VkBuffer`.
-
-    \param allocator
-    \param buffer
-    \param pCreateInfo
-    \param[out] pAllocation Handle to allocated memory.
-    \param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function
-    vmaGetAllocationInfo().
-
-    It only creates #VmaAllocation. To bind the memory to the buffer, use vmaBindBufferMemory().
-
-    This is a special-purpose function. In most cases you should use vmaCreateBuffer().
-
-    You must free the allocation using vmaFreeMemory() when no longer needed.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaAllocateMemoryForBuffer(VmaAllocator VMA_NOT_NULL                   allocator,
-                               VkBuffer VMA_NOT_NULL_NON_DISPATCHABLE      buffer,
-                               const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                               VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                               VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
-
-    /** \brief Allocates memory suitable for given `VkImage`.
-
-    \param allocator
-    \param image
-    \param pCreateInfo
-    \param[out] pAllocation Handle to allocated memory.
-    \param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function
-    vmaGetAllocationInfo().
-
-    It only creates #VmaAllocation. To bind the memory to the buffer, use vmaBindImageMemory().
-
-    This is a special-purpose function. In most cases you should use vmaCreateImage().
-
-    You must free the allocation using vmaFreeMemory() when no longer needed.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaAllocateMemoryForImage(VmaAllocator VMA_NOT_NULL                   allocator,
-                              VkImage VMA_NOT_NULL_NON_DISPATCHABLE       image,
-                              const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                              VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                              VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
-
-    /** \brief Frees memory previously allocated using vmaAllocateMemory(), vmaAllocateMemoryForBuffer(), or
-    vmaAllocateMemoryForImage().
-
-    Passing `VK_NULL_HANDLE` as `allocation` is valid. Such function call is just skipped.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemory(VmaAllocator VMA_NOT_NULL        allocator,
-                                                  const VmaAllocation VMA_NULLABLE allocation);
-
-    /** \brief Frees memory and destroys multiple allocations.
-
-    Word "pages" is just a suggestion to use this function to free pieces of memory used for sparse binding.
-    It is just a general purpose function to free memory and destroy allocations made using e.g. vmaAllocateMemory(),
-    vmaAllocateMemoryPages() and other functions.
-    It may be internally optimized to be more efficient than calling vmaFreeMemory() `allocationCount` times.
-
-    Allocations in `pAllocations` array can come from any memory pools and types.
-    Passing `VK_NULL_HANDLE` as elements of `pAllocations` array is valid. Such entries are just skipped.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemoryPages(VmaAllocator VMA_NOT_NULL allocator,
-                                                       size_t                    allocationCount,
-                                                       const VmaAllocation       VMA_NULLABLE* VMA_NOT_NULL
-                                                           VMA_LEN_IF_NOT_NULL(allocationCount) pAllocations);
-
-    /** \brief Returns current information about specified allocation.
-
-    Current paramteres of given allocation are returned in `pAllocationInfo`.
-
-    Although this function doesn't lock any mutex, so it should be quite efficient,
-    you should avoid calling it too often.
-    You can retrieve same VmaAllocationInfo structure while creating your resource, from function
-    vmaCreateBuffer(), vmaCreateImage(). You can remember it if you are sure parameters don't change
-    (e.g. due to defragmentation).
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationInfo(VmaAllocator VMA_NOT_NULL       allocator,
-                                                         VmaAllocation VMA_NOT_NULL      allocation,
-                                                         VmaAllocationInfo* VMA_NOT_NULL pAllocationInfo);
-
-    /** \brief Sets pUserData in given allocation to new value.
-
-    The value of pointer `pUserData` is copied to allocation's `pUserData`.
-    It is opaque, so you can use it however you want - e.g.
-    as a pointer, ordinal number or some handle to you own data.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationUserData(VmaAllocator VMA_NOT_NULL  allocator,
-                                                             VmaAllocation VMA_NOT_NULL allocation,
-                                                             void* VMA_NULLABLE         pUserData);
-
-    /** \brief Sets pName in given allocation to new value.
-
-    `pName` must be either null, or pointer to a null-terminated string. The function
-    makes local copy of the string and sets it as allocation's `pName`. String
-    passed as pName doesn't need to be valid for whole lifetime of the allocation -
-    you can free it after this call. String previously pointed by allocation's
-    `pName` is freed from memory.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationName(VmaAllocator VMA_NOT_NULL  allocator,
-                                                         VmaAllocation VMA_NOT_NULL allocation,
-                                                         const char* VMA_NULLABLE   pName);
-
-    /**
-    \brief Given an allocation, returns Property Flags of its memory type.
-
-    This is just a convenience function. Same information can be obtained using
-    vmaGetAllocationInfo() + vmaGetMemoryProperties().
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationMemoryProperties(VmaAllocator VMA_NOT_NULL           allocator,
-                                                                     VmaAllocation VMA_NOT_NULL          allocation,
-                                                                     VkMemoryPropertyFlags* VMA_NOT_NULL pFlags);
-
-    /** \brief Maps memory represented by given allocation and returns pointer to it.
-
-    Maps memory represented by given allocation to make it accessible to CPU code.
-    When succeeded, `*ppData` contains pointer to first byte of this memory.
-
-    \warning
-    If the allocation is part of a bigger `VkDeviceMemory` block, returned pointer is
-    correctly offsetted to the beginning of region assigned to this particular allocation.
-    Unlike the result of `vkMapMemory`, it points to the allocation, not to the beginning of the whole block.
-    You should not add VmaAllocationInfo::offset to it!
-
-    Mapping is internally reference-counted and synchronized, so despite raw Vulkan
-    function `vkMapMemory()` cannot be used to map same block of `VkDeviceMemory`
-    multiple times simultaneously, it is safe to call this function on allocations
-    assigned to the same memory block. Actual Vulkan memory will be mapped on first
-    mapping and unmapped on last unmapping.
-
-    If the function succeeded, you must call vmaUnmapMemory() to unmap the
-    allocation when mapping is no longer needed or before freeing the allocation, at
-    the latest.
-
-    It also safe to call this function multiple times on the same allocation. You
-    must call vmaUnmapMemory() same number of times as you called vmaMapMemory().
-
-    It is also safe to call this function on allocation created with
-    #VMA_ALLOCATION_CREATE_MAPPED_BIT flag. Its memory stays mapped all the time.
-    You must still call vmaUnmapMemory() same number of times as you called
-    vmaMapMemory(). You must not call vmaUnmapMemory() additional time to free the
-    "0-th" mapping made automatically due to #VMA_ALLOCATION_CREATE_MAPPED_BIT flag.
-
-    This function fails when used on allocation made in memory type that is not
-    `HOST_VISIBLE`.
-
-    This function doesn't automatically flush or invalidate caches.
-    If the allocation is made from a memory types that is not `HOST_COHERENT`,
-    you also need to use vmaInvalidateAllocation() / vmaFlushAllocation(), as required by Vulkan specification.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaMapMemory(VmaAllocator VMA_NOT_NULL  allocator,
-                                                     VmaAllocation VMA_NOT_NULL allocation,
-                                                     void* VMA_NULLABLE* VMA_NOT_NULL ppData);
-
-    /** \brief Unmaps memory represented by given allocation, mapped previously using vmaMapMemory().
-
-    For details, see description of vmaMapMemory().
-
-    This function doesn't automatically flush or invalidate caches.
-    If the allocation is made from a memory types that is not `HOST_COHERENT`,
-    you also need to use vmaInvalidateAllocation() / vmaFlushAllocation(), as required by Vulkan specification.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaUnmapMemory(VmaAllocator VMA_NOT_NULL  allocator,
-                                                   VmaAllocation VMA_NOT_NULL allocation);
-
-    /** \brief Flushes memory of given allocation.
-
-    Calls `vkFlushMappedMemoryRanges()` for memory associated with given range of given allocation.
-    It needs to be called after writing to a mapped memory for memory types that are not `HOST_COHERENT`.
-    Unmap operation doesn't do that automatically.
-
-    - `offset` must be relative to the beginning of allocation.
-    - `size` can be `VK_WHOLE_SIZE`. It means all memory from `offset` the the end of given allocation.
-    - `offset` and `size` don't have to be aligned.
-      They are internally rounded down/up to multiply of `nonCoherentAtomSize`.
-    - If `size` is 0, this call is ignored.
-    - If memory type that the `allocation` belongs to is not `HOST_VISIBLE` or it is `HOST_COHERENT`,
-      this call is ignored.
-
-    Warning! `offset` and `size` are relative to the contents of given `allocation`.
-    If you mean whole allocation, you can pass 0 and `VK_WHOLE_SIZE`, respectively.
-    Do not pass allocation's offset as `offset`!!!
-
-    This function returns the `VkResult` from `vkFlushMappedMemoryRanges` if it is
-    called, otherwise `VK_SUCCESS`.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocation(VmaAllocator VMA_NOT_NULL  allocator,
-                                                           VmaAllocation VMA_NOT_NULL allocation,
-                                                           VkDeviceSize               offset,
-                                                           VkDeviceSize               size);
-
-    /** \brief Invalidates memory of given allocation.
-
-    Calls `vkInvalidateMappedMemoryRanges()` for memory associated with given range of given allocation.
-    It needs to be called before reading from a mapped memory for memory types that are not `HOST_COHERENT`.
-    Map operation doesn't do that automatically.
-
-    - `offset` must be relative to the beginning of allocation.
-    - `size` can be `VK_WHOLE_SIZE`. It means all memory from `offset` the the end of given allocation.
-    - `offset` and `size` don't have to be aligned.
-      They are internally rounded down/up to multiply of `nonCoherentAtomSize`.
-    - If `size` is 0, this call is ignored.
-    - If memory type that the `allocation` belongs to is not `HOST_VISIBLE` or it is `HOST_COHERENT`,
-      this call is ignored.
-
-    Warning! `offset` and `size` are relative to the contents of given `allocation`.
-    If you mean whole allocation, you can pass 0 and `VK_WHOLE_SIZE`, respectively.
-    Do not pass allocation's offset as `offset`!!!
-
-    This function returns the `VkResult` from `vkInvalidateMappedMemoryRanges` if
-    it is called, otherwise `VK_SUCCESS`.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocation(VmaAllocator VMA_NOT_NULL  allocator,
-                                                                VmaAllocation VMA_NOT_NULL allocation,
-                                                                VkDeviceSize               offset,
-                                                                VkDeviceSize               size);
-
-    /** \brief Flushes memory of given set of allocations.
-
-    Calls `vkFlushMappedMemoryRanges()` for memory associated with given ranges of given allocations.
-    For more information, see documentation of vmaFlushAllocation().
-
-    \param allocator
-    \param allocationCount
-    \param allocations
-    \param offsets If not null, it must point to an array of offsets of regions to flush, relative to the beginning of
-    respective allocations. Null means all ofsets are zero. \param sizes If not null, it must point to an array of sizes
-    of regions to flush in respective allocations. Null means `VK_WHOLE_SIZE` for all allocations.
-
-    This function returns the `VkResult` from `vkFlushMappedMemoryRanges` if it is
-    called, otherwise `VK_SUCCESS`.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaFlushAllocations(VmaAllocator VMA_NOT_NULL allocator,
-                        uint32_t                  allocationCount,
-                        const VmaAllocation VMA_NOT_NULL* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) allocations,
-                        const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) offsets,
-                        const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) sizes);
-
-    /** \brief Invalidates memory of given set of allocations.
-
-    Calls `vkInvalidateMappedMemoryRanges()` for memory associated with given ranges of given allocations.
-    For more information, see documentation of vmaInvalidateAllocation().
-
-    \param allocator
-    \param allocationCount
-    \param allocations
-    \param offsets If not null, it must point to an array of offsets of regions to flush, relative to the beginning of
-    respective allocations. Null means all ofsets are zero. \param sizes If not null, it must point to an array of sizes
-    of regions to flush in respective allocations. Null means `VK_WHOLE_SIZE` for all allocations.
-
-    This function returns the `VkResult` from `vkInvalidateMappedMemoryRanges` if it is
-    called, otherwise `VK_SUCCESS`.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocations(
-        VmaAllocator VMA_NOT_NULL allocator,
-        uint32_t                  allocationCount,
-        const VmaAllocation VMA_NOT_NULL* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) allocations,
-        const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) offsets,
-        const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) sizes);
-
-    /** \brief Checks magic number in margins around all allocations in given memory types (in both default and custom
-    pools) in search for corruptions.
-
-    \param allocator
-    \param memoryTypeBits Bit mask, where each bit set means that a memory type with that index should be checked.
-
-    Corruption detection is enabled only when `VMA_DEBUG_DETECT_CORRUPTION` macro is defined to nonzero,
-    `VMA_DEBUG_MARGIN` is defined to nonzero and only for memory types that are
-    `HOST_VISIBLE` and `HOST_COHERENT`. For more information, see [Corruption detection](@ref
-    debugging_memory_usage_corruption_detection).
-
-    Possible return values:
-
-    - `VK_ERROR_FEATURE_NOT_PRESENT` - corruption detection is not enabled for any of specified memory types.
-    - `VK_SUCCESS` - corruption detection has been performed and succeeded.
-    - `VK_ERROR_UNKNOWN` - corruption detection has been performed and found memory corruptions around one of the
-    allocations. `VMA_ASSERT` is also fired in that case.
-    - Other value: Error returned by Vulkan, e.g. memory mapping failure.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckCorruption(VmaAllocator VMA_NOT_NULL allocator,
-                                                           uint32_t                  memoryTypeBits);
-
-    /** \brief Begins defragmentation process.
-
-    \param allocator Allocator object.
-    \param pInfo Structure filled with parameters of defragmentation.
-    \param[out] pContext Context object that must be passed to vmaEndDefragmentation() to finish defragmentation.
-    \returns
-    - `VK_SUCCESS` if defragmentation can begin.
-    - `VK_ERROR_FEATURE_NOT_PRESENT` if defragmentation is not supported.
-
-    For more information about defragmentation, see documentation chapter:
-    [Defragmentation](@ref defragmentation).
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaBeginDefragmentation(VmaAllocator VMA_NOT_NULL                  allocator,
-                            const VmaDefragmentationInfo* VMA_NOT_NULL pInfo,
-                            VmaDefragmentationContext VMA_NULLABLE* VMA_NOT_NULL pContext);
-
-    /** \brief Ends defragmentation process.
-
-    \param allocator Allocator object.
-    \param context Context object that has been created by vmaBeginDefragmentation().
-    \param[out] pStats Optional stats for the defragmentation. Can be null.
-
-    Use this function to finish defragmentation started by vmaBeginDefragmentation().
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaEndDefragmentation(VmaAllocator VMA_NOT_NULL              allocator,
-                                                          VmaDefragmentationContext VMA_NOT_NULL context,
-                                                          VmaDefragmentationStats* VMA_NULLABLE  pStats);
-
-    /** \brief Starts single defragmentation pass.
-
-    \param allocator Allocator object.
-    \param context Context object that has been created by vmaBeginDefragmentation().
-    \param[out] pPassInfo Computed informations for current pass.
-    \returns
-    - `VK_SUCCESS` if no more moves are possible. Then you can omit call to vmaEndDefragmentationPass() and simply end
-    whole defragmentation.
-    - `VK_INCOMPLETE` if there are pending moves returned in `pPassInfo`. You need to perform them, call
-    vmaEndDefragmentationPass(), and then preferably try another pass with vmaBeginDefragmentationPass().
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaBeginDefragmentationPass(VmaAllocator VMA_NOT_NULL                    allocator,
-                                VmaDefragmentationContext VMA_NOT_NULL       context,
-                                VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo);
-
-    /** \brief Ends single defragmentation pass.
-
-    \param allocator Allocator object.
-    \param context Context object that has been created by vmaBeginDefragmentation().
-    \param pPassInfo Computed informations for current pass filled by vmaBeginDefragmentationPass() and possibly
-    modified by you.
-
-    Returns `VK_SUCCESS` if no more moves are possible or `VK_INCOMPLETE` if more defragmentations are possible.
-
-    Ends incremental defragmentation pass and commits all defragmentation moves from `pPassInfo`.
-    After this call:
-
-    - Allocations at `pPassInfo[i].srcAllocation` that had `pPassInfo[i].operation ==`
-    #VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY (which is the default) will be pointing to the new destination place.
-    - Allocation at `pPassInfo[i].srcAllocation` that had `pPassInfo[i].operation ==`
-    #VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY will be freed.
-
-    If no more moves are possible you can end whole defragmentation.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaEndDefragmentationPass(VmaAllocator VMA_NOT_NULL                    allocator,
-                              VmaDefragmentationContext VMA_NOT_NULL       context,
-                              VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo);
-
-    /** \brief Binds buffer to allocation.
-
-    Binds specified buffer to region of memory represented by specified allocation.
-    Gets `VkDeviceMemory` handle and offset from the allocation.
-    If you want to create a buffer, allocate memory for it and bind them together separately,
-    you should use this function for binding instead of standard `vkBindBufferMemory()`,
-    because it ensures proper synchronization so that when a `VkDeviceMemory` object is used by multiple
-    allocations, calls to `vkBind*Memory()` or `vkMapMemory()` won't happen from multiple threads simultaneously
-    (which is illegal in Vulkan).
-
-    It is recommended to use function vmaCreateBuffer() instead of this one.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory(VmaAllocator VMA_NOT_NULL              allocator,
-                                                            VmaAllocation VMA_NOT_NULL             allocation,
-                                                            VkBuffer VMA_NOT_NULL_NON_DISPATCHABLE buffer);
-
-    /** \brief Binds buffer to allocation with additional parameters.
-
-    \param allocator
-    \param allocation
-    \param allocationLocalOffset Additional offset to be added while binding, relative to the beginning of the
-    `allocation`. Normally it should be 0. \param buffer \param pNext A chain of structures to be attached to
-    `VkBindBufferMemoryInfoKHR` structure used internally. Normally it should be null.
-
-    This function is similar to vmaBindBufferMemory(), but it provides additional parameters.
-
-    If `pNext` is not null, #VmaAllocator object must have been created with #VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT
-    flag or with VmaAllocatorCreateInfo::vulkanApiVersion `>= VK_API_VERSION_1_1`. Otherwise the call fails.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory2(VmaAllocator VMA_NOT_NULL  allocator,
-                                                             VmaAllocation VMA_NOT_NULL allocation,
-                                                             VkDeviceSize               allocationLocalOffset,
-                                                             VkBuffer VMA_NOT_NULL_NON_DISPATCHABLE buffer,
-                                                             const void* VMA_NULLABLE               pNext);
-
-    /** \brief Binds image to allocation.
-
-    Binds specified image to region of memory represented by specified allocation.
-    Gets `VkDeviceMemory` handle and offset from the allocation.
-    If you want to create an image, allocate memory for it and bind them together separately,
-    you should use this function for binding instead of standard `vkBindImageMemory()`,
-    because it ensures proper synchronization so that when a `VkDeviceMemory` object is used by multiple
-    allocations, calls to `vkBind*Memory()` or `vkMapMemory()` won't happen from multiple threads simultaneously
-    (which is illegal in Vulkan).
-
-    It is recommended to use function vmaCreateImage() instead of this one.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory(VmaAllocator VMA_NOT_NULL             allocator,
-                                                           VmaAllocation VMA_NOT_NULL            allocation,
-                                                           VkImage VMA_NOT_NULL_NON_DISPATCHABLE image);
-
-    /** \brief Binds image to allocation with additional parameters.
-
-    \param allocator
-    \param allocation
-    \param allocationLocalOffset Additional offset to be added while binding, relative to the beginning of the
-    `allocation`. Normally it should be 0. \param image \param pNext A chain of structures to be attached to
-    `VkBindImageMemoryInfoKHR` structure used internally. Normally it should be null.
-
-    This function is similar to vmaBindImageMemory(), but it provides additional parameters.
-
-    If `pNext` is not null, #VmaAllocator object must have been created with #VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT
-    flag or with VmaAllocatorCreateInfo::vulkanApiVersion `>= VK_API_VERSION_1_1`. Otherwise the call fails.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory2(VmaAllocator VMA_NOT_NULL             allocator,
-                                                            VmaAllocation VMA_NOT_NULL            allocation,
-                                                            VkDeviceSize                          allocationLocalOffset,
-                                                            VkImage VMA_NOT_NULL_NON_DISPATCHABLE image,
-                                                            const void* VMA_NULLABLE              pNext);
-
-    /** \brief Creates a new `VkBuffer`, allocates and binds memory for it.
-
-    \param allocator
-    \param pBufferCreateInfo
-    \param pAllocationCreateInfo
-    \param[out] pBuffer Buffer that was created.
-    \param[out] pAllocation Allocation that was created.
-    \param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function
-    vmaGetAllocationInfo().
-
-    This function automatically:
-
-    -# Creates buffer.
-    -# Allocates appropriate memory for it.
-    -# Binds the buffer with the memory.
-
-    If any of these operations fail, buffer and allocation are not created,
-    returned value is negative error code, `*pBuffer` and `*pAllocation` are null.
-
-    If the function succeeded, you must destroy both buffer and allocation when you
-    no longer need them using either convenience function vmaDestroyBuffer() or
-    separately, using `vkDestroyBuffer()` and vmaFreeMemory().
-
-    If #VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT flag was used,
-    VK_KHR_dedicated_allocation extension is used internally to query driver whether
-    it requires or prefers the new buffer to have dedicated allocation. If yes,
-    and if dedicated allocation is possible
-    (#VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT is not used), it creates dedicated
-    allocation for this buffer, just like when using
-    #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
-
-    \note This function creates a new `VkBuffer`. Sub-allocation of parts of one large buffer,
-    although recommended as a good practice, is out of scope of this library and could be implemented
-    by the user as a higher-level logic on top of VMA.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateBuffer(VmaAllocator VMA_NOT_NULL                   allocator,
-                    const VkBufferCreateInfo* VMA_NOT_NULL      pBufferCreateInfo,
-                    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
-                    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer,
-                    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                    VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
-
-    /** \brief Creates a buffer with additional minimum alignment.
-
-    Similar to vmaCreateBuffer() but provides additional parameter `minAlignment` which allows to specify custom,
-    minimum alignment to be used when placing the buffer inside a larger memory block, which may be needed e.g.
-    for interop with OpenGL.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateBufferWithAlignment(VmaAllocator VMA_NOT_NULL                   allocator,
-                                 const VkBufferCreateInfo* VMA_NOT_NULL      pBufferCreateInfo,
-                                 const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
-                                 VkDeviceSize                                minAlignment,
-                                 VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer,
-                                 VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                                 VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
-
-    /** \brief Creates a new `VkBuffer`, binds already created memory for it.
-
-    \param allocator
-    \param allocation Allocation that provides memory to be used for binding new buffer to it.
-    \param pBufferCreateInfo
-    \param[out] pBuffer Buffer that was created.
-
-    This function automatically:
-
-    -# Creates buffer.
-    -# Binds the buffer with the supplied memory.
-
-    If any of these operations fail, buffer is not created,
-    returned value is negative error code and `*pBuffer` is null.
-
-    If the function succeeded, you must destroy the buffer when you
-    no longer need it using `vkDestroyBuffer()`. If you want to also destroy the corresponding
-    allocation you can use convenience function vmaDestroyBuffer().
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL              allocator,
-                            VmaAllocation VMA_NOT_NULL             allocation,
-                            const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
-                            VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer);
-
-    /** \brief Destroys Vulkan buffer and frees allocated memory.
-
-    This is just a convenience function equivalent to:
-
-    \code
-    vkDestroyBuffer(device, buffer, allocationCallbacks);
-    vmaFreeMemory(allocator, allocation);
-    \endcode
-
-    It it safe to pass null as buffer and/or allocation.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaDestroyBuffer(VmaAllocator VMA_NOT_NULL              allocator,
-                                                     VkBuffer VMA_NULLABLE_NON_DISPATCHABLE buffer,
-                                                     VmaAllocation VMA_NULLABLE             allocation);
-
-    /// Function similar to vmaCreateBuffer().
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateImage(VmaAllocator VMA_NOT_NULL                   allocator,
-                   const VkImageCreateInfo* VMA_NOT_NULL       pImageCreateInfo,
-                   const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
-                   VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage,
-                   VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                   VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
-
-    /// Function similar to vmaCreateAliasingBuffer().
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateAliasingImage(VmaAllocator VMA_NOT_NULL             allocator,
-                           VmaAllocation VMA_NOT_NULL            allocation,
-                           const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
-                           VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage);
-
-    /** \brief Destroys Vulkan image and frees allocated memory.
-
-    This is just a convenience function equivalent to:
-
-    \code
-    vkDestroyImage(device, image, allocationCallbacks);
-    vmaFreeMemory(allocator, allocation);
-    \endcode
-
-    It it safe to pass null as image and/or allocation.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(VmaAllocator VMA_NOT_NULL             allocator,
-                                                    VkImage VMA_NULLABLE_NON_DISPATCHABLE image,
-                                                    VmaAllocation VMA_NULLABLE            allocation);
-
-    /** @} */
-
-    /**
-    \addtogroup group_virtual
-    @{
-    */
-
-    /** \brief Creates new #VmaVirtualBlock object.
-
-    \param pCreateInfo Parameters for creation.
-    \param[out] pVirtualBlock Returned virtual block object or `VMA_NULL` if creation failed.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateVirtualBlock(const VmaVirtualBlockCreateInfo* VMA_NOT_NULL pCreateInfo,
-                                                              VmaVirtualBlock VMA_NULLABLE* VMA_NOT_NULL pVirtualBlock);
-
-    /** \brief Destroys #VmaVirtualBlock object.
-
-    Please note that you should consciously handle virtual allocations that could remain unfreed in the block.
-    You should either free them individually using vmaVirtualFree() or call vmaClearVirtualBlock()
-    if you are sure this is what you want. If you do neither, an assert is called.
-
-    If you keep pointers to some additional metadata associated with your virtual allocations in their `pUserData`,
-    don't forget to free them.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaDestroyVirtualBlock(VmaVirtualBlock VMA_NULLABLE virtualBlock);
-
-    /** \brief Returns true of the #VmaVirtualBlock is empty - contains 0 virtual allocations and has all its space
-     * available for new allocations.
-     */
-    VMA_CALL_PRE VkBool32 VMA_CALL_POST vmaIsVirtualBlockEmpty(VmaVirtualBlock VMA_NOT_NULL virtualBlock);
-
-    /** \brief Returns information about a specific virtual allocation within a virtual block, like its size and
-     * `pUserData` pointer.
-     */
-    VMA_CALL_PRE void VMA_CALL_POST
-    vmaGetVirtualAllocationInfo(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                                VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation,
-                                VmaVirtualAllocationInfo* VMA_NOT_NULL             pVirtualAllocInfo);
-
-    /** \brief Allocates new virtual allocation inside given #VmaVirtualBlock.
-
-    If the allocation fails due to not enough free space available, `VK_ERROR_OUT_OF_DEVICE_MEMORY` is returned
-    (despite the function doesn't ever allocate actual GPU memory).
-    `pAllocation` is then set to `VK_NULL_HANDLE` and `pOffset`, if not null, it set to `UINT64_MAX`.
-
-    \param virtualBlock Virtual block
-    \param pCreateInfo Parameters for the allocation
-    \param[out] pAllocation Returned handle of the new allocation
-    \param[out] pOffset Returned offset of the new allocation. Optional, can be null.
-    */
-    VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                       const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                       VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pAllocation,
-                       VkDeviceSize* VMA_NULLABLE                                       pOffset);
-
-    /** \brief Frees virtual allocation inside given #VmaVirtualBlock.
-
-    It is correct to call this function with `allocation == VK_NULL_HANDLE` - it does nothing.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaVirtualFree(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                                                   VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE allocation);
-
-    /** \brief Frees all virtual allocations inside given #VmaVirtualBlock.
-
-    You must either call this function or free each virtual allocation individually with vmaVirtualFree()
-    before destroying a virtual block. Otherwise, an assert is called.
-
-    If you keep pointer to some additional metadata associated with your virtual allocation in its `pUserData`,
-    don't forget to free it as well.
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaClearVirtualBlock(VmaVirtualBlock VMA_NOT_NULL virtualBlock);
-
-    /** \brief Changes custom pointer associated with given virtual allocation.
-     */
-    VMA_CALL_PRE void VMA_CALL_POST
-    vmaSetVirtualAllocationUserData(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                                    VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation,
-                                    void* VMA_NULLABLE                                 pUserData);
-
-    /** \brief Calculates and returns statistics about virtual allocations and memory usage in given #VmaVirtualBlock.
-
-    This function is fast to call. For more detailed statistics, see vmaCalculateVirtualBlockStatistics().
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetVirtualBlockStatistics(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
-                                                                 VmaStatistics* VMA_NOT_NULL  pStats);
-
-    /** \brief Calculates and returns detailed statistics about virtual allocations and memory usage in given
-    #VmaVirtualBlock.
-
-    This function is slow to call. Use for debugging purposes.
-    For less detailed statistics, see vmaGetVirtualBlockStatistics().
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaCalculateVirtualBlockStatistics(VmaVirtualBlock VMA_NOT_NULL        virtualBlock,
-                                                                       VmaDetailedStatistics* VMA_NOT_NULL pStats);
-
-    /** @} */
+/**
+\addtogroup group_init
+@{
+*/
+
+/// Creates #VmaAllocator object.
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAllocator(
+    const VmaAllocatorCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaAllocator VMA_NULLABLE* VMA_NOT_NULL pAllocator);
+
+/// Destroys allocator object.
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyAllocator(
+    VmaAllocator VMA_NULLABLE allocator);
+
+/** \brief Returns information about existing #VmaAllocator object - handle to Vulkan device etc.
+
+It might be useful if you want to keep just the #VmaAllocator handle and fetch other required handles to
+`VkPhysicalDevice`, `VkDevice` etc. every time using this function.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocatorInfo(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocatorInfo* VMA_NOT_NULL pAllocatorInfo);
+
+/**
+PhysicalDeviceProperties are fetched from physicalDevice by the allocator.
+You can access it here, without fetching it again on your own.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetPhysicalDeviceProperties(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkPhysicalDeviceProperties* VMA_NULLABLE* VMA_NOT_NULL ppPhysicalDeviceProperties);
+
+/**
+PhysicalDeviceMemoryProperties are fetched from physicalDevice by the allocator.
+You can access it here, without fetching it again on your own.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryProperties(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkPhysicalDeviceMemoryProperties* VMA_NULLABLE* VMA_NOT_NULL ppPhysicalDeviceMemoryProperties);
+
+/**
+\brief Given Memory Type Index, returns Property Flags of this memory type.
+
+This is just a convenience function. Same information can be obtained using
+vmaGetMemoryProperties().
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryTypeProperties(
+    VmaAllocator VMA_NOT_NULL allocator,
+    uint32_t memoryTypeIndex,
+    VkMemoryPropertyFlags* VMA_NOT_NULL pFlags);
+
+/** \brief Sets index of the current frame.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaSetCurrentFrameIndex(
+    VmaAllocator VMA_NOT_NULL allocator,
+    uint32_t frameIndex);
+
+/** @} */
+
+/**
+\addtogroup group_stats
+@{
+*/
+
+/** \brief Retrieves statistics from current state of the Allocator.
+
+This function is called "calculate" not "get" because it has to traverse all
+internal data structures, so it may be quite slow. Use it for debugging purposes.
+For faster but more brief statistics suitable to be called every frame or every allocation,
+use vmaGetHeapBudgets().
+
+Note that when using allocator from multiple threads, returned information may immediately
+become outdated.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaCalculateStatistics(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaTotalStatistics* VMA_NOT_NULL pStats);
+
+/** \brief Retrieves information about current memory usage and budget for all memory heaps.
+
+\param allocator
+\param[out] pBudgets Must point to array with number of elements at least equal to number of memory heaps in physical device used.
+
+This function is called "get" not "calculate" because it is very fast, suitable to be called
+every frame or every allocation. For more detailed statistics use vmaCalculateStatistics().
+
+Note that when using allocator from multiple threads, returned information may immediately
+become outdated.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetHeapBudgets(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaBudget* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL("VkPhysicalDeviceMemoryProperties::memoryHeapCount") pBudgets);
+
+/** @} */
+
+/**
+\addtogroup group_alloc
+@{
+*/
+
+/**
+\brief Helps to find memoryTypeIndex, given memoryTypeBits and VmaAllocationCreateInfo.
+
+This algorithm tries to find a memory type that:
+
+- Is allowed by memoryTypeBits.
+- Contains all the flags from pAllocationCreateInfo->requiredFlags.
+- Matches intended usage.
+- Has as many flags from pAllocationCreateInfo->preferredFlags as possible.
+
+\return Returns VK_ERROR_FEATURE_NOT_PRESENT if not found. Receiving such result
+from this function or any other allocating function probably means that your
+device doesn't support any memory type with requested features for the specific
+type of resource you want to use it for. Please check parameters of your
+resource, like image layout (OPTIMAL versus LINEAR) or mip level count.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndex(
+    VmaAllocator VMA_NOT_NULL allocator,
+    uint32_t memoryTypeBits,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    uint32_t* VMA_NOT_NULL pMemoryTypeIndex);
+
+/**
+\brief Helps to find memoryTypeIndex, given VkBufferCreateInfo and VmaAllocationCreateInfo.
+
+It can be useful e.g. to determine value to be used as VmaPoolCreateInfo::memoryTypeIndex.
+It internally creates a temporary, dummy buffer that never has memory bound.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndexForBufferInfo(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    uint32_t* VMA_NOT_NULL pMemoryTypeIndex);
+
+/**
+\brief Helps to find memoryTypeIndex, given VkImageCreateInfo and VmaAllocationCreateInfo.
+
+It can be useful e.g. to determine value to be used as VmaPoolCreateInfo::memoryTypeIndex.
+It internally creates a temporary, dummy image that never has memory bound.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndexForImageInfo(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    uint32_t* VMA_NOT_NULL pMemoryTypeIndex);
+
+/** \brief Allocates Vulkan device memory and creates #VmaPool object.
+
+\param allocator Allocator object.
+\param pCreateInfo Parameters of pool to create.
+\param[out] pPool Handle to created pool.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreatePool(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VmaPoolCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaPool VMA_NULLABLE* VMA_NOT_NULL pPool);
+
+/** \brief Destroys #VmaPool object and frees Vulkan device memory.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyPool(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaPool VMA_NULLABLE pool);
+
+/** @} */
+
+/**
+\addtogroup group_stats
+@{
+*/
+
+/** \brief Retrieves statistics of existing #VmaPool object.
+
+\param allocator Allocator object.
+\param pool Pool object.
+\param[out] pPoolStats Statistics of specified pool.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolStatistics(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaPool VMA_NOT_NULL pool,
+    VmaStatistics* VMA_NOT_NULL pPoolStats);
+
+/** \brief Retrieves detailed statistics of existing #VmaPool object.
+
+\param allocator Allocator object.
+\param pool Pool object.
+\param[out] pPoolStats Statistics of specified pool.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaCalculatePoolStatistics(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaPool VMA_NOT_NULL pool,
+    VmaDetailedStatistics* VMA_NOT_NULL pPoolStats);
+
+/** @} */
+
+/**
+\addtogroup group_alloc
+@{
+*/
+
+/** \brief Checks magic number in margins around all allocations in given memory pool in search for corruptions.
+
+Corruption detection is enabled only when `VMA_DEBUG_DETECT_CORRUPTION` macro is defined to nonzero,
+`VMA_DEBUG_MARGIN` is defined to nonzero and the pool is created in memory type that is
+`HOST_VISIBLE` and `HOST_COHERENT`. For more information, see [Corruption detection](@ref debugging_memory_usage_corruption_detection).
+
+Possible return values:
+
+- `VK_ERROR_FEATURE_NOT_PRESENT` - corruption detection is not enabled for specified pool.
+- `VK_SUCCESS` - corruption detection has been performed and succeeded.
+- `VK_ERROR_UNKNOWN` - corruption detection has been performed and found memory corruptions around one of the allocations.
+  `VMA_ASSERT` is also fired in that case.
+- Other value: Error returned by Vulkan, e.g. memory mapping failure.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckPoolCorruption(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaPool VMA_NOT_NULL pool);
+
+/** \brief Retrieves name of a custom pool.
+
+After the call `ppName` is either null or points to an internally-owned null-terminated string
+containing name of the pool that was previously set. The pointer becomes invalid when the pool is
+destroyed or its name is changed using vmaSetPoolName().
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolName(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaPool VMA_NOT_NULL pool,
+    const char* VMA_NULLABLE* VMA_NOT_NULL ppName);
+
+/** \brief Sets name of a custom pool.
+
+`pName` can be either null or pointer to a null-terminated string with new name for the pool.
+Function makes internal copy of the string, so it can be changed or freed immediately after this call.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaSetPoolName(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaPool VMA_NOT_NULL pool,
+    const char* VMA_NULLABLE pName);
+
+/** \brief General purpose memory allocation.
+
+\param allocator
+\param pVkMemoryRequirements
+\param pCreateInfo
+\param[out] pAllocation Handle to allocated memory.
+\param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function vmaGetAllocationInfo().
+
+You should free the memory using vmaFreeMemory() or vmaFreeMemoryPages().
+
+It is recommended to use vmaAllocateMemoryForBuffer(), vmaAllocateMemoryForImage(),
+vmaCreateBuffer(), vmaCreateImage() instead whenever possible.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemory(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkMemoryRequirements* VMA_NOT_NULL pVkMemoryRequirements,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
+    VmaAllocationInfo* VMA_NULLABLE pAllocationInfo);
+
+/** \brief General purpose memory allocation for multiple allocation objects at once.
+
+\param allocator Allocator object.
+\param pVkMemoryRequirements Memory requirements for each allocation.
+\param pCreateInfo Creation parameters for each allocation.
+\param allocationCount Number of allocations to make.
+\param[out] pAllocations Pointer to array that will be filled with handles to created allocations.
+\param[out] pAllocationInfo Optional. Pointer to array that will be filled with parameters of created allocations.
+
+You should free the memory using vmaFreeMemory() or vmaFreeMemoryPages().
+
+Word "pages" is just a suggestion to use this function to allocate pieces of memory needed for sparse binding.
+It is just a general purpose allocation function able to make multiple allocations at once.
+It may be internally optimized to be more efficient than calling vmaAllocateMemory() `allocationCount` times.
+
+All allocations are made using same parameters. All of them are created out of the same memory pool and type.
+If any allocation fails, all allocations already made within this function call are also freed, so that when
+returned result is not `VK_SUCCESS`, `pAllocation` array is always entirely filled with `VK_NULL_HANDLE`.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryPages(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkMemoryRequirements* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pVkMemoryRequirements,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pCreateInfo,
+    size_t allocationCount,
+    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pAllocations,
+    VmaAllocationInfo* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) pAllocationInfo);
+
+/** \brief Allocates memory suitable for given `VkBuffer`.
+
+\param allocator
+\param buffer
+\param pCreateInfo
+\param[out] pAllocation Handle to allocated memory.
+\param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function vmaGetAllocationInfo().
+
+It only creates #VmaAllocation. To bind the memory to the buffer, use vmaBindBufferMemory().
+
+This is a special-purpose function. In most cases you should use vmaCreateBuffer().
+
+You must free the allocation using vmaFreeMemory() when no longer needed.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForBuffer(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VkBuffer VMA_NOT_NULL_NON_DISPATCHABLE buffer,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
+    VmaAllocationInfo* VMA_NULLABLE pAllocationInfo);
+
+/** \brief Allocates memory suitable for given `VkImage`.
+
+\param allocator
+\param image
+\param pCreateInfo
+\param[out] pAllocation Handle to allocated memory.
+\param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function vmaGetAllocationInfo().
+
+It only creates #VmaAllocation. To bind the memory to the buffer, use vmaBindImageMemory().
+
+This is a special-purpose function. In most cases you should use vmaCreateImage().
+
+You must free the allocation using vmaFreeMemory() when no longer needed.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForImage(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VkImage VMA_NOT_NULL_NON_DISPATCHABLE image,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
+    VmaAllocationInfo* VMA_NULLABLE pAllocationInfo);
+
+/** \brief Frees memory previously allocated using vmaAllocateMemory(), vmaAllocateMemoryForBuffer(), or vmaAllocateMemoryForImage().
+
+Passing `VK_NULL_HANDLE` as `allocation` is valid. Such function call is just skipped.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemory(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VmaAllocation VMA_NULLABLE allocation);
+
+/** \brief Frees memory and destroys multiple allocations.
+
+Word "pages" is just a suggestion to use this function to free pieces of memory used for sparse binding.
+It is just a general purpose function to free memory and destroy allocations made using e.g. vmaAllocateMemory(),
+vmaAllocateMemoryPages() and other functions.
+It may be internally optimized to be more efficient than calling vmaFreeMemory() `allocationCount` times.
+
+Allocations in `pAllocations` array can come from any memory pools and types.
+Passing `VK_NULL_HANDLE` as elements of `pAllocations` array is valid. Such entries are just skipped.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemoryPages(
+    VmaAllocator VMA_NOT_NULL allocator,
+    size_t allocationCount,
+    const VmaAllocation VMA_NULLABLE* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pAllocations);
+
+/** \brief Returns current information about specified allocation.
+
+Current parameters of given allocation are returned in `pAllocationInfo`.
+
+Although this function doesn't lock any mutex, so it should be quite efficient,
+you should avoid calling it too often.
+You can retrieve same VmaAllocationInfo structure while creating your resource, from function
+vmaCreateBuffer(), vmaCreateImage(). You can remember it if you are sure parameters don't change
+(e.g. due to defragmentation).
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationInfo(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VmaAllocationInfo* VMA_NOT_NULL pAllocationInfo);
+
+/** \brief Sets pUserData in given allocation to new value.
+
+The value of pointer `pUserData` is copied to allocation's `pUserData`.
+It is opaque, so you can use it however you want - e.g.
+as a pointer, ordinal number or some handle to you own data.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationUserData(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    void* VMA_NULLABLE pUserData);
+
+/** \brief Sets pName in given allocation to new value.
+
+`pName` must be either null, or pointer to a null-terminated string. The function
+makes local copy of the string and sets it as allocation's `pName`. String
+passed as pName doesn't need to be valid for whole lifetime of the allocation -
+you can free it after this call. String previously pointed by allocation's
+`pName` is freed from memory.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationName(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    const char* VMA_NULLABLE pName);
+
+/**
+\brief Given an allocation, returns Property Flags of its memory type.
+
+This is just a convenience function. Same information can be obtained using
+vmaGetAllocationInfo() + vmaGetMemoryProperties().
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationMemoryProperties(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkMemoryPropertyFlags* VMA_NOT_NULL pFlags);
+
+/** \brief Maps memory represented by given allocation and returns pointer to it.
+
+Maps memory represented by given allocation to make it accessible to CPU code.
+When succeeded, `*ppData` contains pointer to first byte of this memory.
+
+\warning
+If the allocation is part of a bigger `VkDeviceMemory` block, returned pointer is
+correctly offsetted to the beginning of region assigned to this particular allocation.
+Unlike the result of `vkMapMemory`, it points to the allocation, not to the beginning of the whole block.
+You should not add VmaAllocationInfo::offset to it!
+
+Mapping is internally reference-counted and synchronized, so despite raw Vulkan
+function `vkMapMemory()` cannot be used to map same block of `VkDeviceMemory`
+multiple times simultaneously, it is safe to call this function on allocations
+assigned to the same memory block. Actual Vulkan memory will be mapped on first
+mapping and unmapped on last unmapping.
+
+If the function succeeded, you must call vmaUnmapMemory() to unmap the
+allocation when mapping is no longer needed or before freeing the allocation, at
+the latest.
+
+It also safe to call this function multiple times on the same allocation. You
+must call vmaUnmapMemory() same number of times as you called vmaMapMemory().
+
+It is also safe to call this function on allocation created with
+#VMA_ALLOCATION_CREATE_MAPPED_BIT flag. Its memory stays mapped all the time.
+You must still call vmaUnmapMemory() same number of times as you called
+vmaMapMemory(). You must not call vmaUnmapMemory() additional time to free the
+"0-th" mapping made automatically due to #VMA_ALLOCATION_CREATE_MAPPED_BIT flag.
+
+This function fails when used on allocation made in memory type that is not
+`HOST_VISIBLE`.
+
+This function doesn't automatically flush or invalidate caches.
+If the allocation is made from a memory types that is not `HOST_COHERENT`,
+you also need to use vmaInvalidateAllocation() / vmaFlushAllocation(), as required by Vulkan specification.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaMapMemory(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    void* VMA_NULLABLE* VMA_NOT_NULL ppData);
+
+/** \brief Unmaps memory represented by given allocation, mapped previously using vmaMapMemory().
+
+For details, see description of vmaMapMemory().
+
+This function doesn't automatically flush or invalidate caches.
+If the allocation is made from a memory types that is not `HOST_COHERENT`,
+you also need to use vmaInvalidateAllocation() / vmaFlushAllocation(), as required by Vulkan specification.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaUnmapMemory(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation);
+
+/** \brief Flushes memory of given allocation.
+
+Calls `vkFlushMappedMemoryRanges()` for memory associated with given range of given allocation.
+It needs to be called after writing to a mapped memory for memory types that are not `HOST_COHERENT`.
+Unmap operation doesn't do that automatically.
+
+- `offset` must be relative to the beginning of allocation.
+- `size` can be `VK_WHOLE_SIZE`. It means all memory from `offset` the the end of given allocation.
+- `offset` and `size` don't have to be aligned.
+  They are internally rounded down/up to multiply of `nonCoherentAtomSize`.
+- If `size` is 0, this call is ignored.
+- If memory type that the `allocation` belongs to is not `HOST_VISIBLE` or it is `HOST_COHERENT`,
+  this call is ignored.
+
+Warning! `offset` and `size` are relative to the contents of given `allocation`.
+If you mean whole allocation, you can pass 0 and `VK_WHOLE_SIZE`, respectively.
+Do not pass allocation's offset as `offset`!!!
+
+This function returns the `VkResult` from `vkFlushMappedMemoryRanges` if it is
+called, otherwise `VK_SUCCESS`.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocation(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize offset,
+    VkDeviceSize size);
+
+/** \brief Invalidates memory of given allocation.
+
+Calls `vkInvalidateMappedMemoryRanges()` for memory associated with given range of given allocation.
+It needs to be called before reading from a mapped memory for memory types that are not `HOST_COHERENT`.
+Map operation doesn't do that automatically.
+
+- `offset` must be relative to the beginning of allocation.
+- `size` can be `VK_WHOLE_SIZE`. It means all memory from `offset` the the end of given allocation.
+- `offset` and `size` don't have to be aligned.
+  They are internally rounded down/up to multiply of `nonCoherentAtomSize`.
+- If `size` is 0, this call is ignored.
+- If memory type that the `allocation` belongs to is not `HOST_VISIBLE` or it is `HOST_COHERENT`,
+  this call is ignored.
+
+Warning! `offset` and `size` are relative to the contents of given `allocation`.
+If you mean whole allocation, you can pass 0 and `VK_WHOLE_SIZE`, respectively.
+Do not pass allocation's offset as `offset`!!!
+
+This function returns the `VkResult` from `vkInvalidateMappedMemoryRanges` if
+it is called, otherwise `VK_SUCCESS`.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocation(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize offset,
+    VkDeviceSize size);
+
+/** \brief Flushes memory of given set of allocations.
+
+Calls `vkFlushMappedMemoryRanges()` for memory associated with given ranges of given allocations.
+For more information, see documentation of vmaFlushAllocation().
+
+\param allocator
+\param allocationCount
+\param allocations
+\param offsets If not null, it must point to an array of offsets of regions to flush, relative to the beginning of respective allocations. Null means all ofsets are zero.
+\param sizes If not null, it must point to an array of sizes of regions to flush in respective allocations. Null means `VK_WHOLE_SIZE` for all allocations.
+
+This function returns the `VkResult` from `vkFlushMappedMemoryRanges` if it is
+called, otherwise `VK_SUCCESS`.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocations(
+    VmaAllocator VMA_NOT_NULL allocator,
+    uint32_t allocationCount,
+    const VmaAllocation VMA_NOT_NULL* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) allocations,
+    const VkDeviceSize* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) offsets,
+    const VkDeviceSize* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) sizes);
+
+/** \brief Invalidates memory of given set of allocations.
+
+Calls `vkInvalidateMappedMemoryRanges()` for memory associated with given ranges of given allocations.
+For more information, see documentation of vmaInvalidateAllocation().
+
+\param allocator
+\param allocationCount
+\param allocations
+\param offsets If not null, it must point to an array of offsets of regions to flush, relative to the beginning of respective allocations. Null means all ofsets are zero.
+\param sizes If not null, it must point to an array of sizes of regions to flush in respective allocations. Null means `VK_WHOLE_SIZE` for all allocations.
+
+This function returns the `VkResult` from `vkInvalidateMappedMemoryRanges` if it is
+called, otherwise `VK_SUCCESS`.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocations(
+    VmaAllocator VMA_NOT_NULL allocator,
+    uint32_t allocationCount,
+    const VmaAllocation VMA_NOT_NULL* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) allocations,
+    const VkDeviceSize* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) offsets,
+    const VkDeviceSize* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) sizes);
+
+/** \brief Checks magic number in margins around all allocations in given memory types (in both default and custom pools) in search for corruptions.
+
+\param allocator
+\param memoryTypeBits Bit mask, where each bit set means that a memory type with that index should be checked.
+
+Corruption detection is enabled only when `VMA_DEBUG_DETECT_CORRUPTION` macro is defined to nonzero,
+`VMA_DEBUG_MARGIN` is defined to nonzero and only for memory types that are
+`HOST_VISIBLE` and `HOST_COHERENT`. For more information, see [Corruption detection](@ref debugging_memory_usage_corruption_detection).
+
+Possible return values:
+
+- `VK_ERROR_FEATURE_NOT_PRESENT` - corruption detection is not enabled for any of specified memory types.
+- `VK_SUCCESS` - corruption detection has been performed and succeeded.
+- `VK_ERROR_UNKNOWN` - corruption detection has been performed and found memory corruptions around one of the allocations.
+  `VMA_ASSERT` is also fired in that case.
+- Other value: Error returned by Vulkan, e.g. memory mapping failure.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckCorruption(
+    VmaAllocator VMA_NOT_NULL allocator,
+    uint32_t memoryTypeBits);
+
+/** \brief Begins defragmentation process.
+
+\param allocator Allocator object.
+\param pInfo Structure filled with parameters of defragmentation.
+\param[out] pContext Context object that must be passed to vmaEndDefragmentation() to finish defragmentation.
+\returns
+- `VK_SUCCESS` if defragmentation can begin.
+- `VK_ERROR_FEATURE_NOT_PRESENT` if defragmentation is not supported.
+
+For more information about defragmentation, see documentation chapter:
+[Defragmentation](@ref defragmentation).
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentation(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VmaDefragmentationInfo* VMA_NOT_NULL pInfo,
+    VmaDefragmentationContext VMA_NULLABLE* VMA_NOT_NULL pContext);
+
+/** \brief Ends defragmentation process.
+
+\param allocator Allocator object.
+\param context Context object that has been created by vmaBeginDefragmentation().
+\param[out] pStats Optional stats for the defragmentation. Can be null.
+
+Use this function to finish defragmentation started by vmaBeginDefragmentation().
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaEndDefragmentation(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaDefragmentationContext VMA_NOT_NULL context,
+    VmaDefragmentationStats* VMA_NULLABLE pStats);
+
+/** \brief Starts single defragmentation pass.
+
+\param allocator Allocator object.
+\param context Context object that has been created by vmaBeginDefragmentation().
+\param[out] pPassInfo Computed information for current pass.
+\returns
+- `VK_SUCCESS` if no more moves are possible. Then you can omit call to vmaEndDefragmentationPass() and simply end whole defragmentation.
+- `VK_INCOMPLETE` if there are pending moves returned in `pPassInfo`. You need to perform them, call vmaEndDefragmentationPass(),
+  and then preferably try another pass with vmaBeginDefragmentationPass().
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentationPass(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaDefragmentationContext VMA_NOT_NULL context,
+    VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo);
+
+/** \brief Ends single defragmentation pass.
+
+\param allocator Allocator object.
+\param context Context object that has been created by vmaBeginDefragmentation().
+\param pPassInfo Computed information for current pass filled by vmaBeginDefragmentationPass() and possibly modified by you.
+
+Returns `VK_SUCCESS` if no more moves are possible or `VK_INCOMPLETE` if more defragmentations are possible.
+
+Ends incremental defragmentation pass and commits all defragmentation moves from `pPassInfo`.
+After this call:
+
+- Allocations at `pPassInfo[i].srcAllocation` that had `pPassInfo[i].operation ==` #VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY
+  (which is the default) will be pointing to the new destination place.
+- Allocation at `pPassInfo[i].srcAllocation` that had `pPassInfo[i].operation ==` #VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY
+  will be freed.
+
+If no more moves are possible you can end whole defragmentation.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaEndDefragmentationPass(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaDefragmentationContext VMA_NOT_NULL context,
+    VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo);
+
+/** \brief Binds buffer to allocation.
+
+Binds specified buffer to region of memory represented by specified allocation.
+Gets `VkDeviceMemory` handle and offset from the allocation.
+If you want to create a buffer, allocate memory for it and bind them together separately,
+you should use this function for binding instead of standard `vkBindBufferMemory()`,
+because it ensures proper synchronization so that when a `VkDeviceMemory` object is used by multiple
+allocations, calls to `vkBind*Memory()` or `vkMapMemory()` won't happen from multiple threads simultaneously
+(which is illegal in Vulkan).
+
+It is recommended to use function vmaCreateBuffer() instead of this one.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkBuffer VMA_NOT_NULL_NON_DISPATCHABLE buffer);
+
+/** \brief Binds buffer to allocation with additional parameters.
+
+\param allocator
+\param allocation
+\param allocationLocalOffset Additional offset to be added while binding, relative to the beginning of the `allocation`. Normally it should be 0.
+\param buffer
+\param pNext A chain of structures to be attached to `VkBindBufferMemoryInfoKHR` structure used internally. Normally it should be null.
+
+This function is similar to vmaBindBufferMemory(), but it provides additional parameters.
+
+If `pNext` is not null, #VmaAllocator object must have been created with #VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT flag
+or with VmaAllocatorCreateInfo::vulkanApiVersion `>= VK_API_VERSION_1_1`. Otherwise the call fails.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory2(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize allocationLocalOffset,
+    VkBuffer VMA_NOT_NULL_NON_DISPATCHABLE buffer,
+    const void* VMA_NULLABLE pNext);
+
+/** \brief Binds image to allocation.
+
+Binds specified image to region of memory represented by specified allocation.
+Gets `VkDeviceMemory` handle and offset from the allocation.
+If you want to create an image, allocate memory for it and bind them together separately,
+you should use this function for binding instead of standard `vkBindImageMemory()`,
+because it ensures proper synchronization so that when a `VkDeviceMemory` object is used by multiple
+allocations, calls to `vkBind*Memory()` or `vkMapMemory()` won't happen from multiple threads simultaneously
+(which is illegal in Vulkan).
+
+It is recommended to use function vmaCreateImage() instead of this one.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkImage VMA_NOT_NULL_NON_DISPATCHABLE image);
+
+/** \brief Binds image to allocation with additional parameters.
+
+\param allocator
+\param allocation
+\param allocationLocalOffset Additional offset to be added while binding, relative to the beginning of the `allocation`. Normally it should be 0.
+\param image
+\param pNext A chain of structures to be attached to `VkBindImageMemoryInfoKHR` structure used internally. Normally it should be null.
+
+This function is similar to vmaBindImageMemory(), but it provides additional parameters.
+
+If `pNext` is not null, #VmaAllocator object must have been created with #VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT flag
+or with VmaAllocatorCreateInfo::vulkanApiVersion `>= VK_API_VERSION_1_1`. Otherwise the call fails.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory2(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize allocationLocalOffset,
+    VkImage VMA_NOT_NULL_NON_DISPATCHABLE image,
+    const void* VMA_NULLABLE pNext);
+
+/** \brief Creates a new `VkBuffer`, allocates and binds memory for it.
+
+\param allocator
+\param pBufferCreateInfo
+\param pAllocationCreateInfo
+\param[out] pBuffer Buffer that was created.
+\param[out] pAllocation Allocation that was created.
+\param[out] pAllocationInfo Optional. Information about allocated memory. It can be later fetched using function vmaGetAllocationInfo().
+
+This function automatically:
+
+-# Creates buffer.
+-# Allocates appropriate memory for it.
+-# Binds the buffer with the memory.
+
+If any of these operations fail, buffer and allocation are not created,
+returned value is negative error code, `*pBuffer` and `*pAllocation` are null.
+
+If the function succeeded, you must destroy both buffer and allocation when you
+no longer need them using either convenience function vmaDestroyBuffer() or
+separately, using `vkDestroyBuffer()` and vmaFreeMemory().
+
+If #VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT flag was used,
+VK_KHR_dedicated_allocation extension is used internally to query driver whether
+it requires or prefers the new buffer to have dedicated allocation. If yes,
+and if dedicated allocation is possible
+(#VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT is not used), it creates dedicated
+allocation for this buffer, just like when using
+#VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
+
+\note This function creates a new `VkBuffer`. Sub-allocation of parts of one large buffer,
+although recommended as a good practice, is out of scope of this library and could be implemented
+by the user as a higher-level logic on top of VMA.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBuffer(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer,
+    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
+    VmaAllocationInfo* VMA_NULLABLE pAllocationInfo);
+
+/** \brief Creates a buffer with additional minimum alignment.
+
+Similar to vmaCreateBuffer() but provides additional parameter `minAlignment` which allows to specify custom,
+minimum alignment to be used when placing the buffer inside a larger memory block, which may be needed e.g.
+for interop with OpenGL.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBufferWithAlignment(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    VkDeviceSize minAlignment,
+    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer,
+    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
+    VmaAllocationInfo* VMA_NULLABLE pAllocationInfo);
+
+/** \brief Creates a new `VkBuffer`, binds already created memory for it.
+
+\param allocator
+\param allocation Allocation that provides memory to be used for binding new buffer to it.
+\param pBufferCreateInfo
+\param[out] pBuffer Buffer that was created.
+
+This function automatically:
+
+-# Creates buffer.
+-# Binds the buffer with the supplied memory.
+
+If any of these operations fail, buffer is not created,
+returned value is negative error code and `*pBuffer` is null.
+
+If the function succeeded, you must destroy the buffer when you
+no longer need it using `vkDestroyBuffer()`. If you want to also destroy the corresponding
+allocation you can use convenience function vmaDestroyBuffer().
+
+\note There is a new version of this function augmented with parameter `allocationLocalOffset` - see vmaCreateAliasingBuffer2().
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingBuffer(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer);
+
+/** \brief Creates a new `VkBuffer`, binds already created memory for it.
+
+\param allocator
+\param allocation Allocation that provides memory to be used for binding new buffer to it.
+\param allocationLocalOffset Additional offset to be added while binding, relative to the beginning of the allocation. Normally it should be 0.
+\param pBufferCreateInfo 
+\param[out] pBuffer Buffer that was created.
+
+This function automatically:
+
+-# Creates buffer.
+-# Binds the buffer with the supplied memory.
+
+If any of these operations fail, buffer is not created,
+returned value is negative error code and `*pBuffer` is null.
+
+If the function succeeded, you must destroy the buffer when you
+no longer need it using `vkDestroyBuffer()`. If you want to also destroy the corresponding
+allocation you can use convenience function vmaDestroyBuffer().
+
+\note This is a new version of the function augmented with parameter `allocationLocalOffset`.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingBuffer2(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize allocationLocalOffset,
+    const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer);
+
+/** \brief Destroys Vulkan buffer and frees allocated memory.
+
+This is just a convenience function equivalent to:
+
+\code
+vkDestroyBuffer(device, buffer, allocationCallbacks);
+vmaFreeMemory(allocator, allocation);
+\endcode
+
+It is safe to pass null as buffer and/or allocation.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyBuffer(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE buffer,
+    VmaAllocation VMA_NULLABLE allocation);
+
+/// Function similar to vmaCreateBuffer().
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateImage(
+    VmaAllocator VMA_NOT_NULL allocator,
+    const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
+    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage,
+    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
+    VmaAllocationInfo* VMA_NULLABLE pAllocationInfo);
+
+/// Function similar to vmaCreateAliasingBuffer() but for images.
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingImage(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
+    VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage);
+
+/// Function similar to vmaCreateAliasingBuffer2() but for images.
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingImage2(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize allocationLocalOffset,
+    const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
+    VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage);
+
+/** \brief Destroys Vulkan image and frees allocated memory.
+
+This is just a convenience function equivalent to:
+
+\code
+vkDestroyImage(device, image, allocationCallbacks);
+vmaFreeMemory(allocator, allocation);
+\endcode
+
+It is safe to pass null as image and/or allocation.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VkImage VMA_NULLABLE_NON_DISPATCHABLE image,
+    VmaAllocation VMA_NULLABLE allocation);
+
+/** @} */
+
+/**
+\addtogroup group_virtual
+@{
+*/
+
+/** \brief Creates new #VmaVirtualBlock object.
+
+\param pCreateInfo Parameters for creation.
+\param[out] pVirtualBlock Returned virtual block object or `VMA_NULL` if creation failed.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateVirtualBlock(
+    const VmaVirtualBlockCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaVirtualBlock VMA_NULLABLE* VMA_NOT_NULL pVirtualBlock);
+
+/** \brief Destroys #VmaVirtualBlock object.
+
+Please note that you should consciously handle virtual allocations that could remain unfreed in the block.
+You should either free them individually using vmaVirtualFree() or call vmaClearVirtualBlock()
+if you are sure this is what you want. If you do neither, an assert is called.
+
+If you keep pointers to some additional metadata associated with your virtual allocations in their `pUserData`,
+don't forget to free them.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyVirtualBlock(
+    VmaVirtualBlock VMA_NULLABLE virtualBlock);
+
+/** \brief Returns true of the #VmaVirtualBlock is empty - contains 0 virtual allocations and has all its space available for new allocations.
+*/
+VMA_CALL_PRE VkBool32 VMA_CALL_POST vmaIsVirtualBlockEmpty(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock);
+
+/** \brief Returns information about a specific virtual allocation within a virtual block, like its size and `pUserData` pointer.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetVirtualAllocationInfo(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation, VmaVirtualAllocationInfo* VMA_NOT_NULL pVirtualAllocInfo);
+
+/** \brief Allocates new virtual allocation inside given #VmaVirtualBlock.
+
+If the allocation fails due to not enough free space available, `VK_ERROR_OUT_OF_DEVICE_MEMORY` is returned
+(despite the function doesn't ever allocate actual GPU memory).
+`pAllocation` is then set to `VK_NULL_HANDLE` and `pOffset`, if not null, it set to `UINT64_MAX`.
+
+\param virtualBlock Virtual block
+\param pCreateInfo Parameters for the allocation
+\param[out] pAllocation Returned handle of the new allocation
+\param[out] pOffset Returned offset of the new allocation. Optional, can be null.
+*/
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaVirtualAllocate(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pAllocation,
+    VkDeviceSize* VMA_NULLABLE pOffset);
+
+/** \brief Frees virtual allocation inside given #VmaVirtualBlock.
+
+It is correct to call this function with `allocation == VK_NULL_HANDLE` - it does nothing.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaVirtualFree(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE allocation);
+
+/** \brief Frees all virtual allocations inside given #VmaVirtualBlock.
+
+You must either call this function or free each virtual allocation individually with vmaVirtualFree()
+before destroying a virtual block. Otherwise, an assert is called.
+
+If you keep pointer to some additional metadata associated with your virtual allocation in its `pUserData`,
+don't forget to free it as well.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaClearVirtualBlock(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock);
+
+/** \brief Changes custom pointer associated with given virtual allocation.
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaSetVirtualAllocationUserData(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation,
+    void* VMA_NULLABLE pUserData);
+
+/** \brief Calculates and returns statistics about virtual allocations and memory usage in given #VmaVirtualBlock.
+
+This function is fast to call. For more detailed statistics, see vmaCalculateVirtualBlockStatistics().
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaGetVirtualBlockStatistics(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaStatistics* VMA_NOT_NULL pStats);
+
+/** \brief Calculates and returns detailed statistics about virtual allocations and memory usage in given #VmaVirtualBlock.
+
+This function is slow to call. Use for debugging purposes.
+For less detailed statistics, see vmaGetVirtualBlockStatistics().
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaCalculateVirtualBlockStatistics(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaDetailedStatistics* VMA_NOT_NULL pStats);
+
+/** @} */
 
 #if VMA_STATS_STRING_ENABLED
-    /**
-    \addtogroup group_stats
-    @{
-    */
+/**
+\addtogroup group_stats
+@{
+*/
 
-    /** \brief Builds and returns a null-terminated string in JSON format with information about given #VmaVirtualBlock.
-    \param virtualBlock Virtual block.
-    \param[out] ppStatsString Returned string.
-    \param detailedMap Pass `VK_FALSE` to only obtain statistics as returned by vmaCalculateVirtualBlockStatistics().
-    Pass `VK_TRUE` to also obtain full list of allocations and free spaces.
+/** \brief Builds and returns a null-terminated string in JSON format with information about given #VmaVirtualBlock.
+\param virtualBlock Virtual block.
+\param[out] ppStatsString Returned string.
+\param detailedMap Pass `VK_FALSE` to only obtain statistics as returned by vmaCalculateVirtualBlockStatistics(). Pass `VK_TRUE` to also obtain full list of allocations and free spaces.
 
-    Returned string must be freed using vmaFreeVirtualBlockStatsString().
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaBuildVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
-                                                                    char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
-                                                                    VkBool32                         detailedMap);
+Returned string must be freed using vmaFreeVirtualBlockStatsString().
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaBuildVirtualBlockStatsString(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
+    VkBool32 detailedMap);
 
-    /// Frees a string returned by vmaBuildVirtualBlockStatsString().
-    VMA_CALL_PRE void VMA_CALL_POST vmaFreeVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
-                                                                   char* VMA_NULLABLE           pStatsString);
+/// Frees a string returned by vmaBuildVirtualBlockStatsString().
+VMA_CALL_PRE void VMA_CALL_POST vmaFreeVirtualBlockStatsString(
+    VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    char* VMA_NULLABLE pStatsString);
 
-    /** \brief Builds and returns statistics as a null-terminated string in JSON format.
-    \param allocator
-    \param[out] ppStatsString Must be freed using vmaFreeStatsString() function.
-    \param detailedMap
-    */
-    VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator VMA_NOT_NULL allocator,
-                                                        char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
-                                                        VkBool32                         detailedMap);
+/** \brief Builds and returns statistics as a null-terminated string in JSON format.
+\param allocator
+\param[out] ppStatsString Must be freed using vmaFreeStatsString() function.
+\param detailedMap
+*/
+VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(
+    VmaAllocator VMA_NOT_NULL allocator,
+    char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
+    VkBool32 detailedMap);
 
-    VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(VmaAllocator VMA_NOT_NULL allocator,
-                                                       char* VMA_NULLABLE        pStatsString);
+VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
+    VmaAllocator VMA_NOT_NULL allocator,
+    char* VMA_NULLABLE pStatsString);
 
-    /** @} */
+/** @} */
 
 #endif // VMA_STATS_STRING_ENABLED
 
@@ -2591,10 +2608,14 @@ extern "C"
 #include <type_traits>
 
 #ifdef _MSC_VER
-#include <intrin.h> // For functions like __popcnt, _BitScanForward etc.
+    #include <intrin.h> // For functions like __popcnt, _BitScanForward etc.
 #endif
 #if __cplusplus >= 202002L || _MSVC_LANG >= 202002L // C++20
-#include <bit>                                      // For std::popcount
+    #include <bit> // For std::popcount
+#endif
+
+#if VMA_STATS_STRING_ENABLED
+    #include <cstdio> // For snprintf
 #endif
 
 /*******************************************************************************
@@ -2612,7 +2633,7 @@ internally, like:
     vulkanFunctions.vkAllocateMemory = &vkAllocateMemory;
 */
 #if !defined(VMA_STATIC_VULKAN_FUNCTIONS) && !defined(VK_NO_PROTOTYPES)
-#define VMA_STATIC_VULKAN_FUNCTIONS 1
+    #define VMA_STATIC_VULKAN_FUNCTIONS 1
 #endif
 
 /*
@@ -2626,20 +2647,19 @@ VmaVulkanFunctions::vkGetInstanceProcAddr and vkGetDeviceProcAddr as
 VmaAllocatorCreateInfo::pVulkanFunctions. Other members can be null.
 */
 #if !defined(VMA_DYNAMIC_VULKAN_FUNCTIONS)
-#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
+    #define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
 #endif
 
 #ifndef VMA_USE_STL_SHARED_MUTEX
-// Compiler conforms to C++17.
-#if __cplusplus >= 201703L
-#define VMA_USE_STL_SHARED_MUTEX 1
-// Visual studio defines __cplusplus properly only when passed additional parameter: /Zc:__cplusplus
-// Otherwise it is always 199711L, despite shared_mutex works since Visual Studio 2015 Update 2.
-#elif defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && __cplusplus == 199711L && _MSVC_LANG >= 201703L
-#define VMA_USE_STL_SHARED_MUTEX 1
-#else
-#define VMA_USE_STL_SHARED_MUTEX 0
-#endif
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L // C++17
+        #define VMA_USE_STL_SHARED_MUTEX 1
+    // Visual studio defines __cplusplus properly only when passed additional parameter: /Zc:__cplusplus
+    // Otherwise it is always 199711L, despite shared_mutex works since Visual Studio 2015 Update 2.
+    #elif defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023918 && __cplusplus == 199711L && _MSVC_LANG >= 201703L
+        #define VMA_USE_STL_SHARED_MUTEX 1
+    #else
+        #define VMA_USE_STL_SHARED_MUTEX 0
+    #endif
 #endif
 
 /*
@@ -2664,32 +2684,63 @@ The following headers are used in this CONFIGURATION section only, so feel free 
 remove them if not needed.
 */
 #if !defined(VMA_CONFIGURATION_USER_INCLUDES_H)
-#include <cassert>   // for assert
-#include <algorithm> // for min, max
-#include <mutex>
+    #include <cassert> // for assert
+    #include <algorithm> // for min, max
+    #include <mutex>
 #else
-#include VMA_CONFIGURATION_USER_INCLUDES_H
+    #include VMA_CONFIGURATION_USER_INCLUDES_H
 #endif
 
 #ifndef VMA_NULL
-// Value used as null pointer. Define it to e.g.: nullptr, NULL, 0, (void*)0.
-#define VMA_NULL nullptr
+   // Value used as null pointer. Define it to e.g.: nullptr, NULL, 0, (void*)0.
+   #define VMA_NULL   nullptr
 #endif
+
+#ifndef VMA_FALLTHROUGH
+    #if __cplusplus >= 201703L || _MSVC_LANG >= 201703L // C++17
+        #define VMA_FALLTHROUGH [[fallthrough]]
+    #else
+        #define VMA_FALLTHROUGH
+    #endif
+#endif
+
+// Normal assert to check for programmer's errors, especially in Debug configuration.
+#ifndef VMA_ASSERT
+   #ifdef NDEBUG
+       #define VMA_ASSERT(expr)
+   #else
+       #define VMA_ASSERT(expr)         assert(expr)
+   #endif
+#endif
+
+// Assert that will be called very often, like inside data structures e.g. operator[].
+// Making it non-empty can make program slow.
+#ifndef VMA_HEAVY_ASSERT
+   #ifdef NDEBUG
+       #define VMA_HEAVY_ASSERT(expr)
+   #else
+       #define VMA_HEAVY_ASSERT(expr)   //VMA_ASSERT(expr)
+   #endif
+#endif
+
+// If your compiler is not compatible with C++17 and definition of
+// aligned_alloc() function is missing, uncommenting following line may help:
+
+//#include <malloc.h>
 
 #if defined(__ANDROID_API__) && (__ANDROID_API__ < 16)
 #include <cstdlib>
 static void* vma_aligned_alloc(size_t alignment, size_t size)
 {
     // alignment must be >= sizeof(void*)
-    if (alignment < sizeof(void*))
+    if(alignment < sizeof(void*))
     {
         alignment = sizeof(void*);
     }
 
     return memalign(alignment, size);
 }
-#elif defined(__APPLE__) || defined(__ANDROID__) || \
-    (defined(__linux__) && defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
+#elif defined(__APPLE__) || defined(__ANDROID__) || (defined(__linux__) && defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
 #include <cstdlib>
 
 #if defined(__APPLE__)
@@ -2705,7 +2756,7 @@ static void* vma_aligned_alloc(size_t alignment, size_t size)
     //    // For C++14, usr/include/malloc/_malloc.h declares aligned_alloc()) only
     //    // with the MacOSX11.0 SDK in Xcode 12 (which is what adds
     //    // MAC_OS_X_VERSION_10_16), even though the function is marked
-    //    // availabe for 10.15. That is why the preprocessor checks for 10.16 but
+    //    // available for 10.15. That is why the preprocessor checks for 10.16 but
     //    // the __builtin_available checks for 10.15.
     //    // People who use C++17 could call aligned_alloc with the 10.15 SDK already.
     //    if (__builtin_available(macOS 10.15, iOS 13, *))
@@ -2714,13 +2765,13 @@ static void* vma_aligned_alloc(size_t alignment, size_t size)
     //#endif
 
     // alignment must be >= sizeof(void*)
-    if (alignment < sizeof(void*))
+    if(alignment < sizeof(void*))
     {
         alignment = sizeof(void*);
     }
 
-    void* pointer;
-    if (posix_memalign(&pointer, alignment, size) == 0)
+    void *pointer;
+    if(posix_memalign(&pointer, alignment, size) == 0)
         return pointer;
     return VMA_NULL;
 }
@@ -2729,10 +2780,16 @@ static void* vma_aligned_alloc(size_t alignment, size_t size)
 {
     return _aligned_malloc(size, alignment);
 }
-#else
+#elif __cplusplus >= 201703L || _MSVC_LANG >= 201703L // C++17
 static void* vma_aligned_alloc(size_t alignment, size_t size)
 {
     return aligned_alloc(alignment, size);
+}
+#else
+static void* vma_aligned_alloc(size_t alignment, size_t size)
+{
+    VMA_ASSERT(0 && "Could not implement aligned_alloc automatically. Please enable C++17 or later in your compiler or provide custom implementation of macro VMA_SYSTEM_ALIGNED_MALLOC (and VMA_SYSTEM_ALIGNED_FREE if needed) using the API of your system.");
+    return VMA_NULL;
 }
 #endif
 
@@ -2748,266 +2805,257 @@ static void vma_aligned_free(void* VMA_NULLABLE ptr)
 }
 #endif
 
-// If your compiler is not compatible with C++11 and definition of
-// aligned_alloc() function is missing, uncommeting following line may help:
-
-//#include <malloc.h>
-
-// Normal assert to check for programmer's errors, especially in Debug configuration.
-#ifndef VMA_ASSERT
-#ifdef NDEBUG
-#define VMA_ASSERT(expr)
-#else
-#define VMA_ASSERT(expr) assert(expr)
-#endif
-#endif
-
-// Assert that will be called very often, like inside data structures e.g. operator[].
-// Making it non-empty can make program slow.
-#ifndef VMA_HEAVY_ASSERT
-#ifdef NDEBUG
-#define VMA_HEAVY_ASSERT(expr)
-#else
-#define VMA_HEAVY_ASSERT(expr) // VMA_ASSERT(expr)
-#endif
-#endif
-
 #ifndef VMA_ALIGN_OF
-#define VMA_ALIGN_OF(type) (__alignof(type))
+   #define VMA_ALIGN_OF(type)       (alignof(type))
 #endif
 
 #ifndef VMA_SYSTEM_ALIGNED_MALLOC
-#define VMA_SYSTEM_ALIGNED_MALLOC(size, alignment) vma_aligned_alloc((alignment), (size))
+   #define VMA_SYSTEM_ALIGNED_MALLOC(size, alignment) vma_aligned_alloc((alignment), (size))
 #endif
 
 #ifndef VMA_SYSTEM_ALIGNED_FREE
-// VMA_SYSTEM_FREE is the old name, but might have been defined by the user
-#if defined(VMA_SYSTEM_FREE)
-#define VMA_SYSTEM_ALIGNED_FREE(ptr) VMA_SYSTEM_FREE(ptr)
-#else
-#define VMA_SYSTEM_ALIGNED_FREE(ptr) vma_aligned_free(ptr)
-#endif
+   // VMA_SYSTEM_FREE is the old name, but might have been defined by the user
+   #if defined(VMA_SYSTEM_FREE)
+      #define VMA_SYSTEM_ALIGNED_FREE(ptr)     VMA_SYSTEM_FREE(ptr)
+   #else
+      #define VMA_SYSTEM_ALIGNED_FREE(ptr)     vma_aligned_free(ptr)
+    #endif
 #endif
 
 #ifndef VMA_COUNT_BITS_SET
-// Returns number of bits set to 1 in (v)
-#define VMA_COUNT_BITS_SET(v) VmaCountBitsSet(v)
+    // Returns number of bits set to 1 in (v)
+    #define VMA_COUNT_BITS_SET(v) VmaCountBitsSet(v)
 #endif
 
 #ifndef VMA_BITSCAN_LSB
-// Scans integer for index of first nonzero value from the Least Significant Bit (LSB). If mask is 0 then returns
-// UINT8_MAX
-#define VMA_BITSCAN_LSB(mask) VmaBitScanLSB(mask)
+    // Scans integer for index of first nonzero value from the Least Significant Bit (LSB). If mask is 0 then returns UINT8_MAX
+    #define VMA_BITSCAN_LSB(mask) VmaBitScanLSB(mask)
 #endif
 
 #ifndef VMA_BITSCAN_MSB
-// Scans integer for index of first nonzero value from the Most Significant Bit (MSB). If mask is 0 then returns
-// UINT8_MAX
-#define VMA_BITSCAN_MSB(mask) VmaBitScanMSB(mask)
+    // Scans integer for index of first nonzero value from the Most Significant Bit (MSB). If mask is 0 then returns UINT8_MAX
+    #define VMA_BITSCAN_MSB(mask) VmaBitScanMSB(mask)
 #endif
 
 #ifndef VMA_MIN
-#define VMA_MIN(v1, v2) ((std::min)((v1), (v2)))
+   #define VMA_MIN(v1, v2)    ((std::min)((v1), (v2)))
 #endif
 
 #ifndef VMA_MAX
-#define VMA_MAX(v1, v2) ((std::max)((v1), (v2)))
+   #define VMA_MAX(v1, v2)    ((std::max)((v1), (v2)))
 #endif
 
 #ifndef VMA_SWAP
-#define VMA_SWAP(v1, v2) std::swap((v1), (v2))
+   #define VMA_SWAP(v1, v2)   std::swap((v1), (v2))
 #endif
 
 #ifndef VMA_SORT
-#define VMA_SORT(beg, end, cmp) std::sort(beg, end, cmp)
+   #define VMA_SORT(beg, end, cmp)  std::sort(beg, end, cmp)
+#endif
+
+#ifndef VMA_DEBUG_LOG_FORMAT
+   #define VMA_DEBUG_LOG_FORMAT(format, ...)
+   /*
+   #define VMA_DEBUG_LOG_FORMAT(format, ...) do { \
+       printf((format), __VA_ARGS__); \
+       printf("\n"); \
+   } while(false)
+   */
 #endif
 
 #ifndef VMA_DEBUG_LOG
-#define VMA_DEBUG_LOG(format, ...)
-/*
-#define VMA_DEBUG_LOG(format, ...) do { \
-    printf(format, __VA_ARGS__); \
-    printf("\n"); \
-} while(false)
-*/
+    #define VMA_DEBUG_LOG(str)   VMA_DEBUG_LOG_FORMAT("%s", (str))
+#endif
+
+#ifndef VMA_CLASS_NO_COPY
+    #define VMA_CLASS_NO_COPY(className) \
+        private: \
+            className(const className&) = delete; \
+            className& operator=(const className&) = delete;
+#endif
+#ifndef VMA_CLASS_NO_COPY_NO_MOVE
+    #define VMA_CLASS_NO_COPY_NO_MOVE(className) \
+        private: \
+            className(const className&) = delete; \
+            className(className&&) = delete; \
+            className& operator=(const className&) = delete; \
+            className& operator=(className&&) = delete;
 #endif
 
 // Define this macro to 1 to enable functions: vmaBuildStatsString, vmaFreeStatsString.
 #if VMA_STATS_STRING_ENABLED
-static inline void VmaUint32ToStr(char* VMA_NOT_NULL outStr, size_t strLen, uint32_t num)
-{
-    snprintf(outStr, strLen, "%u", static_cast<unsigned int>(num));
-}
-static inline void VmaUint64ToStr(char* VMA_NOT_NULL outStr, size_t strLen, uint64_t num)
-{
-    snprintf(outStr, strLen, "%llu", static_cast<unsigned long long>(num));
-}
-static inline void VmaPtrToStr(char* VMA_NOT_NULL outStr, size_t strLen, const void* ptr)
-{
-    snprintf(outStr, strLen, "%p", ptr);
-}
+    static inline void VmaUint32ToStr(char* VMA_NOT_NULL outStr, size_t strLen, uint32_t num)
+    {
+        snprintf(outStr, strLen, "%u", static_cast<unsigned int>(num));
+    }
+    static inline void VmaUint64ToStr(char* VMA_NOT_NULL outStr, size_t strLen, uint64_t num)
+    {
+        snprintf(outStr, strLen, "%llu", static_cast<unsigned long long>(num));
+    }
+    static inline void VmaPtrToStr(char* VMA_NOT_NULL outStr, size_t strLen, const void* ptr)
+    {
+        snprintf(outStr, strLen, "%p", ptr);
+    }
 #endif
 
 #ifndef VMA_MUTEX
-class VmaMutex
-{
-  public:
-    void Lock() { m_Mutex.lock(); }
-    void Unlock() { m_Mutex.unlock(); }
-    bool TryLock() { return m_Mutex.try_lock(); }
-
-  private:
-    std::mutex m_Mutex;
-};
-#define VMA_MUTEX VmaMutex
+    class VmaMutex
+    {
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaMutex)
+    public:
+        VmaMutex() { }
+        void Lock() { m_Mutex.lock(); }
+        void Unlock() { m_Mutex.unlock(); }
+        bool TryLock() { return m_Mutex.try_lock(); }
+    private:
+        std::mutex m_Mutex;
+    };
+    #define VMA_MUTEX VmaMutex
 #endif
 
 // Read-write mutex, where "read" is shared access, "write" is exclusive access.
 #ifndef VMA_RW_MUTEX
-#if VMA_USE_STL_SHARED_MUTEX
-// Use std::shared_mutex from C++17.
-#include <shared_mutex>
-class VmaRWMutex
-{
-  public:
-    void LockRead() { m_Mutex.lock_shared(); }
-    void UnlockRead() { m_Mutex.unlock_shared(); }
-    bool TryLockRead() { return m_Mutex.try_lock_shared(); }
-    void LockWrite() { m_Mutex.lock(); }
-    void UnlockWrite() { m_Mutex.unlock(); }
-    bool TryLockWrite() { return m_Mutex.try_lock(); }
-
-  private:
-    std::shared_mutex m_Mutex;
-};
-#define VMA_RW_MUTEX VmaRWMutex
-#elif defined(_WIN32) && defined(WINVER) && WINVER >= 0x0600
-// Use SRWLOCK from WinAPI.
-// Minimum supported client = Windows Vista, server = Windows Server 2008.
-class VmaRWMutex
-{
-  public:
-    VmaRWMutex() { InitializeSRWLock(&m_Lock); }
-    void LockRead() { AcquireSRWLockShared(&m_Lock); }
-    void UnlockRead() { ReleaseSRWLockShared(&m_Lock); }
-    bool TryLockRead() { return TryAcquireSRWLockShared(&m_Lock) != FALSE; }
-    void LockWrite() { AcquireSRWLockExclusive(&m_Lock); }
-    void UnlockWrite() { ReleaseSRWLockExclusive(&m_Lock); }
-    bool TryLockWrite() { return TryAcquireSRWLockExclusive(&m_Lock) != FALSE; }
-
-  private:
-    SRWLOCK m_Lock;
-};
-#define VMA_RW_MUTEX VmaRWMutex
-#else
-// Less efficient fallback: Use normal mutex.
-class VmaRWMutex
-{
-  public:
-    void LockRead() { m_Mutex.Lock(); }
-    void UnlockRead() { m_Mutex.Unlock(); }
-    bool TryLockRead() { return m_Mutex.TryLock(); }
-    void LockWrite() { m_Mutex.Lock(); }
-    void UnlockWrite() { m_Mutex.Unlock(); }
-    bool TryLockWrite() { return m_Mutex.TryLock(); }
-
-  private:
-    VMA_MUTEX m_Mutex;
-};
-#define VMA_RW_MUTEX VmaRWMutex
-#endif // #if VMA_USE_STL_SHARED_MUTEX
+    #if VMA_USE_STL_SHARED_MUTEX
+        // Use std::shared_mutex from C++17.
+        #include <shared_mutex>
+        class VmaRWMutex
+        {
+        public:
+            void LockRead() { m_Mutex.lock_shared(); }
+            void UnlockRead() { m_Mutex.unlock_shared(); }
+            bool TryLockRead() { return m_Mutex.try_lock_shared(); }
+            void LockWrite() { m_Mutex.lock(); }
+            void UnlockWrite() { m_Mutex.unlock(); }
+            bool TryLockWrite() { return m_Mutex.try_lock(); }
+        private:
+            std::shared_mutex m_Mutex;
+        };
+        #define VMA_RW_MUTEX VmaRWMutex
+    #elif defined(_WIN32) && defined(WINVER) && WINVER >= 0x0600
+        // Use SRWLOCK from WinAPI.
+        // Minimum supported client = Windows Vista, server = Windows Server 2008.
+        class VmaRWMutex
+        {
+        public:
+            VmaRWMutex() { InitializeSRWLock(&m_Lock); }
+            void LockRead() { AcquireSRWLockShared(&m_Lock); }
+            void UnlockRead() { ReleaseSRWLockShared(&m_Lock); }
+            bool TryLockRead() { return TryAcquireSRWLockShared(&m_Lock) != FALSE; }
+            void LockWrite() { AcquireSRWLockExclusive(&m_Lock); }
+            void UnlockWrite() { ReleaseSRWLockExclusive(&m_Lock); }
+            bool TryLockWrite() { return TryAcquireSRWLockExclusive(&m_Lock) != FALSE; }
+        private:
+            SRWLOCK m_Lock;
+        };
+        #define VMA_RW_MUTEX VmaRWMutex
+    #else
+        // Less efficient fallback: Use normal mutex.
+        class VmaRWMutex
+        {
+        public:
+            void LockRead() { m_Mutex.Lock(); }
+            void UnlockRead() { m_Mutex.Unlock(); }
+            bool TryLockRead() { return m_Mutex.TryLock(); }
+            void LockWrite() { m_Mutex.Lock(); }
+            void UnlockWrite() { m_Mutex.Unlock(); }
+            bool TryLockWrite() { return m_Mutex.TryLock(); }
+        private:
+            VMA_MUTEX m_Mutex;
+        };
+        #define VMA_RW_MUTEX VmaRWMutex
+    #endif // #if VMA_USE_STL_SHARED_MUTEX
 #endif // #ifndef VMA_RW_MUTEX
 
 /*
 If providing your own implementation, you need to implement a subset of std::atomic.
 */
 #ifndef VMA_ATOMIC_UINT32
-#include <atomic>
-#define VMA_ATOMIC_UINT32 std::atomic<uint32_t>
+    #include <atomic>
+    #define VMA_ATOMIC_UINT32 std::atomic<uint32_t>
 #endif
 
 #ifndef VMA_ATOMIC_UINT64
-#include <atomic>
-#define VMA_ATOMIC_UINT64 std::atomic<uint64_t>
+    #include <atomic>
+    #define VMA_ATOMIC_UINT64 std::atomic<uint64_t>
 #endif
 
 #ifndef VMA_DEBUG_ALWAYS_DEDICATED_MEMORY
-/**
-Every allocation will have its own memory block.
-Define to 1 for debugging purposes only.
-*/
-#define VMA_DEBUG_ALWAYS_DEDICATED_MEMORY (0)
+    /**
+    Every allocation will have its own memory block.
+    Define to 1 for debugging purposes only.
+    */
+    #define VMA_DEBUG_ALWAYS_DEDICATED_MEMORY (0)
 #endif
 
 #ifndef VMA_MIN_ALIGNMENT
-/**
-Minimum alignment of all allocations, in bytes.
-Set to more than 1 for debugging purposes. Must be power of two.
-*/
-#ifdef VMA_DEBUG_ALIGNMENT // Old name
-#define VMA_MIN_ALIGNMENT VMA_DEBUG_ALIGNMENT
-#else
-#define VMA_MIN_ALIGNMENT (1)
-#endif
+    /**
+    Minimum alignment of all allocations, in bytes.
+    Set to more than 1 for debugging purposes. Must be power of two.
+    */
+    #ifdef VMA_DEBUG_ALIGNMENT // Old name
+        #define VMA_MIN_ALIGNMENT VMA_DEBUG_ALIGNMENT
+    #else
+        #define VMA_MIN_ALIGNMENT (1)
+    #endif
 #endif
 
 #ifndef VMA_DEBUG_MARGIN
-/**
-Minimum margin after every allocation, in bytes.
-Set nonzero for debugging purposes only.
-*/
-#define VMA_DEBUG_MARGIN (0)
+    /**
+    Minimum margin after every allocation, in bytes.
+    Set nonzero for debugging purposes only.
+    */
+    #define VMA_DEBUG_MARGIN (0)
 #endif
 
 #ifndef VMA_DEBUG_INITIALIZE_ALLOCATIONS
-/**
-Define this macro to 1 to automatically fill new allocations and destroyed
-allocations with some bit pattern.
-*/
-#define VMA_DEBUG_INITIALIZE_ALLOCATIONS (0)
+    /**
+    Define this macro to 1 to automatically fill new allocations and destroyed
+    allocations with some bit pattern.
+    */
+    #define VMA_DEBUG_INITIALIZE_ALLOCATIONS (0)
 #endif
 
 #ifndef VMA_DEBUG_DETECT_CORRUPTION
-/**
-Define this macro to 1 together with non-zero value of VMA_DEBUG_MARGIN to
-enable writing magic value to the margin after every allocation and
-validating it, so that memory corruptions (out-of-bounds writes) are detected.
-*/
-#define VMA_DEBUG_DETECT_CORRUPTION (0)
+    /**
+    Define this macro to 1 together with non-zero value of VMA_DEBUG_MARGIN to
+    enable writing magic value to the margin after every allocation and
+    validating it, so that memory corruptions (out-of-bounds writes) are detected.
+    */
+    #define VMA_DEBUG_DETECT_CORRUPTION (0)
 #endif
 
 #ifndef VMA_DEBUG_GLOBAL_MUTEX
-/**
-Set this to 1 for debugging purposes only, to enable single mutex protecting all
-entry calls to the library. Can be useful for debugging multithreading issues.
-*/
-#define VMA_DEBUG_GLOBAL_MUTEX (0)
+    /**
+    Set this to 1 for debugging purposes only, to enable single mutex protecting all
+    entry calls to the library. Can be useful for debugging multithreading issues.
+    */
+    #define VMA_DEBUG_GLOBAL_MUTEX (0)
 #endif
 
 #ifndef VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY
-/**
-Minimum value for VkPhysicalDeviceLimits::bufferImageGranularity.
-Set to more than 1 for debugging purposes only. Must be power of two.
-*/
-#define VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY (1)
+    /**
+    Minimum value for VkPhysicalDeviceLimits::bufferImageGranularity.
+    Set to more than 1 for debugging purposes only. Must be power of two.
+    */
+    #define VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY (1)
 #endif
 
 #ifndef VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT
-/*
-Set this to 1 to make VMA never exceed VkPhysicalDeviceLimits::maxMemoryAllocationCount
-and return error instead of leaving up to Vulkan implementation what to do in such cases.
-*/
-#define VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT (0)
+    /*
+    Set this to 1 to make VMA never exceed VkPhysicalDeviceLimits::maxMemoryAllocationCount
+    and return error instead of leaving up to Vulkan implementation what to do in such cases.
+    */
+    #define VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT (0)
 #endif
 
 #ifndef VMA_SMALL_HEAP_MAX_SIZE
-/// Maximum size of a memory heap in Vulkan to consider it "small".
-#define VMA_SMALL_HEAP_MAX_SIZE (1024ull * 1024 * 1024)
+   /// Maximum size of a memory heap in Vulkan to consider it "small".
+   #define VMA_SMALL_HEAP_MAX_SIZE (1024ull * 1024 * 1024)
 #endif
 
 #ifndef VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE
-/// Default size of a block allocated as single VkDeviceMemory from a "large" heap.
-#define VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE (256ull * 1024 * 1024)
+   /// Default size of a block allocated as single VkDeviceMemory from a "large" heap.
+   #define VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE (256ull * 1024 * 1024)
 #endif
 
 /*
@@ -3015,35 +3063,24 @@ Mapping hysteresis is a logic that launches when vmaMapMemory/vmaUnmapMemory is 
 or a persistently mapped allocation is created and destroyed several times in a row.
 It keeps additional +1 mapping of a device memory block to prevent calling actual
 vkMapMemory/vkUnmapMemory too many times, which may improve performance and help
-tools like RenderDOc.
+tools like RenderDoc.
 */
 #ifndef VMA_MAPPING_HYSTERESIS_ENABLED
-#define VMA_MAPPING_HYSTERESIS_ENABLED 1
+    #define VMA_MAPPING_HYSTERESIS_ENABLED 1
 #endif
 
-#ifndef VMA_CLASS_NO_COPY
-#define VMA_CLASS_NO_COPY(className)      \
-  private:                                \
-    className(const className&) = delete; \
-    className& operator=(const className&) = delete;
-#endif
-
-#define VMA_VALIDATE(cond)                                \
-    do                                                    \
-    {                                                     \
-        if (!(cond))                                      \
-        {                                                 \
-            VMA_ASSERT(0 && "Validation failed: " #cond); \
-            return false;                                 \
-        }                                                 \
-    } while (false)
+#define VMA_VALIDATE(cond) do { if(!(cond)) { \
+        VMA_ASSERT(0 && "Validation failed: " #cond); \
+        return false; \
+    } } while(false)
 
 /*******************************************************************************
 END OF CONFIGURATION
 */
 #endif // _VMA_CONFIGURATION
 
-static const uint8_t VMA_ALLOCATION_FILL_PATTERN_CREATED   = 0xDC;
+
+static const uint8_t VMA_ALLOCATION_FILL_PATTERN_CREATED = 0xDC;
 static const uint8_t VMA_ALLOCATION_FILL_PATTERN_DESTROYED = 0xEF;
 // Decimal 2139416166, float NaN, little-endian binary 66 E6 84 7F.
 static const uint32_t VMA_CORRUPTION_DETECTION_MAGIC_VALUE = 0x7F84E666;
@@ -3051,40 +3088,47 @@ static const uint32_t VMA_CORRUPTION_DETECTION_MAGIC_VALUE = 0x7F84E666;
 // Copy of some Vulkan definitions so we don't need to check their existence just to handle few constants.
 static const uint32_t VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY = 0x00000040;
 static const uint32_t VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD_COPY = 0x00000080;
-static const uint32_t VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_COPY  = 0x00020000;
-static const uint32_t VK_IMAGE_CREATE_DISJOINT_BIT_COPY               = 0x00000200;
-static const int32_t  VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT_COPY    = 1000158000;
-static const uint32_t VMA_ALLOCATION_INTERNAL_STRATEGY_MIN_OFFSET     = 0x10000000u;
-static const uint32_t VMA_ALLOCATION_TRY_COUNT                        = 32;
-static const uint32_t VMA_VENDOR_ID_AMD                               = 4098;
+static const uint32_t VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_COPY = 0x00020000;
+static const uint32_t VK_IMAGE_CREATE_DISJOINT_BIT_COPY = 0x00000200;
+static const int32_t VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT_COPY = 1000158000;
+static const uint32_t VMA_ALLOCATION_INTERNAL_STRATEGY_MIN_OFFSET = 0x10000000u;
+static const uint32_t VMA_ALLOCATION_TRY_COUNT = 32;
+static const uint32_t VMA_VENDOR_ID_AMD = 4098;
 
 // This one is tricky. Vulkan specification defines this code as available since
 // Vulkan 1.0, but doesn't actually define it in Vulkan SDK earlier than 1.2.131.
 // See pull request #207.
 #define VK_ERROR_UNKNOWN_COPY ((VkResult)-13)
 
+
 #if VMA_STATS_STRING_ENABLED
 // Correspond to values of enum VmaSuballocationType.
-static const char* VMA_SUBALLOCATION_TYPE_NAMES[] = {
-    "FREE", "UNKNOWN", "BUFFER", "IMAGE_UNKNOWN", "IMAGE_LINEAR", "IMAGE_OPTIMAL",
+static const char* VMA_SUBALLOCATION_TYPE_NAMES[] =
+{
+    "FREE",
+    "UNKNOWN",
+    "BUFFER",
+    "IMAGE_UNKNOWN",
+    "IMAGE_LINEAR",
+    "IMAGE_OPTIMAL",
 };
 #endif
 
-static VkAllocationCallbacks VmaEmptyAllocationCallbacks = {
-    VMA_NULL, VMA_NULL, VMA_NULL, VMA_NULL, VMA_NULL, VMA_NULL
-};
+static VkAllocationCallbacks VmaEmptyAllocationCallbacks =
+    { VMA_NULL, VMA_NULL, VMA_NULL, VMA_NULL, VMA_NULL, VMA_NULL };
+
 
 #ifndef _VMA_ENUM_DECLARATIONS
 
 enum VmaSuballocationType
 {
-    VMA_SUBALLOCATION_TYPE_FREE          = 0,
-    VMA_SUBALLOCATION_TYPE_UNKNOWN       = 1,
-    VMA_SUBALLOCATION_TYPE_BUFFER        = 2,
+    VMA_SUBALLOCATION_TYPE_FREE = 0,
+    VMA_SUBALLOCATION_TYPE_UNKNOWN = 1,
+    VMA_SUBALLOCATION_TYPE_BUFFER = 2,
     VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN = 3,
-    VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR  = 4,
+    VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR = 4,
     VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL = 5,
-    VMA_SUBALLOCATION_TYPE_MAX_ENUM      = 0x7FFFFFFF
+    VMA_SUBALLOCATION_TYPE_MAX_ENUM = 0x7FFFFFFF
 };
 
 enum VMA_CACHE_OPERATION
@@ -3107,37 +3151,37 @@ enum class VmaAllocationRequestType
 
 #ifndef _VMA_FORWARD_DECLARATIONS
 // Opaque handle used by allocation algorithms to identify single allocation in any conforming way.
-VK_DEFINE_NON_DISPATCHABLE_HANDLE(VmaAllocHandle);
+VK_DEFINE_NON_DISPATCHABLE_HANDLE(VmaAllocHandle)
 
 struct VmaMutexLock;
 struct VmaMutexLockRead;
 struct VmaMutexLockWrite;
 
-template <typename T>
+template<typename T>
 struct AtomicTransactionalIncrement;
 
-template <typename T>
+template<typename T>
 struct VmaStlAllocator;
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 class VmaVector;
 
-template <typename T, typename AllocatorT, size_t N>
+template<typename T, typename AllocatorT, size_t N>
 class VmaSmallVector;
 
-template <typename T>
+template<typename T>
 class VmaPoolAllocator;
 
-template <typename T>
+template<typename T>
 struct VmaListItem;
 
-template <typename T>
+template<typename T>
 class VmaRawList;
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 class VmaList;
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 class VmaIntrusiveLinkedList;
 
 // Unused in this version
@@ -3184,6 +3228,7 @@ class VmaAllocationObjectAllocator;
 
 #endif // _VMA_FORWARD_DECLARATIONS
 
+
 #ifndef _VMA_FUNCTIONS
 
 /*
@@ -3205,10 +3250,10 @@ static inline uint32_t VmaCountBitsSet(uint32_t v)
     return std::popcount(v);
 #else
     uint32_t c = v - ((v >> 1) & 0x55555555);
-    c          = ((c >> 2) & 0x33333333) + (c & 0x33333333);
-    c          = ((c >> 4) + c) & 0x0F0F0F0F;
-    c          = ((c >> 8) + c) & 0x00FF00FF;
-    c          = ((c >> 16) + c) & 0x0000FFFF;
+    c = ((c >> 2) & 0x33333333) + (c & 0x33333333);
+    c = ((c >> 4) + c) & 0x0F0F0F0F;
+    c = ((c >> 8) + c) & 0x00FF00FF;
+    c = ((c >> 16) + c) & 0x0000FFFF;
     return c;
 #endif
 }
@@ -3223,7 +3268,7 @@ static inline uint8_t VmaBitScanLSB(uint64_t mask)
 #elif defined __GNUC__ || defined __clang__
     return static_cast<uint8_t>(__builtin_ffsll(mask)) - 1U;
 #else
-    uint8_t  pos = 0;
+    uint8_t pos = 0;
     uint64_t bit = 1;
     do
     {
@@ -3245,7 +3290,7 @@ static inline uint8_t VmaBitScanLSB(uint32_t mask)
 #elif defined __GNUC__ || defined __clang__
     return static_cast<uint8_t>(__builtin_ffs(mask)) - 1U;
 #else
-    uint8_t  pos = 0;
+    uint8_t pos = 0;
     uint32_t bit = 1;
     do
     {
@@ -3267,7 +3312,7 @@ static inline uint8_t VmaBitScanMSB(uint64_t mask)
     if (mask)
         return 63 - static_cast<uint8_t>(__builtin_clzll(mask));
 #else
-    uint8_t  pos = 63;
+    uint8_t pos = 63;
     uint64_t bit = 1ULL << 63;
     do
     {
@@ -3289,7 +3334,7 @@ static inline uint8_t VmaBitScanMSB(uint32_t mask)
     if (mask)
         return 31 - static_cast<uint8_t>(__builtin_clz(mask));
 #else
-    uint8_t  pos = 31;
+    uint8_t pos = 31;
     uint32_t bit = 1UL << 31;
     do
     {
@@ -3321,7 +3366,7 @@ static inline T VmaAlignUp(T val, T alignment)
     return (val + alignment - 1) & ~(alignment - 1);
 }
 
-// Aligns given value down to nearest multiply of align value. For example: VmaAlignUp(11, 8) = 8.
+// Aligns given value down to nearest multiply of align value. For example: VmaAlignDown(11, 8) = 8.
 // Use types like uint32_t, uint64_t as T.
 template <typename T>
 static inline T VmaAlignDown(T val, T alignment)
@@ -3406,15 +3451,16 @@ ResourceA must be in less memory offset than ResourceB.
 Algorithm is based on "Vulkan 1.0.39 - A Specification (with all registered Vulkan extensions)"
 chapter 11.6 "Resource Memory Association", paragraph "Buffer-Image Granularity".
 */
-static inline bool VmaBlocksOnSamePage(VkDeviceSize resourceAOffset,
-                                       VkDeviceSize resourceASize,
-                                       VkDeviceSize resourceBOffset,
-                                       VkDeviceSize pageSize)
+static inline bool VmaBlocksOnSamePage(
+    VkDeviceSize resourceAOffset,
+    VkDeviceSize resourceASize,
+    VkDeviceSize resourceBOffset,
+    VkDeviceSize pageSize)
 {
     VMA_ASSERT(resourceAOffset + resourceASize <= resourceBOffset && resourceASize > 0 && pageSize > 0);
-    VkDeviceSize resourceAEnd       = resourceAOffset + resourceASize - 1;
-    VkDeviceSize resourceAEndPage   = resourceAEnd & ~(pageSize - 1);
-    VkDeviceSize resourceBStart     = resourceBOffset;
+    VkDeviceSize resourceAEnd = resourceAOffset + resourceASize - 1;
+    VkDeviceSize resourceAEndPage = resourceAEnd & ~(pageSize - 1);
+    VkDeviceSize resourceBStart = resourceBOffset;
     VkDeviceSize resourceBStartPage = resourceBStart & ~(pageSize - 1);
     return resourceAEndPage == resourceBStartPage;
 }
@@ -3425,8 +3471,9 @@ VkPhysicalDeviceLimits::bufferImageGranularity. They conflict if one is buffer
 or linear image and another one is optimal image. If type is unknown, behave
 conservatively.
 */
-static inline bool VmaIsBufferImageGranularityConflict(VmaSuballocationType suballocType1,
-                                                       VmaSuballocationType suballocType2)
+static inline bool VmaIsBufferImageGranularityConflict(
+    VmaSuballocationType suballocType1,
+    VmaSuballocationType suballocType2)
 {
     if (suballocType1 > suballocType2)
     {
@@ -3435,31 +3482,34 @@ static inline bool VmaIsBufferImageGranularityConflict(VmaSuballocationType suba
 
     switch (suballocType1)
     {
-        case VMA_SUBALLOCATION_TYPE_FREE:
-            return false;
-        case VMA_SUBALLOCATION_TYPE_UNKNOWN:
-            return true;
-        case VMA_SUBALLOCATION_TYPE_BUFFER:
-            return suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN ||
-                   suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL;
-        case VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN:
-            return suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN ||
-                   suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR ||
-                   suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL;
-        case VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR:
-            return suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL;
-        case VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL:
-            return false;
-        default:
-            VMA_ASSERT(0);
-            return true;
+    case VMA_SUBALLOCATION_TYPE_FREE:
+        return false;
+    case VMA_SUBALLOCATION_TYPE_UNKNOWN:
+        return true;
+    case VMA_SUBALLOCATION_TYPE_BUFFER:
+        return
+            suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN ||
+            suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL;
+    case VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN:
+        return
+            suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN ||
+            suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR ||
+            suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL;
+    case VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR:
+        return
+            suballocType2 == VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL;
+    case VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL:
+        return false;
+    default:
+        VMA_ASSERT(0);
+        return true;
     }
 }
 
 static void VmaWriteMagicValue(void* pData, VkDeviceSize offset)
 {
 #if VMA_DEBUG_MARGIN > 0 && VMA_DEBUG_DETECT_CORRUPTION
-    uint32_t*    pDst        = (uint32_t*)((char*)pData + offset);
+    uint32_t* pDst = (uint32_t*)((char*)pData + offset);
     const size_t numberCount = VMA_DEBUG_MARGIN / sizeof(uint32_t);
     for (size_t i = 0; i < numberCount; ++i, ++pDst)
     {
@@ -3473,8 +3523,8 @@ static void VmaWriteMagicValue(void* pData, VkDeviceSize offset)
 static bool VmaValidateMagicValue(const void* pData, VkDeviceSize offset)
 {
 #if VMA_DEBUG_MARGIN > 0 && VMA_DEBUG_DETECT_CORRUPTION
-    const uint32_t* pSrc        = (const uint32_t*)((const char*)pData + offset);
-    const size_t    numberCount = VMA_DEBUG_MARGIN / sizeof(uint32_t);
+    const uint32_t* pSrc = (const uint32_t*)((const char*)pData + offset);
+    const size_t numberCount = VMA_DEBUG_MARGIN / sizeof(uint32_t);
     for (size_t i = 0; i < numberCount; ++i, ++pSrc)
     {
         if (*pSrc != VMA_CORRUPTION_DETECTION_MAGIC_VALUE)
@@ -3495,8 +3545,9 @@ static void VmaFillGpuDefragmentationBufferCreateInfo(VkBufferCreateInfo& outBuf
     memset(&outBufCreateInfo, 0, sizeof(outBufCreateInfo));
     outBufCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     outBufCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    outBufCreateInfo.size  = (VkDeviceSize)VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE; // Example size.
+    outBufCreateInfo.size = (VkDeviceSize)VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE; // Example size.
 }
+
 
 /*
 Performs binary search and returns iterator to first element that is greater or
@@ -3510,10 +3561,10 @@ new element with value (key) should be inserted.
 template <typename CmpLess, typename IterT, typename KeyT>
 static IterT VmaBinaryFindFirstNotLess(IterT beg, IterT end, const KeyT& key, const CmpLess& cmp)
 {
-    size_t down = 0, up = (end - beg);
+    size_t down = 0, up = size_t(end - beg);
     while (down < up)
     {
-        const size_t mid = down + (up - down) / 2; // Overflow-safe midpoint calculation
+        const size_t mid = down + (up - down) / 2;  // Overflow-safe midpoint calculation
         if (cmp(*(beg + mid), key))
         {
             down = mid + 1;
@@ -3526,11 +3577,13 @@ static IterT VmaBinaryFindFirstNotLess(IterT beg, IterT end, const KeyT& key, co
     return beg + down;
 }
 
-template <typename CmpLess, typename IterT, typename KeyT>
+template<typename CmpLess, typename IterT, typename KeyT>
 IterT VmaBinaryFindSorted(const IterT& beg, const IterT& end, const KeyT& value, const CmpLess& cmp)
 {
-    IterT it = VmaBinaryFindFirstNotLess<CmpLess, IterT, KeyT>(beg, end, value, cmp);
-    if (it == end || (!cmp(*it, value) && !cmp(value, *it)))
+    IterT it = VmaBinaryFindFirstNotLess<CmpLess, IterT, KeyT>(
+        beg, end, value, cmp);
+    if (it == end ||
+        (!cmp(*it, value) && !cmp(value, *it)))
     {
         return it;
     }
@@ -3542,7 +3595,7 @@ Returns true if all pointers in the array are not-null and unique.
 Warning! O(n^2) complexity. Use only inside VMA_HEAVY_ASSERT.
 T must be pointer type, e.g. VmaAllocation, VmaPool.
 */
-template <typename T>
+template<typename T>
 static bool VmaValidatePointerArray(uint32_t count, const T* arr)
 {
     for (uint32_t i = 0; i < count; ++i)
@@ -3563,161 +3616,154 @@ static bool VmaValidatePointerArray(uint32_t count, const T* arr)
     return true;
 }
 
-template <typename MainT, typename NewT>
+template<typename MainT, typename NewT>
 static inline void VmaPnextChainPushFront(MainT* mainStruct, NewT* newStruct)
 {
-    newStruct->pNext  = mainStruct->pNext;
+    newStruct->pNext = mainStruct->pNext;
     mainStruct->pNext = newStruct;
 }
 
 // This is the main algorithm that guides the selection of a memory type best for an allocation -
 // converts usage to required/preferred/not preferred flags.
 static bool FindMemoryPreferences(
-    bool                           isIntegratedGPU,
+    bool isIntegratedGPU,
     const VmaAllocationCreateInfo& allocCreateInfo,
-    VkFlags                bufImgUsage, // VkBufferCreateInfo::usage or VkImageCreateInfo::usage. UINT32_MAX if unknown.
+    VkFlags bufImgUsage, // VkBufferCreateInfo::usage or VkImageCreateInfo::usage. UINT32_MAX if unknown.
     VkMemoryPropertyFlags& outRequiredFlags,
     VkMemoryPropertyFlags& outPreferredFlags,
     VkMemoryPropertyFlags& outNotPreferredFlags)
 {
-    outRequiredFlags     = allocCreateInfo.requiredFlags;
-    outPreferredFlags    = allocCreateInfo.preferredFlags;
+    outRequiredFlags = allocCreateInfo.requiredFlags;
+    outPreferredFlags = allocCreateInfo.preferredFlags;
     outNotPreferredFlags = 0;
 
-    switch (allocCreateInfo.usage)
+    switch(allocCreateInfo.usage)
     {
-        case VMA_MEMORY_USAGE_UNKNOWN:
-            break;
-        case VMA_MEMORY_USAGE_GPU_ONLY:
-            if (!isIntegratedGPU || (outPreferredFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
-            {
-                outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-            }
-            break;
-        case VMA_MEMORY_USAGE_CPU_ONLY:
-            outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-            break;
-        case VMA_MEMORY_USAGE_CPU_TO_GPU:
-            outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-            if (!isIntegratedGPU || (outPreferredFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
-            {
-                outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-            }
-            break;
-        case VMA_MEMORY_USAGE_GPU_TO_CPU:
-            outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-            outPreferredFlags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-            break;
-        case VMA_MEMORY_USAGE_CPU_COPY:
-            outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-            break;
-        case VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED:
-            outRequiredFlags |= VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
-            break;
-        case VMA_MEMORY_USAGE_AUTO:
-        case VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE:
-        case VMA_MEMORY_USAGE_AUTO_PREFER_HOST:
+    case VMA_MEMORY_USAGE_UNKNOWN:
+        break;
+    case VMA_MEMORY_USAGE_GPU_ONLY:
+        if(!isIntegratedGPU || (outPreferredFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
         {
-            if (bufImgUsage == UINT32_MAX)
-            {
-                VMA_ASSERT(0 && "VMA_MEMORY_USAGE_AUTO* values can only be used with functions like vmaCreateBuffer, "
-                                "vmaCreateImage so that the details of the created resource are known.");
-                return false;
-            }
-            // This relies on values of VK_IMAGE_USAGE_TRANSFER* being the same VK_BUFFER_IMAGE_TRANSFER*.
-            const bool deviceAccess =
-                (bufImgUsage & ~(VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT)) != 0;
-            const bool hostAccessSequentialWrite =
-                (allocCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT) != 0;
-            const bool hostAccessRandom = (allocCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT) != 0;
-            const bool hostAccessAllowTransferInstead =
-                (allocCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT) != 0;
-            const bool preferDevice = allocCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
-            const bool preferHost   = allocCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
+            outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        }
+        break;
+    case VMA_MEMORY_USAGE_CPU_ONLY:
+        outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        break;
+    case VMA_MEMORY_USAGE_CPU_TO_GPU:
+        outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+        if(!isIntegratedGPU || (outPreferredFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
+        {
+            outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        }
+        break;
+    case VMA_MEMORY_USAGE_GPU_TO_CPU:
+        outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+        outPreferredFlags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+        break;
+    case VMA_MEMORY_USAGE_CPU_COPY:
+        outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        break;
+    case VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED:
+        outRequiredFlags |= VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
+        break;
+    case VMA_MEMORY_USAGE_AUTO:
+    case VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE:
+    case VMA_MEMORY_USAGE_AUTO_PREFER_HOST:
+    {
+        if(bufImgUsage == UINT32_MAX)
+        {
+            VMA_ASSERT(0 && "VMA_MEMORY_USAGE_AUTO* values can only be used with functions like vmaCreateBuffer, vmaCreateImage so that the details of the created resource are known.");
+            return false;
+        }
+        // This relies on values of VK_IMAGE_USAGE_TRANSFER* being the same VK_BUFFER_IMAGE_TRANSFER*.
+        const bool deviceAccess = (bufImgUsage & ~(VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT)) != 0;
+        const bool hostAccessSequentialWrite = (allocCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT) != 0;
+        const bool hostAccessRandom = (allocCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT) != 0;
+        const bool hostAccessAllowTransferInstead = (allocCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT) != 0;
+        const bool preferDevice = allocCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        const bool preferHost = allocCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
 
-            // CPU random access - e.g. a buffer written to or transferred from GPU to read back on CPU.
-            if (hostAccessRandom)
+        // CPU random access - e.g. a buffer written to or transferred from GPU to read back on CPU.
+        if(hostAccessRandom)
+        {
+            if(!isIntegratedGPU && deviceAccess && hostAccessAllowTransferInstead && !preferHost)
             {
-                if (!isIntegratedGPU && deviceAccess && hostAccessAllowTransferInstead && !preferHost)
-                {
-                    // Nice if it will end up in HOST_VISIBLE, but more importantly prefer DEVICE_LOCAL.
-                    // Omitting HOST_VISIBLE here is intentional.
-                    // In case there is DEVICE_LOCAL | HOST_VISIBLE | HOST_CACHED, it will pick that one.
-                    // Otherwise, this will give same weight to DEVICE_LOCAL as HOST_VISIBLE | HOST_CACHED and select
-                    // the former if occurs first on the list.
-                    outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-                }
-                else
-                {
-                    // Always CPU memory, cached.
-                    outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-                }
+                // Nice if it will end up in HOST_VISIBLE, but more importantly prefer DEVICE_LOCAL.
+                // Omitting HOST_VISIBLE here is intentional.
+                // In case there is DEVICE_LOCAL | HOST_VISIBLE | HOST_CACHED, it will pick that one.
+                // Otherwise, this will give same weight to DEVICE_LOCAL as HOST_VISIBLE | HOST_CACHED and select the former if occurs first on the list.
+                outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
             }
-            // CPU sequential write - may be CPU or host-visible GPU memory, uncached and write-combined.
-            else if (hostAccessSequentialWrite)
-            {
-                // Want uncached and write-combined.
-                outNotPreferredFlags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-
-                if (!isIntegratedGPU && deviceAccess && hostAccessAllowTransferInstead && !preferHost)
-                {
-                    outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-                }
-                else
-                {
-                    outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-                    // Direct GPU access, CPU sequential write (e.g. a dynamic uniform buffer updated every frame)
-                    if (deviceAccess)
-                    {
-                        // Could go to CPU memory or GPU BAR/unified. Up to the user to decide. If no preference, choose
-                        // GPU memory.
-                        if (preferHost)
-                            outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-                        else
-                            outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-                    }
-                    // GPU no direct access, CPU sequential write (e.g. an upload buffer to be transferred to the GPU)
-                    else
-                    {
-                        // Could go to CPU memory or GPU BAR/unified. Up to the user to decide. If no preference, choose
-                        // CPU memory.
-                        if (preferDevice)
-                            outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-                        else
-                            outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-                    }
-                }
-            }
-            // No CPU access
             else
             {
-                // GPU access, no CPU access (e.g. a color attachment image) - prefer GPU memory
-                if (deviceAccess)
+                // Always CPU memory, cached.
+                outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+            }
+        }
+        // CPU sequential write - may be CPU or host-visible GPU memory, uncached and write-combined.
+        else if(hostAccessSequentialWrite)
+        {
+            // Want uncached and write-combined.
+            outNotPreferredFlags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+
+            if(!isIntegratedGPU && deviceAccess && hostAccessAllowTransferInstead && !preferHost)
+            {
+                outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+            }
+            else
+            {
+                outRequiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+                // Direct GPU access, CPU sequential write (e.g. a dynamic uniform buffer updated every frame)
+                if(deviceAccess)
                 {
-                    // ...unless there is a clear preference from the user not to do so.
-                    if (preferHost)
+                    // Could go to CPU memory or GPU BAR/unified. Up to the user to decide. If no preference, choose GPU memory.
+                    if(preferHost)
                         outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
                     else
                         outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
                 }
-                // No direct GPU access, no CPU access, just transfers.
-                // It may be staging copy intended for e.g. preserving image for next frame (then better GPU memory) or
-                // a "swap file" copy to free some GPU memory (then better CPU memory).
-                // Up to the user to decide. If no preferece, assume the former and choose GPU memory.
-                if (preferHost)
+                // GPU no direct access, CPU sequential write (e.g. an upload buffer to be transferred to the GPU)
+                else
+                {
+                    // Could go to CPU memory or GPU BAR/unified. Up to the user to decide. If no preference, choose CPU memory.
+                    if(preferDevice)
+                        outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+                    else
+                        outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+                }
+            }
+        }
+        // No CPU access
+        else
+        {
+            // GPU access, no CPU access (e.g. a color attachment image) - prefer GPU memory
+            if(deviceAccess)
+            {
+                // ...unless there is a clear preference from the user not to do so.
+                if(preferHost)
                     outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
                 else
                     outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
             }
-            break;
+            // No direct GPU access, no CPU access, just transfers.
+            // It may be staging copy intended for e.g. preserving image for next frame (then better GPU memory) or
+            // a "swap file" copy to free some GPU memory (then better CPU memory).
+            // Up to the user to decide. If no preferece, assume the former and choose GPU memory.
+            if(preferHost)
+                outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+            else
+                outPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         }
-        default:
-            VMA_ASSERT(0);
+        break;
+    }
+    default:
+        VMA_ASSERT(0);
     }
 
     // Avoid DEVICE_COHERENT unless explicitly requested.
-    if (((allocCreateInfo.requiredFlags | allocCreateInfo.preferredFlags) &
-         (VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY | VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD_COPY)) == 0)
+    if(((allocCreateInfo.requiredFlags | allocCreateInfo.preferredFlags) &
+        (VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY | VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD_COPY)) == 0)
     {
         outNotPreferredFlags |= VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD_COPY;
     }
@@ -3731,10 +3777,14 @@ static bool FindMemoryPreferences(
 static void* VmaMalloc(const VkAllocationCallbacks* pAllocationCallbacks, size_t size, size_t alignment)
 {
     void* result = VMA_NULL;
-    if ((pAllocationCallbacks != VMA_NULL) && (pAllocationCallbacks->pfnAllocation != VMA_NULL))
+    if ((pAllocationCallbacks != VMA_NULL) &&
+        (pAllocationCallbacks->pfnAllocation != VMA_NULL))
     {
         result = (*pAllocationCallbacks->pfnAllocation)(
-            pAllocationCallbacks->pUserData, size, alignment, VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
+            pAllocationCallbacks->pUserData,
+            size,
+            alignment,
+            VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
     }
     else
     {
@@ -3746,7 +3796,8 @@ static void* VmaMalloc(const VkAllocationCallbacks* pAllocationCallbacks, size_t
 
 static void VmaFree(const VkAllocationCallbacks* pAllocationCallbacks, void* ptr)
 {
-    if ((pAllocationCallbacks != VMA_NULL) && (pAllocationCallbacks->pfnFree != VMA_NULL))
+    if ((pAllocationCallbacks != VMA_NULL) &&
+        (pAllocationCallbacks->pfnFree != VMA_NULL))
     {
         (*pAllocationCallbacks->pfnFree)(pAllocationCallbacks->pUserData, ptr);
     }
@@ -3756,35 +3807,35 @@ static void VmaFree(const VkAllocationCallbacks* pAllocationCallbacks, void* ptr
     }
 }
 
-template <typename T>
+template<typename T>
 static T* VmaAllocate(const VkAllocationCallbacks* pAllocationCallbacks)
 {
     return (T*)VmaMalloc(pAllocationCallbacks, sizeof(T), VMA_ALIGN_OF(T));
 }
 
-template <typename T>
+template<typename T>
 static T* VmaAllocateArray(const VkAllocationCallbacks* pAllocationCallbacks, size_t count)
 {
     return (T*)VmaMalloc(pAllocationCallbacks, sizeof(T) * count, VMA_ALIGN_OF(T));
 }
 
-#define vma_new(allocator, type) new (VmaAllocate<type>(allocator))(type)
+#define vma_new(allocator, type)   new(VmaAllocate<type>(allocator))(type)
 
-#define vma_new_array(allocator, type, count) new (VmaAllocateArray<type>((allocator), (count)))(type)
+#define vma_new_array(allocator, type, count)   new(VmaAllocateArray<type>((allocator), (count)))(type)
 
-template <typename T>
+template<typename T>
 static void vma_delete(const VkAllocationCallbacks* pAllocationCallbacks, T* ptr)
 {
     ptr->~T();
     VmaFree(pAllocationCallbacks, ptr);
 }
 
-template <typename T>
+template<typename T>
 static void vma_delete_array(const VkAllocationCallbacks* pAllocationCallbacks, T* ptr, size_t count)
 {
     if (ptr != VMA_NULL)
     {
-        for (size_t i = count; i--;)
+        for (size_t i = count; i--; )
         {
             ptr[i].~T();
         }
@@ -3796,8 +3847,8 @@ static char* VmaCreateStringCopy(const VkAllocationCallbacks* allocs, const char
 {
     if (srcStr != VMA_NULL)
     {
-        const size_t len    = strlen(srcStr);
-        char* const  result = vma_new_array(allocs, char, len + 1);
+        const size_t len = strlen(srcStr);
+        char* const result = vma_new_array(allocs, char, len + 1);
         memcpy(result, srcStr, len + 1);
         return result;
     }
@@ -3827,20 +3878,27 @@ static void VmaFreeString(const VkAllocationCallbacks* allocs, char* str)
     }
 }
 
-template <typename CmpLess, typename VectorT>
+template<typename CmpLess, typename VectorT>
 size_t VmaVectorInsertSorted(VectorT& vector, const typename VectorT::value_type& value)
 {
-    const size_t indexToInsert =
-        VmaBinaryFindFirstNotLess(vector.data(), vector.data() + vector.size(), value, CmpLess()) - vector.data();
+    const size_t indexToInsert = VmaBinaryFindFirstNotLess(
+        vector.data(),
+        vector.data() + vector.size(),
+        value,
+        CmpLess()) - vector.data();
     VmaVectorInsert(vector, indexToInsert, value);
     return indexToInsert;
 }
 
-template <typename CmpLess, typename VectorT>
+template<typename CmpLess, typename VectorT>
 bool VmaVectorRemoveSorted(VectorT& vector, const typename VectorT::value_type& value)
 {
-    CmpLess                    comparator;
-    typename VectorT::iterator it = VmaBinaryFindFirstNotLess(vector.begin(), vector.end(), value, comparator);
+    CmpLess comparator;
+    typename VectorT::iterator it = VmaBinaryFindFirstNotLess(
+        vector.begin(),
+        vector.end(),
+        value,
+        comparator);
     if ((it != vector.end()) && !comparator(*it, value) && !comparator(value, *it))
     {
         size_t indexToRemove = it - vector.begin();
@@ -3855,9 +3913,9 @@ bool VmaVectorRemoveSorted(VectorT& vector, const typename VectorT::value_type& 
 
 static void VmaClearStatistics(VmaStatistics& outStats)
 {
-    outStats.blockCount      = 0;
+    outStats.blockCount = 0;
     outStats.allocationCount = 0;
-    outStats.blockBytes      = 0;
+    outStats.blockBytes = 0;
     outStats.allocationBytes = 0;
 }
 
@@ -3872,9 +3930,9 @@ static void VmaAddStatistics(VmaStatistics& inoutStats, const VmaStatistics& src
 static void VmaClearDetailedStatistics(VmaDetailedStatistics& outStats)
 {
     VmaClearStatistics(outStats.statistics);
-    outStats.unusedRangeCount   = 0;
-    outStats.allocationSizeMin  = VK_WHOLE_SIZE;
-    outStats.allocationSizeMax  = 0;
+    outStats.unusedRangeCount = 0;
+    outStats.allocationSizeMin = VK_WHOLE_SIZE;
+    outStats.allocationSizeMax = 0;
     outStats.unusedRangeSizeMin = VK_WHOLE_SIZE;
     outStats.unusedRangeSizeMax = 0;
 }
@@ -3898,8 +3956,8 @@ static void VmaAddDetailedStatistics(VmaDetailedStatistics& inoutStats, const Vm
 {
     VmaAddStatistics(inoutStats.statistics, src.statistics);
     inoutStats.unusedRangeCount += src.unusedRangeCount;
-    inoutStats.allocationSizeMin  = VMA_MIN(inoutStats.allocationSizeMin, src.allocationSizeMin);
-    inoutStats.allocationSizeMax  = VMA_MAX(inoutStats.allocationSizeMax, src.allocationSizeMax);
+    inoutStats.allocationSizeMin = VMA_MIN(inoutStats.allocationSizeMin, src.allocationSizeMin);
+    inoutStats.allocationSizeMax = VMA_MAX(inoutStats.allocationSizeMax, src.allocationSizeMax);
     inoutStats.unusedRangeSizeMin = VMA_MIN(inoutStats.unusedRangeSizeMin, src.unusedRangeSizeMin);
     inoutStats.unusedRangeSizeMax = VMA_MAX(inoutStats.unusedRangeSizeMax, src.unusedRangeSizeMax);
 }
@@ -3910,133 +3968,108 @@ static void VmaAddDetailedStatistics(VmaDetailedStatistics& inoutStats, const Vm
 // Helper RAII class to lock a mutex in constructor and unlock it in destructor (at the end of scope).
 struct VmaMutexLock
 {
-    VMA_CLASS_NO_COPY(VmaMutexLock)
-  public:
-    VmaMutexLock(VMA_MUTEX& mutex, bool useMutex = true) : m_pMutex(useMutex ? &mutex : VMA_NULL)
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaMutexLock)
+public:
+    VmaMutexLock(VMA_MUTEX& mutex, bool useMutex = true) :
+        m_pMutex(useMutex ? &mutex : VMA_NULL)
     {
-        if (m_pMutex)
-        {
-            m_pMutex->Lock();
-        }
+        if (m_pMutex) { m_pMutex->Lock(); }
     }
-    ~VmaMutexLock()
-    {
-        if (m_pMutex)
-        {
-            m_pMutex->Unlock();
-        }
-    }
+    ~VmaMutexLock() {  if (m_pMutex) { m_pMutex->Unlock(); } }
 
-  private:
+private:
     VMA_MUTEX* m_pMutex;
 };
 
 // Helper RAII class to lock a RW mutex in constructor and unlock it in destructor (at the end of scope), for reading.
 struct VmaMutexLockRead
 {
-    VMA_CLASS_NO_COPY(VmaMutexLockRead)
-  public:
-    VmaMutexLockRead(VMA_RW_MUTEX& mutex, bool useMutex) : m_pMutex(useMutex ? &mutex : VMA_NULL)
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaMutexLockRead)
+public:
+    VmaMutexLockRead(VMA_RW_MUTEX& mutex, bool useMutex) :
+        m_pMutex(useMutex ? &mutex : VMA_NULL)
     {
-        if (m_pMutex)
-        {
-            m_pMutex->LockRead();
-        }
+        if (m_pMutex) { m_pMutex->LockRead(); }
     }
-    ~VmaMutexLockRead()
-    {
-        if (m_pMutex)
-        {
-            m_pMutex->UnlockRead();
-        }
-    }
+    ~VmaMutexLockRead() { if (m_pMutex) { m_pMutex->UnlockRead(); } }
 
-  private:
+private:
     VMA_RW_MUTEX* m_pMutex;
 };
 
 // Helper RAII class to lock a RW mutex in constructor and unlock it in destructor (at the end of scope), for writing.
 struct VmaMutexLockWrite
 {
-    VMA_CLASS_NO_COPY(VmaMutexLockWrite)
-  public:
-    VmaMutexLockWrite(VMA_RW_MUTEX& mutex, bool useMutex) : m_pMutex(useMutex ? &mutex : VMA_NULL)
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaMutexLockWrite)
+public:
+    VmaMutexLockWrite(VMA_RW_MUTEX& mutex, bool useMutex)
+        : m_pMutex(useMutex ? &mutex : VMA_NULL)
     {
-        if (m_pMutex)
-        {
-            m_pMutex->LockWrite();
-        }
+        if (m_pMutex) { m_pMutex->LockWrite(); }
     }
-    ~VmaMutexLockWrite()
-    {
-        if (m_pMutex)
-        {
-            m_pMutex->UnlockWrite();
-        }
-    }
+    ~VmaMutexLockWrite() { if (m_pMutex) { m_pMutex->UnlockWrite(); } }
 
-  private:
+private:
     VMA_RW_MUTEX* m_pMutex;
 };
 
 #if VMA_DEBUG_GLOBAL_MUTEX
-static VMA_MUTEX gDebugGlobalMutex;
-#define VMA_DEBUG_GLOBAL_MUTEX_LOCK VmaMutexLock debugGlobalMutexLock(gDebugGlobalMutex, true);
+    static VMA_MUTEX gDebugGlobalMutex;
+    #define VMA_DEBUG_GLOBAL_MUTEX_LOCK VmaMutexLock debugGlobalMutexLock(gDebugGlobalMutex, true);
 #else
-#define VMA_DEBUG_GLOBAL_MUTEX_LOCK
+    #define VMA_DEBUG_GLOBAL_MUTEX_LOCK
 #endif
 #endif // _VMA_MUTEX_LOCK
 
 #ifndef _VMA_ATOMIC_TRANSACTIONAL_INCREMENT
 // An object that increments given atomic but decrements it back in the destructor unless Commit() is called.
-template <typename T>
+template<typename AtomicT>
 struct AtomicTransactionalIncrement
 {
-  public:
-    typedef std::atomic<T> AtomicT;
+public:
+    using T = decltype(AtomicT().load());
 
     ~AtomicTransactionalIncrement()
     {
-        if (m_Atomic)
+        if(m_Atomic)
             --(*m_Atomic);
     }
 
     void Commit() { m_Atomic = nullptr; }
-    T    Increment(AtomicT* atomic)
+    T Increment(AtomicT* atomic)
     {
         m_Atomic = atomic;
         return m_Atomic->fetch_add(1);
     }
 
-  private:
+private:
     AtomicT* m_Atomic = nullptr;
 };
 #endif // _VMA_ATOMIC_TRANSACTIONAL_INCREMENT
 
 #ifndef _VMA_STL_ALLOCATOR
 // STL-compatible allocator.
-template <typename T>
+template<typename T>
 struct VmaStlAllocator
 {
     const VkAllocationCallbacks* const m_pCallbacks;
-    typedef T                          value_type;
+    typedef T value_type;
 
     VmaStlAllocator(const VkAllocationCallbacks* pCallbacks) : m_pCallbacks(pCallbacks) {}
-    template <typename U>
-    VmaStlAllocator(const VmaStlAllocator<U>& src) : m_pCallbacks(src.m_pCallbacks)
-    {}
+    template<typename U>
+    VmaStlAllocator(const VmaStlAllocator<U>& src) : m_pCallbacks(src.m_pCallbacks) {}
     VmaStlAllocator(const VmaStlAllocator&) = default;
     VmaStlAllocator& operator=(const VmaStlAllocator&) = delete;
 
-    T*   allocate(size_t n) { return VmaAllocateArray<T>(m_pCallbacks, n); }
+    T* allocate(size_t n) { return VmaAllocateArray<T>(m_pCallbacks, n); }
     void deallocate(T* p, size_t n) { VmaFree(m_pCallbacks, p); }
 
-    template <typename U>
+    template<typename U>
     bool operator==(const VmaStlAllocator<U>& rhs) const
     {
         return m_pCallbacks == rhs.m_pCallbacks;
     }
-    template <typename U>
+    template<typename U>
     bool operator!=(const VmaStlAllocator<U>& rhs) const
     {
         return m_pCallbacks != rhs.m_pCallbacks;
@@ -4048,12 +4081,12 @@ struct VmaStlAllocator
 /* Class with interface compatible with subset of std::vector.
 T must be POD because constructors and destructors are not called and memcpy is
 used for these objects. */
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 class VmaVector
 {
-  public:
-    typedef T        value_type;
-    typedef T*       iterator;
+public:
+    typedef T value_type;
+    typedef T* iterator;
     typedef const T* const_iterator;
 
     VmaVector(const AllocatorT& allocator);
@@ -4065,48 +4098,24 @@ class VmaVector
     VmaVector& operator=(const VmaVector& rhs);
     ~VmaVector() { VmaFree(m_Allocator.m_pCallbacks, m_pArray); }
 
-    bool   empty() const { return m_Count == 0; }
+    bool empty() const { return m_Count == 0; }
     size_t size() const { return m_Count; }
-    T*     data() { return m_pArray; }
-    T&     front()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return m_pArray[0];
-    }
-    T& back()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return m_pArray[m_Count - 1];
-    }
+    T* data() { return m_pArray; }
+    T& front() { VMA_HEAVY_ASSERT(m_Count > 0); return m_pArray[0]; }
+    T& back() { VMA_HEAVY_ASSERT(m_Count > 0); return m_pArray[m_Count - 1]; }
     const T* data() const { return m_pArray; }
-    const T& front() const
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return m_pArray[0];
-    }
-    const T& back() const
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return m_pArray[m_Count - 1];
-    }
+    const T& front() const { VMA_HEAVY_ASSERT(m_Count > 0); return m_pArray[0]; }
+    const T& back() const { VMA_HEAVY_ASSERT(m_Count > 0); return m_pArray[m_Count - 1]; }
 
-    iterator       begin() { return m_pArray; }
-    iterator       end() { return m_pArray + m_Count; }
+    iterator begin() { return m_pArray; }
+    iterator end() { return m_pArray + m_Count; }
     const_iterator cbegin() const { return m_pArray; }
     const_iterator cend() const { return m_pArray + m_Count; }
     const_iterator begin() const { return cbegin(); }
     const_iterator end() const { return cend(); }
 
-    void pop_front()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        remove(0);
-    }
-    void pop_back()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        resize(size() - 1);
-    }
+    void pop_front() { VMA_HEAVY_ASSERT(m_Count > 0); remove(0); }
+    void pop_back() { VMA_HEAVY_ASSERT(m_Count > 0); resize(size() - 1); }
     void push_front(const T& src) { insert(0, src); }
 
     void push_back(const T& src);
@@ -4117,41 +4126,37 @@ class VmaVector
     void insert(size_t index, const T& src);
     void remove(size_t index);
 
-    T& operator[](size_t index)
-    {
-        VMA_HEAVY_ASSERT(index < m_Count);
-        return m_pArray[index];
-    }
-    const T& operator[](size_t index) const
-    {
-        VMA_HEAVY_ASSERT(index < m_Count);
-        return m_pArray[index];
-    }
+    T& operator[](size_t index) { VMA_HEAVY_ASSERT(index < m_Count); return m_pArray[index]; }
+    const T& operator[](size_t index) const { VMA_HEAVY_ASSERT(index < m_Count); return m_pArray[index]; }
 
-  private:
+private:
     AllocatorT m_Allocator;
-    T*         m_pArray;
-    size_t     m_Count;
-    size_t     m_Capacity;
+    T* m_pArray;
+    size_t m_Count;
+    size_t m_Capacity;
 };
 
 #ifndef _VMA_VECTOR_FUNCTIONS
-template <typename T, typename AllocatorT>
-VmaVector<T, AllocatorT>::VmaVector(const AllocatorT& allocator) :
-    m_Allocator(allocator), m_pArray(VMA_NULL), m_Count(0), m_Capacity(0)
-{}
+template<typename T, typename AllocatorT>
+VmaVector<T, AllocatorT>::VmaVector(const AllocatorT& allocator)
+    : m_Allocator(allocator),
+    m_pArray(VMA_NULL),
+    m_Count(0),
+    m_Capacity(0) {}
 
-template <typename T, typename AllocatorT>
-VmaVector<T, AllocatorT>::VmaVector(size_t count, const AllocatorT& allocator) :
-    m_Allocator(allocator), m_pArray(count ? (T*)VmaAllocateArray<T>(allocator.m_pCallbacks, count) : VMA_NULL),
-    m_Count(count), m_Capacity(count)
-{}
+template<typename T, typename AllocatorT>
+VmaVector<T, AllocatorT>::VmaVector(size_t count, const AllocatorT& allocator)
+    : m_Allocator(allocator),
+    m_pArray(count ? (T*)VmaAllocateArray<T>(allocator.m_pCallbacks, count) : VMA_NULL),
+    m_Count(count),
+    m_Capacity(count) {}
 
-template <typename T, typename AllocatorT>
-VmaVector<T, AllocatorT>::VmaVector(const VmaVector& src) :
-    m_Allocator(src.m_Allocator),
+template<typename T, typename AllocatorT>
+VmaVector<T, AllocatorT>::VmaVector(const VmaVector& src)
+    : m_Allocator(src.m_Allocator),
     m_pArray(src.m_Count ? (T*)VmaAllocateArray<T>(src.m_Allocator.m_pCallbacks, src.m_Count) : VMA_NULL),
-    m_Count(src.m_Count), m_Capacity(src.m_Count)
+    m_Count(src.m_Count),
+    m_Capacity(src.m_Count)
 {
     if (m_Count != 0)
     {
@@ -4159,7 +4164,7 @@ VmaVector<T, AllocatorT>::VmaVector(const VmaVector& src) :
     }
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 VmaVector<T, AllocatorT>& VmaVector<T, AllocatorT>::operator=(const VmaVector& rhs)
 {
     if (&rhs != this)
@@ -4173,7 +4178,7 @@ VmaVector<T, AllocatorT>& VmaVector<T, AllocatorT>::operator=(const VmaVector& r
     return *this;
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 void VmaVector<T, AllocatorT>::push_back(const T& src)
 {
     const size_t newIndex = size();
@@ -4181,7 +4186,7 @@ void VmaVector<T, AllocatorT>::push_back(const T& src)
     m_pArray[newIndex] = src;
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 void VmaVector<T, AllocatorT>::reserve(size_t newCapacity, bool freeMemory)
 {
     newCapacity = VMA_MAX(newCapacity, m_Count);
@@ -4200,11 +4205,11 @@ void VmaVector<T, AllocatorT>::reserve(size_t newCapacity, bool freeMemory)
         }
         VmaFree(m_Allocator.m_pCallbacks, m_pArray);
         m_Capacity = newCapacity;
-        m_pArray   = newArray;
+        m_pArray = newArray;
     }
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 void VmaVector<T, AllocatorT>::resize(size_t newCount)
 {
     size_t newCapacity = m_Capacity;
@@ -4215,7 +4220,7 @@ void VmaVector<T, AllocatorT>::resize(size_t newCount)
 
     if (newCapacity != m_Capacity)
     {
-        T* const     newArray = newCapacity ? VmaAllocateArray<T>(m_Allocator.m_pCallbacks, newCapacity) : VMA_NULL;
+        T* const newArray = newCapacity ? VmaAllocateArray<T>(m_Allocator.m_pCallbacks, newCapacity) : VMA_NULL;
         const size_t elementsToCopy = VMA_MIN(m_Count, newCount);
         if (elementsToCopy != 0)
         {
@@ -4223,13 +4228,13 @@ void VmaVector<T, AllocatorT>::resize(size_t newCount)
         }
         VmaFree(m_Allocator.m_pCallbacks, m_pArray);
         m_Capacity = newCapacity;
-        m_pArray   = newArray;
+        m_pArray = newArray;
     }
 
     m_Count = newCount;
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 void VmaVector<T, AllocatorT>::shrink_to_fit()
 {
     if (m_Capacity > m_Count)
@@ -4242,11 +4247,11 @@ void VmaVector<T, AllocatorT>::shrink_to_fit()
         }
         VmaFree(m_Allocator.m_pCallbacks, m_pArray);
         m_Capacity = m_Count;
-        m_pArray   = newArray;
+        m_pArray = newArray;
     }
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 void VmaVector<T, AllocatorT>::insert(size_t index, const T& src)
 {
     VMA_HEAVY_ASSERT(index <= m_Count);
@@ -4259,7 +4264,7 @@ void VmaVector<T, AllocatorT>::insert(size_t index, const T& src)
     m_pArray[index] = src;
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 void VmaVector<T, AllocatorT>::remove(size_t index)
 {
     VMA_HEAVY_ASSERT(index < m_Count);
@@ -4272,13 +4277,13 @@ void VmaVector<T, AllocatorT>::remove(size_t index)
 }
 #endif // _VMA_VECTOR_FUNCTIONS
 
-template <typename T, typename allocatorT>
+template<typename T, typename allocatorT>
 static void VmaVectorInsert(VmaVector<T, allocatorT>& vec, size_t index, const T& item)
 {
     vec.insert(index, item);
 }
 
-template <typename T, typename allocatorT>
+template<typename T, typename allocatorT>
 static void VmaVectorRemove(VmaVector<T, allocatorT>& vec, size_t index)
 {
     vec.remove(index);
@@ -4293,59 +4298,35 @@ It contains some number of elements in-place, which allows it to avoid heap allo
 when the actual number of elements is below that threshold. This allows normal "small"
 cases to be fast without losing generality for large inputs.
 */
-template <typename T, typename AllocatorT, size_t N>
+template<typename T, typename AllocatorT, size_t N>
 class VmaSmallVector
 {
-  public:
-    typedef T  value_type;
+public:
+    typedef T value_type;
     typedef T* iterator;
 
     VmaSmallVector(const AllocatorT& allocator);
     VmaSmallVector(size_t count, const AllocatorT& allocator);
-    template <typename SrcT, typename SrcAllocatorT, size_t SrcN>
+    template<typename SrcT, typename SrcAllocatorT, size_t SrcN>
     VmaSmallVector(const VmaSmallVector<SrcT, SrcAllocatorT, SrcN>&) = delete;
-    template <typename SrcT, typename SrcAllocatorT, size_t SrcN>
+    template<typename SrcT, typename SrcAllocatorT, size_t SrcN>
     VmaSmallVector<T, AllocatorT, N>& operator=(const VmaSmallVector<SrcT, SrcAllocatorT, SrcN>&) = delete;
-    ~VmaSmallVector()                                                                             = default;
+    ~VmaSmallVector() = default;
 
-    bool   empty() const { return m_Count == 0; }
+    bool empty() const { return m_Count == 0; }
     size_t size() const { return m_Count; }
-    T*     data() { return m_Count > N ? m_DynamicArray.data() : m_StaticArray; }
-    T&     front()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return data()[0];
-    }
-    T& back()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return data()[m_Count - 1];
-    }
+    T* data() { return m_Count > N ? m_DynamicArray.data() : m_StaticArray; }
+    T& front() { VMA_HEAVY_ASSERT(m_Count > 0); return data()[0]; }
+    T& back() { VMA_HEAVY_ASSERT(m_Count > 0); return data()[m_Count - 1]; }
     const T* data() const { return m_Count > N ? m_DynamicArray.data() : m_StaticArray; }
-    const T& front() const
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return data()[0];
-    }
-    const T& back() const
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        return data()[m_Count - 1];
-    }
+    const T& front() const { VMA_HEAVY_ASSERT(m_Count > 0); return data()[0]; }
+    const T& back() const { VMA_HEAVY_ASSERT(m_Count > 0); return data()[m_Count - 1]; }
 
     iterator begin() { return data(); }
     iterator end() { return data() + m_Count; }
 
-    void pop_front()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        remove(0);
-    }
-    void pop_back()
-    {
-        VMA_HEAVY_ASSERT(m_Count > 0);
-        resize(size() - 1);
-    }
+    void pop_front() { VMA_HEAVY_ASSERT(m_Count > 0); remove(0); }
+    void pop_back() { VMA_HEAVY_ASSERT(m_Count > 0); resize(size() - 1); }
     void push_front(const T& src) { insert(0, src); }
 
     void push_back(const T& src);
@@ -4354,34 +4335,27 @@ class VmaSmallVector
     void insert(size_t index, const T& src);
     void remove(size_t index);
 
-    T& operator[](size_t index)
-    {
-        VMA_HEAVY_ASSERT(index < m_Count);
-        return data()[index];
-    }
-    const T& operator[](size_t index) const
-    {
-        VMA_HEAVY_ASSERT(index < m_Count);
-        return data()[index];
-    }
+    T& operator[](size_t index) { VMA_HEAVY_ASSERT(index < m_Count); return data()[index]; }
+    const T& operator[](size_t index) const { VMA_HEAVY_ASSERT(index < m_Count); return data()[index]; }
 
-  private:
-    size_t                   m_Count;
-    T                        m_StaticArray[N]; // Used when m_Size <= N
-    VmaVector<T, AllocatorT> m_DynamicArray;   // Used when m_Size > N
+private:
+    size_t m_Count;
+    T m_StaticArray[N]; // Used when m_Size <= N
+    VmaVector<T, AllocatorT> m_DynamicArray; // Used when m_Size > N
 };
 
 #ifndef _VMA_SMALL_VECTOR_FUNCTIONS
-template <typename T, typename AllocatorT, size_t N>
-VmaSmallVector<T, AllocatorT, N>::VmaSmallVector(const AllocatorT& allocator) : m_Count(0), m_DynamicArray(allocator)
-{}
+template<typename T, typename AllocatorT, size_t N>
+VmaSmallVector<T, AllocatorT, N>::VmaSmallVector(const AllocatorT& allocator)
+    : m_Count(0),
+    m_DynamicArray(allocator) {}
 
-template <typename T, typename AllocatorT, size_t N>
-VmaSmallVector<T, AllocatorT, N>::VmaSmallVector(size_t count, const AllocatorT& allocator) :
-    m_Count(count), m_DynamicArray(count > N ? count : 0, allocator)
-{}
+template<typename T, typename AllocatorT, size_t N>
+VmaSmallVector<T, AllocatorT, N>::VmaSmallVector(size_t count, const AllocatorT& allocator)
+    : m_Count(count),
+    m_DynamicArray(count > N ? count : 0, allocator) {}
 
-template <typename T, typename AllocatorT, size_t N>
+template<typename T, typename AllocatorT, size_t N>
 void VmaSmallVector<T, AllocatorT, N>::push_back(const T& src)
 {
     const size_t newIndex = size();
@@ -4389,7 +4363,7 @@ void VmaSmallVector<T, AllocatorT, N>::push_back(const T& src)
     data()[newIndex] = src;
 }
 
-template <typename T, typename AllocatorT, size_t N>
+template<typename T, typename AllocatorT, size_t N>
 void VmaSmallVector<T, AllocatorT, N>::resize(size_t newCount, bool freeMemory)
 {
     if (newCount > N && m_Count > N)
@@ -4430,7 +4404,7 @@ void VmaSmallVector<T, AllocatorT, N>::resize(size_t newCount, bool freeMemory)
     m_Count = newCount;
 }
 
-template <typename T, typename AllocatorT, size_t N>
+template<typename T, typename AllocatorT, size_t N>
 void VmaSmallVector<T, AllocatorT, N>::clear(bool freeMemory)
 {
     m_DynamicArray.clear();
@@ -4441,7 +4415,7 @@ void VmaSmallVector<T, AllocatorT, N>::clear(bool freeMemory)
     m_Count = 0;
 }
 
-template <typename T, typename AllocatorT, size_t N>
+template<typename T, typename AllocatorT, size_t N>
 void VmaSmallVector<T, AllocatorT, N>::insert(size_t index, const T& src)
 {
     VMA_HEAVY_ASSERT(index <= m_Count);
@@ -4450,22 +4424,20 @@ void VmaSmallVector<T, AllocatorT, N>::insert(size_t index, const T& src)
     T* const dataPtr = data();
     if (index < oldCount)
     {
-        //  I know, this could be more optimal for case where memmove can be memcpy directly from m_StaticArray to
-        //  m_DynamicArray.
+        //  I know, this could be more optimal for case where memmove can be memcpy directly from m_StaticArray to m_DynamicArray.
         memmove(dataPtr + (index + 1), dataPtr + index, (oldCount - index) * sizeof(T));
     }
     dataPtr[index] = src;
 }
 
-template <typename T, typename AllocatorT, size_t N>
+template<typename T, typename AllocatorT, size_t N>
 void VmaSmallVector<T, AllocatorT, N>::remove(size_t index)
 {
     VMA_HEAVY_ASSERT(index < m_Count);
     const size_t oldCount = size();
     if (index < oldCount - 1)
     {
-        //  I know, this could be more optimal for case where memmove can be memcpy directly from m_DynamicArray to
-        //  m_StaticArray.
+        //  I know, this could be more optimal for case where memmove can be memcpy directly from m_DynamicArray to m_StaticArray.
         T* const dataPtr = data();
         memmove(dataPtr + index, dataPtr + (index + 1), (oldCount - index - 1) * sizeof(T));
     }
@@ -4480,18 +4452,17 @@ Allocator for objects of type T using a list of arrays (pools) to speed up
 allocation. Number of elements that can be allocated is not bounded because
 allocator can create multiple blocks.
 */
-template <typename T>
+template<typename T>
 class VmaPoolAllocator
 {
-    VMA_CLASS_NO_COPY(VmaPoolAllocator)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaPoolAllocator)
+public:
     VmaPoolAllocator(const VkAllocationCallbacks* pAllocationCallbacks, uint32_t firstBlockCapacity);
     ~VmaPoolAllocator();
-    template <typename... Types>
-    T*   Alloc(Types&&... args);
+    template<typename... Types> T* Alloc(Types&&... args);
     void Free(T* ptr);
 
-  private:
+private:
     union Item
     {
         uint32_t NextFreeIndex;
@@ -4499,28 +4470,29 @@ class VmaPoolAllocator
     };
     struct ItemBlock
     {
-        Item*    pItems;
+        Item* pItems;
         uint32_t Capacity;
         uint32_t FirstFreeIndex;
     };
 
-    const VkAllocationCallbacks*                     m_pAllocationCallbacks;
-    const uint32_t                                   m_FirstBlockCapacity;
+    const VkAllocationCallbacks* m_pAllocationCallbacks;
+    const uint32_t m_FirstBlockCapacity;
     VmaVector<ItemBlock, VmaStlAllocator<ItemBlock>> m_ItemBlocks;
 
     ItemBlock& CreateNewBlock();
 };
 
 #ifndef _VMA_POOL_ALLOCATOR_FUNCTIONS
-template <typename T>
-VmaPoolAllocator<T>::VmaPoolAllocator(const VkAllocationCallbacks* pAllocationCallbacks, uint32_t firstBlockCapacity) :
-    m_pAllocationCallbacks(pAllocationCallbacks), m_FirstBlockCapacity(firstBlockCapacity),
+template<typename T>
+VmaPoolAllocator<T>::VmaPoolAllocator(const VkAllocationCallbacks* pAllocationCallbacks, uint32_t firstBlockCapacity)
+    : m_pAllocationCallbacks(pAllocationCallbacks),
+    m_FirstBlockCapacity(firstBlockCapacity),
     m_ItemBlocks(VmaStlAllocator<ItemBlock>(pAllocationCallbacks))
 {
     VMA_ASSERT(m_FirstBlockCapacity > 1);
 }
 
-template <typename T>
+template<typename T>
 VmaPoolAllocator<T>::~VmaPoolAllocator()
 {
     for (size_t i = m_ItemBlocks.size(); i--;)
@@ -4528,38 +4500,37 @@ VmaPoolAllocator<T>::~VmaPoolAllocator()
     m_ItemBlocks.clear();
 }
 
-template <typename T>
-template <typename... Types>
-T* VmaPoolAllocator<T>::Alloc(Types&&... args)
+template<typename T>
+template<typename... Types> T* VmaPoolAllocator<T>::Alloc(Types&&... args)
 {
-    for (size_t i = m_ItemBlocks.size(); i--;)
+    for (size_t i = m_ItemBlocks.size(); i--; )
     {
         ItemBlock& block = m_ItemBlocks[i];
         // This block has some free items: Use first one.
         if (block.FirstFreeIndex != UINT32_MAX)
         {
-            Item* const pItem    = &block.pItems[block.FirstFreeIndex];
+            Item* const pItem = &block.pItems[block.FirstFreeIndex];
             block.FirstFreeIndex = pItem->NextFreeIndex;
-            T* result            = (T*)&pItem->Value;
-            new (result) T(std::forward<Types>(args)...); // Explicit constructor call.
+            T* result = (T*)&pItem->Value;
+            new(result)T(std::forward<Types>(args)...); // Explicit constructor call.
             return result;
         }
     }
 
     // No block has free item: Create new one and use it.
-    ItemBlock&  newBlock    = CreateNewBlock();
-    Item* const pItem       = &newBlock.pItems[0];
+    ItemBlock& newBlock = CreateNewBlock();
+    Item* const pItem = &newBlock.pItems[0];
     newBlock.FirstFreeIndex = pItem->NextFreeIndex;
-    T* result               = (T*)&pItem->Value;
-    new (result) T(std::forward<Types>(args)...); // Explicit constructor call.
+    T* result = (T*)&pItem->Value;
+    new(result) T(std::forward<Types>(args)...); // Explicit constructor call.
     return result;
 }
 
-template <typename T>
+template<typename T>
 void VmaPoolAllocator<T>::Free(T* ptr)
 {
     // Search all memory blocks to find ptr.
-    for (size_t i = m_ItemBlocks.size(); i--;)
+    for (size_t i = m_ItemBlocks.size(); i--; )
     {
         ItemBlock& block = m_ItemBlocks[i];
 
@@ -4571,27 +4542,33 @@ void VmaPoolAllocator<T>::Free(T* ptr)
         if ((pItemPtr >= block.pItems) && (pItemPtr < block.pItems + block.Capacity))
         {
             ptr->~T(); // Explicit destructor call.
-            const uint32_t index    = static_cast<uint32_t>(pItemPtr - block.pItems);
+            const uint32_t index = static_cast<uint32_t>(pItemPtr - block.pItems);
             pItemPtr->NextFreeIndex = block.FirstFreeIndex;
-            block.FirstFreeIndex    = index;
+            block.FirstFreeIndex = index;
             return;
         }
     }
     VMA_ASSERT(0 && "Pointer doesn't belong to this memory pool.");
 }
 
-template <typename T>
+template<typename T>
 typename VmaPoolAllocator<T>::ItemBlock& VmaPoolAllocator<T>::CreateNewBlock()
 {
-    const uint32_t newBlockCapacity =
-        m_ItemBlocks.empty() ? m_FirstBlockCapacity : m_ItemBlocks.back().Capacity * 3 / 2;
+    const uint32_t newBlockCapacity = m_ItemBlocks.empty() ?
+        m_FirstBlockCapacity : m_ItemBlocks.back().Capacity * 3 / 2;
 
-    const ItemBlock newBlock = { vma_new_array(m_pAllocationCallbacks, Item, newBlockCapacity), newBlockCapacity, 0 };
+    const ItemBlock newBlock =
+    {
+        vma_new_array(m_pAllocationCallbacks, Item, newBlockCapacity),
+        newBlockCapacity,
+        0
+    };
 
     m_ItemBlocks.push_back(newBlock);
 
     // Setup singly-linked list of all free items in this block.
-    for (uint32_t i = 0; i < newBlockCapacity - 1; ++i) newBlock.pItems[i].NextFreeIndex = i + 1;
+    for (uint32_t i = 0; i < newBlockCapacity - 1; ++i)
+        newBlock.pItems[i].NextFreeIndex = i + 1;
     newBlock.pItems[newBlockCapacity - 1].NextFreeIndex = UINT32_MAX;
     return m_ItemBlocks.back();
 }
@@ -4599,20 +4576,20 @@ typename VmaPoolAllocator<T>::ItemBlock& VmaPoolAllocator<T>::CreateNewBlock()
 #endif // _VMA_POOL_ALLOCATOR
 
 #ifndef _VMA_RAW_LIST
-template <typename T>
+template<typename T>
 struct VmaListItem
 {
     VmaListItem* pPrev;
     VmaListItem* pNext;
-    T            Value;
+    T Value;
 };
 
 // Doubly linked list.
-template <typename T>
+template<typename T>
 class VmaRawList
 {
-    VMA_CLASS_NO_COPY(VmaRawList)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaRawList)
+public:
     typedef VmaListItem<T> ItemType;
 
     VmaRawList(const VkAllocationCallbacks* pAllocationCallbacks);
@@ -4621,10 +4598,10 @@ class VmaRawList
     ~VmaRawList() = default;
 
     size_t GetCount() const { return m_Count; }
-    bool   IsEmpty() const { return m_Count == 0; }
+    bool IsEmpty() const { return m_Count == 0; }
 
-    ItemType*       Front() { return m_pFront; }
-    ItemType*       Back() { return m_pBack; }
+    ItemType* Front() { return m_pFront; }
+    ItemType* Back() { return m_pBack; }
     const ItemType* Front() const { return m_pFront; }
     const ItemType* Back() const { return m_pBack; }
 
@@ -4632,8 +4609,8 @@ class VmaRawList
     ItemType* PushBack();
     ItemType* PushFront(const T& value);
     ItemType* PushBack(const T& value);
-    void      PopFront();
-    void      PopBack();
+    void PopFront();
+    void PopBack();
 
     // Item can be null - it means PushBack.
     ItemType* InsertBefore(ItemType* pItem);
@@ -4645,87 +4622,89 @@ class VmaRawList
     void Clear();
     void Remove(ItemType* pItem);
 
-  private:
+private:
     const VkAllocationCallbacks* const m_pAllocationCallbacks;
-    VmaPoolAllocator<ItemType>         m_ItemAllocator;
-    ItemType*                          m_pFront;
-    ItemType*                          m_pBack;
-    size_t                             m_Count;
+    VmaPoolAllocator<ItemType> m_ItemAllocator;
+    ItemType* m_pFront;
+    ItemType* m_pBack;
+    size_t m_Count;
 };
 
 #ifndef _VMA_RAW_LIST_FUNCTIONS
-template <typename T>
-VmaRawList<T>::VmaRawList(const VkAllocationCallbacks* pAllocationCallbacks) :
-    m_pAllocationCallbacks(pAllocationCallbacks), m_ItemAllocator(pAllocationCallbacks, 128), m_pFront(VMA_NULL),
-    m_pBack(VMA_NULL), m_Count(0)
-{}
+template<typename T>
+VmaRawList<T>::VmaRawList(const VkAllocationCallbacks* pAllocationCallbacks)
+    : m_pAllocationCallbacks(pAllocationCallbacks),
+    m_ItemAllocator(pAllocationCallbacks, 128),
+    m_pFront(VMA_NULL),
+    m_pBack(VMA_NULL),
+    m_Count(0) {}
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::PushFront()
 {
     ItemType* const pNewItem = m_ItemAllocator.Alloc();
-    pNewItem->pPrev          = VMA_NULL;
+    pNewItem->pPrev = VMA_NULL;
     if (IsEmpty())
     {
         pNewItem->pNext = VMA_NULL;
-        m_pFront        = pNewItem;
-        m_pBack         = pNewItem;
-        m_Count         = 1;
+        m_pFront = pNewItem;
+        m_pBack = pNewItem;
+        m_Count = 1;
     }
     else
     {
         pNewItem->pNext = m_pFront;
         m_pFront->pPrev = pNewItem;
-        m_pFront        = pNewItem;
+        m_pFront = pNewItem;
         ++m_Count;
     }
     return pNewItem;
 }
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::PushBack()
 {
     ItemType* const pNewItem = m_ItemAllocator.Alloc();
-    pNewItem->pNext          = VMA_NULL;
-    if (IsEmpty())
+    pNewItem->pNext = VMA_NULL;
+    if(IsEmpty())
     {
         pNewItem->pPrev = VMA_NULL;
-        m_pFront        = pNewItem;
-        m_pBack         = pNewItem;
-        m_Count         = 1;
+        m_pFront = pNewItem;
+        m_pBack = pNewItem;
+        m_Count = 1;
     }
     else
     {
         pNewItem->pPrev = m_pBack;
-        m_pBack->pNext  = pNewItem;
-        m_pBack         = pNewItem;
+        m_pBack->pNext = pNewItem;
+        m_pBack = pNewItem;
         ++m_Count;
     }
     return pNewItem;
 }
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::PushFront(const T& value)
 {
     ItemType* const pNewItem = PushFront();
-    pNewItem->Value          = value;
+    pNewItem->Value = value;
     return pNewItem;
 }
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::PushBack(const T& value)
 {
     ItemType* const pNewItem = PushBack();
-    pNewItem->Value          = value;
+    pNewItem->Value = value;
     return pNewItem;
 }
 
-template <typename T>
+template<typename T>
 void VmaRawList<T>::PopFront()
 {
     VMA_HEAVY_ASSERT(m_Count > 0);
     ItemType* const pFrontItem = m_pFront;
-    ItemType* const pNextItem  = pFrontItem->pNext;
+    ItemType* const pNextItem = pFrontItem->pNext;
     if (pNextItem != VMA_NULL)
     {
         pNextItem->pPrev = VMA_NULL;
@@ -4735,13 +4714,13 @@ void VmaRawList<T>::PopFront()
     --m_Count;
 }
 
-template <typename T>
+template<typename T>
 void VmaRawList<T>::PopBack()
 {
     VMA_HEAVY_ASSERT(m_Count > 0);
     ItemType* const pBackItem = m_pBack;
     ItemType* const pPrevItem = pBackItem->pPrev;
-    if (pPrevItem != VMA_NULL)
+    if(pPrevItem != VMA_NULL)
     {
         pPrevItem->pNext = VMA_NULL;
     }
@@ -4750,7 +4729,7 @@ void VmaRawList<T>::PopBack()
     --m_Count;
 }
 
-template <typename T>
+template<typename T>
 void VmaRawList<T>::Clear()
 {
     if (IsEmpty() == false)
@@ -4763,18 +4742,18 @@ void VmaRawList<T>::Clear()
             pItem = pPrevItem;
         }
         m_pFront = VMA_NULL;
-        m_pBack  = VMA_NULL;
-        m_Count  = 0;
+        m_pBack = VMA_NULL;
+        m_Count = 0;
     }
 }
 
-template <typename T>
+template<typename T>
 void VmaRawList<T>::Remove(ItemType* pItem)
 {
     VMA_HEAVY_ASSERT(pItem != VMA_NULL);
     VMA_HEAVY_ASSERT(m_Count > 0);
 
-    if (pItem->pPrev != VMA_NULL)
+    if(pItem->pPrev != VMA_NULL)
     {
         pItem->pPrev->pNext = pItem->pNext;
     }
@@ -4784,7 +4763,7 @@ void VmaRawList<T>::Remove(ItemType* pItem)
         m_pFront = pItem->pNext;
     }
 
-    if (pItem->pNext != VMA_NULL)
+    if(pItem->pNext != VMA_NULL)
     {
         pItem->pNext->pPrev = pItem->pPrev;
     }
@@ -4798,17 +4777,17 @@ void VmaRawList<T>::Remove(ItemType* pItem)
     --m_Count;
 }
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::InsertBefore(ItemType* pItem)
 {
-    if (pItem != VMA_NULL)
+    if(pItem != VMA_NULL)
     {
         ItemType* const prevItem = pItem->pPrev;
-        ItemType* const newItem  = m_ItemAllocator.Alloc();
-        newItem->pPrev           = prevItem;
-        newItem->pNext           = pItem;
-        pItem->pPrev             = newItem;
-        if (prevItem != VMA_NULL)
+        ItemType* const newItem = m_ItemAllocator.Alloc();
+        newItem->pPrev = prevItem;
+        newItem->pNext = pItem;
+        pItem->pPrev = newItem;
+        if(prevItem != VMA_NULL)
         {
             prevItem->pNext = newItem;
         }
@@ -4824,17 +4803,17 @@ VmaListItem<T>* VmaRawList<T>::InsertBefore(ItemType* pItem)
         return PushBack();
 }
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::InsertAfter(ItemType* pItem)
 {
-    if (pItem != VMA_NULL)
+    if(pItem != VMA_NULL)
     {
         ItemType* const nextItem = pItem->pNext;
-        ItemType* const newItem  = m_ItemAllocator.Alloc();
-        newItem->pNext           = nextItem;
-        newItem->pPrev           = pItem;
-        pItem->pNext             = newItem;
-        if (nextItem != VMA_NULL)
+        ItemType* const newItem = m_ItemAllocator.Alloc();
+        newItem->pNext = nextItem;
+        newItem->pPrev = pItem;
+        pItem->pNext = newItem;
+        if(nextItem != VMA_NULL)
         {
             nextItem->pPrev = newItem;
         }
@@ -4850,30 +4829,30 @@ VmaListItem<T>* VmaRawList<T>::InsertAfter(ItemType* pItem)
         return PushFront();
 }
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::InsertBefore(ItemType* pItem, const T& value)
 {
     ItemType* const newItem = InsertBefore(pItem);
-    newItem->Value          = value;
+    newItem->Value = value;
     return newItem;
 }
 
-template <typename T>
+template<typename T>
 VmaListItem<T>* VmaRawList<T>::InsertAfter(ItemType* pItem, const T& value)
 {
     ItemType* const newItem = InsertAfter(pItem);
-    newItem->Value          = value;
+    newItem->Value = value;
     return newItem;
 }
 #endif // _VMA_RAW_LIST_FUNCTIONS
 #endif // _VMA_RAW_LIST
 
 #ifndef _VMA_LIST
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 class VmaList
 {
-    VMA_CLASS_NO_COPY(VmaList)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaList)
+public:
     class reverse_iterator;
     class const_iterator;
     class const_reverse_iterator;
@@ -4882,174 +4861,78 @@ class VmaList
     {
         friend class const_iterator;
         friend class VmaList<T, AllocatorT>;
-
-      public:
-        iterator() : m_pList(VMA_NULL), m_pItem(VMA_NULL) {}
+    public:
+        iterator() :  m_pList(VMA_NULL), m_pItem(VMA_NULL) {}
         iterator(const reverse_iterator& src) : m_pList(src.m_pList), m_pItem(src.m_pItem) {}
 
-        T& operator*() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return m_pItem->Value;
-        }
-        T* operator->() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return &m_pItem->Value;
-        }
+        T& operator*() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return m_pItem->Value; }
+        T* operator->() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return &m_pItem->Value; }
 
-        bool operator==(const iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem == rhs.m_pItem;
-        }
-        bool operator!=(const iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem != rhs.m_pItem;
-        }
+        bool operator==(const iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem == rhs.m_pItem; }
+        bool operator!=(const iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem != rhs.m_pItem; }
 
-        iterator operator++(int)
-        {
-            iterator result = *this;
-            ++*this;
-            return result;
-        }
-        iterator operator--(int)
-        {
-            iterator result = *this;
-            --*this;
-            return result;
-        }
+        iterator operator++(int) { iterator result = *this; ++*this; return result; }
+        iterator operator--(int) { iterator result = *this; --*this; return result; }
 
-        iterator& operator++()
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            m_pItem = m_pItem->pNext;
-            return *this;
-        }
+        iterator& operator++() { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); m_pItem = m_pItem->pNext; return *this; }
         iterator& operator--();
 
-      private:
-        VmaRawList<T>*  m_pList;
+    private:
+        VmaRawList<T>* m_pList;
         VmaListItem<T>* m_pItem;
 
-        iterator(VmaRawList<T>* pList, VmaListItem<T>* pItem) : m_pList(pList), m_pItem(pItem) {}
+        iterator(VmaRawList<T>* pList, VmaListItem<T>* pItem) : m_pList(pList),  m_pItem(pItem) {}
     };
     class reverse_iterator
     {
         friend class const_reverse_iterator;
         friend class VmaList<T, AllocatorT>;
-
-      public:
+    public:
         reverse_iterator() : m_pList(VMA_NULL), m_pItem(VMA_NULL) {}
         reverse_iterator(const iterator& src) : m_pList(src.m_pList), m_pItem(src.m_pItem) {}
 
-        T& operator*() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return m_pItem->Value;
-        }
-        T* operator->() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return &m_pItem->Value;
-        }
+        T& operator*() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return m_pItem->Value; }
+        T* operator->() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return &m_pItem->Value; }
 
-        bool operator==(const reverse_iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem == rhs.m_pItem;
-        }
-        bool operator!=(const reverse_iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem != rhs.m_pItem;
-        }
+        bool operator==(const reverse_iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem == rhs.m_pItem; }
+        bool operator!=(const reverse_iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem != rhs.m_pItem; }
 
-        reverse_iterator operator++(int)
-        {
-            reverse_iterator result = *this;
-            ++*this;
-            return result;
-        }
-        reverse_iterator operator--(int)
-        {
-            reverse_iterator result = *this;
-            --*this;
-            return result;
-        }
+        reverse_iterator operator++(int) { reverse_iterator result = *this; ++* this; return result; }
+        reverse_iterator operator--(int) { reverse_iterator result = *this; --* this; return result; }
 
-        reverse_iterator& operator++()
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            m_pItem = m_pItem->pPrev;
-            return *this;
-        }
+        reverse_iterator& operator++() { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); m_pItem = m_pItem->pPrev; return *this; }
         reverse_iterator& operator--();
 
-      private:
-        VmaRawList<T>*  m_pList;
+    private:
+        VmaRawList<T>* m_pList;
         VmaListItem<T>* m_pItem;
 
-        reverse_iterator(VmaRawList<T>* pList, VmaListItem<T>* pItem) : m_pList(pList), m_pItem(pItem) {}
+        reverse_iterator(VmaRawList<T>* pList, VmaListItem<T>* pItem) : m_pList(pList),  m_pItem(pItem) {}
     };
     class const_iterator
     {
         friend class VmaList<T, AllocatorT>;
-
-      public:
+    public:
         const_iterator() : m_pList(VMA_NULL), m_pItem(VMA_NULL) {}
         const_iterator(const iterator& src) : m_pList(src.m_pList), m_pItem(src.m_pItem) {}
         const_iterator(const reverse_iterator& src) : m_pList(src.m_pList), m_pItem(src.m_pItem) {}
 
         iterator drop_const() { return { const_cast<VmaRawList<T>*>(m_pList), const_cast<VmaListItem<T>*>(m_pItem) }; }
 
-        const T& operator*() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return m_pItem->Value;
-        }
-        const T* operator->() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return &m_pItem->Value;
-        }
+        const T& operator*() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return m_pItem->Value; }
+        const T* operator->() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return &m_pItem->Value; }
 
-        bool operator==(const const_iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem == rhs.m_pItem;
-        }
-        bool operator!=(const const_iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem != rhs.m_pItem;
-        }
+        bool operator==(const const_iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem == rhs.m_pItem; }
+        bool operator!=(const const_iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem != rhs.m_pItem; }
 
-        const_iterator operator++(int)
-        {
-            const_iterator result = *this;
-            ++*this;
-            return result;
-        }
-        const_iterator operator--(int)
-        {
-            const_iterator result = *this;
-            --*this;
-            return result;
-        }
+        const_iterator operator++(int) { const_iterator result = *this; ++* this; return result; }
+        const_iterator operator--(int) { const_iterator result = *this; --* this; return result; }
 
-        const_iterator& operator++()
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            m_pItem = m_pItem->pNext;
-            return *this;
-        }
+        const_iterator& operator++() { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); m_pItem = m_pItem->pNext; return *this; }
         const_iterator& operator--();
 
-      private:
-        const VmaRawList<T>*  m_pList;
+    private:
+        const VmaRawList<T>* m_pList;
         const VmaListItem<T>* m_pItem;
 
         const_iterator(const VmaRawList<T>* pList, const VmaListItem<T>* pItem) : m_pList(pList), m_pItem(pItem) {}
@@ -5057,71 +4940,35 @@ class VmaList
     class const_reverse_iterator
     {
         friend class VmaList<T, AllocatorT>;
-
-      public:
+    public:
         const_reverse_iterator() : m_pList(VMA_NULL), m_pItem(VMA_NULL) {}
         const_reverse_iterator(const reverse_iterator& src) : m_pList(src.m_pList), m_pItem(src.m_pItem) {}
         const_reverse_iterator(const iterator& src) : m_pList(src.m_pList), m_pItem(src.m_pItem) {}
 
-        reverse_iterator drop_const()
-        {
-            return { const_cast<VmaRawList<T>*>(m_pList), const_cast<VmaListItem<T>*>(m_pItem) };
-        }
+        reverse_iterator drop_const() { return { const_cast<VmaRawList<T>*>(m_pList), const_cast<VmaListItem<T>*>(m_pItem) }; }
 
-        const T& operator*() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return m_pItem->Value;
-        }
-        const T* operator->() const
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            return &m_pItem->Value;
-        }
+        const T& operator*() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return m_pItem->Value; }
+        const T* operator->() const { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); return &m_pItem->Value; }
 
-        bool operator==(const const_reverse_iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem == rhs.m_pItem;
-        }
-        bool operator!=(const const_reverse_iterator& rhs) const
-        {
-            VMA_HEAVY_ASSERT(m_pList == rhs.m_pList);
-            return m_pItem != rhs.m_pItem;
-        }
+        bool operator==(const const_reverse_iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem == rhs.m_pItem; }
+        bool operator!=(const const_reverse_iterator& rhs) const { VMA_HEAVY_ASSERT(m_pList == rhs.m_pList); return m_pItem != rhs.m_pItem; }
 
-        const_reverse_iterator operator++(int)
-        {
-            const_reverse_iterator result = *this;
-            ++*this;
-            return result;
-        }
-        const_reverse_iterator operator--(int)
-        {
-            const_reverse_iterator result = *this;
-            --*this;
-            return result;
-        }
+        const_reverse_iterator operator++(int) { const_reverse_iterator result = *this; ++* this; return result; }
+        const_reverse_iterator operator--(int) { const_reverse_iterator result = *this; --* this; return result; }
 
-        const_reverse_iterator& operator++()
-        {
-            VMA_HEAVY_ASSERT(m_pItem != VMA_NULL);
-            m_pItem = m_pItem->pPrev;
-            return *this;
-        }
+        const_reverse_iterator& operator++() { VMA_HEAVY_ASSERT(m_pItem != VMA_NULL); m_pItem = m_pItem->pPrev; return *this; }
         const_reverse_iterator& operator--();
 
-      private:
-        const VmaRawList<T>*  m_pList;
+    private:
+        const VmaRawList<T>* m_pList;
         const VmaListItem<T>* m_pItem;
 
-        const_reverse_iterator(const VmaRawList<T>* pList, const VmaListItem<T>* pItem) : m_pList(pList), m_pItem(pItem)
-        {}
+        const_reverse_iterator(const VmaRawList<T>* pList, const VmaListItem<T>* pItem) : m_pList(pList), m_pItem(pItem) {}
     };
 
     VmaList(const AllocatorT& allocator) : m_RawList(allocator.m_pCallbacks) {}
 
-    bool   empty() const { return m_RawList.IsEmpty(); }
+    bool empty() const { return m_RawList.IsEmpty(); }
     size_t size() const { return m_RawList.GetCount(); }
 
     iterator begin() { return iterator(&m_RawList, m_RawList.Front()); }
@@ -5142,21 +4989,18 @@ class VmaList
     const_reverse_iterator rbegin() const { return crbegin(); }
     const_reverse_iterator rend() const { return crend(); }
 
-    void     push_back(const T& value) { m_RawList.PushBack(value); }
-    iterator insert(iterator it, const T& value)
-    {
-        return iterator(&m_RawList, m_RawList.InsertBefore(it.m_pItem, value));
-    }
+    void push_back(const T& value) { m_RawList.PushBack(value); }
+    iterator insert(iterator it, const T& value) { return iterator(&m_RawList, m_RawList.InsertBefore(it.m_pItem, value)); }
 
     void clear() { m_RawList.Clear(); }
     void erase(iterator it) { m_RawList.Remove(it.m_pItem); }
 
-  private:
+private:
     VmaRawList<T> m_RawList;
 };
 
 #ifndef _VMA_LIST_FUNCTIONS
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 typename VmaList<T, AllocatorT>::iterator& VmaList<T, AllocatorT>::iterator::operator--()
 {
     if (m_pItem != VMA_NULL)
@@ -5171,7 +5015,7 @@ typename VmaList<T, AllocatorT>::iterator& VmaList<T, AllocatorT>::iterator::ope
     return *this;
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 typename VmaList<T, AllocatorT>::reverse_iterator& VmaList<T, AllocatorT>::reverse_iterator::operator--()
 {
     if (m_pItem != VMA_NULL)
@@ -5186,7 +5030,7 @@ typename VmaList<T, AllocatorT>::reverse_iterator& VmaList<T, AllocatorT>::rever
     return *this;
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 typename VmaList<T, AllocatorT>::const_iterator& VmaList<T, AllocatorT>::const_iterator::operator--()
 {
     if (m_pItem != VMA_NULL)
@@ -5201,7 +5045,7 @@ typename VmaList<T, AllocatorT>::const_iterator& VmaList<T, AllocatorT>::const_i
     return *this;
 }
 
-template <typename T, typename AllocatorT>
+template<typename T, typename AllocatorT>
 typename VmaList<T, AllocatorT>::const_reverse_iterator& VmaList<T, AllocatorT>::const_reverse_iterator::operator--()
 {
     if (m_pItem != VMA_NULL)
@@ -5230,31 +5074,31 @@ struct MyItemTypeTraits
     static ItemType*& AccessNext(ItemType* item) { return item->myNextPtr; }
 };
 */
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 class VmaIntrusiveLinkedList
 {
-  public:
+public:
     typedef typename ItemTypeTraits::ItemType ItemType;
-    static ItemType*                          GetPrev(const ItemType* item) { return ItemTypeTraits::GetPrev(item); }
-    static ItemType*                          GetNext(const ItemType* item) { return ItemTypeTraits::GetNext(item); }
+    static ItemType* GetPrev(const ItemType* item) { return ItemTypeTraits::GetPrev(item); }
+    static ItemType* GetNext(const ItemType* item) { return ItemTypeTraits::GetNext(item); }
 
     // Movable, not copyable.
     VmaIntrusiveLinkedList() = default;
-    VmaIntrusiveLinkedList(VmaIntrusiveLinkedList&& src);
+    VmaIntrusiveLinkedList(VmaIntrusiveLinkedList && src);
     VmaIntrusiveLinkedList(const VmaIntrusiveLinkedList&) = delete;
-    VmaIntrusiveLinkedList& operator                      =(VmaIntrusiveLinkedList&& src);
+    VmaIntrusiveLinkedList& operator=(VmaIntrusiveLinkedList&& src);
     VmaIntrusiveLinkedList& operator=(const VmaIntrusiveLinkedList&) = delete;
     ~VmaIntrusiveLinkedList() { VMA_HEAVY_ASSERT(IsEmpty()); }
 
-    size_t          GetCount() const { return m_Count; }
-    bool            IsEmpty() const { return m_Count == 0; }
-    ItemType*       Front() { return m_Front; }
-    ItemType*       Back() { return m_Back; }
+    size_t GetCount() const { return m_Count; }
+    bool IsEmpty() const { return m_Count == 0; }
+    ItemType* Front() { return m_Front; }
+    ItemType* Back() { return m_Back; }
     const ItemType* Front() const { return m_Front; }
     const ItemType* Back() const { return m_Back; }
 
-    void      PushBack(ItemType* item);
-    void      PushFront(ItemType* item);
+    void PushBack(ItemType* item);
+    void PushFront(ItemType* item);
     ItemType* PopBack();
     ItemType* PopFront();
 
@@ -5265,75 +5109,75 @@ class VmaIntrusiveLinkedList
     void Remove(ItemType* item);
     void RemoveAll();
 
-  private:
+private:
     ItemType* m_Front = VMA_NULL;
-    ItemType* m_Back  = VMA_NULL;
-    size_t    m_Count = 0;
+    ItemType* m_Back = VMA_NULL;
+    size_t m_Count = 0;
 };
 
 #ifndef _VMA_INTRUSIVE_LINKED_LIST_FUNCTIONS
-template <typename ItemTypeTraits>
-VmaIntrusiveLinkedList<ItemTypeTraits>::VmaIntrusiveLinkedList(VmaIntrusiveLinkedList&& src) :
-    m_Front(src.m_Front), m_Back(src.m_Back), m_Count(src.m_Count)
+template<typename ItemTypeTraits>
+VmaIntrusiveLinkedList<ItemTypeTraits>::VmaIntrusiveLinkedList(VmaIntrusiveLinkedList&& src)
+    : m_Front(src.m_Front), m_Back(src.m_Back), m_Count(src.m_Count)
 {
     src.m_Front = src.m_Back = VMA_NULL;
-    src.m_Count              = 0;
+    src.m_Count = 0;
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 VmaIntrusiveLinkedList<ItemTypeTraits>& VmaIntrusiveLinkedList<ItemTypeTraits>::operator=(VmaIntrusiveLinkedList&& src)
 {
     if (&src != this)
     {
         VMA_HEAVY_ASSERT(IsEmpty());
-        m_Front     = src.m_Front;
-        m_Back      = src.m_Back;
-        m_Count     = src.m_Count;
+        m_Front = src.m_Front;
+        m_Back = src.m_Back;
+        m_Count = src.m_Count;
         src.m_Front = src.m_Back = VMA_NULL;
-        src.m_Count              = 0;
+        src.m_Count = 0;
     }
     return *this;
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 void VmaIntrusiveLinkedList<ItemTypeTraits>::PushBack(ItemType* item)
 {
     VMA_HEAVY_ASSERT(ItemTypeTraits::GetPrev(item) == VMA_NULL && ItemTypeTraits::GetNext(item) == VMA_NULL);
     if (IsEmpty())
     {
         m_Front = item;
-        m_Back  = item;
+        m_Back = item;
         m_Count = 1;
     }
     else
     {
-        ItemTypeTraits::AccessPrev(item)   = m_Back;
+        ItemTypeTraits::AccessPrev(item) = m_Back;
         ItemTypeTraits::AccessNext(m_Back) = item;
-        m_Back                             = item;
+        m_Back = item;
         ++m_Count;
     }
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 void VmaIntrusiveLinkedList<ItemTypeTraits>::PushFront(ItemType* item)
 {
     VMA_HEAVY_ASSERT(ItemTypeTraits::GetPrev(item) == VMA_NULL && ItemTypeTraits::GetNext(item) == VMA_NULL);
     if (IsEmpty())
     {
         m_Front = item;
-        m_Back  = item;
+        m_Back = item;
         m_Count = 1;
     }
     else
     {
-        ItemTypeTraits::AccessNext(item)    = m_Front;
+        ItemTypeTraits::AccessNext(item) = m_Front;
         ItemTypeTraits::AccessPrev(m_Front) = item;
-        m_Front                             = item;
+        m_Front = item;
         ++m_Count;
     }
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 typename VmaIntrusiveLinkedList<ItemTypeTraits>::ItemType* VmaIntrusiveLinkedList<ItemTypeTraits>::PopBack()
 {
     VMA_HEAVY_ASSERT(m_Count > 0);
@@ -5350,12 +5194,12 @@ typename VmaIntrusiveLinkedList<ItemTypeTraits>::ItemType* VmaIntrusiveLinkedLis
     return backItem;
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 typename VmaIntrusiveLinkedList<ItemTypeTraits>::ItemType* VmaIntrusiveLinkedList<ItemTypeTraits>::PopFront()
 {
     VMA_HEAVY_ASSERT(m_Count > 0);
     ItemType* const frontItem = m_Front;
-    ItemType* const nextItem  = ItemTypeTraits::GetNext(frontItem);
+    ItemType* const nextItem = ItemTypeTraits::GetNext(frontItem);
     if (nextItem != VMA_NULL)
     {
         ItemTypeTraits::AccessPrev(nextItem) = VMA_NULL;
@@ -5367,16 +5211,15 @@ typename VmaIntrusiveLinkedList<ItemTypeTraits>::ItemType* VmaIntrusiveLinkedLis
     return frontItem;
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 void VmaIntrusiveLinkedList<ItemTypeTraits>::InsertBefore(ItemType* existingItem, ItemType* newItem)
 {
-    VMA_HEAVY_ASSERT(newItem != VMA_NULL && ItemTypeTraits::GetPrev(newItem) == VMA_NULL &&
-                     ItemTypeTraits::GetNext(newItem) == VMA_NULL);
+    VMA_HEAVY_ASSERT(newItem != VMA_NULL && ItemTypeTraits::GetPrev(newItem) == VMA_NULL && ItemTypeTraits::GetNext(newItem) == VMA_NULL);
     if (existingItem != VMA_NULL)
     {
-        ItemType* const prevItem                 = ItemTypeTraits::GetPrev(existingItem);
-        ItemTypeTraits::AccessPrev(newItem)      = prevItem;
-        ItemTypeTraits::AccessNext(newItem)      = existingItem;
+        ItemType* const prevItem = ItemTypeTraits::GetPrev(existingItem);
+        ItemTypeTraits::AccessPrev(newItem) = prevItem;
+        ItemTypeTraits::AccessNext(newItem) = existingItem;
         ItemTypeTraits::AccessPrev(existingItem) = newItem;
         if (prevItem != VMA_NULL)
         {
@@ -5393,16 +5236,15 @@ void VmaIntrusiveLinkedList<ItemTypeTraits>::InsertBefore(ItemType* existingItem
         PushBack(newItem);
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 void VmaIntrusiveLinkedList<ItemTypeTraits>::InsertAfter(ItemType* existingItem, ItemType* newItem)
 {
-    VMA_HEAVY_ASSERT(newItem != VMA_NULL && ItemTypeTraits::GetPrev(newItem) == VMA_NULL &&
-                     ItemTypeTraits::GetNext(newItem) == VMA_NULL);
+    VMA_HEAVY_ASSERT(newItem != VMA_NULL && ItemTypeTraits::GetPrev(newItem) == VMA_NULL && ItemTypeTraits::GetNext(newItem) == VMA_NULL);
     if (existingItem != VMA_NULL)
     {
-        ItemType* const nextItem                 = ItemTypeTraits::GetNext(existingItem);
-        ItemTypeTraits::AccessNext(newItem)      = nextItem;
-        ItemTypeTraits::AccessPrev(newItem)      = existingItem;
+        ItemType* const nextItem = ItemTypeTraits::GetNext(existingItem);
+        ItemTypeTraits::AccessNext(newItem) = nextItem;
+        ItemTypeTraits::AccessPrev(newItem) = existingItem;
         ItemTypeTraits::AccessNext(existingItem) = newItem;
         if (nextItem != VMA_NULL)
         {
@@ -5419,7 +5261,7 @@ void VmaIntrusiveLinkedList<ItemTypeTraits>::InsertAfter(ItemType* existingItem,
         return PushFront(newItem);
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 void VmaIntrusiveLinkedList<ItemTypeTraits>::Remove(ItemType* item)
 {
     VMA_HEAVY_ASSERT(item != VMA_NULL && m_Count > 0);
@@ -5447,7 +5289,7 @@ void VmaIntrusiveLinkedList<ItemTypeTraits>::Remove(ItemType* item)
     --m_Count;
 }
 
-template <typename ItemTypeTraits>
+template<typename ItemTypeTraits>
 void VmaIntrusiveLinkedList<ItemTypeTraits>::RemoveAll()
 {
     if (!IsEmpty())
@@ -5455,13 +5297,13 @@ void VmaIntrusiveLinkedList<ItemTypeTraits>::RemoveAll()
         ItemType* item = m_Back;
         while (item != VMA_NULL)
         {
-            ItemType* const prevItem         = ItemTypeTraits::AccessPrev(item);
+            ItemType* const prevItem = ItemTypeTraits::AccessPrev(item);
             ItemTypeTraits::AccessPrev(item) = VMA_NULL;
             ItemTypeTraits::AccessNext(item) = VMA_NULL;
-            item                             = prevItem;
+            item = prevItem;
         }
         m_Front = VMA_NULL;
-        m_Back  = VMA_NULL;
+        m_Back = VMA_NULL;
         m_Count = 0;
     }
 }
@@ -5564,23 +5406,21 @@ void VmaMap<KeyT, ValueT>::erase(iterator it)
 #if !defined(_VMA_STRING_BUILDER) && VMA_STATS_STRING_ENABLED
 class VmaStringBuilder
 {
-  public:
-    VmaStringBuilder(const VkAllocationCallbacks* allocationCallbacks) :
-        m_Data(VmaStlAllocator<char>(allocationCallbacks))
-    {}
+public:
+    VmaStringBuilder(const VkAllocationCallbacks* allocationCallbacks) : m_Data(VmaStlAllocator<char>(allocationCallbacks)) {}
     ~VmaStringBuilder() = default;
 
-    size_t      GetLength() const { return m_Data.size(); }
+    size_t GetLength() const { return m_Data.size(); }
     const char* GetData() const { return m_Data.data(); }
-    void        AddNewLine() { Add('\n'); }
-    void        Add(char ch) { m_Data.push_back(ch); }
+    void AddNewLine() { Add('\n'); }
+    void Add(char ch) { m_Data.push_back(ch); }
 
     void Add(const char* pStr);
     void AddNumber(uint32_t num);
     void AddNumber(uint64_t num);
     void AddPointer(const void* ptr);
 
-  private:
+private:
     VmaVector<char, VmaStlAllocator<char>> m_Data;
 };
 
@@ -5603,7 +5443,7 @@ void VmaStringBuilder::AddNumber(uint32_t num)
     char* p = &buf[10];
     do
     {
-        *--p = '0' + (num % 10);
+        *--p = '0' + (char)(num % 10);
         num /= 10;
     } while (num);
     Add(p);
@@ -5616,7 +5456,7 @@ void VmaStringBuilder::AddNumber(uint64_t num)
     char* p = &buf[20];
     do
     {
-        *--p = '0' + (num % 10);
+        *--p = '0' + (char)(num % 10);
         num /= 10;
     } while (num);
     Add(p);
@@ -5638,8 +5478,8 @@ VmaStringBuilder passed to the constructor.
 */
 class VmaJsonWriter
 {
-    VMA_CLASS_NO_COPY(VmaJsonWriter)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaJsonWriter)
+public:
     // sb - string builder to write the document to. Must remain alive for the whole lifetime of this object.
     VmaJsonWriter(const VkAllocationCallbacks* pAllocationCallbacks, VmaStringBuilder& sb);
     ~VmaJsonWriter();
@@ -5672,7 +5512,6 @@ class VmaJsonWriter
     // Posts next part of an open string. The number is converted to decimal characters.
     void ContinueString(uint32_t n);
     void ContinueString(uint64_t n);
-    void ContinueString_Size(size_t n);
     // Posts next part of an open string. Pointer value is converted to characters
     // using "%p" formatting - shown as hexadecimal number, e.g.: 000000081276Ad00
     void ContinueString_Pointer(const void* ptr);
@@ -5682,14 +5521,12 @@ class VmaJsonWriter
     // Writes a number value.
     void WriteNumber(uint32_t n);
     void WriteNumber(uint64_t n);
-    void WriteSize(uint32_t n);
-    void WriteSize(uint64_t n);
     // Writes a boolean value - false or true.
     void WriteBool(bool b);
     // Writes a null value.
     void WriteNull();
 
-  private:
+private:
     enum COLLECTION_TYPE
     {
         COLLECTION_TYPE_OBJECT,
@@ -5698,20 +5535,15 @@ class VmaJsonWriter
     struct StackItem
     {
         COLLECTION_TYPE type;
-        uint32_t        valueCount;
-        bool            singleLineMode;
+        uint32_t valueCount;
+        bool singleLineMode;
     };
 
     static const char* const INDENT;
 
-    VmaStringBuilder&                                m_SB;
-    VmaVector<StackItem, VmaStlAllocator<StackItem>> m_Stack;
-    bool                                             m_InsideString;
-
-    // Write size_t for less than 64bits
-    void WriteSize(uint32_t n, std::integral_constant<bool, false>) { m_SB.AddNumber(static_cast<uint32_t>(n)); }
-    // Write size_t for 64bits
-    void WriteSize(uint64_t n, std::integral_constant<bool, true>) { m_SB.AddNumber(static_cast<uint64_t>(n)); }
+    VmaStringBuilder& m_SB;
+    VmaVector< StackItem, VmaStlAllocator<StackItem> > m_Stack;
+    bool m_InsideString;
 
     void BeginValue(bool isString);
     void WriteIndent(bool oneLess = false);
@@ -5719,9 +5551,10 @@ class VmaJsonWriter
 const char* const VmaJsonWriter::INDENT = "  ";
 
 #ifndef _VMA_JSON_WRITER_FUNCTIONS
-VmaJsonWriter::VmaJsonWriter(const VkAllocationCallbacks* pAllocationCallbacks, VmaStringBuilder& sb) :
-    m_SB(sb), m_Stack(VmaStlAllocator<StackItem>(pAllocationCallbacks)), m_InsideString(false)
-{}
+VmaJsonWriter::VmaJsonWriter(const VkAllocationCallbacks* pAllocationCallbacks, VmaStringBuilder& sb)
+    : m_SB(sb),
+    m_Stack(VmaStlAllocator<StackItem>(pAllocationCallbacks)),
+    m_InsideString(false) {}
 
 VmaJsonWriter::~VmaJsonWriter()
 {
@@ -5737,8 +5570,8 @@ void VmaJsonWriter::BeginObject(bool singleLine)
     m_SB.Add('{');
 
     StackItem item;
-    item.type           = COLLECTION_TYPE_OBJECT;
-    item.valueCount     = 0;
+    item.type = COLLECTION_TYPE_OBJECT;
+    item.valueCount = 0;
     item.singleLineMode = singleLine;
     m_Stack.push_back(item);
 }
@@ -5762,8 +5595,8 @@ void VmaJsonWriter::BeginArray(bool singleLine)
     m_SB.Add('[');
 
     StackItem item;
-    item.type           = COLLECTION_TYPE_ARRAY;
-    item.valueCount     = 0;
+    item.type = COLLECTION_TYPE_ARRAY;
+    item.valueCount = 0;
     item.singleLineMode = singleLine;
     m_Stack.push_back(item);
 }
@@ -5818,28 +5651,26 @@ void VmaJsonWriter::ContinueString(const char* pStr)
         {
             m_SB.Add(ch);
         }
-        else
-            switch (ch)
-            {
-                case '\b':
-                    m_SB.Add("\\b");
-                    break;
-                case '\f':
-                    m_SB.Add("\\f");
-                    break;
-                case '\n':
-                    m_SB.Add("\\n");
-                    break;
-                case '\r':
-                    m_SB.Add("\\r");
-                    break;
-                case '\t':
-                    m_SB.Add("\\t");
-                    break;
-                default:
-                    VMA_ASSERT(0 && "Character not currently supported.");
-                    break;
-            }
+        else switch (ch)
+        {
+        case '\b':
+            m_SB.Add("\\b");
+            break;
+        case '\f':
+            m_SB.Add("\\f");
+            break;
+        case '\n':
+            m_SB.Add("\\n");
+            break;
+        case '\r':
+            m_SB.Add("\\r");
+            break;
+        case '\t':
+            m_SB.Add("\\t");
+            break;
+        default:
+            VMA_ASSERT(0 && "Character not currently supported.");
+        }
     }
 }
 
@@ -5853,14 +5684,6 @@ void VmaJsonWriter::ContinueString(uint64_t n)
 {
     VMA_ASSERT(m_InsideString);
     m_SB.AddNumber(n);
-}
-
-void VmaJsonWriter::ContinueString_Size(size_t n)
-{
-    VMA_ASSERT(m_InsideString);
-    // Fix for AppleClang incorrect type casting
-    // TODO: Change to if constexpr when C++17 used as minimal standard
-    WriteSize(n, std::is_same<size_t, uint64_t>{});
 }
 
 void VmaJsonWriter::ContinueString_Pointer(const void* ptr)
@@ -5894,24 +5717,6 @@ void VmaJsonWriter::WriteNumber(uint64_t n)
     m_SB.AddNumber(n);
 }
 
-void VmaJsonWriter::WriteSize(uint32_t n)
-{
-    VMA_ASSERT(!m_InsideString);
-    BeginValue(false);
-    // Fix for AppleClang incorrect type casting
-    // TODO: Change to if constexpr when C++17 used as minimal standard
-    WriteSize(n, std::is_same<uint32_t, uint64_t>{});
-}
-
-void VmaJsonWriter::WriteSize(uint64_t n)
-{
-    VMA_ASSERT(!m_InsideString);
-    BeginValue(false);
-    // Fix for AppleClang incorrect type casting
-    // TODO: Change to if constexpr when C++17 used as minimal standard
-    WriteSize(n, std::is_same<uint64_t, uint64_t>{});
-}
-
 void VmaJsonWriter::WriteBool(bool b)
 {
     VMA_ASSERT(!m_InsideString);
@@ -5931,12 +5736,14 @@ void VmaJsonWriter::BeginValue(bool isString)
     if (!m_Stack.empty())
     {
         StackItem& currItem = m_Stack.back();
-        if (currItem.type == COLLECTION_TYPE_OBJECT && currItem.valueCount % 2 == 0)
+        if (currItem.type == COLLECTION_TYPE_OBJECT &&
+            currItem.valueCount % 2 == 0)
         {
             VMA_ASSERT(isString);
         }
 
-        if (currItem.type == COLLECTION_TYPE_OBJECT && currItem.valueCount % 2 != 0)
+        if (currItem.type == COLLECTION_TYPE_OBJECT &&
+            currItem.valueCount % 2 != 0)
         {
             m_SB.Add(": ");
         }
@@ -6009,8 +5816,8 @@ static void VmaPrintDetailedStatistics(VmaJsonWriter& json, const VmaDetailedSta
 
 class VmaMappingHysteresis
 {
-    VMA_CLASS_NO_COPY(VmaMappingHysteresis)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaMappingHysteresis)
+public:
     VmaMappingHysteresis() = default;
 
     uint32_t GetExtraMapping() const { return m_ExtraMapping; }
@@ -6020,10 +5827,10 @@ class VmaMappingHysteresis
     bool PostMap()
     {
 #if VMA_MAPPING_HYSTERESIS_ENABLED
-        if (m_ExtraMapping == 0)
+        if(m_ExtraMapping == 0)
         {
             ++m_MajorCounter;
-            if (m_MajorCounter >= COUNTER_MIN_EXTRA_MAPPING)
+            if(m_MajorCounter >= COUNTER_MIN_EXTRA_MAPPING)
             {
                 m_ExtraMapping = 1;
                 m_MajorCounter = 0;
@@ -6041,7 +5848,7 @@ class VmaMappingHysteresis
     void PostUnmap()
     {
 #if VMA_MAPPING_HYSTERESIS_ENABLED
-        if (m_ExtraMapping == 0)
+        if(m_ExtraMapping == 0)
             ++m_MajorCounter;
         else // m_ExtraMapping == 1
             PostMinorCounter();
@@ -6052,7 +5859,7 @@ class VmaMappingHysteresis
     void PostAlloc()
     {
 #if VMA_MAPPING_HYSTERESIS_ENABLED
-        if (m_ExtraMapping == 1)
+        if(m_ExtraMapping == 1)
             ++m_MajorCounter;
         else // m_ExtraMapping == 0
             PostMinorCounter();
@@ -6064,10 +5871,11 @@ class VmaMappingHysteresis
     bool PostFree()
     {
 #if VMA_MAPPING_HYSTERESIS_ENABLED
-        if (m_ExtraMapping == 1)
+        if(m_ExtraMapping == 1)
         {
             ++m_MajorCounter;
-            if (m_MajorCounter >= COUNTER_MIN_EXTRA_MAPPING && m_MajorCounter > m_MinorCounter + 1)
+            if(m_MajorCounter >= COUNTER_MIN_EXTRA_MAPPING &&
+                m_MajorCounter > m_MinorCounter + 1)
             {
                 m_ExtraMapping = 0;
                 m_MajorCounter = 0;
@@ -6081,7 +5889,7 @@ class VmaMappingHysteresis
         return false;
     }
 
-  private:
+private:
     static const int32_t COUNTER_MIN_EXTRA_MAPPING = 7;
 
     uint32_t m_MinorCounter = 0;
@@ -6090,11 +5898,11 @@ class VmaMappingHysteresis
 
     void PostMinorCounter()
     {
-        if (m_MinorCounter < m_MajorCounter)
+        if(m_MinorCounter < m_MajorCounter)
         {
             ++m_MinorCounter;
         }
-        else if (m_MajorCounter > 0)
+        else if(m_MajorCounter > 0)
         {
             --m_MajorCounter;
             --m_MinorCounter;
@@ -6115,75 +5923,77 @@ Thread-safety:
 */
 class VmaDeviceMemoryBlock
 {
-    VMA_CLASS_NO_COPY(VmaDeviceMemoryBlock)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaDeviceMemoryBlock)
+public:
     VmaBlockMetadata* m_pMetadata;
 
     VmaDeviceMemoryBlock(VmaAllocator hAllocator);
     ~VmaDeviceMemoryBlock();
 
     // Always call after construction.
-    void Init(VmaAllocator   hAllocator,
-              VmaPool        hParentPool,
-              uint32_t       newMemoryTypeIndex,
-              VkDeviceMemory newMemory,
-              VkDeviceSize   newSize,
-              uint32_t       id,
-              uint32_t       algorithm,
-              VkDeviceSize   bufferImageGranularity);
+    void Init(
+        VmaAllocator hAllocator,
+        VmaPool hParentPool,
+        uint32_t newMemoryTypeIndex,
+        VkDeviceMemory newMemory,
+        VkDeviceSize newSize,
+        uint32_t id,
+        uint32_t algorithm,
+        VkDeviceSize bufferImageGranularity);
     // Always call before destruction.
     void Destroy(VmaAllocator allocator);
 
-    VmaPool        GetParentPool() const { return m_hParentPool; }
+    VmaPool GetParentPool() const { return m_hParentPool; }
     VkDeviceMemory GetDeviceMemory() const { return m_hMemory; }
-    uint32_t       GetMemoryTypeIndex() const { return m_MemoryTypeIndex; }
-    uint32_t       GetId() const { return m_Id; }
-    void*          GetMappedData() const { return m_pMappedData; }
-    uint32_t       GetMapRefCount() const { return m_MapCount; }
+    uint32_t GetMemoryTypeIndex() const { return m_MemoryTypeIndex; }
+    uint32_t GetId() const { return m_Id; }
+    void* GetMappedData() const { return m_pMappedData; }
+    uint32_t GetMapRefCount() const { return m_MapCount; }
 
     // Call when allocation/free was made from m_pMetadata.
     // Used for m_MappingHysteresis.
-    void PostAlloc() { m_MappingHysteresis.PostAlloc(); }
+    void PostAlloc(VmaAllocator hAllocator);
     void PostFree(VmaAllocator hAllocator);
 
     // Validates all data structures inside this object. If not valid, returns false.
-    bool     Validate() const;
+    bool Validate() const;
     VkResult CheckCorruption(VmaAllocator hAllocator);
 
     // ppData can be null.
     VkResult Map(VmaAllocator hAllocator, uint32_t count, void** ppData);
-    void     Unmap(VmaAllocator hAllocator, uint32_t count);
+    void Unmap(VmaAllocator hAllocator, uint32_t count);
 
     VkResult WriteMagicValueAfterAllocation(VmaAllocator hAllocator, VkDeviceSize allocOffset, VkDeviceSize allocSize);
-    VkResult
-    ValidateMagicValueAfterAllocation(VmaAllocator hAllocator, VkDeviceSize allocOffset, VkDeviceSize allocSize);
+    VkResult ValidateMagicValueAfterAllocation(VmaAllocator hAllocator, VkDeviceSize allocOffset, VkDeviceSize allocSize);
 
-    VkResult BindBufferMemory(const VmaAllocator  hAllocator,
-                              const VmaAllocation hAllocation,
-                              VkDeviceSize        allocationLocalOffset,
-                              VkBuffer            hBuffer,
-                              const void*         pNext);
-    VkResult BindImageMemory(const VmaAllocator  hAllocator,
-                             const VmaAllocation hAllocation,
-                             VkDeviceSize        allocationLocalOffset,
-                             VkImage             hImage,
-                             const void*         pNext);
+    VkResult BindBufferMemory(
+        const VmaAllocator hAllocator,
+        const VmaAllocation hAllocation,
+        VkDeviceSize allocationLocalOffset,
+        VkBuffer hBuffer,
+        const void* pNext);
+    VkResult BindImageMemory(
+        const VmaAllocator hAllocator,
+        const VmaAllocation hAllocation,
+        VkDeviceSize allocationLocalOffset,
+        VkImage hImage,
+        const void* pNext);
 
-  private:
-    VmaPool        m_hParentPool; // VK_NULL_HANDLE if not belongs to custom pool.
-    uint32_t       m_MemoryTypeIndex;
-    uint32_t       m_Id;
+private:
+    VmaPool m_hParentPool; // VK_NULL_HANDLE if not belongs to custom pool.
+    uint32_t m_MemoryTypeIndex;
+    uint32_t m_Id;
     VkDeviceMemory m_hMemory;
 
     /*
-    Protects access to m_hMemory so it is not used by multiple threads simultaneously, e.g. vkMapMemory,
-    vkBindBufferMemory. Also protects m_MapCount, m_pMappedData. Allocations, deallocations, any change in m_pMetadata
-    is protected by parent's VmaBlockVector::m_Mutex.
+    Protects access to m_hMemory so it is not used by multiple threads simultaneously, e.g. vkMapMemory, vkBindBufferMemory.
+    Also protects m_MapCount, m_pMappedData.
+    Allocations, deallocations, any change in m_pMetadata is protected by parent's VmaBlockVector::m_Mutex.
     */
-    VMA_MUTEX            m_MapAndBindMutex;
+    VMA_MUTEX m_MapAndBindMutex;
     VmaMappingHysteresis m_MappingHysteresis;
-    uint32_t             m_MapCount;
-    void*                m_pMappedData;
+    uint32_t m_MapCount;
+    void* m_pMappedData;
 };
 #endif // _VMA_DEVICE_MEMORY_BLOCK
 
@@ -6194,11 +6004,11 @@ struct VmaAllocation_T
 
     enum FLAGS
     {
-        FLAG_PERSISTENT_MAP  = 0x01,
-        FLAG_MAPPING_ALLOWED = 0x02,
+        FLAG_PERSISTENT_MAP   = 0x01,
+        FLAG_MAPPING_ALLOWED  = 0x02,
     };
 
-  public:
+public:
     enum ALLOCATION_TYPE
     {
         ALLOCATION_TYPE_NONE,
@@ -6210,51 +6020,49 @@ struct VmaAllocation_T
     VmaAllocation_T(bool mappingAllowed);
     ~VmaAllocation_T();
 
-    void InitBlockAllocation(VmaDeviceMemoryBlock* block,
-                             VmaAllocHandle        allocHandle,
-                             VkDeviceSize          alignment,
-                             VkDeviceSize          size,
-                             uint32_t              memoryTypeIndex,
-                             VmaSuballocationType  suballocationType,
-                             bool                  mapped);
+    void InitBlockAllocation(
+        VmaDeviceMemoryBlock* block,
+        VmaAllocHandle allocHandle,
+        VkDeviceSize alignment,
+        VkDeviceSize size,
+        uint32_t memoryTypeIndex,
+        VmaSuballocationType suballocationType,
+        bool mapped);
     // pMappedData not null means allocation is created with MAPPED flag.
-    void InitDedicatedAllocation(VmaPool              hParentPool,
-                                 uint32_t             memoryTypeIndex,
-                                 VkDeviceMemory       hMemory,
-                                 VmaSuballocationType suballocationType,
-                                 void*                pMappedData,
-                                 VkDeviceSize         size);
+    void InitDedicatedAllocation(
+        VmaPool hParentPool,
+        uint32_t memoryTypeIndex,
+        VkDeviceMemory hMemory,
+        VmaSuballocationType suballocationType,
+        void* pMappedData,
+        VkDeviceSize size);
 
-    ALLOCATION_TYPE      GetType() const { return (ALLOCATION_TYPE)m_Type; }
-    VkDeviceSize         GetAlignment() const { return m_Alignment; }
-    VkDeviceSize         GetSize() const { return m_Size; }
-    void*                GetUserData() const { return m_pUserData; }
-    const char*          GetName() const { return m_pName; }
+    ALLOCATION_TYPE GetType() const { return (ALLOCATION_TYPE)m_Type; }
+    VkDeviceSize GetAlignment() const { return m_Alignment; }
+    VkDeviceSize GetSize() const { return m_Size; }
+    void* GetUserData() const { return m_pUserData; }
+    const char* GetName() const { return m_pName; }
     VmaSuballocationType GetSuballocationType() const { return (VmaSuballocationType)m_SuballocationType; }
 
-    VmaDeviceMemoryBlock* GetBlock() const
-    {
-        VMA_ASSERT(m_Type == ALLOCATION_TYPE_BLOCK);
-        return m_BlockAllocation.m_Block;
-    }
+    VmaDeviceMemoryBlock* GetBlock() const { VMA_ASSERT(m_Type == ALLOCATION_TYPE_BLOCK); return m_BlockAllocation.m_Block; }
     uint32_t GetMemoryTypeIndex() const { return m_MemoryTypeIndex; }
-    bool     IsPersistentMap() const { return (m_Flags & FLAG_PERSISTENT_MAP) != 0; }
-    bool     IsMappingAllowed() const { return (m_Flags & FLAG_MAPPING_ALLOWED) != 0; }
+    bool IsPersistentMap() const { return (m_Flags & FLAG_PERSISTENT_MAP) != 0; }
+    bool IsMappingAllowed() const { return (m_Flags & FLAG_MAPPING_ALLOWED) != 0; }
 
-    void           SetUserData(VmaAllocator hAllocator, void* pUserData) { m_pUserData = pUserData; }
-    void           SetName(VmaAllocator hAllocator, const char* pName);
-    void           FreeName(VmaAllocator hAllocator);
-    uint8_t        SwapBlockAllocation(VmaAllocator hAllocator, VmaAllocation allocation);
+    void SetUserData(VmaAllocator hAllocator, void* pUserData) { m_pUserData = pUserData; }
+    void SetName(VmaAllocator hAllocator, const char* pName);
+    void FreeName(VmaAllocator hAllocator);
+    uint8_t SwapBlockAllocation(VmaAllocator hAllocator, VmaAllocation allocation);
     VmaAllocHandle GetAllocHandle() const;
-    VkDeviceSize   GetOffset() const;
-    VmaPool        GetParentPool() const;
+    VkDeviceSize GetOffset() const;
+    VmaPool GetParentPool() const;
     VkDeviceMemory GetMemory() const;
-    void*          GetMappedData() const;
+    void* GetMappedData() const;
 
-    void     BlockAllocMap();
-    void     BlockAllocUnmap();
+    void BlockAllocMap();
+    void BlockAllocUnmap();
     VkResult DedicatedAllocMap(VmaAllocator hAllocator, void** ppData);
-    void     DedicatedAllocUnmap(VmaAllocator hAllocator);
+    void DedicatedAllocUnmap(VmaAllocator hAllocator);
 
 #if VMA_STATS_STRING_ENABLED
     uint32_t GetBufferImageUsage() const { return m_BufferImageUsage; }
@@ -6263,19 +6071,19 @@ struct VmaAllocation_T
     void PrintParameters(class VmaJsonWriter& json) const;
 #endif
 
-  private:
+private:
     // Allocation out of VmaDeviceMemoryBlock.
     struct BlockAllocation
     {
         VmaDeviceMemoryBlock* m_Block;
-        VmaAllocHandle        m_AllocHandle;
+        VmaAllocHandle m_AllocHandle;
     };
     // Allocation for an object that has its own private VkDeviceMemory.
     struct DedicatedAllocation
     {
-        VmaPool          m_hParentPool; // VK_NULL_HANDLE if not belongs to custom pool.
-        VkDeviceMemory   m_hMemory;
-        void*            m_pMappedData; // Not null means memory is mapped.
+        VmaPool m_hParentPool; // VK_NULL_HANDLE if not belongs to custom pool.
+        VkDeviceMemory m_hMemory;
+        void* m_pMappedData; // Not null means memory is mapped.
         VmaAllocation_T* m_Prev;
         VmaAllocation_T* m_Next;
     };
@@ -6289,11 +6097,11 @@ struct VmaAllocation_T
 
     VkDeviceSize m_Alignment;
     VkDeviceSize m_Size;
-    void*        m_pUserData;
-    char*        m_pName;
-    uint32_t     m_MemoryTypeIndex;
-    uint8_t      m_Type;              // ALLOCATION_TYPE
-    uint8_t      m_SuballocationType; // VmaSuballocationType
+    void* m_pUserData;
+    char* m_pName;
+    uint32_t m_MemoryTypeIndex;
+    uint8_t m_Type; // ALLOCATION_TYPE
+    uint8_t m_SuballocationType; // VmaSuballocationType
     // Reference counter for vmaMapMemory()/vmaUnmapMemory().
     uint8_t m_MapCount;
     uint8_t m_Flags; // enum FLAGS
@@ -6338,7 +6146,8 @@ Thread-safe, synchronized internally.
 */
 class VmaDedicatedAllocationList
 {
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaDedicatedAllocationList)
+public:
     VmaDedicatedAllocationList() {}
     ~VmaDedicatedAllocationList();
 
@@ -6356,11 +6165,11 @@ class VmaDedicatedAllocationList
     void Register(VmaAllocation alloc);
     void Unregister(VmaAllocation alloc);
 
-  private:
+private:
     typedef VmaIntrusiveLinkedList<VmaDedicatedAllocationListItemTraits> DedicatedAllocationLinkedList;
 
-    bool                          m_UseMutex = true;
-    VMA_RW_MUTEX                  m_Mutex;
+    bool m_UseMutex = true;
+    VMA_RW_MUTEX m_Mutex;
     DedicatedAllocationLinkedList m_AllocationList;
 };
 
@@ -6378,10 +6187,11 @@ VmaDedicatedAllocationList::~VmaDedicatedAllocationList()
 
 bool VmaDedicatedAllocationList::Validate()
 {
-    const size_t     declaredCount = m_AllocationList.GetCount();
-    size_t           actualCount   = 0;
+    const size_t declaredCount = m_AllocationList.GetCount();
+    size_t actualCount = 0;
     VmaMutexLockRead lock(m_Mutex, m_UseMutex);
-    for (VmaAllocation alloc = m_AllocationList.Front(); alloc != VMA_NULL; alloc = m_AllocationList.GetNext(alloc))
+    for (VmaAllocation alloc = m_AllocationList.Front();
+        alloc != VMA_NULL; alloc = m_AllocationList.GetNext(alloc))
     {
         ++actualCount;
     }
@@ -6392,7 +6202,7 @@ bool VmaDedicatedAllocationList::Validate()
 
 void VmaDedicatedAllocationList::AddDetailedStatistics(VmaDetailedStatistics& inoutStats)
 {
-    for (auto* item = m_AllocationList.Front(); item != nullptr; item = DedicatedAllocationLinkedList::GetNext(item))
+    for(auto* item = m_AllocationList.Front(); item != nullptr; item = DedicatedAllocationLinkedList::GetNext(item))
     {
         const VkDeviceSize size = item->GetSize();
         inoutStats.statistics.blockCount++;
@@ -6409,7 +6219,7 @@ void VmaDedicatedAllocationList::AddStatistics(VmaStatistics& inoutStats)
     inoutStats.blockCount += allocCount;
     inoutStats.allocationCount += allocCount;
 
-    for (auto* item = m_AllocationList.Front(); item != nullptr; item = DedicatedAllocationLinkedList::GetNext(item))
+    for(auto* item = m_AllocationList.Front(); item != nullptr; item = DedicatedAllocationLinkedList::GetNext(item))
     {
         const VkDeviceSize size = item->GetSize();
         inoutStats.blockBytes += size;
@@ -6422,7 +6232,8 @@ void VmaDedicatedAllocationList::BuildStatsString(VmaJsonWriter& json)
 {
     VmaMutexLockRead lock(m_Mutex, m_UseMutex);
     json.BeginArray();
-    for (VmaAllocation alloc = m_AllocationList.Front(); alloc != VMA_NULL; alloc = m_AllocationList.GetNext(alloc))
+    for (VmaAllocation alloc = m_AllocationList.Front();
+        alloc != VMA_NULL; alloc = m_AllocationList.GetNext(alloc))
     {
         json.BeginObject(true);
         alloc->PrintParameters(json);
@@ -6459,31 +6270,39 @@ allocated memory block or free.
 */
 struct VmaSuballocation
 {
-    VkDeviceSize         offset;
-    VkDeviceSize         size;
-    void*                userData;
+    VkDeviceSize offset;
+    VkDeviceSize size;
+    void* userData;
     VmaSuballocationType type;
 };
 
 // Comparator for offsets.
 struct VmaSuballocationOffsetLess
 {
-    bool operator()(const VmaSuballocation& lhs, const VmaSuballocation& rhs) const { return lhs.offset < rhs.offset; }
+    bool operator()(const VmaSuballocation& lhs, const VmaSuballocation& rhs) const
+    {
+        return lhs.offset < rhs.offset;
+    }
 };
 
 struct VmaSuballocationOffsetGreater
 {
-    bool operator()(const VmaSuballocation& lhs, const VmaSuballocation& rhs) const { return lhs.offset > rhs.offset; }
+    bool operator()(const VmaSuballocation& lhs, const VmaSuballocation& rhs) const
+    {
+        return lhs.offset > rhs.offset;
+    }
 };
 
 struct VmaSuballocationItemSizeLess
 {
-    bool operator()(const VmaSuballocationList::iterator lhs, const VmaSuballocationList::iterator rhs) const
+    bool operator()(const VmaSuballocationList::iterator lhs,
+        const VmaSuballocationList::iterator rhs) const
     {
         return lhs->size < rhs->size;
     }
 
-    bool operator()(const VmaSuballocationList::iterator lhs, VkDeviceSize rhsSize) const
+    bool operator()(const VmaSuballocationList::iterator lhs,
+        VkDeviceSize rhsSize) const
     {
         return lhs->size < rhsSize;
     }
@@ -6497,12 +6316,12 @@ item points to a FREE suballocation.
 */
 struct VmaAllocationRequest
 {
-    VmaAllocHandle                 allocHandle;
-    VkDeviceSize                   size;
+    VmaAllocHandle allocHandle;
+    VkDeviceSize size;
     VmaSuballocationList::iterator item;
-    void*                          customData;
-    uint64_t                       algorithmData;
-    VmaAllocationRequestType       type;
+    void* customData;
+    uint64_t algorithmData;
+    VmaAllocationRequestType type;
 };
 #endif // _VMA_ALLOCATION_REQUEST
 
@@ -6513,36 +6332,35 @@ in a single VkDeviceMemory block.
 */
 class VmaBlockMetadata
 {
-  public:
-    // pAllocationCallbacks, if not null, must be owned externally - alive and unchanged for the whole lifetime of this
-    // object.
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaBlockMetadata)
+public:
+    // pAllocationCallbacks, if not null, must be owned externally - alive and unchanged for the whole lifetime of this object.
     VmaBlockMetadata(const VkAllocationCallbacks* pAllocationCallbacks,
-                     VkDeviceSize                 bufferImageGranularity,
-                     bool                         isVirtual);
+        VkDeviceSize bufferImageGranularity, bool isVirtual);
     virtual ~VmaBlockMetadata() = default;
 
     virtual void Init(VkDeviceSize size) { m_Size = size; }
-    bool         IsVirtual() const { return m_IsVirtual; }
+    bool IsVirtual() const { return m_IsVirtual; }
     VkDeviceSize GetSize() const { return m_Size; }
 
     // Validates all data structures inside this object. If not valid, returns false.
-    virtual bool         Validate() const            = 0;
-    virtual size_t       GetAllocationCount() const  = 0;
-    virtual size_t       GetFreeRegionsCount() const = 0;
-    virtual VkDeviceSize GetSumFreeSize() const      = 0;
+    virtual bool Validate() const = 0;
+    virtual size_t GetAllocationCount() const = 0;
+    virtual size_t GetFreeRegionsCount() const = 0;
+    virtual VkDeviceSize GetSumFreeSize() const = 0;
     // Returns true if this block is empty - contains only single free suballocation.
-    virtual bool         IsEmpty() const                                                                  = 0;
-    virtual void         GetAllocationInfo(VmaAllocHandle allocHandle, VmaVirtualAllocationInfo& outInfo) = 0;
-    virtual VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const                            = 0;
-    virtual void*        GetAllocationUserData(VmaAllocHandle allocHandle) const                          = 0;
+    virtual bool IsEmpty() const = 0;
+    virtual void GetAllocationInfo(VmaAllocHandle allocHandle, VmaVirtualAllocationInfo& outInfo) = 0;
+    virtual VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const = 0;
+    virtual void* GetAllocationUserData(VmaAllocHandle allocHandle) const = 0;
 
-    virtual VmaAllocHandle GetAllocationListBegin() const                    = 0;
+    virtual VmaAllocHandle GetAllocationListBegin() const = 0;
     virtual VmaAllocHandle GetNextAllocation(VmaAllocHandle prevAlloc) const = 0;
-    virtual VkDeviceSize   GetNextFreeRegionSize(VmaAllocHandle alloc) const = 0;
+    virtual VkDeviceSize GetNextFreeRegionSize(VmaAllocHandle alloc) const = 0;
 
     // Shouldn't modify blockCount.
     virtual void AddDetailedStatistics(VmaDetailedStatistics& inoutStats) const = 0;
-    virtual void AddStatistics(VmaStatistics& inoutStats) const                 = 0;
+    virtual void AddStatistics(VmaStatistics& inoutStats) const = 0;
 
 #if VMA_STATS_STRING_ENABLED
     virtual void PrintDetailedMap(class VmaJsonWriter& json) const = 0;
@@ -6552,18 +6370,21 @@ class VmaBlockMetadata
     // If succeeded, fills pAllocationRequest and returns true.
     // If failed, returns false.
     virtual bool CreateAllocationRequest(
-        VkDeviceSize         allocSize,
-        VkDeviceSize         allocAlignment,
-        bool                 upperAddress,
+        VkDeviceSize allocSize,
+        VkDeviceSize allocAlignment,
+        bool upperAddress,
         VmaSuballocationType allocType,
         // Always one of VMA_ALLOCATION_CREATE_STRATEGY_* or VMA_ALLOCATION_INTERNAL_STRATEGY_* flags.
-        uint32_t              strategy,
+        uint32_t strategy,
         VmaAllocationRequest* pAllocationRequest) = 0;
 
     virtual VkResult CheckCorruption(const void* pBlockData) = 0;
 
     // Makes actual allocation based on request. Request must already be checked and valid.
-    virtual void Alloc(const VmaAllocationRequest& request, VmaSuballocationType type, void* userData) = 0;
+    virtual void Alloc(
+        const VmaAllocationRequest& request,
+        VmaSuballocationType type,
+        void* userData) = 0;
 
     // Frees suballocation assigned to given memory region.
     virtual void Free(VmaAllocHandle allocHandle) = 0;
@@ -6573,103 +6394,93 @@ class VmaBlockMetadata
     virtual void Clear() = 0;
 
     virtual void SetAllocationUserData(VmaAllocHandle allocHandle, void* userData) = 0;
-    virtual void DebugLogAllAllocations() const                                    = 0;
+    virtual void DebugLogAllAllocations() const = 0;
 
-  protected:
+protected:
     const VkAllocationCallbacks* GetAllocationCallbacks() const { return m_pAllocationCallbacks; }
-    VkDeviceSize                 GetBufferImageGranularity() const { return m_BufferImageGranularity; }
-    VkDeviceSize                 GetDebugMargin() const { return IsVirtual() ? 0 : VMA_DEBUG_MARGIN; }
+    VkDeviceSize GetBufferImageGranularity() const { return m_BufferImageGranularity; }
+    VkDeviceSize GetDebugMargin() const { return VkDeviceSize(IsVirtual() ? 0 : VMA_DEBUG_MARGIN); }
 
     void DebugLogAllocation(VkDeviceSize offset, VkDeviceSize size, void* userData) const;
 #if VMA_STATS_STRING_ENABLED
     // mapRefCount == UINT32_MAX means unspecified.
     void PrintDetailedMap_Begin(class VmaJsonWriter& json,
-                                VkDeviceSize         unusedBytes,
-                                size_t               allocationCount,
-                                size_t               unusedRangeCount) const;
+        VkDeviceSize unusedBytes,
+        size_t allocationCount,
+        size_t unusedRangeCount) const;
     void PrintDetailedMap_Allocation(class VmaJsonWriter& json,
-                                     VkDeviceSize         offset,
-                                     VkDeviceSize         size,
-                                     void*                userData) const;
-    void PrintDetailedMap_UnusedRange(class VmaJsonWriter& json, VkDeviceSize offset, VkDeviceSize size) const;
+        VkDeviceSize offset, VkDeviceSize size, void* userData) const;
+    void PrintDetailedMap_UnusedRange(class VmaJsonWriter& json,
+        VkDeviceSize offset,
+        VkDeviceSize size) const;
     void PrintDetailedMap_End(class VmaJsonWriter& json) const;
 #endif
 
-  private:
-    VkDeviceSize                 m_Size;
+private:
+    VkDeviceSize m_Size;
     const VkAllocationCallbacks* m_pAllocationCallbacks;
-    const VkDeviceSize           m_BufferImageGranularity;
-    const bool                   m_IsVirtual;
+    const VkDeviceSize m_BufferImageGranularity;
+    const bool m_IsVirtual;
 };
 
 #ifndef _VMA_BLOCK_METADATA_FUNCTIONS
 VmaBlockMetadata::VmaBlockMetadata(const VkAllocationCallbacks* pAllocationCallbacks,
-                                   VkDeviceSize                 bufferImageGranularity,
-                                   bool                         isVirtual) :
-    m_Size(0),
-    m_pAllocationCallbacks(pAllocationCallbacks), m_BufferImageGranularity(bufferImageGranularity),
-    m_IsVirtual(isVirtual)
-{}
+    VkDeviceSize bufferImageGranularity, bool isVirtual)
+    : m_Size(0),
+    m_pAllocationCallbacks(pAllocationCallbacks),
+    m_BufferImageGranularity(bufferImageGranularity),
+    m_IsVirtual(isVirtual) {}
 
 void VmaBlockMetadata::DebugLogAllocation(VkDeviceSize offset, VkDeviceSize size, void* userData) const
 {
     if (IsVirtual())
     {
-        VMA_DEBUG_LOG("UNFREED VIRTUAL ALLOCATION; Offset: %llu; Size: %llu; UserData: %p", offset, size, userData);
+        VMA_DEBUG_LOG_FORMAT("UNFREED VIRTUAL ALLOCATION; Offset: %llu; Size: %llu; UserData: %p", offset, size, userData);
     }
     else
     {
         VMA_ASSERT(userData != VMA_NULL);
         VmaAllocation allocation = reinterpret_cast<VmaAllocation>(userData);
 
-        userData         = allocation->GetUserData();
+        userData = allocation->GetUserData();
         const char* name = allocation->GetName();
 
 #if VMA_STATS_STRING_ENABLED
-        VMA_DEBUG_LOG("UNFREED ALLOCATION; Offset: %llu; Size: %llu; UserData: %p; Name: %s; Type: %s; Usage: %u",
-                      offset,
-                      size,
-                      userData,
-                      name ? name : "vma_empty",
-                      VMA_SUBALLOCATION_TYPE_NAMES[allocation->GetSuballocationType()],
-                      allocation->GetBufferImageUsage());
+        VMA_DEBUG_LOG_FORMAT("UNFREED ALLOCATION; Offset: %llu; Size: %llu; UserData: %p; Name: %s; Type: %s; Usage: %u",
+            offset, size, userData, name ? name : "vma_empty",
+            VMA_SUBALLOCATION_TYPE_NAMES[allocation->GetSuballocationType()],
+            allocation->GetBufferImageUsage());
 #else
-        VMA_DEBUG_LOG("UNFREED ALLOCATION; Offset: %llu; Size: %llu; UserData: %p; Name: %s; Type: %u",
-                      offset,
-                      size,
-                      userData,
-                      name ? name : "vma_empty",
-                      (uint32_t)allocation->GetSuballocationType());
+        VMA_DEBUG_LOG_FORMAT("UNFREED ALLOCATION; Offset: %llu; Size: %llu; UserData: %p; Name: %s; Type: %u",
+            offset, size, userData, name ? name : "vma_empty",
+            (uint32_t)allocation->GetSuballocationType());
 #endif // VMA_STATS_STRING_ENABLED
     }
+
 }
 
 #if VMA_STATS_STRING_ENABLED
 void VmaBlockMetadata::PrintDetailedMap_Begin(class VmaJsonWriter& json,
-                                              VkDeviceSize         unusedBytes,
-                                              size_t               allocationCount,
-                                              size_t               unusedRangeCount) const
+    VkDeviceSize unusedBytes, size_t allocationCount, size_t unusedRangeCount) const
 {
     json.WriteString("TotalBytes");
     json.WriteNumber(GetSize());
 
     json.WriteString("UnusedBytes");
-    json.WriteSize(unusedBytes);
+    json.WriteNumber(unusedBytes);
 
     json.WriteString("Allocations");
-    json.WriteSize(allocationCount);
+    json.WriteNumber((uint64_t)allocationCount);
 
     json.WriteString("UnusedRanges");
-    json.WriteSize(unusedRangeCount);
+    json.WriteNumber((uint64_t)unusedRangeCount);
 
     json.WriteString("Suballocations");
     json.BeginArray();
 }
 
 void VmaBlockMetadata::PrintDetailedMap_Allocation(class VmaJsonWriter& json,
-                                                   VkDeviceSize         offset,
-                                                   VkDeviceSize         size,
-                                                   void*                userData) const
+    VkDeviceSize offset, VkDeviceSize size, void* userData) const
 {
     json.BeginObject(true);
 
@@ -6697,8 +6508,7 @@ void VmaBlockMetadata::PrintDetailedMap_Allocation(class VmaJsonWriter& json,
 }
 
 void VmaBlockMetadata::PrintDetailedMap_UnusedRange(class VmaJsonWriter& json,
-                                                    VkDeviceSize         offset,
-                                                    VkDeviceSize         size) const
+    VkDeviceSize offset, VkDeviceSize size) const
 {
     json.BeginObject(true);
 
@@ -6726,11 +6536,11 @@ void VmaBlockMetadata::PrintDetailedMap_End(class VmaJsonWriter& json) const
 // Before deleting object of this class remember to call 'Destroy()'
 class VmaBlockBufferImageGranularity final
 {
-  public:
+public:
     struct ValidationContext
     {
         const VkAllocationCallbacks* allocCallbacks;
-        uint16_t*                    pageAllocs;
+        uint16_t* pageAllocs;
     };
 
     VmaBlockBufferImageGranularity(VkDeviceSize bufferImageGranularity);
@@ -6743,53 +6553,49 @@ class VmaBlockBufferImageGranularity final
     void Destroy(const VkAllocationCallbacks* pAllocationCallbacks);
 
     void RoundupAllocRequest(VmaSuballocationType allocType,
-                             VkDeviceSize&        inOutAllocSize,
-                             VkDeviceSize&        inOutAllocAlignment) const;
+        VkDeviceSize& inOutAllocSize,
+        VkDeviceSize& inOutAllocAlignment) const;
 
-    bool CheckConflictAndAlignUp(VkDeviceSize&        inOutAllocOffset,
-                                 VkDeviceSize         allocSize,
-                                 VkDeviceSize         blockOffset,
-                                 VkDeviceSize         blockSize,
-                                 VmaSuballocationType allocType) const;
+    bool CheckConflictAndAlignUp(VkDeviceSize& inOutAllocOffset,
+        VkDeviceSize allocSize,
+        VkDeviceSize blockOffset,
+        VkDeviceSize blockSize,
+        VmaSuballocationType allocType) const;
 
     void AllocPages(uint8_t allocType, VkDeviceSize offset, VkDeviceSize size);
     void FreePages(VkDeviceSize offset, VkDeviceSize size);
     void Clear();
 
-    ValidationContext StartValidation(const VkAllocationCallbacks* pAllocationCallbacks, bool isVirutal) const;
-    bool              Validate(ValidationContext& ctx, VkDeviceSize offset, VkDeviceSize size) const;
-    bool              FinishValidation(ValidationContext& ctx) const;
+    ValidationContext StartValidation(const VkAllocationCallbacks* pAllocationCallbacks,
+        bool isVirutal) const;
+    bool Validate(ValidationContext& ctx, VkDeviceSize offset, VkDeviceSize size) const;
+    bool FinishValidation(ValidationContext& ctx) const;
 
-  private:
+private:
     static const uint16_t MAX_LOW_BUFFER_IMAGE_GRANULARITY = 256;
 
     struct RegionInfo
     {
-        uint8_t  allocType;
+        uint8_t allocType;
         uint16_t allocCount;
     };
 
     VkDeviceSize m_BufferImageGranularity;
-    uint32_t     m_RegionCount;
-    RegionInfo*  m_RegionInfo;
+    uint32_t m_RegionCount;
+    RegionInfo* m_RegionInfo;
 
-    uint32_t GetStartPage(VkDeviceSize offset) const
-    {
-        return OffsetToPageIndex(offset & ~(m_BufferImageGranularity - 1));
-    }
-    uint32_t GetEndPage(VkDeviceSize offset, VkDeviceSize size) const
-    {
-        return OffsetToPageIndex((offset + size - 1) & ~(m_BufferImageGranularity - 1));
-    }
+    uint32_t GetStartPage(VkDeviceSize offset) const { return OffsetToPageIndex(offset & ~(m_BufferImageGranularity - 1)); }
+    uint32_t GetEndPage(VkDeviceSize offset, VkDeviceSize size) const { return OffsetToPageIndex((offset + size - 1) & ~(m_BufferImageGranularity - 1)); }
 
     uint32_t OffsetToPageIndex(VkDeviceSize offset) const;
-    void     AllocPage(RegionInfo& page, uint8_t allocType);
+    void AllocPage(RegionInfo& page, uint8_t allocType);
 };
 
 #ifndef _VMA_BLOCK_BUFFER_IMAGE_GRANULARITY_FUNCTIONS
-VmaBlockBufferImageGranularity::VmaBlockBufferImageGranularity(VkDeviceSize bufferImageGranularity) :
-    m_BufferImageGranularity(bufferImageGranularity), m_RegionCount(0), m_RegionInfo(VMA_NULL)
-{}
+VmaBlockBufferImageGranularity::VmaBlockBufferImageGranularity(VkDeviceSize bufferImageGranularity)
+    : m_BufferImageGranularity(bufferImageGranularity),
+    m_RegionCount(0),
+    m_RegionInfo(VMA_NULL) {}
 
 VmaBlockBufferImageGranularity::~VmaBlockBufferImageGranularity()
 {
@@ -6801,7 +6607,7 @@ void VmaBlockBufferImageGranularity::Init(const VkAllocationCallbacks* pAllocati
     if (IsEnabled())
     {
         m_RegionCount = static_cast<uint32_t>(VmaDivideRoundingUp(size, m_BufferImageGranularity));
-        m_RegionInfo  = vma_new_array(pAllocationCallbacks, RegionInfo, m_RegionCount);
+        m_RegionInfo = vma_new_array(pAllocationCallbacks, RegionInfo, m_RegionCount);
         memset(m_RegionInfo, 0, m_RegionCount * sizeof(RegionInfo));
     }
 }
@@ -6816,32 +6622,33 @@ void VmaBlockBufferImageGranularity::Destroy(const VkAllocationCallbacks* pAlloc
 }
 
 void VmaBlockBufferImageGranularity::RoundupAllocRequest(VmaSuballocationType allocType,
-                                                         VkDeviceSize&        inOutAllocSize,
-                                                         VkDeviceSize&        inOutAllocAlignment) const
+    VkDeviceSize& inOutAllocSize,
+    VkDeviceSize& inOutAllocAlignment) const
 {
-    if (m_BufferImageGranularity > 1 && m_BufferImageGranularity <= MAX_LOW_BUFFER_IMAGE_GRANULARITY)
+    if (m_BufferImageGranularity > 1 &&
+        m_BufferImageGranularity <= MAX_LOW_BUFFER_IMAGE_GRANULARITY)
     {
-        if (allocType == VMA_SUBALLOCATION_TYPE_UNKNOWN || allocType == VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN ||
+        if (allocType == VMA_SUBALLOCATION_TYPE_UNKNOWN ||
+            allocType == VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN ||
             allocType == VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL)
         {
             inOutAllocAlignment = VMA_MAX(inOutAllocAlignment, m_BufferImageGranularity);
-            inOutAllocSize      = VmaAlignUp(inOutAllocSize, m_BufferImageGranularity);
+            inOutAllocSize = VmaAlignUp(inOutAllocSize, m_BufferImageGranularity);
         }
     }
 }
 
-bool VmaBlockBufferImageGranularity::CheckConflictAndAlignUp(VkDeviceSize&        inOutAllocOffset,
-                                                             VkDeviceSize         allocSize,
-                                                             VkDeviceSize         blockOffset,
-                                                             VkDeviceSize         blockSize,
-                                                             VmaSuballocationType allocType) const
+bool VmaBlockBufferImageGranularity::CheckConflictAndAlignUp(VkDeviceSize& inOutAllocOffset,
+    VkDeviceSize allocSize,
+    VkDeviceSize blockOffset,
+    VkDeviceSize blockSize,
+    VmaSuballocationType allocType) const
 {
     if (IsEnabled())
     {
         uint32_t startPage = GetStartPage(inOutAllocOffset);
         if (m_RegionInfo[startPage].allocCount > 0 &&
-            VmaIsBufferImageGranularityConflict(static_cast<VmaSuballocationType>(m_RegionInfo[startPage].allocType),
-                                                allocType))
+            VmaIsBufferImageGranularityConflict(static_cast<VmaSuballocationType>(m_RegionInfo[startPage].allocType), allocType))
         {
             inOutAllocOffset = VmaAlignUp(inOutAllocOffset, m_BufferImageGranularity);
             if (blockSize < allocSize + inOutAllocOffset - blockOffset)
@@ -6849,9 +6656,9 @@ bool VmaBlockBufferImageGranularity::CheckConflictAndAlignUp(VkDeviceSize&      
             ++startPage;
         }
         uint32_t endPage = GetEndPage(inOutAllocOffset, allocSize);
-        if (endPage != startPage && m_RegionInfo[endPage].allocCount > 0 &&
-            VmaIsBufferImageGranularityConflict(static_cast<VmaSuballocationType>(m_RegionInfo[endPage].allocType),
-                                                allocType))
+        if (endPage != startPage &&
+            m_RegionInfo[endPage].allocCount > 0 &&
+            VmaIsBufferImageGranularityConflict(static_cast<VmaSuballocationType>(m_RegionInfo[endPage].allocType), allocType))
         {
             return true;
         }
@@ -6896,8 +6703,8 @@ void VmaBlockBufferImageGranularity::Clear()
         memset(m_RegionInfo, 0, m_RegionCount * sizeof(RegionInfo));
 }
 
-VmaBlockBufferImageGranularity::ValidationContext
-VmaBlockBufferImageGranularity::StartValidation(const VkAllocationCallbacks* pAllocationCallbacks, bool isVirutal) const
+VmaBlockBufferImageGranularity::ValidationContext VmaBlockBufferImageGranularity::StartValidation(
+    const VkAllocationCallbacks* pAllocationCallbacks, bool isVirutal) const
 {
     ValidationContext ctx{ pAllocationCallbacks, VMA_NULL };
     if (!isVirutal && IsEnabled())
@@ -6908,7 +6715,8 @@ VmaBlockBufferImageGranularity::StartValidation(const VkAllocationCallbacks* pAl
     return ctx;
 }
 
-bool VmaBlockBufferImageGranularity::Validate(ValidationContext& ctx, VkDeviceSize offset, VkDeviceSize size) const
+bool VmaBlockBufferImageGranularity::Validate(ValidationContext& ctx,
+    VkDeviceSize offset, VkDeviceSize size) const
 {
     if (IsEnabled())
     {
@@ -6950,7 +6758,7 @@ uint32_t VmaBlockBufferImageGranularity::OffsetToPageIndex(VkDeviceSize offset) 
 
 void VmaBlockBufferImageGranularity::AllocPage(RegionInfo& page, uint8_t allocType)
 {
-    // When current alloc type is free then it can be overriden by new type
+    // When current alloc type is free then it can be overridden by new type
     if (page.allocCount == 0 || (page.allocCount > 0 && page.allocType == VMA_SUBALLOCATION_TYPE_FREE))
         page.allocType = allocType;
 
@@ -6965,7 +6773,7 @@ class VmaBlockMetadata_Generic : public VmaBlockMetadata
 {
     friend class VmaDefragmentationAlgorithm_Generic;
     friend class VmaDefragmentationAlgorithm_Fast;
-    VMA_CLASS_NO_COPY(VmaBlockMetadata_Generic)
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaBlockMetadata_Generic)
 public:
     VmaBlockMetadata_Generic(const VkAllocationCallbacks* pAllocationCallbacks,
         VkDeviceSize bufferImageGranularity, bool isVirtual);
@@ -6975,7 +6783,7 @@ public:
     VkDeviceSize GetSumFreeSize() const override { return m_SumFreeSize; }
     bool IsEmpty() const override { return (m_Suballocations.size() == 1) && (m_FreeCount == 1); }
     void Free(VmaAllocHandle allocHandle) override { FreeSuballocation(FindAtOffset((VkDeviceSize)allocHandle - 1)); }
-    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override { return (VkDeviceSize)allocHandle - 1; };
+    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override { return (VkDeviceSize)allocHandle - 1; }
 
     void Init(VkDeviceSize size) override;
     bool Validate() const override;
@@ -7804,22 +7612,18 @@ GetSize() +-------+
 */
 class VmaBlockMetadata_Linear : public VmaBlockMetadata
 {
-    VMA_CLASS_NO_COPY(VmaBlockMetadata_Linear)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaBlockMetadata_Linear)
+public:
     VmaBlockMetadata_Linear(const VkAllocationCallbacks* pAllocationCallbacks,
-                            VkDeviceSize                 bufferImageGranularity,
-                            bool                         isVirtual);
+        VkDeviceSize bufferImageGranularity, bool isVirtual);
     virtual ~VmaBlockMetadata_Linear() = default;
 
     VkDeviceSize GetSumFreeSize() const override { return m_SumFreeSize; }
-    bool         IsEmpty() const override { return GetAllocationCount() == 0; }
-    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override
-    {
-        return (VkDeviceSize)allocHandle - 1;
-    };
+    bool IsEmpty() const override { return GetAllocationCount() == 0; }
+    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override { return (VkDeviceSize)allocHandle - 1; }
 
-    void   Init(VkDeviceSize size) override;
-    bool   Validate() const override;
+    void Init(VkDeviceSize size) override;
+    bool Validate() const override;
     size_t GetAllocationCount() const override;
     size_t GetFreeRegionsCount() const override;
 
@@ -7830,28 +7634,32 @@ class VmaBlockMetadata_Linear : public VmaBlockMetadata
     void PrintDetailedMap(class VmaJsonWriter& json) const override;
 #endif
 
-    bool CreateAllocationRequest(VkDeviceSize          allocSize,
-                                 VkDeviceSize          allocAlignment,
-                                 bool                  upperAddress,
-                                 VmaSuballocationType  allocType,
-                                 uint32_t              strategy,
-                                 VmaAllocationRequest* pAllocationRequest) override;
+    bool CreateAllocationRequest(
+        VkDeviceSize allocSize,
+        VkDeviceSize allocAlignment,
+        bool upperAddress,
+        VmaSuballocationType allocType,
+        uint32_t strategy,
+        VmaAllocationRequest* pAllocationRequest) override;
 
     VkResult CheckCorruption(const void* pBlockData) override;
 
-    void Alloc(const VmaAllocationRequest& request, VmaSuballocationType type, void* userData) override;
+    void Alloc(
+        const VmaAllocationRequest& request,
+        VmaSuballocationType type,
+        void* userData) override;
 
-    void           Free(VmaAllocHandle allocHandle) override;
-    void           GetAllocationInfo(VmaAllocHandle allocHandle, VmaVirtualAllocationInfo& outInfo) override;
-    void*          GetAllocationUserData(VmaAllocHandle allocHandle) const override;
+    void Free(VmaAllocHandle allocHandle) override;
+    void GetAllocationInfo(VmaAllocHandle allocHandle, VmaVirtualAllocationInfo& outInfo) override;
+    void* GetAllocationUserData(VmaAllocHandle allocHandle) const override;
     VmaAllocHandle GetAllocationListBegin() const override;
     VmaAllocHandle GetNextAllocation(VmaAllocHandle prevAlloc) const override;
-    VkDeviceSize   GetNextFreeRegionSize(VmaAllocHandle alloc) const override;
-    void           Clear() override;
-    void           SetAllocationUserData(VmaAllocHandle allocHandle, void* userData) override;
-    void           DebugLogAllAllocations() const override;
+    VkDeviceSize GetNextFreeRegionSize(VmaAllocHandle alloc) const override;
+    void Clear() override;
+    void SetAllocationUserData(VmaAllocHandle allocHandle, void* userData) override;
+    void DebugLogAllAllocations() const override;
 
-  private:
+private:
     /*
     There are two suballocation vectors, used in ping-pong way.
     The one with index m_1stVectorIndex is called 1st.
@@ -7877,10 +7685,10 @@ class VmaBlockMetadata_Linear : public VmaBlockMetadata
         SECOND_VECTOR_DOUBLE_STACK,
     };
 
-    VkDeviceSize            m_SumFreeSize;
+    VkDeviceSize m_SumFreeSize;
     SuballocationVectorType m_Suballocations0, m_Suballocations1;
-    uint32_t                m_1stVectorIndex;
-    SECOND_VECTOR_MODE      m_2ndVectorMode;
+    uint32_t m_1stVectorIndex;
+    SECOND_VECTOR_MODE m_2ndVectorMode;
     // Number of items in 1st vector with hAllocation = null at the beginning.
     size_t m_1stNullItemsBeginCount;
     // Number of other items in 1st vector with hAllocation = null somewhere in the middle.
@@ -7888,49 +7696,41 @@ class VmaBlockMetadata_Linear : public VmaBlockMetadata
     // Number of items in 2nd vector with hAllocation = null.
     size_t m_2ndNullItemsCount;
 
-    SuballocationVectorType& AccessSuballocations1st()
-    {
-        return m_1stVectorIndex ? m_Suballocations1 : m_Suballocations0;
-    }
-    SuballocationVectorType& AccessSuballocations2nd()
-    {
-        return m_1stVectorIndex ? m_Suballocations0 : m_Suballocations1;
-    }
-    const SuballocationVectorType& AccessSuballocations1st() const
-    {
-        return m_1stVectorIndex ? m_Suballocations1 : m_Suballocations0;
-    }
-    const SuballocationVectorType& AccessSuballocations2nd() const
-    {
-        return m_1stVectorIndex ? m_Suballocations0 : m_Suballocations1;
-    }
+    SuballocationVectorType& AccessSuballocations1st() { return m_1stVectorIndex ? m_Suballocations1 : m_Suballocations0; }
+    SuballocationVectorType& AccessSuballocations2nd() { return m_1stVectorIndex ? m_Suballocations0 : m_Suballocations1; }
+    const SuballocationVectorType& AccessSuballocations1st() const { return m_1stVectorIndex ? m_Suballocations1 : m_Suballocations0; }
+    const SuballocationVectorType& AccessSuballocations2nd() const { return m_1stVectorIndex ? m_Suballocations0 : m_Suballocations1; }
 
     VmaSuballocation& FindSuballocation(VkDeviceSize offset) const;
-    bool              ShouldCompact1st() const;
-    void              CleanupAfterFree();
+    bool ShouldCompact1st() const;
+    void CleanupAfterFree();
 
-    bool CreateAllocationRequest_LowerAddress(VkDeviceSize          allocSize,
-                                              VkDeviceSize          allocAlignment,
-                                              VmaSuballocationType  allocType,
-                                              uint32_t              strategy,
-                                              VmaAllocationRequest* pAllocationRequest);
-    bool CreateAllocationRequest_UpperAddress(VkDeviceSize          allocSize,
-                                              VkDeviceSize          allocAlignment,
-                                              VmaSuballocationType  allocType,
-                                              uint32_t              strategy,
-                                              VmaAllocationRequest* pAllocationRequest);
+    bool CreateAllocationRequest_LowerAddress(
+        VkDeviceSize allocSize,
+        VkDeviceSize allocAlignment,
+        VmaSuballocationType allocType,
+        uint32_t strategy,
+        VmaAllocationRequest* pAllocationRequest);
+    bool CreateAllocationRequest_UpperAddress(
+        VkDeviceSize allocSize,
+        VkDeviceSize allocAlignment,
+        VmaSuballocationType allocType,
+        uint32_t strategy,
+        VmaAllocationRequest* pAllocationRequest);
 };
 
 #ifndef _VMA_BLOCK_METADATA_LINEAR_FUNCTIONS
 VmaBlockMetadata_Linear::VmaBlockMetadata_Linear(const VkAllocationCallbacks* pAllocationCallbacks,
-                                                 VkDeviceSize                 bufferImageGranularity,
-                                                 bool                         isVirtual) :
-    VmaBlockMetadata(pAllocationCallbacks, bufferImageGranularity, isVirtual),
-    m_SumFreeSize(0), m_Suballocations0(VmaStlAllocator<VmaSuballocation>(pAllocationCallbacks)),
-    m_Suballocations1(VmaStlAllocator<VmaSuballocation>(pAllocationCallbacks)), m_1stVectorIndex(0),
-    m_2ndVectorMode(SECOND_VECTOR_EMPTY), m_1stNullItemsBeginCount(0), m_1stNullItemsMiddleCount(0),
-    m_2ndNullItemsCount(0)
-{}
+    VkDeviceSize bufferImageGranularity, bool isVirtual)
+    : VmaBlockMetadata(pAllocationCallbacks, bufferImageGranularity, isVirtual),
+    m_SumFreeSize(0),
+    m_Suballocations0(VmaStlAllocator<VmaSuballocation>(pAllocationCallbacks)),
+    m_Suballocations1(VmaStlAllocator<VmaSuballocation>(pAllocationCallbacks)),
+    m_1stVectorIndex(0),
+    m_2ndVectorMode(SECOND_VECTOR_EMPTY),
+    m_1stNullItemsBeginCount(0),
+    m_1stNullItemsMiddleCount(0),
+    m_2ndNullItemsCount(0) {}
 
 void VmaBlockMetadata_Linear::Init(VkDeviceSize size)
 {
@@ -7944,8 +7744,9 @@ bool VmaBlockMetadata_Linear::Validate() const
     const SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
 
     VMA_VALIDATE(suballocations2nd.empty() == (m_2ndVectorMode == SECOND_VECTOR_EMPTY));
-    VMA_VALIDATE(!suballocations1st.empty() || suballocations2nd.empty() ||
-                 m_2ndVectorMode != SECOND_VECTOR_RING_BUFFER);
+    VMA_VALIDATE(!suballocations1st.empty() ||
+        suballocations2nd.empty() ||
+        m_2ndVectorMode != SECOND_VECTOR_RING_BUFFER);
 
     if (!suballocations1st.empty())
     {
@@ -7963,19 +7764,19 @@ bool VmaBlockMetadata_Linear::Validate() const
     VMA_VALIDATE(m_1stNullItemsBeginCount + m_1stNullItemsMiddleCount <= suballocations1st.size());
     VMA_VALIDATE(m_2ndNullItemsCount <= suballocations2nd.size());
 
-    VkDeviceSize       sumUsedSize      = 0;
-    const size_t       suballoc1stCount = suballocations1st.size();
-    const VkDeviceSize debugMargin      = GetDebugMargin();
-    VkDeviceSize       offset           = 0;
+    VkDeviceSize sumUsedSize = 0;
+    const size_t suballoc1stCount = suballocations1st.size();
+    const VkDeviceSize debugMargin = GetDebugMargin();
+    VkDeviceSize offset = 0;
 
     if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
     {
         const size_t suballoc2ndCount = suballocations2nd.size();
-        size_t       nullItem2ndCount = 0;
+        size_t nullItem2ndCount = 0;
         for (size_t i = 0; i < suballoc2ndCount; ++i)
         {
             const VmaSuballocation& suballoc = suballocations2nd[i];
-            const bool              currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
+            const bool currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
 
             VmaAllocation const alloc = (VmaAllocation)suballoc.userData;
             if (!IsVirtual())
@@ -8007,7 +7808,8 @@ bool VmaBlockMetadata_Linear::Validate() const
     for (size_t i = 0; i < m_1stNullItemsBeginCount; ++i)
     {
         const VmaSuballocation& suballoc = suballocations1st[i];
-        VMA_VALIDATE(suballoc.type == VMA_SUBALLOCATION_TYPE_FREE && suballoc.userData == VMA_NULL);
+        VMA_VALIDATE(suballoc.type == VMA_SUBALLOCATION_TYPE_FREE &&
+            suballoc.userData == VMA_NULL);
     }
 
     size_t nullItem1stCount = m_1stNullItemsBeginCount;
@@ -8015,7 +7817,7 @@ bool VmaBlockMetadata_Linear::Validate() const
     for (size_t i = m_1stNullItemsBeginCount; i < suballoc1stCount; ++i)
     {
         const VmaSuballocation& suballoc = suballocations1st[i];
-        const bool              currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
+        const bool currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
 
         VmaAllocation const alloc = (VmaAllocation)suballoc.userData;
         if (!IsVirtual())
@@ -8046,11 +7848,11 @@ bool VmaBlockMetadata_Linear::Validate() const
     if (m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK)
     {
         const size_t suballoc2ndCount = suballocations2nd.size();
-        size_t       nullItem2ndCount = 0;
-        for (size_t i = suballoc2ndCount; i--;)
+        size_t nullItem2ndCount = 0;
+        for (size_t i = suballoc2ndCount; i--; )
         {
             const VmaSuballocation& suballoc = suballocations2nd[i];
-            const bool              currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
+            const bool currFree = (suballoc.type == VMA_SUBALLOCATION_TYPE_FREE);
 
             VmaAllocation const alloc = (VmaAllocation)suballoc.userData;
             if (!IsVirtual())
@@ -8088,7 +7890,7 @@ bool VmaBlockMetadata_Linear::Validate() const
 size_t VmaBlockMetadata_Linear::GetAllocationCount() const
 {
     return AccessSuballocations1st().size() - m_1stNullItemsBeginCount - m_1stNullItemsMiddleCount +
-           AccessSuballocations2nd().size() - m_2ndNullItemsCount;
+        AccessSuballocations2nd().size() - m_2ndNullItemsCount;
 }
 
 size_t VmaBlockMetadata_Linear::GetFreeRegionsCount() const
@@ -8100,11 +7902,11 @@ size_t VmaBlockMetadata_Linear::GetFreeRegionsCount() const
 
 void VmaBlockMetadata_Linear::AddDetailedStatistics(VmaDetailedStatistics& inoutStats) const
 {
-    const VkDeviceSize             size              = GetSize();
+    const VkDeviceSize size = GetSize();
     const SuballocationVectorType& suballocations1st = AccessSuballocations1st();
     const SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
-    const size_t                   suballoc1stCount  = suballocations1st.size();
-    const size_t                   suballoc2ndCount  = suballocations2nd.size();
+    const size_t suballoc1stCount = suballocations1st.size();
+    const size_t suballoc2ndCount = suballocations2nd.size();
 
     inoutStats.statistics.blockCount++;
     inoutStats.statistics.blockBytes += size;
@@ -8114,11 +7916,12 @@ void VmaBlockMetadata_Linear::AddDetailedStatistics(VmaDetailedStatistics& inout
     if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
     {
         const VkDeviceSize freeSpace2ndTo1stEnd = suballocations1st[m_1stNullItemsBeginCount].offset;
-        size_t             nextAlloc2ndIndex    = 0;
+        size_t nextAlloc2ndIndex = 0;
         while (lastOffset < freeSpace2ndTo1stEnd)
         {
             // Find next non-null allocation or move nextAllocIndex to the end.
-            while (nextAlloc2ndIndex < suballoc2ndCount && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex < suballoc2ndCount &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 ++nextAlloc2ndIndex;
             }
@@ -8160,13 +7963,14 @@ void VmaBlockMetadata_Linear::AddDetailedStatistics(VmaDetailedStatistics& inout
         }
     }
 
-    size_t             nextAlloc1stIndex = m_1stNullItemsBeginCount;
+    size_t nextAlloc1stIndex = m_1stNullItemsBeginCount;
     const VkDeviceSize freeSpace1stTo2ndEnd =
         m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK ? suballocations2nd.back().offset : size;
     while (lastOffset < freeSpace1stTo2ndEnd)
     {
         // Find next non-null allocation or move nextAllocIndex to the end.
-        while (nextAlloc1stIndex < suballoc1stCount && suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
+        while (nextAlloc1stIndex < suballoc1stCount &&
+            suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
         {
             ++nextAlloc1stIndex;
         }
@@ -8213,7 +8017,8 @@ void VmaBlockMetadata_Linear::AddDetailedStatistics(VmaDetailedStatistics& inout
         while (lastOffset < size)
         {
             // Find next non-null allocation or move nextAllocIndex to the end.
-            while (nextAlloc2ndIndex != SIZE_MAX && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex != SIZE_MAX &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 --nextAlloc2ndIndex;
             }
@@ -8260,9 +8065,9 @@ void VmaBlockMetadata_Linear::AddStatistics(VmaStatistics& inoutStats) const
 {
     const SuballocationVectorType& suballocations1st = AccessSuballocations1st();
     const SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
-    const VkDeviceSize             size              = GetSize();
-    const size_t                   suballoc1stCount  = suballocations1st.size();
-    const size_t                   suballoc2ndCount  = suballocations2nd.size();
+    const VkDeviceSize size = GetSize();
+    const size_t suballoc1stCount = suballocations1st.size();
+    const size_t suballoc2ndCount = suballocations2nd.size();
 
     inoutStats.blockCount++;
     inoutStats.blockBytes += size;
@@ -8273,11 +8078,12 @@ void VmaBlockMetadata_Linear::AddStatistics(VmaStatistics& inoutStats) const
     if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
     {
         const VkDeviceSize freeSpace2ndTo1stEnd = suballocations1st[m_1stNullItemsBeginCount].offset;
-        size_t             nextAlloc2ndIndex    = m_1stNullItemsBeginCount;
+        size_t nextAlloc2ndIndex = m_1stNullItemsBeginCount;
         while (lastOffset < freeSpace2ndTo1stEnd)
         {
             // Find next non-null allocation or move nextAlloc2ndIndex to the end.
-            while (nextAlloc2ndIndex < suballoc2ndCount && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex < suballoc2ndCount &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 ++nextAlloc2ndIndex;
             }
@@ -8287,43 +8093,31 @@ void VmaBlockMetadata_Linear::AddStatistics(VmaStatistics& inoutStats) const
             {
                 const VmaSuballocation& suballoc = suballocations2nd[nextAlloc2ndIndex];
 
-                // 1. Process free space before this allocation.
-                if (lastOffset < suballoc.offset)
-                {
-                    // There is free space from lastOffset to suballoc.offset.
-                    const VkDeviceSize unusedRangeSize = suballoc.offset - lastOffset;
-                }
-
-                // 2. Process this allocation.
+                // Process this allocation.
                 // There is allocation with suballoc.offset, suballoc.size.
                 ++inoutStats.allocationCount;
 
-                // 3. Prepare for next iteration.
+                // Prepare for next iteration.
                 lastOffset = suballoc.offset + suballoc.size;
                 ++nextAlloc2ndIndex;
             }
             // We are at the end.
             else
             {
-                if (lastOffset < freeSpace2ndTo1stEnd)
-                {
-                    // There is free space from lastOffset to freeSpace2ndTo1stEnd.
-                    const VkDeviceSize unusedRangeSize = freeSpace2ndTo1stEnd - lastOffset;
-                }
-
                 // End of loop.
                 lastOffset = freeSpace2ndTo1stEnd;
             }
         }
     }
 
-    size_t             nextAlloc1stIndex = m_1stNullItemsBeginCount;
+    size_t nextAlloc1stIndex = m_1stNullItemsBeginCount;
     const VkDeviceSize freeSpace1stTo2ndEnd =
         m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK ? suballocations2nd.back().offset : size;
     while (lastOffset < freeSpace1stTo2ndEnd)
     {
         // Find next non-null allocation or move nextAllocIndex to the end.
-        while (nextAlloc1stIndex < suballoc1stCount && suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
+        while (nextAlloc1stIndex < suballoc1stCount &&
+            suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
         {
             ++nextAlloc1stIndex;
         }
@@ -8333,30 +8127,17 @@ void VmaBlockMetadata_Linear::AddStatistics(VmaStatistics& inoutStats) const
         {
             const VmaSuballocation& suballoc = suballocations1st[nextAlloc1stIndex];
 
-            // 1. Process free space before this allocation.
-            if (lastOffset < suballoc.offset)
-            {
-                // There is free space from lastOffset to suballoc.offset.
-                const VkDeviceSize unusedRangeSize = suballoc.offset - lastOffset;
-            }
-
-            // 2. Process this allocation.
+            // Process this allocation.
             // There is allocation with suballoc.offset, suballoc.size.
             ++inoutStats.allocationCount;
 
-            // 3. Prepare for next iteration.
+            // Prepare for next iteration.
             lastOffset = suballoc.offset + suballoc.size;
             ++nextAlloc1stIndex;
         }
         // We are at the end.
         else
         {
-            if (lastOffset < freeSpace1stTo2ndEnd)
-            {
-                // There is free space from lastOffset to freeSpace1stTo2ndEnd.
-                const VkDeviceSize unusedRangeSize = freeSpace1stTo2ndEnd - lastOffset;
-            }
-
             // End of loop.
             lastOffset = freeSpace1stTo2ndEnd;
         }
@@ -8368,7 +8149,8 @@ void VmaBlockMetadata_Linear::AddStatistics(VmaStatistics& inoutStats) const
         while (lastOffset < size)
         {
             // Find next non-null allocation or move nextAlloc2ndIndex to the end.
-            while (nextAlloc2ndIndex != SIZE_MAX && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex != SIZE_MAX &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 --nextAlloc2ndIndex;
             }
@@ -8378,30 +8160,17 @@ void VmaBlockMetadata_Linear::AddStatistics(VmaStatistics& inoutStats) const
             {
                 const VmaSuballocation& suballoc = suballocations2nd[nextAlloc2ndIndex];
 
-                // 1. Process free space before this allocation.
-                if (lastOffset < suballoc.offset)
-                {
-                    // There is free space from lastOffset to suballoc.offset.
-                    const VkDeviceSize unusedRangeSize = suballoc.offset - lastOffset;
-                }
-
-                // 2. Process this allocation.
+                // Process this allocation.
                 // There is allocation with suballoc.offset, suballoc.size.
                 ++inoutStats.allocationCount;
 
-                // 3. Prepare for next iteration.
+                // Prepare for next iteration.
                 lastOffset = suballoc.offset + suballoc.size;
                 --nextAlloc2ndIndex;
             }
             // We are at the end.
             else
             {
-                if (lastOffset < size)
-                {
-                    // There is free space from lastOffset to size.
-                    const VkDeviceSize unusedRangeSize = size - lastOffset;
-                }
-
                 // End of loop.
                 lastOffset = size;
             }
@@ -8412,16 +8181,16 @@ void VmaBlockMetadata_Linear::AddStatistics(VmaStatistics& inoutStats) const
 #if VMA_STATS_STRING_ENABLED
 void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
 {
-    const VkDeviceSize             size              = GetSize();
+    const VkDeviceSize size = GetSize();
     const SuballocationVectorType& suballocations1st = AccessSuballocations1st();
     const SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
-    const size_t                   suballoc1stCount  = suballocations1st.size();
-    const size_t                   suballoc2ndCount  = suballocations2nd.size();
+    const size_t suballoc1stCount = suballocations1st.size();
+    const size_t suballoc2ndCount = suballocations2nd.size();
 
     // FIRST PASS
 
-    size_t       unusedRangeCount = 0;
-    VkDeviceSize usedBytes        = 0;
+    size_t unusedRangeCount = 0;
+    VkDeviceSize usedBytes = 0;
 
     VkDeviceSize lastOffset = 0;
 
@@ -8429,11 +8198,12 @@ void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
     if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
     {
         const VkDeviceSize freeSpace2ndTo1stEnd = suballocations1st[m_1stNullItemsBeginCount].offset;
-        size_t             nextAlloc2ndIndex    = 0;
+        size_t nextAlloc2ndIndex = 0;
         while (lastOffset < freeSpace2ndTo1stEnd)
         {
             // Find next non-null allocation or move nextAlloc2ndIndex to the end.
-            while (nextAlloc2ndIndex < suballoc2ndCount && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex < suballoc2ndCount &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 ++nextAlloc2ndIndex;
             }
@@ -8474,14 +8244,15 @@ void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
         }
     }
 
-    size_t             nextAlloc1stIndex = m_1stNullItemsBeginCount;
-    size_t             alloc1stCount     = 0;
+    size_t nextAlloc1stIndex = m_1stNullItemsBeginCount;
+    size_t alloc1stCount = 0;
     const VkDeviceSize freeSpace1stTo2ndEnd =
         m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK ? suballocations2nd.back().offset : size;
     while (lastOffset < freeSpace1stTo2ndEnd)
     {
         // Find next non-null allocation or move nextAllocIndex to the end.
-        while (nextAlloc1stIndex < suballoc1stCount && suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
+        while (nextAlloc1stIndex < suballoc1stCount &&
+            suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
         {
             ++nextAlloc1stIndex;
         }
@@ -8527,7 +8298,8 @@ void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
         while (lastOffset < size)
         {
             // Find next non-null allocation or move nextAlloc2ndIndex to the end.
-            while (nextAlloc2ndIndex != SIZE_MAX && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex != SIZE_MAX &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 --nextAlloc2ndIndex;
             }
@@ -8577,11 +8349,12 @@ void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
     if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
     {
         const VkDeviceSize freeSpace2ndTo1stEnd = suballocations1st[m_1stNullItemsBeginCount].offset;
-        size_t             nextAlloc2ndIndex    = 0;
+        size_t nextAlloc2ndIndex = 0;
         while (lastOffset < freeSpace2ndTo1stEnd)
         {
             // Find next non-null allocation or move nextAlloc2ndIndex to the end.
-            while (nextAlloc2ndIndex < suballoc2ndCount && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex < suballoc2ndCount &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 ++nextAlloc2ndIndex;
             }
@@ -8627,7 +8400,8 @@ void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
     while (lastOffset < freeSpace1stTo2ndEnd)
     {
         // Find next non-null allocation or move nextAllocIndex to the end.
-        while (nextAlloc1stIndex < suballoc1stCount && suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
+        while (nextAlloc1stIndex < suballoc1stCount &&
+            suballocations1st[nextAlloc1stIndex].userData == VMA_NULL)
         {
             ++nextAlloc1stIndex;
         }
@@ -8674,7 +8448,8 @@ void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
         while (lastOffset < size)
         {
             // Find next non-null allocation or move nextAlloc2ndIndex to the end.
-            while (nextAlloc2ndIndex != SIZE_MAX && suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
+            while (nextAlloc2ndIndex != SIZE_MAX &&
+                suballocations2nd[nextAlloc2ndIndex].userData == VMA_NULL)
             {
                 --nextAlloc2ndIndex;
             }
@@ -8720,22 +8495,24 @@ void VmaBlockMetadata_Linear::PrintDetailedMap(class VmaJsonWriter& json) const
 }
 #endif // VMA_STATS_STRING_ENABLED
 
-bool VmaBlockMetadata_Linear::CreateAllocationRequest(VkDeviceSize          allocSize,
-                                                      VkDeviceSize          allocAlignment,
-                                                      bool                  upperAddress,
-                                                      VmaSuballocationType  allocType,
-                                                      uint32_t              strategy,
-                                                      VmaAllocationRequest* pAllocationRequest)
+bool VmaBlockMetadata_Linear::CreateAllocationRequest(
+    VkDeviceSize allocSize,
+    VkDeviceSize allocAlignment,
+    bool upperAddress,
+    VmaSuballocationType allocType,
+    uint32_t strategy,
+    VmaAllocationRequest* pAllocationRequest)
 {
     VMA_ASSERT(allocSize > 0);
     VMA_ASSERT(allocType != VMA_SUBALLOCATION_TYPE_FREE);
     VMA_ASSERT(pAllocationRequest != VMA_NULL);
     VMA_HEAVY_ASSERT(Validate());
     pAllocationRequest->size = allocSize;
-    return upperAddress ? CreateAllocationRequest_UpperAddress(
-                              allocSize, allocAlignment, allocType, strategy, pAllocationRequest)
-                        : CreateAllocationRequest_LowerAddress(
-                              allocSize, allocAlignment, allocType, strategy, pAllocationRequest);
+    return upperAddress ?
+        CreateAllocationRequest_UpperAddress(
+            allocSize, allocAlignment, allocType, strategy, pAllocationRequest) :
+        CreateAllocationRequest_LowerAddress(
+            allocSize, allocAlignment, allocType, strategy, pAllocationRequest);
 }
 
 VkResult VmaBlockMetadata_Linear::CheckCorruption(const void* pBlockData)
@@ -8772,67 +8549,68 @@ VkResult VmaBlockMetadata_Linear::CheckCorruption(const void* pBlockData)
     return VK_SUCCESS;
 }
 
-void VmaBlockMetadata_Linear::Alloc(const VmaAllocationRequest& request, VmaSuballocationType type, void* userData)
+void VmaBlockMetadata_Linear::Alloc(
+    const VmaAllocationRequest& request,
+    VmaSuballocationType type,
+    void* userData)
 {
-    const VkDeviceSize     offset      = (VkDeviceSize)request.allocHandle - 1;
+    const VkDeviceSize offset = (VkDeviceSize)request.allocHandle - 1;
     const VmaSuballocation newSuballoc = { offset, request.size, userData, type };
 
     switch (request.type)
     {
-        case VmaAllocationRequestType::UpperAddress:
+    case VmaAllocationRequestType::UpperAddress:
+    {
+        VMA_ASSERT(m_2ndVectorMode != SECOND_VECTOR_RING_BUFFER &&
+            "CRITICAL ERROR: Trying to use linear allocator as double stack while it was already used as ring buffer.");
+        SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
+        suballocations2nd.push_back(newSuballoc);
+        m_2ndVectorMode = SECOND_VECTOR_DOUBLE_STACK;
+    }
+    break;
+    case VmaAllocationRequestType::EndOf1st:
+    {
+        SuballocationVectorType& suballocations1st = AccessSuballocations1st();
+
+        VMA_ASSERT(suballocations1st.empty() ||
+            offset >= suballocations1st.back().offset + suballocations1st.back().size);
+        // Check if it fits before the end of the block.
+        VMA_ASSERT(offset + request.size <= GetSize());
+
+        suballocations1st.push_back(newSuballoc);
+    }
+    break;
+    case VmaAllocationRequestType::EndOf2nd:
+    {
+        SuballocationVectorType& suballocations1st = AccessSuballocations1st();
+        // New allocation at the end of 2-part ring buffer, so before first allocation from 1st vector.
+        VMA_ASSERT(!suballocations1st.empty() &&
+            offset + request.size <= suballocations1st[m_1stNullItemsBeginCount].offset);
+        SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
+
+        switch (m_2ndVectorMode)
         {
-            VMA_ASSERT(m_2ndVectorMode != SECOND_VECTOR_RING_BUFFER &&
-                       "CRITICAL ERROR: Trying to use linear allocator as double stack while it was already used as "
-                       "ring buffer.");
-            SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
-            suballocations2nd.push_back(newSuballoc);
-            m_2ndVectorMode = SECOND_VECTOR_DOUBLE_STACK;
-        }
-        break;
-        case VmaAllocationRequestType::EndOf1st:
-        {
-            SuballocationVectorType& suballocations1st = AccessSuballocations1st();
-
-            VMA_ASSERT(suballocations1st.empty() ||
-                       offset >= suballocations1st.back().offset + suballocations1st.back().size);
-            // Check if it fits before the end of the block.
-            VMA_ASSERT(offset + request.size <= GetSize());
-
-            suballocations1st.push_back(newSuballoc);
-        }
-        break;
-        case VmaAllocationRequestType::EndOf2nd:
-        {
-            SuballocationVectorType& suballocations1st = AccessSuballocations1st();
-            // New allocation at the end of 2-part ring buffer, so before first allocation from 1st vector.
-            VMA_ASSERT(!suballocations1st.empty() &&
-                       offset + request.size <= suballocations1st[m_1stNullItemsBeginCount].offset);
-            SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
-
-            switch (m_2ndVectorMode)
-            {
-                case SECOND_VECTOR_EMPTY:
-                    // First allocation from second part ring buffer.
-                    VMA_ASSERT(suballocations2nd.empty());
-                    m_2ndVectorMode = SECOND_VECTOR_RING_BUFFER;
-                    break;
-                case SECOND_VECTOR_RING_BUFFER:
-                    // 2-part ring buffer is already started.
-                    VMA_ASSERT(!suballocations2nd.empty());
-                    break;
-                case SECOND_VECTOR_DOUBLE_STACK:
-                    VMA_ASSERT(0 && "CRITICAL ERROR: Trying to use linear allocator as ring buffer while it was "
-                                    "already used as double stack.");
-                    break;
-                default:
-                    VMA_ASSERT(0);
-            }
-
-            suballocations2nd.push_back(newSuballoc);
-        }
-        break;
+        case SECOND_VECTOR_EMPTY:
+            // First allocation from second part ring buffer.
+            VMA_ASSERT(suballocations2nd.empty());
+            m_2ndVectorMode = SECOND_VECTOR_RING_BUFFER;
+            break;
+        case SECOND_VECTOR_RING_BUFFER:
+            // 2-part ring buffer is already started.
+            VMA_ASSERT(!suballocations2nd.empty());
+            break;
+        case SECOND_VECTOR_DOUBLE_STACK:
+            VMA_ASSERT(0 && "CRITICAL ERROR: Trying to use linear allocator as ring buffer while it was already used as double stack.");
+            break;
         default:
-            VMA_ASSERT(0 && "CRITICAL INTERNAL ERROR.");
+            VMA_ASSERT(0);
+        }
+
+        suballocations2nd.push_back(newSuballoc);
+    }
+    break;
+    default:
+        VMA_ASSERT(0 && "CRITICAL INTERNAL ERROR.");
     }
 
     m_SumFreeSize -= newSuballoc.size;
@@ -8842,7 +8620,7 @@ void VmaBlockMetadata_Linear::Free(VmaAllocHandle allocHandle)
 {
     SuballocationVectorType& suballocations1st = AccessSuballocations1st();
     SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
-    VkDeviceSize             offset            = (VkDeviceSize)allocHandle - 1;
+    VkDeviceSize offset = (VkDeviceSize)allocHandle - 1;
 
     if (!suballocations1st.empty())
     {
@@ -8850,7 +8628,7 @@ void VmaBlockMetadata_Linear::Free(VmaAllocHandle allocHandle)
         VmaSuballocation& firstSuballoc = suballocations1st[m_1stNullItemsBeginCount];
         if (firstSuballoc.offset == offset)
         {
-            firstSuballoc.type     = VMA_SUBALLOCATION_TYPE_FREE;
+            firstSuballoc.type = VMA_SUBALLOCATION_TYPE_FREE;
             firstSuballoc.userData = VMA_NULL;
             m_SumFreeSize += firstSuballoc.size;
             ++m_1stNullItemsBeginCount;
@@ -8860,7 +8638,8 @@ void VmaBlockMetadata_Linear::Free(VmaAllocHandle allocHandle)
     }
 
     // Last allocation in 2-part ring buffer or top of upper stack (same logic).
-    if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER || m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK)
+    if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER ||
+        m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK)
     {
         VmaSuballocation& lastSuballoc = suballocations2nd.back();
         if (lastSuballoc.offset == offset)
@@ -8890,14 +8669,14 @@ void VmaBlockMetadata_Linear::Free(VmaAllocHandle allocHandle)
 
     // Item from the middle of 1st vector.
     {
-        const SuballocationVectorType::iterator it =
-            VmaBinaryFindSorted(suballocations1st.begin() + m_1stNullItemsBeginCount,
-                                suballocations1st.end(),
-                                refSuballoc,
-                                VmaSuballocationOffsetLess());
+        const SuballocationVectorType::iterator it = VmaBinaryFindSorted(
+            suballocations1st.begin() + m_1stNullItemsBeginCount,
+            suballocations1st.end(),
+            refSuballoc,
+            VmaSuballocationOffsetLess());
         if (it != suballocations1st.end())
         {
-            it->type     = VMA_SUBALLOCATION_TYPE_FREE;
+            it->type = VMA_SUBALLOCATION_TYPE_FREE;
             it->userData = VMA_NULL;
             ++m_1stNullItemsMiddleCount;
             m_SumFreeSize += it->size;
@@ -8909,15 +8688,12 @@ void VmaBlockMetadata_Linear::Free(VmaAllocHandle allocHandle)
     if (m_2ndVectorMode != SECOND_VECTOR_EMPTY)
     {
         // Item from the middle of 2nd vector.
-        const SuballocationVectorType::iterator it =
-            m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER
-                ? VmaBinaryFindSorted(
-                      suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetLess())
-                : VmaBinaryFindSorted(
-                      suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetGreater());
+        const SuballocationVectorType::iterator it = m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER ?
+            VmaBinaryFindSorted(suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetLess()) :
+            VmaBinaryFindSorted(suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetGreater());
         if (it != suballocations2nd.end())
         {
-            it->type     = VMA_SUBALLOCATION_TYPE_FREE;
+            it->type = VMA_SUBALLOCATION_TYPE_FREE;
             it->userData = VMA_NULL;
             ++m_2ndNullItemsCount;
             m_SumFreeSize += it->size;
@@ -8931,10 +8707,10 @@ void VmaBlockMetadata_Linear::Free(VmaAllocHandle allocHandle)
 
 void VmaBlockMetadata_Linear::GetAllocationInfo(VmaAllocHandle allocHandle, VmaVirtualAllocationInfo& outInfo)
 {
-    outInfo.offset             = (VkDeviceSize)allocHandle - 1;
+    outInfo.offset = (VkDeviceSize)allocHandle - 1;
     VmaSuballocation& suballoc = FindSuballocation(outInfo.offset);
-    outInfo.size               = suballoc.size;
-    outInfo.pUserData          = suballoc.userData;
+    outInfo.size = suballoc.size;
+    outInfo.pUserData = suballoc.userData;
 }
 
 void* VmaBlockMetadata_Linear::GetAllocationUserData(VmaAllocHandle allocHandle) const
@@ -8969,16 +8745,16 @@ void VmaBlockMetadata_Linear::Clear()
     m_Suballocations0.clear();
     m_Suballocations1.clear();
     // Leaving m_1stVectorIndex unchanged - it doesn't matter.
-    m_2ndVectorMode           = SECOND_VECTOR_EMPTY;
-    m_1stNullItemsBeginCount  = 0;
+    m_2ndVectorMode = SECOND_VECTOR_EMPTY;
+    m_1stNullItemsBeginCount = 0;
     m_1stNullItemsMiddleCount = 0;
-    m_2ndNullItemsCount       = 0;
+    m_2ndNullItemsCount = 0;
 }
 
 void VmaBlockMetadata_Linear::SetAllocationUserData(VmaAllocHandle allocHandle, void* userData)
 {
     VmaSuballocation& suballoc = FindSuballocation((VkDeviceSize)allocHandle - 1);
-    suballoc.userData          = userData;
+    suballoc.userData = userData;
 }
 
 void VmaBlockMetadata_Linear::DebugLogAllAllocations() const
@@ -9005,11 +8781,11 @@ VmaSuballocation& VmaBlockMetadata_Linear::FindSuballocation(VkDeviceSize offset
 
     // Item from the 1st vector.
     {
-        SuballocationVectorType::const_iterator it =
-            VmaBinaryFindSorted(suballocations1st.begin() + m_1stNullItemsBeginCount,
-                                suballocations1st.end(),
-                                refSuballoc,
-                                VmaSuballocationOffsetLess());
+        SuballocationVectorType::const_iterator it = VmaBinaryFindSorted(
+            suballocations1st.begin() + m_1stNullItemsBeginCount,
+            suballocations1st.end(),
+            refSuballoc,
+            VmaSuballocationOffsetLess());
         if (it != suballocations1st.end())
         {
             return const_cast<VmaSuballocation&>(*it);
@@ -9019,12 +8795,9 @@ VmaSuballocation& VmaBlockMetadata_Linear::FindSuballocation(VkDeviceSize offset
     if (m_2ndVectorMode != SECOND_VECTOR_EMPTY)
     {
         // Rest of members stays uninitialized intentionally for better performance.
-        SuballocationVectorType::const_iterator it =
-            m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER
-                ? VmaBinaryFindSorted(
-                      suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetLess())
-                : VmaBinaryFindSorted(
-                      suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetGreater());
+        SuballocationVectorType::const_iterator it = m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER ?
+            VmaBinaryFindSorted(suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetLess()) :
+            VmaBinaryFindSorted(suballocations2nd.begin(), suballocations2nd.end(), refSuballoc, VmaSuballocationOffsetGreater());
         if (it != suballocations2nd.end())
         {
             return const_cast<VmaSuballocation&>(*it);
@@ -9051,10 +8824,10 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
     {
         suballocations1st.clear();
         suballocations2nd.clear();
-        m_1stNullItemsBeginCount  = 0;
+        m_1stNullItemsBeginCount = 0;
         m_1stNullItemsMiddleCount = 0;
-        m_2ndNullItemsCount       = 0;
-        m_2ndVectorMode           = SECOND_VECTOR_EMPTY;
+        m_2ndNullItemsCount = 0;
+        m_2ndVectorMode = SECOND_VECTOR_EMPTY;
     }
     else
     {
@@ -9064,28 +8837,31 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
 
         // Find more null items at the beginning of 1st vector.
         while (m_1stNullItemsBeginCount < suballoc1stCount &&
-               suballocations1st[m_1stNullItemsBeginCount].type == VMA_SUBALLOCATION_TYPE_FREE)
+            suballocations1st[m_1stNullItemsBeginCount].type == VMA_SUBALLOCATION_TYPE_FREE)
         {
             ++m_1stNullItemsBeginCount;
             --m_1stNullItemsMiddleCount;
         }
 
         // Find more null items at the end of 1st vector.
-        while (m_1stNullItemsMiddleCount > 0 && suballocations1st.back().type == VMA_SUBALLOCATION_TYPE_FREE)
+        while (m_1stNullItemsMiddleCount > 0 &&
+            suballocations1st.back().type == VMA_SUBALLOCATION_TYPE_FREE)
         {
             --m_1stNullItemsMiddleCount;
             suballocations1st.pop_back();
         }
 
         // Find more null items at the end of 2nd vector.
-        while (m_2ndNullItemsCount > 0 && suballocations2nd.back().type == VMA_SUBALLOCATION_TYPE_FREE)
+        while (m_2ndNullItemsCount > 0 &&
+            suballocations2nd.back().type == VMA_SUBALLOCATION_TYPE_FREE)
         {
             --m_2ndNullItemsCount;
             suballocations2nd.pop_back();
         }
 
         // Find more null items at the beginning of 2nd vector.
-        while (m_2ndNullItemsCount > 0 && suballocations2nd[0].type == VMA_SUBALLOCATION_TYPE_FREE)
+        while (m_2ndNullItemsCount > 0 &&
+            suballocations2nd[0].type == VMA_SUBALLOCATION_TYPE_FREE)
         {
             --m_2ndNullItemsCount;
             VmaVectorRemove(suballocations2nd, 0);
@@ -9094,7 +8870,7 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
         if (ShouldCompact1st())
         {
             const size_t nonNullItemCount = suballoc1stCount - nullItem1stCount;
-            size_t       srcIndex         = m_1stNullItemsBeginCount;
+            size_t srcIndex = m_1stNullItemsBeginCount;
             for (size_t dstIndex = 0; dstIndex < nonNullItemCount; ++dstIndex)
             {
                 while (suballocations1st[srcIndex].type == VMA_SUBALLOCATION_TYPE_FREE)
@@ -9108,7 +8884,7 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
                 ++srcIndex;
             }
             suballocations1st.resize(nonNullItemCount);
-            m_1stNullItemsBeginCount  = 0;
+            m_1stNullItemsBeginCount = 0;
             m_1stNullItemsMiddleCount = 0;
         }
 
@@ -9127,10 +8903,10 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
             if (!suballocations2nd.empty() && m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
             {
                 // Swap 1st with 2nd. Now 2nd is empty.
-                m_2ndVectorMode           = SECOND_VECTOR_EMPTY;
+                m_2ndVectorMode = SECOND_VECTOR_EMPTY;
                 m_1stNullItemsMiddleCount = m_2ndNullItemsCount;
                 while (m_1stNullItemsBeginCount < suballocations2nd.size() &&
-                       suballocations2nd[m_1stNullItemsBeginCount].type == VMA_SUBALLOCATION_TYPE_FREE)
+                    suballocations2nd[m_1stNullItemsBeginCount].type == VMA_SUBALLOCATION_TYPE_FREE)
                 {
                     ++m_1stNullItemsBeginCount;
                     --m_1stNullItemsMiddleCount;
@@ -9144,17 +8920,18 @@ void VmaBlockMetadata_Linear::CleanupAfterFree()
     VMA_HEAVY_ASSERT(Validate());
 }
 
-bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize          allocSize,
-                                                                   VkDeviceSize          allocAlignment,
-                                                                   VmaSuballocationType  allocType,
-                                                                   uint32_t              strategy,
-                                                                   VmaAllocationRequest* pAllocationRequest)
+bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(
+    VkDeviceSize allocSize,
+    VkDeviceSize allocAlignment,
+    VmaSuballocationType allocType,
+    uint32_t strategy,
+    VmaAllocationRequest* pAllocationRequest)
 {
-    const VkDeviceSize       blockSize              = GetSize();
-    const VkDeviceSize       debugMargin            = GetDebugMargin();
-    const VkDeviceSize       bufferImageGranularity = GetBufferImageGranularity();
-    SuballocationVectorType& suballocations1st      = AccessSuballocations1st();
-    SuballocationVectorType& suballocations2nd      = AccessSuballocations2nd();
+    const VkDeviceSize blockSize = GetSize();
+    const VkDeviceSize debugMargin = GetDebugMargin();
+    const VkDeviceSize bufferImageGranularity = GetBufferImageGranularity();
+    SuballocationVectorType& suballocations1st = AccessSuballocations1st();
+    SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
 
     if (m_2ndVectorMode == SECOND_VECTOR_EMPTY || m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK)
     {
@@ -9164,7 +8941,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
         if (!suballocations1st.empty())
         {
             const VmaSuballocation& lastSuballoc = suballocations1st.back();
-            resultBaseOffset                     = lastSuballoc.offset + lastSuballoc.size + debugMargin;
+            resultBaseOffset = lastSuballoc.offset + lastSuballoc.size + debugMargin;
         }
 
         // Start from offset equal to beginning of free space.
@@ -9178,7 +8955,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
         if (bufferImageGranularity > 1 && bufferImageGranularity != allocAlignment && !suballocations1st.empty())
         {
             bool bufferImageGranularityConflict = false;
-            for (size_t prevSuballocIndex = suballocations1st.size(); prevSuballocIndex--;)
+            for (size_t prevSuballocIndex = suballocations1st.size(); prevSuballocIndex--; )
             {
                 const VmaSuballocation& prevSuballoc = suballocations1st[prevSuballocIndex];
                 if (VmaBlocksOnSamePage(prevSuballoc.offset, prevSuballoc.size, resultOffset, bufferImageGranularity))
@@ -9199,18 +8976,17 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
             }
         }
 
-        const VkDeviceSize freeSpaceEnd =
-            m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK ? suballocations2nd.back().offset : blockSize;
+        const VkDeviceSize freeSpaceEnd = m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK ?
+            suballocations2nd.back().offset : blockSize;
 
         // There is enough free space at the end after alignment.
         if (resultOffset + allocSize + debugMargin <= freeSpaceEnd)
         {
             // Check next suballocations for BufferImageGranularity conflicts.
             // If conflict exists, allocation cannot be made here.
-            if ((allocSize % bufferImageGranularity || resultOffset % bufferImageGranularity) &&
-                m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK)
+            if ((allocSize % bufferImageGranularity || resultOffset % bufferImageGranularity) && m_2ndVectorMode == SECOND_VECTOR_DOUBLE_STACK)
             {
-                for (size_t nextSuballocIndex = suballocations2nd.size(); nextSuballocIndex--;)
+                for (size_t nextSuballocIndex = suballocations2nd.size(); nextSuballocIndex--; )
                 {
                     const VmaSuballocation& nextSuballoc = suballocations2nd[nextSuballocIndex];
                     if (VmaBlocksOnSamePage(resultOffset, allocSize, nextSuballoc.offset, bufferImageGranularity))
@@ -9246,7 +9022,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
         if (!suballocations2nd.empty())
         {
             const VmaSuballocation& lastSuballoc = suballocations2nd.back();
-            resultBaseOffset                     = lastSuballoc.offset + lastSuballoc.size + debugMargin;
+            resultBaseOffset = lastSuballoc.offset + lastSuballoc.size + debugMargin;
         }
 
         // Start from offset equal to beginning of free space.
@@ -9260,7 +9036,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
         if (bufferImageGranularity > 1 && bufferImageGranularity != allocAlignment && !suballocations2nd.empty())
         {
             bool bufferImageGranularityConflict = false;
-            for (size_t prevSuballocIndex = suballocations2nd.size(); prevSuballocIndex--;)
+            for (size_t prevSuballocIndex = suballocations2nd.size(); prevSuballocIndex--; )
             {
                 const VmaSuballocation& prevSuballoc = suballocations2nd[prevSuballocIndex];
                 if (VmaBlocksOnSamePage(prevSuballoc.offset, prevSuballoc.size, resultOffset, bufferImageGranularity))
@@ -9285,15 +9061,15 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
 
         // There is enough free space at the end after alignment.
         if ((index1st == suballocations1st.size() && resultOffset + allocSize + debugMargin <= blockSize) ||
-            (index1st < suballocations1st.size() &&
-             resultOffset + allocSize + debugMargin <= suballocations1st[index1st].offset))
+            (index1st < suballocations1st.size() && resultOffset + allocSize + debugMargin <= suballocations1st[index1st].offset))
         {
             // Check next suballocations for BufferImageGranularity conflicts.
             // If conflict exists, allocation cannot be made here.
             if (allocSize % bufferImageGranularity || resultOffset % bufferImageGranularity)
             {
-                for (size_t nextSuballocIndex = index1st; nextSuballocIndex < suballocations1st.size();
-                     nextSuballocIndex++)
+                for (size_t nextSuballocIndex = index1st;
+                    nextSuballocIndex < suballocations1st.size();
+                    nextSuballocIndex++)
                 {
                     const VmaSuballocation& nextSuballoc = suballocations1st[nextSuballocIndex];
                     if (VmaBlocksOnSamePage(resultOffset, allocSize, nextSuballoc.offset, bufferImageGranularity))
@@ -9313,7 +9089,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
 
             // All tests passed: Success.
             pAllocationRequest->allocHandle = (VmaAllocHandle)(resultOffset + 1);
-            pAllocationRequest->type        = VmaAllocationRequestType::EndOf2nd;
+            pAllocationRequest->type = VmaAllocationRequestType::EndOf2nd;
             // pAllocationRequest->item, customData unused.
             return true;
         }
@@ -9322,22 +9098,21 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_LowerAddress(VkDeviceSize 
     return false;
 }
 
-bool VmaBlockMetadata_Linear::CreateAllocationRequest_UpperAddress(VkDeviceSize          allocSize,
-                                                                   VkDeviceSize          allocAlignment,
-                                                                   VmaSuballocationType  allocType,
-                                                                   uint32_t              strategy,
-                                                                   VmaAllocationRequest* pAllocationRequest)
+bool VmaBlockMetadata_Linear::CreateAllocationRequest_UpperAddress(
+    VkDeviceSize allocSize,
+    VkDeviceSize allocAlignment,
+    VmaSuballocationType allocType,
+    uint32_t strategy,
+    VmaAllocationRequest* pAllocationRequest)
 {
-    const VkDeviceSize       blockSize              = GetSize();
-    const VkDeviceSize       bufferImageGranularity = GetBufferImageGranularity();
-    SuballocationVectorType& suballocations1st      = AccessSuballocations1st();
-    SuballocationVectorType& suballocations2nd      = AccessSuballocations2nd();
+    const VkDeviceSize blockSize = GetSize();
+    const VkDeviceSize bufferImageGranularity = GetBufferImageGranularity();
+    SuballocationVectorType& suballocations1st = AccessSuballocations1st();
+    SuballocationVectorType& suballocations2nd = AccessSuballocations2nd();
 
     if (m_2ndVectorMode == SECOND_VECTOR_RING_BUFFER)
     {
-        VMA_ASSERT(
-            0 &&
-            "Trying to use pool with linear algorithm as double stack, while it is already being used as ring buffer.");
+        VMA_ASSERT(0 && "Trying to use pool with linear algorithm as double stack, while it is already being used as ring buffer.");
         return false;
     }
 
@@ -9350,7 +9125,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_UpperAddress(VkDeviceSize 
     if (!suballocations2nd.empty())
     {
         const VmaSuballocation& lastSuballoc = suballocations2nd.back();
-        resultBaseOffset                     = lastSuballoc.offset - allocSize;
+        resultBaseOffset = lastSuballoc.offset - allocSize;
         if (allocSize > lastSuballoc.offset)
         {
             return false;
@@ -9380,7 +9155,7 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_UpperAddress(VkDeviceSize 
     if (bufferImageGranularity > 1 && bufferImageGranularity != allocAlignment && !suballocations2nd.empty())
     {
         bool bufferImageGranularityConflict = false;
-        for (size_t nextSuballocIndex = suballocations2nd.size(); nextSuballocIndex--;)
+        for (size_t nextSuballocIndex = suballocations2nd.size(); nextSuballocIndex--; )
         {
             const VmaSuballocation& nextSuballoc = suballocations2nd[nextSuballocIndex];
             if (VmaBlocksOnSamePage(resultOffset, allocSize, nextSuballoc.offset, bufferImageGranularity))
@@ -9402,15 +9177,16 @@ bool VmaBlockMetadata_Linear::CreateAllocationRequest_UpperAddress(VkDeviceSize 
     }
 
     // There is enough free space.
-    const VkDeviceSize endOf1st =
-        !suballocations1st.empty() ? suballocations1st.back().offset + suballocations1st.back().size : 0;
+    const VkDeviceSize endOf1st = !suballocations1st.empty() ?
+        suballocations1st.back().offset + suballocations1st.back().size :
+        0;
     if (endOf1st + debugMargin <= resultOffset)
     {
         // Check previous suballocations for BufferImageGranularity conflicts.
         // If conflict exists, allocation cannot be made here.
         if (bufferImageGranularity > 1)
         {
-            for (size_t prevSuballocIndex = suballocations1st.size(); prevSuballocIndex--;)
+            for (size_t prevSuballocIndex = suballocations1st.size(); prevSuballocIndex--; )
             {
                 const VmaSuballocation& prevSuballoc = suballocations1st[prevSuballocIndex];
                 if (VmaBlocksOnSamePage(prevSuballoc.offset, prevSuballoc.size, resultOffset, bufferImageGranularity))
@@ -9455,7 +9231,7 @@ m_LevelCount is the maximum number of levels to use in the current object.
 */
 class VmaBlockMetadata_Buddy : public VmaBlockMetadata
 {
-    VMA_CLASS_NO_COPY(VmaBlockMetadata_Buddy)
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaBlockMetadata_Buddy)
 public:
     VmaBlockMetadata_Buddy(const VkAllocationCallbacks* pAllocationCallbacks,
         VkDeviceSize bufferImageGranularity, bool isVirtual);
@@ -9465,7 +9241,7 @@ public:
     VkDeviceSize GetSumFreeSize() const override { return m_SumFreeSize + GetUnusableSize(); }
     bool IsEmpty() const override { return m_Root->type == Node::TYPE_FREE; }
     VkResult CheckCorruption(const void* pBlockData) override { return VK_ERROR_FEATURE_NOT_PRESENT; }
-    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override { return (VkDeviceSize)allocHandle - 1; };
+    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override { return (VkDeviceSize)allocHandle - 1; }
     void DebugLogAllAllocations() const override { DebugLogAllAllocationNode(m_Root, 0); }
 
     void Init(VkDeviceSize size) override;
@@ -10154,21 +9930,17 @@ void VmaBlockMetadata_Buddy::PrintDetailedMapNode(class VmaJsonWriter& json, con
 // VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT for fastest alloc time possible.
 class VmaBlockMetadata_TLSF : public VmaBlockMetadata
 {
-    VMA_CLASS_NO_COPY(VmaBlockMetadata_TLSF)
-  public:
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaBlockMetadata_TLSF)
+public:
     VmaBlockMetadata_TLSF(const VkAllocationCallbacks* pAllocationCallbacks,
-                          VkDeviceSize                 bufferImageGranularity,
-                          bool                         isVirtual);
+        VkDeviceSize bufferImageGranularity, bool isVirtual);
     virtual ~VmaBlockMetadata_TLSF();
 
-    size_t       GetAllocationCount() const override { return m_AllocCount; }
-    size_t       GetFreeRegionsCount() const override { return m_BlocksFreeCount + 1; }
+    size_t GetAllocationCount() const override { return m_AllocCount; }
+    size_t GetFreeRegionsCount() const override { return m_BlocksFreeCount + 1; }
     VkDeviceSize GetSumFreeSize() const override { return m_BlocksFreeSize + m_NullBlock->size; }
-    bool         IsEmpty() const override { return m_NullBlock->offset == 0; }
-    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override
-    {
-        return ((Block*)allocHandle)->offset;
-    };
+    bool IsEmpty() const override { return m_NullBlock->offset == 0; }
+    VkDeviceSize GetAllocationOffset(VmaAllocHandle allocHandle) const override { return ((Block*)allocHandle)->offset; }
 
     void Init(VkDeviceSize size) override;
     bool Validate() const override;
@@ -10180,65 +9952,61 @@ class VmaBlockMetadata_TLSF : public VmaBlockMetadata
     void PrintDetailedMap(class VmaJsonWriter& json) const override;
 #endif
 
-    bool CreateAllocationRequest(VkDeviceSize          allocSize,
-                                 VkDeviceSize          allocAlignment,
-                                 bool                  upperAddress,
-                                 VmaSuballocationType  allocType,
-                                 uint32_t              strategy,
-                                 VmaAllocationRequest* pAllocationRequest) override;
+    bool CreateAllocationRequest(
+        VkDeviceSize allocSize,
+        VkDeviceSize allocAlignment,
+        bool upperAddress,
+        VmaSuballocationType allocType,
+        uint32_t strategy,
+        VmaAllocationRequest* pAllocationRequest) override;
 
     VkResult CheckCorruption(const void* pBlockData) override;
-    void     Alloc(const VmaAllocationRequest& request, VmaSuballocationType type, void* userData) override;
+    void Alloc(
+        const VmaAllocationRequest& request,
+        VmaSuballocationType type,
+        void* userData) override;
 
-    void           Free(VmaAllocHandle allocHandle) override;
-    void           GetAllocationInfo(VmaAllocHandle allocHandle, VmaVirtualAllocationInfo& outInfo) override;
-    void*          GetAllocationUserData(VmaAllocHandle allocHandle) const override;
+    void Free(VmaAllocHandle allocHandle) override;
+    void GetAllocationInfo(VmaAllocHandle allocHandle, VmaVirtualAllocationInfo& outInfo) override;
+    void* GetAllocationUserData(VmaAllocHandle allocHandle) const override;
     VmaAllocHandle GetAllocationListBegin() const override;
     VmaAllocHandle GetNextAllocation(VmaAllocHandle prevAlloc) const override;
-    VkDeviceSize   GetNextFreeRegionSize(VmaAllocHandle alloc) const override;
-    void           Clear() override;
-    void           SetAllocationUserData(VmaAllocHandle allocHandle, void* userData) override;
-    void           DebugLogAllAllocations() const override;
+    VkDeviceSize GetNextFreeRegionSize(VmaAllocHandle alloc) const override;
+    void Clear() override;
+    void SetAllocationUserData(VmaAllocHandle allocHandle, void* userData) override;
+    void DebugLogAllAllocations() const override;
 
-  private:
+private:
     // According to original paper it should be preferable 4 or 5:
     // M. Masmano, I. Ripoll, A. Crespo, and J. Real "TLSF: a New Dynamic Memory Allocator for Real-Time Systems"
     // http://www.gii.upv.es/tlsf/files/ecrts04_tlsf.pdf
-    static const uint8_t  SECOND_LEVEL_INDEX        = 5;
-    static const uint16_t SMALL_BUFFER_SIZE         = 256;
+    static const uint8_t SECOND_LEVEL_INDEX = 5;
+    static const uint16_t SMALL_BUFFER_SIZE = 256;
     static const uint32_t INITIAL_BLOCK_ALLOC_COUNT = 16;
-    static const uint8_t  MEMORY_CLASS_SHIFT        = 7;
-    static const uint8_t  MAX_MEMORY_CLASSES        = 65 - MEMORY_CLASS_SHIFT;
+    static const uint8_t MEMORY_CLASS_SHIFT = 7;
+    static const uint8_t MAX_MEMORY_CLASSES = 65 - MEMORY_CLASS_SHIFT;
 
     class Block
     {
-      public:
+    public:
         VkDeviceSize offset;
         VkDeviceSize size;
-        Block*       prevPhysical;
-        Block*       nextPhysical;
+        Block* prevPhysical;
+        Block* nextPhysical;
 
-        void   MarkFree() { prevFree = VMA_NULL; }
-        void   MarkTaken() { prevFree = this; }
-        bool   IsFree() const { return prevFree != this; }
-        void*& UserData()
-        {
-            VMA_HEAVY_ASSERT(!IsFree());
-            return userData;
-        }
+        void MarkFree() { prevFree = VMA_NULL; }
+        void MarkTaken() { prevFree = this; }
+        bool IsFree() const { return prevFree != this; }
+        void*& UserData() { VMA_HEAVY_ASSERT(!IsFree()); return userData; }
         Block*& PrevFree() { return prevFree; }
-        Block*& NextFree()
-        {
-            VMA_HEAVY_ASSERT(IsFree());
-            return nextFree;
-        }
+        Block*& NextFree() { VMA_HEAVY_ASSERT(IsFree()); return nextFree; }
 
-      private:
+    private:
         Block* prevFree; // Address of the same block here indicates that block is taken
         union
         {
             Block* nextFree;
-            void*  userData;
+            void* userData;
         };
     };
 
@@ -10247,20 +10015,20 @@ class VmaBlockMetadata_TLSF : public VmaBlockMetadata
     size_t m_BlocksFreeCount;
     // Total size of free blocks excluding null block
     VkDeviceSize m_BlocksFreeSize;
-    uint32_t     m_IsFreeBitmap;
-    uint8_t      m_MemoryClasses;
-    uint32_t     m_InnerIsFreeBitmap[MAX_MEMORY_CLASSES];
-    uint32_t     m_ListsCount;
+    uint32_t m_IsFreeBitmap;
+    uint8_t m_MemoryClasses;
+    uint32_t m_InnerIsFreeBitmap[MAX_MEMORY_CLASSES];
+    uint32_t m_ListsCount;
     /*
-     * 0: 0-3 lists for small buffers
-     * 1+: 0-(2^SLI-1) lists for normal buffers
-     */
-    Block**                        m_FreeList;
-    VmaPoolAllocator<Block>        m_BlockAllocator;
-    Block*                         m_NullBlock;
+    * 0: 0-3 lists for small buffers
+    * 1+: 0-(2^SLI-1) lists for normal buffers
+    */
+    Block** m_FreeList;
+    VmaPoolAllocator<Block> m_BlockAllocator;
+    Block* m_NullBlock;
     VmaBlockBufferImageGranularity m_GranularityHandler;
 
-    uint8_t  SizeToMemoryClass(VkDeviceSize size) const;
+    uint8_t SizeToMemoryClass(VkDeviceSize size) const;
     uint16_t SizeToSecondIndex(VkDeviceSize size, uint8_t memoryClass) const;
     uint32_t GetListIndex(uint8_t memoryClass, uint16_t secondIndex) const;
     uint32_t GetListIndex(VkDeviceSize size) const;
@@ -10270,23 +10038,29 @@ class VmaBlockMetadata_TLSF : public VmaBlockMetadata
     void MergeBlock(Block* block, Block* prev);
 
     Block* FindFreeBlock(VkDeviceSize size, uint32_t& listIndex) const;
-    bool   CheckBlock(Block&                block,
-                      uint32_t              listIndex,
-                      VkDeviceSize          allocSize,
-                      VkDeviceSize          allocAlignment,
-                      VmaSuballocationType  allocType,
-                      VmaAllocationRequest* pAllocationRequest);
+    bool CheckBlock(
+        Block& block,
+        uint32_t listIndex,
+        VkDeviceSize allocSize,
+        VkDeviceSize allocAlignment,
+        VmaSuballocationType allocType,
+        VmaAllocationRequest* pAllocationRequest);
 };
 
 #ifndef _VMA_BLOCK_METADATA_TLSF_FUNCTIONS
 VmaBlockMetadata_TLSF::VmaBlockMetadata_TLSF(const VkAllocationCallbacks* pAllocationCallbacks,
-                                             VkDeviceSize                 bufferImageGranularity,
-                                             bool                         isVirtual) :
-    VmaBlockMetadata(pAllocationCallbacks, bufferImageGranularity, isVirtual),
-    m_AllocCount(0), m_BlocksFreeCount(0), m_BlocksFreeSize(0), m_IsFreeBitmap(0), m_MemoryClasses(0), m_ListsCount(0),
-    m_FreeList(VMA_NULL), m_BlockAllocator(pAllocationCallbacks, INITIAL_BLOCK_ALLOC_COUNT), m_NullBlock(VMA_NULL),
-    m_GranularityHandler(bufferImageGranularity)
-{}
+    VkDeviceSize bufferImageGranularity, bool isVirtual)
+    : VmaBlockMetadata(pAllocationCallbacks, bufferImageGranularity, isVirtual),
+    m_AllocCount(0),
+    m_BlocksFreeCount(0),
+    m_BlocksFreeSize(0),
+    m_IsFreeBitmap(0),
+    m_MemoryClasses(0),
+    m_ListsCount(0),
+    m_FreeList(VMA_NULL),
+    m_BlockAllocator(pAllocationCallbacks, INITIAL_BLOCK_ALLOC_COUNT),
+    m_NullBlock(VMA_NULL),
+    m_GranularityHandler(bufferImageGranularity) {}
 
 VmaBlockMetadata_TLSF::~VmaBlockMetadata_TLSF()
 {
@@ -10302,23 +10076,23 @@ void VmaBlockMetadata_TLSF::Init(VkDeviceSize size)
     if (!IsVirtual())
         m_GranularityHandler.Init(GetAllocationCallbacks(), size);
 
-    m_NullBlock               = m_BlockAllocator.Alloc();
-    m_NullBlock->size         = size;
-    m_NullBlock->offset       = 0;
+    m_NullBlock = m_BlockAllocator.Alloc();
+    m_NullBlock->size = size;
+    m_NullBlock->offset = 0;
     m_NullBlock->prevPhysical = VMA_NULL;
     m_NullBlock->nextPhysical = VMA_NULL;
     m_NullBlock->MarkFree();
     m_NullBlock->NextFree() = VMA_NULL;
     m_NullBlock->PrevFree() = VMA_NULL;
-    uint8_t  memoryClass    = SizeToMemoryClass(size);
-    uint16_t sli            = SizeToSecondIndex(size, memoryClass);
-    m_ListsCount            = (memoryClass == 0 ? 0 : (memoryClass - 1) * (1UL << SECOND_LEVEL_INDEX) + sli) + 1;
+    uint8_t memoryClass = SizeToMemoryClass(size);
+    uint16_t sli = SizeToSecondIndex(size, memoryClass);
+    m_ListsCount = (memoryClass == 0 ? 0 : (memoryClass - 1) * (1UL << SECOND_LEVEL_INDEX) + sli) + 1;
     if (IsVirtual())
         m_ListsCount += 1UL << SECOND_LEVEL_INDEX;
     else
         m_ListsCount += 4;
 
-    m_MemoryClasses = memoryClass + 2;
+    m_MemoryClasses = memoryClass + uint8_t(2);
     memset(m_InnerIsFreeBitmap, 0, MAX_MEMORY_CLASSES * sizeof(uint32_t));
 
     m_FreeList = vma_new_array(GetAllocationCallbacks(), Block*, m_ListsCount);
@@ -10329,10 +10103,10 @@ bool VmaBlockMetadata_TLSF::Validate() const
 {
     VMA_VALIDATE(GetSumFreeSize() <= GetSize());
 
-    VkDeviceSize calculatedSize     = m_NullBlock->size;
+    VkDeviceSize calculatedSize = m_NullBlock->size;
     VkDeviceSize calculatedFreeSize = m_NullBlock->size;
-    size_t       allocCount         = 0;
-    size_t       freeCount          = 0;
+    size_t allocCount = 0;
+    size_t freeCount = 0;
 
     // Check integrity of free lists
     for (uint32_t list = 0; list < m_ListsCount; ++list)
@@ -10351,8 +10125,8 @@ bool VmaBlockMetadata_TLSF::Validate() const
         }
     }
 
-    VkDeviceSize nextOffset  = m_NullBlock->offset;
-    auto         validateCtx = m_GranularityHandler.StartValidation(GetAllocationCallbacks(), IsVirtual());
+    VkDeviceSize nextOffset = m_NullBlock->offset;
+    auto validateCtx = m_GranularityHandler.StartValidation(GetAllocationCallbacks(), IsVirtual());
 
     VMA_VALIDATE(m_NullBlock->nextPhysical == VMA_NULL);
     if (m_NullBlock->prevPhysical)
@@ -10450,8 +10224,8 @@ void VmaBlockMetadata_TLSF::AddStatistics(VmaStatistics& inoutStats) const
 #if VMA_STATS_STRING_ENABLED
 void VmaBlockMetadata_TLSF::PrintDetailedMap(class VmaJsonWriter& json) const
 {
-    size_t                                     blockCount = m_AllocCount + m_BlocksFreeCount;
-    VmaStlAllocator<Block*>                    allocator(GetAllocationCallbacks());
+    size_t blockCount = m_AllocCount + m_BlocksFreeCount;
+    VmaStlAllocator<Block*> allocator(GetAllocationCallbacks());
     VmaVector<Block*, VmaStlAllocator<Block*>> blockList(blockCount, allocator);
 
     size_t i = blockCount;
@@ -10466,9 +10240,9 @@ void VmaBlockMetadata_TLSF::PrintDetailedMap(class VmaJsonWriter& json) const
     AddDetailedStatistics(stats);
 
     PrintDetailedMap_Begin(json,
-                           stats.statistics.blockBytes - stats.statistics.allocationBytes,
-                           stats.statistics.allocationCount,
-                           stats.unusedRangeCount);
+        stats.statistics.blockBytes - stats.statistics.allocationBytes,
+        stats.statistics.allocationCount,
+        stats.unusedRangeCount);
 
     for (; i < blockCount; ++i)
     {
@@ -10485,12 +10259,13 @@ void VmaBlockMetadata_TLSF::PrintDetailedMap(class VmaJsonWriter& json) const
 }
 #endif
 
-bool VmaBlockMetadata_TLSF::CreateAllocationRequest(VkDeviceSize          allocSize,
-                                                    VkDeviceSize          allocAlignment,
-                                                    bool                  upperAddress,
-                                                    VmaSuballocationType  allocType,
-                                                    uint32_t              strategy,
-                                                    VmaAllocationRequest* pAllocationRequest)
+bool VmaBlockMetadata_TLSF::CreateAllocationRequest(
+    VkDeviceSize allocSize,
+    VkDeviceSize allocAlignment,
+    bool upperAddress,
+    VmaSuballocationType allocType,
+    uint32_t strategy,
+    VmaAllocationRequest* pAllocationRequest)
 {
     VMA_ASSERT(allocSize > 0 && "Cannot allocate empty block!");
     VMA_ASSERT(!upperAddress && "VMA_ALLOCATION_CREATE_UPPER_ADDRESS_BIT can be used only with linear algorithm.");
@@ -10510,7 +10285,7 @@ bool VmaBlockMetadata_TLSF::CreateAllocationRequest(VkDeviceSize          allocS
 
     // Round up to the next block
     VkDeviceSize sizeForNextList = allocSize;
-    VkDeviceSize smallSizeStep   = SMALL_BUFFER_SIZE / (IsVirtual() ? 1 << SECOND_LEVEL_INDEX : 4);
+    VkDeviceSize smallSizeStep = VkDeviceSize(SMALL_BUFFER_SIZE / (IsVirtual() ? 1 << SECOND_LEVEL_INDEX : 4));
     if (allocSize > SMALL_BUFFER_SIZE)
     {
         sizeForNextList += (1ULL << (VMA_BITSCAN_MSB(allocSize) - SECOND_LEVEL_INDEX));
@@ -10522,16 +10297,15 @@ bool VmaBlockMetadata_TLSF::CreateAllocationRequest(VkDeviceSize          allocS
 
     uint32_t nextListIndex = 0;
     uint32_t prevListIndex = 0;
-    Block*   nextListBlock = VMA_NULL;
-    Block*   prevListBlock = VMA_NULL;
+    Block* nextListBlock = VMA_NULL;
+    Block* prevListBlock = VMA_NULL;
 
     // Check blocks according to strategies
     if (strategy & VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT)
     {
         // Quick check for larger block first
         nextListBlock = FindFreeBlock(sizeForNextList, nextListIndex);
-        if (nextListBlock != VMA_NULL &&
-            CheckBlock(*nextListBlock, nextListIndex, allocSize, allocAlignment, allocType, pAllocationRequest))
+        if (nextListBlock != VMA_NULL && CheckBlock(*nextListBlock, nextListIndex, allocSize, allocAlignment, allocType, pAllocationRequest))
             return true;
 
         // If not fitted then null block
@@ -10579,10 +10353,10 @@ bool VmaBlockMetadata_TLSF::CreateAllocationRequest(VkDeviceSize          allocS
             nextListBlock = nextListBlock->NextFree();
         }
     }
-    else if (strategy & VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT)
+    else if (strategy & VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT )
     {
         // Perform search from the start
-        VmaStlAllocator<Block*>                    allocator(GetAllocationCallbacks());
+        VmaStlAllocator<Block*> allocator(GetAllocationCallbacks());
         VmaVector<Block*, VmaStlAllocator<Block*>> blockList(m_BlocksFreeCount, allocator);
 
         size_t i = m_BlocksFreeCount;
@@ -10664,20 +10438,23 @@ VkResult VmaBlockMetadata_TLSF::CheckCorruption(const void* pBlockData)
     return VK_SUCCESS;
 }
 
-void VmaBlockMetadata_TLSF::Alloc(const VmaAllocationRequest& request, VmaSuballocationType type, void* userData)
+void VmaBlockMetadata_TLSF::Alloc(
+    const VmaAllocationRequest& request,
+    VmaSuballocationType type,
+    void* userData)
 {
     VMA_ASSERT(request.type == VmaAllocationRequestType::TLSF);
 
     // Get block and pop it from the free list
-    Block*       currentBlock = (Block*)request.allocHandle;
-    VkDeviceSize offset       = request.algorithmData;
+    Block* currentBlock = (Block*)request.allocHandle;
+    VkDeviceSize offset = request.algorithmData;
     VMA_ASSERT(currentBlock != VMA_NULL);
     VMA_ASSERT(currentBlock->offset <= offset);
 
     if (currentBlock != m_NullBlock)
         RemoveFreeBlock(currentBlock);
 
-    VkDeviceSize debugMargin       = GetDebugMargin();
+    VkDeviceSize debugMargin = GetDebugMargin();
     VkDeviceSize misssingAlignment = offset - currentBlock->offset;
 
     // Append missing alignment to prev block or create new one
@@ -10703,13 +10480,13 @@ void VmaBlockMetadata_TLSF::Alloc(const VmaAllocationRequest& request, VmaSuball
         }
         else
         {
-            Block* newBlock            = m_BlockAllocator.Alloc();
+            Block* newBlock = m_BlockAllocator.Alloc();
             currentBlock->prevPhysical = newBlock;
-            prevBlock->nextPhysical    = newBlock;
-            newBlock->prevPhysical     = prevBlock;
-            newBlock->nextPhysical     = currentBlock;
-            newBlock->size             = misssingAlignment;
-            newBlock->offset           = currentBlock->offset;
+            prevBlock->nextPhysical = newBlock;
+            newBlock->prevPhysical = prevBlock;
+            newBlock->nextPhysical = currentBlock;
+            newBlock->size = misssingAlignment;
+            newBlock->offset = currentBlock->offset;
             newBlock->MarkTaken();
 
             InsertFreeBlock(newBlock);
@@ -10725,14 +10502,14 @@ void VmaBlockMetadata_TLSF::Alloc(const VmaAllocationRequest& request, VmaSuball
         if (currentBlock == m_NullBlock)
         {
             // Setup new null block
-            m_NullBlock               = m_BlockAllocator.Alloc();
-            m_NullBlock->size         = 0;
-            m_NullBlock->offset       = currentBlock->offset + size;
+            m_NullBlock = m_BlockAllocator.Alloc();
+            m_NullBlock->size = 0;
+            m_NullBlock->offset = currentBlock->offset + size;
             m_NullBlock->prevPhysical = currentBlock;
             m_NullBlock->nextPhysical = VMA_NULL;
             m_NullBlock->MarkFree();
-            m_NullBlock->PrevFree()    = VMA_NULL;
-            m_NullBlock->NextFree()    = VMA_NULL;
+            m_NullBlock->PrevFree() = VMA_NULL;
+            m_NullBlock->NextFree() = VMA_NULL;
             currentBlock->nextPhysical = m_NullBlock;
             currentBlock->MarkTaken();
         }
@@ -10742,13 +10519,13 @@ void VmaBlockMetadata_TLSF::Alloc(const VmaAllocationRequest& request, VmaSuball
         VMA_ASSERT(currentBlock->size > size && "Proper block already found, shouldn't find smaller one!");
 
         // Create new free block
-        Block* newBlock            = m_BlockAllocator.Alloc();
-        newBlock->size             = currentBlock->size - size;
-        newBlock->offset           = currentBlock->offset + size;
-        newBlock->prevPhysical     = currentBlock;
-        newBlock->nextPhysical     = currentBlock->nextPhysical;
+        Block* newBlock = m_BlockAllocator.Alloc();
+        newBlock->size = currentBlock->size - size;
+        newBlock->offset = currentBlock->offset + size;
+        newBlock->prevPhysical = currentBlock;
+        newBlock->nextPhysical = currentBlock->nextPhysical;
         currentBlock->nextPhysical = newBlock;
-        currentBlock->size         = size;
+        currentBlock->size = size;
 
         if (currentBlock == m_NullBlock)
         {
@@ -10770,27 +10547,27 @@ void VmaBlockMetadata_TLSF::Alloc(const VmaAllocationRequest& request, VmaSuball
     if (debugMargin > 0)
     {
         currentBlock->size -= debugMargin;
-        Block* newBlock        = m_BlockAllocator.Alloc();
-        newBlock->size         = debugMargin;
-        newBlock->offset       = currentBlock->offset + currentBlock->size;
+        Block* newBlock = m_BlockAllocator.Alloc();
+        newBlock->size = debugMargin;
+        newBlock->offset = currentBlock->offset + currentBlock->size;
         newBlock->prevPhysical = currentBlock;
         newBlock->nextPhysical = currentBlock->nextPhysical;
         newBlock->MarkTaken();
         currentBlock->nextPhysical->prevPhysical = newBlock;
-        currentBlock->nextPhysical               = newBlock;
+        currentBlock->nextPhysical = newBlock;
         InsertFreeBlock(newBlock);
     }
 
     if (!IsVirtual())
-        m_GranularityHandler.AllocPages(
-            (uint8_t)(uintptr_t)request.customData, currentBlock->offset, currentBlock->size);
+        m_GranularityHandler.AllocPages((uint8_t)(uintptr_t)request.customData,
+            currentBlock->offset, currentBlock->size);
     ++m_AllocCount;
 }
 
 void VmaBlockMetadata_TLSF::Free(VmaAllocHandle allocHandle)
 {
     Block* block = (Block*)allocHandle;
-    Block* next  = block->nextPhysical;
+    Block* next = block->nextPhysical;
     VMA_ASSERT(!block->IsFree() && "Block is already free!");
 
     if (!IsVirtual())
@@ -10803,7 +10580,7 @@ void VmaBlockMetadata_TLSF::Free(VmaAllocHandle allocHandle)
         RemoveFreeBlock(next);
         MergeBlock(next, block);
         block = next;
-        next  = next->nextPhysical;
+        next = next->nextPhysical;
     }
 
     // Try merging
@@ -10830,8 +10607,8 @@ void VmaBlockMetadata_TLSF::GetAllocationInfo(VmaAllocHandle allocHandle, VmaVir
 {
     Block* block = (Block*)allocHandle;
     VMA_ASSERT(!block->IsFree() && "Cannot get allocation info for free block!");
-    outInfo.offset    = block->offset;
-    outInfo.size      = block->size;
+    outInfo.offset = block->offset;
+    outInfo.size = block->size;
     outInfo.pUserData = block->UserData();
 }
 
@@ -10881,13 +10658,13 @@ VkDeviceSize VmaBlockMetadata_TLSF::GetNextFreeRegionSize(VmaAllocHandle alloc) 
 
 void VmaBlockMetadata_TLSF::Clear()
 {
-    m_AllocCount              = 0;
-    m_BlocksFreeCount         = 0;
-    m_BlocksFreeSize          = 0;
-    m_IsFreeBitmap            = 0;
-    m_NullBlock->offset       = 0;
-    m_NullBlock->size         = GetSize();
-    Block* block              = m_NullBlock->prevPhysical;
+    m_AllocCount = 0;
+    m_BlocksFreeCount = 0;
+    m_BlocksFreeSize = 0;
+    m_IsFreeBitmap = 0;
+    m_NullBlock->offset = 0;
+    m_NullBlock->size = GetSize();
+    Block* block = m_NullBlock->prevPhysical;
     m_NullBlock->prevPhysical = VMA_NULL;
     while (block)
     {
@@ -10917,7 +10694,7 @@ void VmaBlockMetadata_TLSF::DebugLogAllAllocations() const
 uint8_t VmaBlockMetadata_TLSF::SizeToMemoryClass(VkDeviceSize size) const
 {
     if (size > SMALL_BUFFER_SIZE)
-        return VMA_BITSCAN_MSB(size) - MEMORY_CLASS_SHIFT;
+        return uint8_t(VMA_BITSCAN_MSB(size) - MEMORY_CLASS_SHIFT);
     return 0;
 }
 
@@ -10930,8 +10707,7 @@ uint16_t VmaBlockMetadata_TLSF::SizeToSecondIndex(VkDeviceSize size, uint8_t mem
         else
             return static_cast<uint16_t>((size - 1) / 64);
     }
-    return static_cast<uint16_t>((size >> (memoryClass + MEMORY_CLASS_SHIFT - SECOND_LEVEL_INDEX)) ^
-                                 (1U << SECOND_LEVEL_INDEX));
+    return static_cast<uint16_t>((size >> (memoryClass + MEMORY_CLASS_SHIFT - SECOND_LEVEL_INDEX)) ^ (1U << SECOND_LEVEL_INDEX));
 }
 
 uint32_t VmaBlockMetadata_TLSF::GetListIndex(uint8_t memoryClass, uint16_t secondIndex) const
@@ -10963,9 +10739,9 @@ void VmaBlockMetadata_TLSF::RemoveFreeBlock(Block* block)
         block->PrevFree()->NextFree() = block->NextFree();
     else
     {
-        uint8_t  memClass    = SizeToMemoryClass(block->size);
+        uint8_t memClass = SizeToMemoryClass(block->size);
         uint16_t secondIndex = SizeToSecondIndex(block->size, memClass);
-        uint32_t index       = GetListIndex(memClass, secondIndex);
+        uint32_t index = GetListIndex(memClass, secondIndex);
         VMA_ASSERT(m_FreeList[index] == block);
         m_FreeList[index] = block->NextFree();
         if (block->NextFree() == VMA_NULL)
@@ -10986,9 +10762,9 @@ void VmaBlockMetadata_TLSF::InsertFreeBlock(Block* block)
     VMA_ASSERT(block != m_NullBlock);
     VMA_ASSERT(!block->IsFree() && "Cannot insert block twice!");
 
-    uint8_t  memClass    = SizeToMemoryClass(block->size);
+    uint8_t memClass = SizeToMemoryClass(block->size);
     uint16_t secondIndex = SizeToSecondIndex(block->size, memClass);
-    uint32_t index       = GetListIndex(memClass, secondIndex);
+    uint32_t index = GetListIndex(memClass, secondIndex);
     VMA_ASSERT(index < m_ListsCount);
     block->PrevFree() = VMA_NULL;
     block->NextFree() = m_FreeList[index];
@@ -11006,7 +10782,7 @@ void VmaBlockMetadata_TLSF::InsertFreeBlock(Block* block)
 
 void VmaBlockMetadata_TLSF::MergeBlock(Block* block, Block* prev)
 {
-    VMA_ASSERT(block->prevPhysical == prev && "Cannot merge seperate physical regions!");
+    VMA_ASSERT(block->prevPhysical == prev && "Cannot merge separate physical regions!");
     VMA_ASSERT(!prev->IsFree() && "Cannot merge block that belongs to free list!");
 
     block->offset = prev->offset;
@@ -11019,17 +10795,17 @@ void VmaBlockMetadata_TLSF::MergeBlock(Block* block, Block* prev)
 
 VmaBlockMetadata_TLSF::Block* VmaBlockMetadata_TLSF::FindFreeBlock(VkDeviceSize size, uint32_t& listIndex) const
 {
-    uint8_t  memoryClass  = SizeToMemoryClass(size);
+    uint8_t memoryClass = SizeToMemoryClass(size);
     uint32_t innerFreeMap = m_InnerIsFreeBitmap[memoryClass] & (~0U << SizeToSecondIndex(size, memoryClass));
     if (!innerFreeMap)
     {
-        // Check higher levels for avaiable blocks
+        // Check higher levels for available blocks
         uint32_t freeMap = m_IsFreeBitmap & (~0UL << (memoryClass + 1));
         if (!freeMap)
-            return VMA_NULL; // No more memory avaible
+            return VMA_NULL; // No more memory available
 
         // Find lowest free region
-        memoryClass  = VMA_BITSCAN_LSB(freeMap);
+        memoryClass = VMA_BITSCAN_LSB(freeMap);
         innerFreeMap = m_InnerIsFreeBitmap[memoryClass];
         VMA_ASSERT(innerFreeMap != 0);
     }
@@ -11039,12 +10815,13 @@ VmaBlockMetadata_TLSF::Block* VmaBlockMetadata_TLSF::FindFreeBlock(VkDeviceSize 
     return m_FreeList[listIndex];
 }
 
-bool VmaBlockMetadata_TLSF::CheckBlock(Block&                block,
-                                       uint32_t              listIndex,
-                                       VkDeviceSize          allocSize,
-                                       VkDeviceSize          allocAlignment,
-                                       VmaSuballocationType  allocType,
-                                       VmaAllocationRequest* pAllocationRequest)
+bool VmaBlockMetadata_TLSF::CheckBlock(
+    Block& block,
+    uint32_t listIndex,
+    VkDeviceSize allocSize,
+    VkDeviceSize allocAlignment,
+    VmaSuballocationType allocType,
+    VmaAllocationRequest* pAllocationRequest)
 {
     VMA_ASSERT(block.IsFree() && "Block is already taken!");
 
@@ -11058,10 +10835,10 @@ bool VmaBlockMetadata_TLSF::CheckBlock(Block&                block,
         return false;
 
     // Alloc successful
-    pAllocationRequest->type          = VmaAllocationRequestType::TLSF;
-    pAllocationRequest->allocHandle   = (VmaAllocHandle)&block;
-    pAllocationRequest->size          = allocSize - GetDebugMargin();
-    pAllocationRequest->customData    = (void*)allocType;
+    pAllocationRequest->type = VmaAllocationRequestType::TLSF;
+    pAllocationRequest->allocHandle = (VmaAllocHandle)&block;
+    pAllocationRequest->size = allocSize - GetDebugMargin();
+    pAllocationRequest->customData = (void*)allocType;
     pAllocationRequest->algorithmData = alignedOffset;
 
     // Place block at the start of list if it's normal block
@@ -11070,8 +10847,8 @@ bool VmaBlockMetadata_TLSF::CheckBlock(Block&                block,
         block.PrevFree()->NextFree() = block.NextFree();
         if (block.NextFree())
             block.NextFree()->PrevFree() = block.PrevFree();
-        block.PrevFree()      = VMA_NULL;
-        block.NextFree()      = m_FreeList[listIndex];
+        block.PrevFree() = VMA_NULL;
+        block.NextFree() = m_FreeList[listIndex];
         m_FreeList[listIndex] = &block;
         if (block.NextFree())
             block.NextFree()->PrevFree() = &block;
@@ -11092,50 +10869,52 @@ Synchronized internally with a mutex.
 class VmaBlockVector
 {
     friend struct VmaDefragmentationContext_T;
-    VMA_CLASS_NO_COPY(VmaBlockVector)
-  public:
-    VmaBlockVector(VmaAllocator hAllocator,
-                   VmaPool      hParentPool,
-                   uint32_t     memoryTypeIndex,
-                   VkDeviceSize preferredBlockSize,
-                   size_t       minBlockCount,
-                   size_t       maxBlockCount,
-                   VkDeviceSize bufferImageGranularity,
-                   bool         explicitBlockSize,
-                   uint32_t     algorithm,
-                   float        priority,
-                   VkDeviceSize minAllocationAlignment,
-                   void*        pMemoryAllocateNext);
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaBlockVector)
+public:
+    VmaBlockVector(
+        VmaAllocator hAllocator,
+        VmaPool hParentPool,
+        uint32_t memoryTypeIndex,
+        VkDeviceSize preferredBlockSize,
+        size_t minBlockCount,
+        size_t maxBlockCount,
+        VkDeviceSize bufferImageGranularity,
+        bool explicitBlockSize,
+        uint32_t algorithm,
+        float priority,
+        VkDeviceSize minAllocationAlignment,
+        void* pMemoryAllocateNext);
     ~VmaBlockVector();
 
     VmaAllocator GetAllocator() const { return m_hAllocator; }
-    VmaPool      GetParentPool() const { return m_hParentPool; }
-    bool         IsCustomPool() const { return m_hParentPool != VMA_NULL; }
-    uint32_t     GetMemoryTypeIndex() const { return m_MemoryTypeIndex; }
+    VmaPool GetParentPool() const { return m_hParentPool; }
+    bool IsCustomPool() const { return m_hParentPool != VMA_NULL; }
+    uint32_t GetMemoryTypeIndex() const { return m_MemoryTypeIndex; }
     VkDeviceSize GetPreferredBlockSize() const { return m_PreferredBlockSize; }
     VkDeviceSize GetBufferImageGranularity() const { return m_BufferImageGranularity; }
-    uint32_t     GetAlgorithm() const { return m_Algorithm; }
-    bool         HasExplicitBlockSize() const { return m_ExplicitBlockSize; }
-    float        GetPriority() const { return m_Priority; }
-    const void*  GetAllocationNextPtr() const { return m_pMemoryAllocateNext; }
+    uint32_t GetAlgorithm() const { return m_Algorithm; }
+    bool HasExplicitBlockSize() const { return m_ExplicitBlockSize; }
+    float GetPriority() const { return m_Priority; }
+    const void* GetAllocationNextPtr() const { return m_pMemoryAllocateNext; }
     // To be used only while the m_Mutex is locked. Used during defragmentation.
     size_t GetBlockCount() const { return m_Blocks.size(); }
     // To be used only while the m_Mutex is locked. Used during defragmentation.
     VmaDeviceMemoryBlock* GetBlock(size_t index) const { return m_Blocks[index]; }
-    VMA_RW_MUTEX&         GetMutex() { return m_Mutex; }
+    VMA_RW_MUTEX &GetMutex() { return m_Mutex; }
 
     VkResult CreateMinBlocks();
-    void     AddStatistics(VmaStatistics& inoutStats);
-    void     AddDetailedStatistics(VmaDetailedStatistics& inoutStats);
-    bool     IsEmpty();
-    bool     IsCorruptionDetectionEnabled() const;
+    void AddStatistics(VmaStatistics& inoutStats);
+    void AddDetailedStatistics(VmaDetailedStatistics& inoutStats);
+    bool IsEmpty();
+    bool IsCorruptionDetectionEnabled() const;
 
-    VkResult Allocate(VkDeviceSize                   size,
-                      VkDeviceSize                   alignment,
-                      const VmaAllocationCreateInfo& createInfo,
-                      VmaSuballocationType           suballocType,
-                      size_t                         allocationCount,
-                      VmaAllocation*                 pAllocations);
+    VkResult Allocate(
+        VkDeviceSize size,
+        VkDeviceSize alignment,
+        const VmaAllocationCreateInfo& createInfo,
+        VmaSuballocationType suballocType,
+        size_t allocationCount,
+        VmaAllocation* pAllocations);
 
     void Free(const VmaAllocation hAllocation);
 
@@ -11145,25 +10924,25 @@ class VmaBlockVector
 
     VkResult CheckCorruption();
 
-  private:
+private:
     const VmaAllocator m_hAllocator;
-    const VmaPool      m_hParentPool;
-    const uint32_t     m_MemoryTypeIndex;
+    const VmaPool m_hParentPool;
+    const uint32_t m_MemoryTypeIndex;
     const VkDeviceSize m_PreferredBlockSize;
-    const size_t       m_MinBlockCount;
-    const size_t       m_MaxBlockCount;
+    const size_t m_MinBlockCount;
+    const size_t m_MaxBlockCount;
     const VkDeviceSize m_BufferImageGranularity;
-    const bool         m_ExplicitBlockSize;
-    const uint32_t     m_Algorithm;
-    const float        m_Priority;
+    const bool m_ExplicitBlockSize;
+    const uint32_t m_Algorithm;
+    const float m_Priority;
     const VkDeviceSize m_MinAllocationAlignment;
 
-    void* const  m_pMemoryAllocateNext;
+    void* const m_pMemoryAllocateNext;
     VMA_RW_MUTEX m_Mutex;
     // Incrementally sorted by sumFreeSize, ascending.
     VmaVector<VmaDeviceMemoryBlock*, VmaStlAllocator<VmaDeviceMemoryBlock*>> m_Blocks;
-    uint32_t                                                                 m_NextBlockId;
-    bool                                                                     m_IncrementalSort = true;
+    uint32_t m_NextBlockId;
+    bool m_IncrementalSort = true;
 
     void SetIncrementalSort(bool val) { m_IncrementalSort = val; }
 
@@ -11175,40 +10954,45 @@ class VmaBlockVector
     void IncrementallySortBlocks();
     void SortByFreeSize();
 
-    VkResult AllocatePage(VkDeviceSize                   size,
-                          VkDeviceSize                   alignment,
-                          const VmaAllocationCreateInfo& createInfo,
-                          VmaSuballocationType           suballocType,
-                          VmaAllocation*                 pAllocation);
+    VkResult AllocatePage(
+        VkDeviceSize size,
+        VkDeviceSize alignment,
+        const VmaAllocationCreateInfo& createInfo,
+        VmaSuballocationType suballocType,
+        VmaAllocation* pAllocation);
 
-    VkResult AllocateFromBlock(VmaDeviceMemoryBlock*    pBlock,
-                               VkDeviceSize             size,
-                               VkDeviceSize             alignment,
-                               VmaAllocationCreateFlags allocFlags,
-                               void*                    pUserData,
-                               VmaSuballocationType     suballocType,
-                               uint32_t                 strategy,
-                               VmaAllocation*           pAllocation);
+    VkResult AllocateFromBlock(
+        VmaDeviceMemoryBlock* pBlock,
+        VkDeviceSize size,
+        VkDeviceSize alignment,
+        VmaAllocationCreateFlags allocFlags,
+        void* pUserData,
+        VmaSuballocationType suballocType,
+        uint32_t strategy,
+        VmaAllocation* pAllocation);
 
-    VkResult CommitAllocationRequest(VmaAllocationRequest&    allocRequest,
-                                     VmaDeviceMemoryBlock*    pBlock,
-                                     VkDeviceSize             alignment,
-                                     VmaAllocationCreateFlags allocFlags,
-                                     void*                    pUserData,
-                                     VmaSuballocationType     suballocType,
-                                     VmaAllocation*           pAllocation);
+    VkResult CommitAllocationRequest(
+        VmaAllocationRequest& allocRequest,
+        VmaDeviceMemoryBlock* pBlock,
+        VkDeviceSize alignment,
+        VmaAllocationCreateFlags allocFlags,
+        void* pUserData,
+        VmaSuballocationType suballocType,
+        VmaAllocation* pAllocation);
 
     VkResult CreateBlock(VkDeviceSize blockSize, size_t* pNewBlockIndex);
-    bool     HasEmptyBlock();
+    bool HasEmptyBlock();
 };
 #endif // _VMA_BLOCK_VECTOR
 
 #ifndef _VMA_DEFRAGMENTATION_CONTEXT
 struct VmaDefragmentationContext_T
 {
-    VMA_CLASS_NO_COPY(VmaDefragmentationContext_T)
-  public:
-    VmaDefragmentationContext_T(VmaAllocator hAllocator, const VmaDefragmentationInfo& info);
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaDefragmentationContext_T)
+public:
+    VmaDefragmentationContext_T(
+        VmaAllocator hAllocator,
+        const VmaDefragmentationInfo& info);
     ~VmaDefragmentationContext_T();
 
     void GetStats(VmaDefragmentationStats& outStats) { outStats = m_GlobalStats; }
@@ -11216,72 +11000,62 @@ struct VmaDefragmentationContext_T
     VkResult DefragmentPassBegin(VmaDefragmentationPassMoveInfo& moveInfo);
     VkResult DefragmentPassEnd(VmaDefragmentationPassMoveInfo& moveInfo);
 
-  private:
+private:
     // Max number of allocations to ignore due to size constraints before ending single pass
     static const uint8_t MAX_ALLOCS_TO_IGNORE = 16;
-    enum class CounterStatus
-    {
-        Pass,
-        Ignore,
-        End
-    };
+    enum class CounterStatus { Pass, Ignore, End };
 
     struct FragmentedBlock
     {
-        uint32_t              data;
+        uint32_t data;
         VmaDeviceMemoryBlock* block;
     };
     struct StateBalanced
     {
-        VkDeviceSize avgFreeSize  = 0;
+        VkDeviceSize avgFreeSize = 0;
         VkDeviceSize avgAllocSize = UINT64_MAX;
     };
     struct StateExtensive
     {
         enum class Operation : uint8_t
         {
-            FindFreeBlockBuffer,
-            FindFreeBlockTexture,
-            FindFreeBlockAll,
-            MoveBuffers,
-            MoveTextures,
-            MoveAll,
-            Cleanup,
-            Done
+            FindFreeBlockBuffer, FindFreeBlockTexture, FindFreeBlockAll,
+            MoveBuffers, MoveTextures, MoveAll,
+            Cleanup, Done
         };
 
-        Operation operation      = Operation::FindFreeBlockTexture;
-        size_t    firstFreeBlock = SIZE_MAX;
+        Operation operation = Operation::FindFreeBlockTexture;
+        size_t firstFreeBlock = SIZE_MAX;
     };
     struct MoveAllocationData
     {
-        VkDeviceSize             size;
-        VkDeviceSize             alignment;
-        VmaSuballocationType     type;
+        VkDeviceSize size;
+        VkDeviceSize alignment;
+        VmaSuballocationType type;
         VmaAllocationCreateFlags flags;
-        VmaDefragmentationMove   move = {};
+        VmaDefragmentationMove move = {};
     };
 
     const VkDeviceSize m_MaxPassBytes;
-    const uint32_t     m_MaxPassAllocations;
+    const uint32_t m_MaxPassAllocations;
 
-    VmaStlAllocator<VmaDefragmentationMove>                                    m_MoveAllocator;
+    VmaStlAllocator<VmaDefragmentationMove> m_MoveAllocator;
     VmaVector<VmaDefragmentationMove, VmaStlAllocator<VmaDefragmentationMove>> m_Moves;
 
-    uint8_t                 m_IgnoredAllocs = 0;
-    uint32_t                m_Algorithm;
-    uint32_t                m_BlockVectorCount;
-    VmaBlockVector*         m_PoolBlockVector;
-    VmaBlockVector**        m_pBlockVectors;
-    size_t                  m_ImmovableBlockCount = 0;
-    VmaDefragmentationStats m_GlobalStats         = { 0 };
-    VmaDefragmentationStats m_PassStats           = { 0 };
-    void*                   m_AlgorithmState      = VMA_NULL;
+    uint8_t m_IgnoredAllocs = 0;
+    uint32_t m_Algorithm;
+    uint32_t m_BlockVectorCount;
+    VmaBlockVector* m_PoolBlockVector;
+    VmaBlockVector** m_pBlockVectors;
+    size_t m_ImmovableBlockCount = 0;
+    VmaDefragmentationStats m_GlobalStats = { 0 };
+    VmaDefragmentationStats m_PassStats = { 0 };
+    void* m_AlgorithmState = VMA_NULL;
 
     static MoveAllocationData GetMoveData(VmaAllocHandle handle, VmaBlockMetadata* metadata);
-    CounterStatus             CheckCounters(VkDeviceSize bytes);
-    bool                      IncrementCounters(VkDeviceSize bytes);
-    bool                      ReallocWithinBlock(VmaBlockVector& vector, VmaDeviceMemoryBlock* block);
+    CounterStatus CheckCounters(VkDeviceSize bytes);
+    bool IncrementCounters(VkDeviceSize bytes);
+    bool ReallocWithinBlock(VmaBlockVector& vector, VmaDeviceMemoryBlock* block);
     bool AllocInOtherBlock(size_t start, size_t end, MoveAllocationData& data, VmaBlockVector& vector);
 
     bool ComputeDefragmentation(VmaBlockVector& vector, size_t index);
@@ -11292,11 +11066,8 @@ struct VmaDefragmentationContext_T
 
     void UpdateVectorStatistics(VmaBlockVector& vector, StateBalanced& state);
     bool MoveDataToFreeBlocks(VmaSuballocationType currentType,
-                              VmaBlockVector&      vector,
-                              size_t               firstFreeBlock,
-                              bool&                texturePresent,
-                              bool&                bufferPresent,
-                              bool&                otherPresent);
+        VmaBlockVector& vector, size_t firstFreeBlock,
+        bool& texturePresent, bool& bufferPresent, bool& otherPresent);
 };
 #endif // _VMA_DEFRAGMENTATION_CONTEXT
 
@@ -11304,31 +11075,30 @@ struct VmaDefragmentationContext_T
 struct VmaPool_T
 {
     friend struct VmaPoolListItemTraits;
-    VMA_CLASS_NO_COPY(VmaPool_T)
-  public:
-    VmaBlockVector             m_BlockVector;
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaPool_T)
+public:
+    VmaBlockVector m_BlockVector;
     VmaDedicatedAllocationList m_DedicatedAllocations;
 
-    VmaPool_T(VmaAllocator hAllocator, const VmaPoolCreateInfo& createInfo, VkDeviceSize preferredBlockSize);
+    VmaPool_T(
+        VmaAllocator hAllocator,
+        const VmaPoolCreateInfo& createInfo,
+        VkDeviceSize preferredBlockSize);
     ~VmaPool_T();
 
     uint32_t GetId() const { return m_Id; }
-    void     SetId(uint32_t id)
-    {
-        VMA_ASSERT(m_Id == 0);
-        m_Id = id;
-    }
+    void SetId(uint32_t id) { VMA_ASSERT(m_Id == 0); m_Id = id; }
 
     const char* GetName() const { return m_Name; }
-    void        SetName(const char* pName);
+    void SetName(const char* pName);
 
 #if VMA_STATS_STRING_ENABLED
-    // void PrintDetailedMap(class VmaStringBuilder& sb);
+    //void PrintDetailedMap(class VmaStringBuilder& sb);
 #endif
 
-  private:
-    uint32_t   m_Id;
-    char*      m_Name;
+private:
+    uint32_t m_Id;
+    char* m_Name;
     VmaPool_T* m_PrevPool = VMA_NULL;
     VmaPool_T* m_NextPool = VMA_NULL;
 };
@@ -11337,8 +11107,8 @@ struct VmaPoolListItemTraits
 {
     typedef VmaPool_T ItemType;
 
-    static ItemType*  GetPrev(const ItemType* item) { return item->m_PrevPool; }
-    static ItemType*  GetNext(const ItemType* item) { return item->m_NextPool; }
+    static ItemType* GetPrev(const ItemType* item) { return item->m_PrevPool; }
+    static ItemType* GetNext(const ItemType* item) { return item->m_NextPool; }
     static ItemType*& AccessPrev(ItemType* item) { return item->m_PrevPool; }
     static ItemType*& AccessNext(ItemType* item) { return item->m_NextPool; }
 };
@@ -11347,6 +11117,9 @@ struct VmaPoolListItemTraits
 #ifndef _VMA_CURRENT_BUDGET_DATA
 struct VmaCurrentBudgetData
 {
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaCurrentBudgetData)
+public:
+
     VMA_ATOMIC_UINT32 m_BlockCount[VK_MAX_MEMORY_HEAPS];
     VMA_ATOMIC_UINT32 m_AllocationCount[VK_MAX_MEMORY_HEAPS];
     VMA_ATOMIC_UINT64 m_BlockBytes[VK_MAX_MEMORY_HEAPS];
@@ -11354,10 +11127,10 @@ struct VmaCurrentBudgetData
 
 #if VMA_MEMORY_BUDGET
     VMA_ATOMIC_UINT32 m_OperationsSinceBudgetFetch;
-    VMA_RW_MUTEX      m_BudgetMutex;
-    uint64_t          m_VulkanUsage[VK_MAX_MEMORY_HEAPS];
-    uint64_t          m_VulkanBudget[VK_MAX_MEMORY_HEAPS];
-    uint64_t          m_BlockBytesAtBudgetFetch[VK_MAX_MEMORY_HEAPS];
+    VMA_RW_MUTEX m_BudgetMutex;
+    uint64_t m_VulkanUsage[VK_MAX_MEMORY_HEAPS];
+    uint64_t m_VulkanBudget[VK_MAX_MEMORY_HEAPS];
+    uint64_t m_BlockBytesAtBudgetFetch[VK_MAX_MEMORY_HEAPS];
 #endif // VMA_MEMORY_BUDGET
 
     VmaCurrentBudgetData();
@@ -11371,13 +11144,13 @@ VmaCurrentBudgetData::VmaCurrentBudgetData()
 {
     for (uint32_t heapIndex = 0; heapIndex < VK_MAX_MEMORY_HEAPS; ++heapIndex)
     {
-        m_BlockCount[heapIndex]      = 0;
+        m_BlockCount[heapIndex] = 0;
         m_AllocationCount[heapIndex] = 0;
-        m_BlockBytes[heapIndex]      = 0;
+        m_BlockBytes[heapIndex] = 0;
         m_AllocationBytes[heapIndex] = 0;
 #if VMA_MEMORY_BUDGET
-        m_VulkanUsage[heapIndex]             = 0;
-        m_VulkanBudget[heapIndex]            = 0;
+        m_VulkanUsage[heapIndex] = 0;
+        m_VulkanBudget[heapIndex] = 0;
         m_BlockBytesAtBudgetFetch[heapIndex] = 0;
 #endif
     }
@@ -11415,22 +11188,20 @@ Thread-safe wrapper over VmaPoolAllocator free list, for allocation of VmaAlloca
 */
 class VmaAllocationObjectAllocator
 {
-    VMA_CLASS_NO_COPY(VmaAllocationObjectAllocator)
-  public:
-    VmaAllocationObjectAllocator(const VkAllocationCallbacks* pAllocationCallbacks) :
-        m_Allocator(pAllocationCallbacks, 1024)
-    {}
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaAllocationObjectAllocator)
+public:
+    VmaAllocationObjectAllocator(const VkAllocationCallbacks* pAllocationCallbacks)
+        : m_Allocator(pAllocationCallbacks, 1024) {}
 
-    template <typename... Types>
-    VmaAllocation Allocate(Types&&... args);
-    void          Free(VmaAllocation hAlloc);
+    template<typename... Types> VmaAllocation Allocate(Types&&... args);
+    void Free(VmaAllocation hAlloc);
 
-  private:
-    VMA_MUTEX                         m_Mutex;
+private:
+    VMA_MUTEX m_Mutex;
     VmaPoolAllocator<VmaAllocation_T> m_Allocator;
 };
 
-template <typename... Types>
+template<typename... Types>
 VmaAllocation VmaAllocationObjectAllocator::Allocate(Types&&... args)
 {
     VmaMutexLock mutexLock(m_Mutex);
@@ -11447,55 +11218,51 @@ void VmaAllocationObjectAllocator::Free(VmaAllocation hAlloc)
 #ifndef _VMA_VIRTUAL_BLOCK_T
 struct VmaVirtualBlock_T
 {
-    VMA_CLASS_NO_COPY(VmaVirtualBlock_T)
-  public:
-    const bool                  m_AllocationCallbacksSpecified;
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaVirtualBlock_T)
+public:
+    const bool m_AllocationCallbacksSpecified;
     const VkAllocationCallbacks m_AllocationCallbacks;
 
     VmaVirtualBlock_T(const VmaVirtualBlockCreateInfo& createInfo);
     ~VmaVirtualBlock_T();
 
     VkResult Init() { return VK_SUCCESS; }
-    bool     IsEmpty() const { return m_Metadata->IsEmpty(); }
-    void     Free(VmaVirtualAllocation allocation) { m_Metadata->Free((VmaAllocHandle)allocation); }
-    void     SetAllocationUserData(VmaVirtualAllocation allocation, void* userData)
-    {
-        m_Metadata->SetAllocationUserData((VmaAllocHandle)allocation, userData);
-    }
+    bool IsEmpty() const { return m_Metadata->IsEmpty(); }
+    void Free(VmaVirtualAllocation allocation) { m_Metadata->Free((VmaAllocHandle)allocation); }
+    void SetAllocationUserData(VmaVirtualAllocation allocation, void* userData) { m_Metadata->SetAllocationUserData((VmaAllocHandle)allocation, userData); }
     void Clear() { m_Metadata->Clear(); }
 
     const VkAllocationCallbacks* GetAllocationCallbacks() const;
-    void                         GetAllocationInfo(VmaVirtualAllocation allocation, VmaVirtualAllocationInfo& outInfo);
-    VkResult                     Allocate(const VmaVirtualAllocationCreateInfo& createInfo,
-                                          VmaVirtualAllocation&                 outAllocation,
-                                          VkDeviceSize*                         outOffset);
-    void                         GetStatistics(VmaStatistics& outStats) const;
-    void                         CalculateDetailedStatistics(VmaDetailedStatistics& outStats) const;
+    void GetAllocationInfo(VmaVirtualAllocation allocation, VmaVirtualAllocationInfo& outInfo);
+    VkResult Allocate(const VmaVirtualAllocationCreateInfo& createInfo, VmaVirtualAllocation& outAllocation,
+        VkDeviceSize* outOffset);
+    void GetStatistics(VmaStatistics& outStats) const;
+    void CalculateDetailedStatistics(VmaDetailedStatistics& outStats) const;
 #if VMA_STATS_STRING_ENABLED
     void BuildStatsString(bool detailedMap, VmaStringBuilder& sb) const;
 #endif
 
-  private:
+private:
     VmaBlockMetadata* m_Metadata;
 };
 
 #ifndef _VMA_VIRTUAL_BLOCK_T_FUNCTIONS
-VmaVirtualBlock_T::VmaVirtualBlock_T(const VmaVirtualBlockCreateInfo& createInfo) :
-    m_AllocationCallbacksSpecified(createInfo.pAllocationCallbacks != VMA_NULL),
-    m_AllocationCallbacks(createInfo.pAllocationCallbacks != VMA_NULL ? *createInfo.pAllocationCallbacks
-                                                                      : VmaEmptyAllocationCallbacks)
+VmaVirtualBlock_T::VmaVirtualBlock_T(const VmaVirtualBlockCreateInfo& createInfo)
+    : m_AllocationCallbacksSpecified(createInfo.pAllocationCallbacks != VMA_NULL),
+    m_AllocationCallbacks(createInfo.pAllocationCallbacks != VMA_NULL ? *createInfo.pAllocationCallbacks : VmaEmptyAllocationCallbacks)
 {
     const uint32_t algorithm = createInfo.flags & VMA_VIRTUAL_BLOCK_CREATE_ALGORITHM_MASK;
     switch (algorithm)
     {
-        default:
-            VMA_ASSERT(0);
-        case 0:
-            m_Metadata = vma_new(GetAllocationCallbacks(), VmaBlockMetadata_TLSF)(VK_NULL_HANDLE, 1, true);
-            break;
-        case VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT:
-            m_Metadata = vma_new(GetAllocationCallbacks(), VmaBlockMetadata_Linear)(VK_NULL_HANDLE, 1, true);
-            break;
+    case 0:
+        m_Metadata = vma_new(GetAllocationCallbacks(), VmaBlockMetadata_TLSF)(VK_NULL_HANDLE, 1, true);
+        break;
+    case VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT:
+        m_Metadata = vma_new(GetAllocationCallbacks(), VmaBlockMetadata_Linear)(VK_NULL_HANDLE, 1, true);
+        break;
+    default:
+        VMA_ASSERT(0);
+        m_Metadata = vma_new(GetAllocationCallbacks(), VmaBlockMetadata_TLSF)(VK_NULL_HANDLE, 1, true);
     }
 
     m_Metadata->Init(createInfo.size);
@@ -11503,13 +11270,12 @@ VmaVirtualBlock_T::VmaVirtualBlock_T(const VmaVirtualBlockCreateInfo& createInfo
 
 VmaVirtualBlock_T::~VmaVirtualBlock_T()
 {
-    // Define macro VMA_DEBUG_LOG to receive the list of the unfreed allocations
+    // Define macro VMA_DEBUG_LOG_FORMAT to receive the list of the unfreed allocations
     if (!m_Metadata->IsEmpty())
         m_Metadata->DebugLogAllAllocations();
     // This is the most important assert in the entire library.
     // Hitting it means you have some memory leak - unreleased virtual allocations.
-    VMA_ASSERT(m_Metadata->IsEmpty() &&
-               "Some virtual allocations were not freed before destruction of this virtual block!");
+    VMA_ASSERT(m_Metadata->IsEmpty() && "Some virtual allocations were not freed before destruction of this virtual block!");
 
     vma_delete(GetAllocationCallbacks(), m_Metadata);
 }
@@ -11524,24 +11290,23 @@ void VmaVirtualBlock_T::GetAllocationInfo(VmaVirtualAllocation allocation, VmaVi
     m_Metadata->GetAllocationInfo((VmaAllocHandle)allocation, outInfo);
 }
 
-VkResult VmaVirtualBlock_T::Allocate(const VmaVirtualAllocationCreateInfo& createInfo,
-                                     VmaVirtualAllocation&                 outAllocation,
-                                     VkDeviceSize*                         outOffset)
+VkResult VmaVirtualBlock_T::Allocate(const VmaVirtualAllocationCreateInfo& createInfo, VmaVirtualAllocation& outAllocation,
+    VkDeviceSize* outOffset)
 {
     VmaAllocationRequest request = {};
-    if (m_Metadata->CreateAllocationRequest(createInfo.size,                                // allocSize
-                                            VMA_MAX(createInfo.alignment, (VkDeviceSize)1), // allocAlignment
-                                            (createInfo.flags & VMA_VIRTUAL_ALLOCATION_CREATE_UPPER_ADDRESS_BIT) !=
-                                                0,                          // upperAddress
-                                            VMA_SUBALLOCATION_TYPE_UNKNOWN, // allocType - unimportant
-                                            createInfo.flags & VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MASK, // strategy
-                                            &request))
+    if (m_Metadata->CreateAllocationRequest(
+        createInfo.size, // allocSize
+        VMA_MAX(createInfo.alignment, (VkDeviceSize)1), // allocAlignment
+        (createInfo.flags & VMA_VIRTUAL_ALLOCATION_CREATE_UPPER_ADDRESS_BIT) != 0, // upperAddress
+        VMA_SUBALLOCATION_TYPE_UNKNOWN, // allocType - unimportant
+        createInfo.flags & VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MASK, // strategy
+        &request))
     {
         m_Metadata->Alloc(request,
-                          VMA_SUBALLOCATION_TYPE_UNKNOWN, // type - unimportant
-                          createInfo.pUserData);
+            VMA_SUBALLOCATION_TYPE_UNKNOWN, // type - unimportant
+            createInfo.pUserData);
         outAllocation = (VmaVirtualAllocation)request.allocHandle;
-        if (outOffset)
+        if(outOffset)
             *outOffset = m_Metadata->GetAllocationOffset(request.allocHandle);
         return VK_SUCCESS;
     }
@@ -11589,38 +11354,39 @@ void VmaVirtualBlock_T::BuildStatsString(bool detailedMap, VmaStringBuilder& sb)
 #endif // _VMA_VIRTUAL_BLOCK_T_FUNCTIONS
 #endif // _VMA_VIRTUAL_BLOCK_T
 
+
 // Main allocator object.
 struct VmaAllocator_T
 {
-    VMA_CLASS_NO_COPY(VmaAllocator_T)
-  public:
-    bool       m_UseMutex;
-    uint32_t   m_VulkanApiVersion;
-    bool       m_UseKhrDedicatedAllocation; // Can be set only if m_VulkanApiVersion < VK_MAKE_VERSION(1, 1, 0).
-    bool       m_UseKhrBindMemory2;         // Can be set only if m_VulkanApiVersion < VK_MAKE_VERSION(1, 1, 0).
-    bool       m_UseExtMemoryBudget;
-    bool       m_UseAmdDeviceCoherentMemory;
-    bool       m_UseKhrBufferDeviceAddress;
-    bool       m_UseExtMemoryPriority;
-    VkDevice   m_hDevice;
+    VMA_CLASS_NO_COPY_NO_MOVE(VmaAllocator_T)
+public:
+    bool m_UseMutex;
+    uint32_t m_VulkanApiVersion;
+    bool m_UseKhrDedicatedAllocation; // Can be set only if m_VulkanApiVersion < VK_MAKE_VERSION(1, 1, 0).
+    bool m_UseKhrBindMemory2; // Can be set only if m_VulkanApiVersion < VK_MAKE_VERSION(1, 1, 0).
+    bool m_UseExtMemoryBudget;
+    bool m_UseAmdDeviceCoherentMemory;
+    bool m_UseKhrBufferDeviceAddress;
+    bool m_UseExtMemoryPriority;
+    VkDevice m_hDevice;
     VkInstance m_hInstance;
-    bool       m_AllocationCallbacksSpecified;
-    VkAllocationCallbacks        m_AllocationCallbacks;
-    VmaDeviceMemoryCallbacks     m_DeviceMemoryCallbacks;
+    bool m_AllocationCallbacksSpecified;
+    VkAllocationCallbacks m_AllocationCallbacks;
+    VmaDeviceMemoryCallbacks m_DeviceMemoryCallbacks;
     VmaAllocationObjectAllocator m_AllocationObjectAllocator;
 
     // Each bit (1 << i) is set if HeapSizeLimit is enabled for that heap, so cannot allocate more than the heap size.
     uint32_t m_HeapSizeLimitMask;
 
-    VkPhysicalDeviceProperties       m_PhysicalDeviceProperties;
+    VkPhysicalDeviceProperties m_PhysicalDeviceProperties;
     VkPhysicalDeviceMemoryProperties m_MemProps;
 
     // Default pools.
-    VmaBlockVector*            m_pBlockVectors[VK_MAX_MEMORY_TYPES];
+    VmaBlockVector* m_pBlockVectors[VK_MAX_MEMORY_TYPES];
     VmaDedicatedAllocationList m_DedicatedAllocations[VK_MAX_MEMORY_TYPES];
 
     VmaCurrentBudgetData m_Budget;
-    VMA_ATOMIC_UINT32    m_DeviceMemoryCount; // Total number of VkDeviceMemory objects.
+    VMA_ATOMIC_UINT32 m_DeviceMemoryCount; // Total number of VkDeviceMemory objects.
 
     VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo);
     VkResult Init(const VmaAllocatorCreateInfo* pCreateInfo);
@@ -11630,14 +11396,18 @@ struct VmaAllocator_T
     {
         return m_AllocationCallbacksSpecified ? &m_AllocationCallbacks : VMA_NULL;
     }
-    const VmaVulkanFunctions& GetVulkanFunctions() const { return m_VulkanFunctions; }
+    const VmaVulkanFunctions& GetVulkanFunctions() const
+    {
+        return m_VulkanFunctions;
+    }
 
     VkPhysicalDevice GetPhysicalDevice() const { return m_PhysicalDevice; }
 
     VkDeviceSize GetBufferImageGranularity() const
     {
-        return VMA_MAX(static_cast<VkDeviceSize>(VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY),
-                       m_PhysicalDeviceProperties.limits.bufferImageGranularity);
+        return VMA_MAX(
+            static_cast<VkDeviceSize>(VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY),
+            m_PhysicalDeviceProperties.limits.bufferImageGranularity);
     }
 
     uint32_t GetMemoryHeapCount() const { return m_MemProps.memoryHeapCount; }
@@ -11651,16 +11421,15 @@ struct VmaAllocator_T
     // True when specific memory type is HOST_VISIBLE but not HOST_COHERENT.
     bool IsMemoryTypeNonCoherent(uint32_t memTypeIndex) const
     {
-        return (m_MemProps.memoryTypes[memTypeIndex].propertyFlags &
-                (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) ==
-               VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+        return (m_MemProps.memoryTypes[memTypeIndex].propertyFlags & (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) ==
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
     }
     // Minimum alignment for all allocations in specific memory type.
     VkDeviceSize GetMemoryTypeMinAlignment(uint32_t memTypeIndex) const
     {
-        return IsMemoryTypeNonCoherent(memTypeIndex)
-                   ? VMA_MAX((VkDeviceSize)VMA_MIN_ALIGNMENT, m_PhysicalDeviceProperties.limits.nonCoherentAtomSize)
-                   : (VkDeviceSize)VMA_MIN_ALIGNMENT;
+        return IsMemoryTypeNonCoherent(memTypeIndex) ?
+            VMA_MAX((VkDeviceSize)VMA_MIN_ALIGNMENT, m_PhysicalDeviceProperties.limits.nonCoherentAtomSize) :
+            (VkDeviceSize)VMA_MIN_ALIGNMENT;
     }
 
     bool IsIntegratedGpu() const
@@ -11670,38 +11439,44 @@ struct VmaAllocator_T
 
     uint32_t GetGlobalMemoryTypeBits() const { return m_GlobalMemoryTypeBits; }
 
-    void     GetBufferMemoryRequirements(VkBuffer              hBuffer,
-                                         VkMemoryRequirements& memReq,
-                                         bool&                 requiresDedicatedAllocation,
-                                         bool&                 prefersDedicatedAllocation) const;
-    void     GetImageMemoryRequirements(VkImage               hImage,
-                                        VkMemoryRequirements& memReq,
-                                        bool&                 requiresDedicatedAllocation,
-                                        bool&                 prefersDedicatedAllocation) const;
+    void GetBufferMemoryRequirements(
+        VkBuffer hBuffer,
+        VkMemoryRequirements& memReq,
+        bool& requiresDedicatedAllocation,
+        bool& prefersDedicatedAllocation) const;
+    void GetImageMemoryRequirements(
+        VkImage hImage,
+        VkMemoryRequirements& memReq,
+        bool& requiresDedicatedAllocation,
+        bool& prefersDedicatedAllocation) const;
     VkResult FindMemoryTypeIndex(
-        uint32_t                       memoryTypeBits,
+        uint32_t memoryTypeBits,
         const VmaAllocationCreateInfo* pAllocationCreateInfo,
-        VkFlags   bufImgUsage, // VkBufferCreateInfo::usage or VkImageCreateInfo::usage. UINT32_MAX if unknown.
+        VkFlags bufImgUsage, // VkBufferCreateInfo::usage or VkImageCreateInfo::usage. UINT32_MAX if unknown.
         uint32_t* pMemoryTypeIndex) const;
 
     // Main allocation function.
-    VkResult AllocateMemory(const VkMemoryRequirements&    vkMemReq,
-                            bool                           requiresDedicatedAllocation,
-                            bool                           prefersDedicatedAllocation,
-                            VkBuffer                       dedicatedBuffer,
-                            VkImage                        dedicatedImage,
-                            VkFlags                        dedicatedBufferImageUsage, // UINT32_MAX if unknown.
-                            const VmaAllocationCreateInfo& createInfo,
-                            VmaSuballocationType           suballocType,
-                            size_t                         allocationCount,
-                            VmaAllocation*                 pAllocations);
+    VkResult AllocateMemory(
+        const VkMemoryRequirements& vkMemReq,
+        bool requiresDedicatedAllocation,
+        bool prefersDedicatedAllocation,
+        VkBuffer dedicatedBuffer,
+        VkImage dedicatedImage,
+        VkFlags dedicatedBufferImageUsage, // UINT32_MAX if unknown.
+        const VmaAllocationCreateInfo& createInfo,
+        VmaSuballocationType suballocType,
+        size_t allocationCount,
+        VmaAllocation* pAllocations);
 
     // Main deallocation function.
-    void FreeMemory(size_t allocationCount, const VmaAllocation* pAllocations);
+    void FreeMemory(
+        size_t allocationCount,
+        const VmaAllocation* pAllocations);
 
     void CalculateStatistics(VmaTotalStatistics* pStats);
 
-    void GetHeapBudgets(VmaBudget* outBudgets, uint32_t firstHeap, uint32_t heapCount);
+    void GetHeapBudgets(
+        VmaBudget* outBudgets, uint32_t firstHeap, uint32_t heapCount);
 
 #if VMA_STATS_STRING_ENABLED
     void PrintDetailedMap(class VmaJsonWriter& json);
@@ -11710,11 +11485,11 @@ struct VmaAllocator_T
     void GetAllocationInfo(VmaAllocation hAllocation, VmaAllocationInfo* pAllocationInfo);
 
     VkResult CreatePool(const VmaPoolCreateInfo* pCreateInfo, VmaPool* pPool);
-    void     DestroyPool(VmaPool pool);
-    void     GetPoolStatistics(VmaPool pool, VmaStatistics* pPoolStats);
-    void     CalculatePoolStatistics(VmaPool pool, VmaDetailedStatistics* pPoolStats);
+    void DestroyPool(VmaPool pool);
+    void GetPoolStatistics(VmaPool pool, VmaStatistics* pPoolStats);
+    void CalculatePoolStatistics(VmaPool pool, VmaDetailedStatistics* pPoolStats);
 
-    void     SetCurrentFrameIndex(uint32_t frameIndex);
+    void SetCurrentFrameIndex(uint32_t frameIndex);
     uint32_t GetCurrentFrameIndex() const { return m_CurrentFrameIndex.load(); }
 
     VkResult CheckPoolCorruption(VmaPool hPool);
@@ -11725,29 +11500,41 @@ struct VmaAllocator_T
     // Call to Vulkan function vkFreeMemory with accompanying bookkeeping.
     void FreeVulkanMemory(uint32_t memoryType, VkDeviceSize size, VkDeviceMemory hMemory);
     // Call to Vulkan function vkBindBufferMemory or vkBindBufferMemory2KHR.
-    VkResult BindVulkanBuffer(VkDeviceMemory memory, VkDeviceSize memoryOffset, VkBuffer buffer, const void* pNext);
+    VkResult BindVulkanBuffer(
+        VkDeviceMemory memory,
+        VkDeviceSize memoryOffset,
+        VkBuffer buffer,
+        const void* pNext);
     // Call to Vulkan function vkBindImageMemory or vkBindImageMemory2KHR.
-    VkResult BindVulkanImage(VkDeviceMemory memory, VkDeviceSize memoryOffset, VkImage image, const void* pNext);
+    VkResult BindVulkanImage(
+        VkDeviceMemory memory,
+        VkDeviceSize memoryOffset,
+        VkImage image,
+        const void* pNext);
 
     VkResult Map(VmaAllocation hAllocation, void** ppData);
-    void     Unmap(VmaAllocation hAllocation);
+    void Unmap(VmaAllocation hAllocation);
 
-    VkResult BindBufferMemory(VmaAllocation hAllocation,
-                              VkDeviceSize  allocationLocalOffset,
-                              VkBuffer      hBuffer,
-                              const void*   pNext);
-    VkResult
-    BindImageMemory(VmaAllocation hAllocation, VkDeviceSize allocationLocalOffset, VkImage hImage, const void* pNext);
+    VkResult BindBufferMemory(
+        VmaAllocation hAllocation,
+        VkDeviceSize allocationLocalOffset,
+        VkBuffer hBuffer,
+        const void* pNext);
+    VkResult BindImageMemory(
+        VmaAllocation hAllocation,
+        VkDeviceSize allocationLocalOffset,
+        VkImage hImage,
+        const void* pNext);
 
-    VkResult FlushOrInvalidateAllocation(VmaAllocation       hAllocation,
-                                         VkDeviceSize        offset,
-                                         VkDeviceSize        size,
-                                         VMA_CACHE_OPERATION op);
-    VkResult FlushOrInvalidateAllocations(uint32_t             allocationCount,
-                                          const VmaAllocation* allocations,
-                                          const VkDeviceSize*  offsets,
-                                          const VkDeviceSize*  sizes,
-                                          VMA_CACHE_OPERATION  op);
+    VkResult FlushOrInvalidateAllocation(
+        VmaAllocation hAllocation,
+        VkDeviceSize offset, VkDeviceSize size,
+        VMA_CACHE_OPERATION op);
+    VkResult FlushOrInvalidateAllocations(
+        uint32_t allocationCount,
+        const VmaAllocation* allocations,
+        const VkDeviceSize* offsets, const VkDeviceSize* sizes,
+        VMA_CACHE_OPERATION op);
 
     void FillAllocation(const VmaAllocation hAllocation, uint8_t pattern);
 
@@ -11764,17 +11551,17 @@ struct VmaAllocator_T
     }
 #endif // #if VMA_EXTERNAL_MEMORY
 
-  private:
+private:
     VkDeviceSize m_PreferredLargeHeapBlockSize;
 
-    VkPhysicalDevice  m_PhysicalDevice;
+    VkPhysicalDevice m_PhysicalDevice;
     VMA_ATOMIC_UINT32 m_CurrentFrameIndex;
     VMA_ATOMIC_UINT32 m_GpuDefragmentationMemoryTypeBits; // UINT32_MAX means uninitialized.
 #if VMA_EXTERNAL_MEMORY
     VkExternalMemoryHandleTypeFlagsKHR m_TypeExternalMemoryHandleTypes[VK_MAX_MEMORY_TYPES];
 #endif // #if VMA_EXTERNAL_MEMORY
 
-    VMA_RW_MUTEX                                          m_PoolsMutex;
+    VMA_RW_MUTEX m_PoolsMutex;
     typedef VmaIntrusiveLinkedList<VmaPoolListItemTraits> PoolList;
     // Protected by m_PoolsMutex.
     PoolList m_Pools;
@@ -11801,60 +11588,66 @@ struct VmaAllocator_T
 
     VkDeviceSize CalcPreferredBlockSize(uint32_t memTypeIndex);
 
-    VkResult AllocateMemoryOfType(VmaPool                        pool,
-                                  VkDeviceSize                   size,
-                                  VkDeviceSize                   alignment,
-                                  bool                           dedicatedPreferred,
-                                  VkBuffer                       dedicatedBuffer,
-                                  VkImage                        dedicatedImage,
-                                  VkFlags                        dedicatedBufferImageUsage,
-                                  const VmaAllocationCreateInfo& createInfo,
-                                  uint32_t                       memTypeIndex,
-                                  VmaSuballocationType           suballocType,
-                                  VmaDedicatedAllocationList&    dedicatedAllocations,
-                                  VmaBlockVector&                blockVector,
-                                  size_t                         allocationCount,
-                                  VmaAllocation*                 pAllocations);
+    VkResult AllocateMemoryOfType(
+        VmaPool pool,
+        VkDeviceSize size,
+        VkDeviceSize alignment,
+        bool dedicatedPreferred,
+        VkBuffer dedicatedBuffer,
+        VkImage dedicatedImage,
+        VkFlags dedicatedBufferImageUsage,
+        const VmaAllocationCreateInfo& createInfo,
+        uint32_t memTypeIndex,
+        VmaSuballocationType suballocType,
+        VmaDedicatedAllocationList& dedicatedAllocations,
+        VmaBlockVector& blockVector,
+        size_t allocationCount,
+        VmaAllocation* pAllocations);
 
     // Helper function only to be used inside AllocateDedicatedMemory.
-    VkResult AllocateDedicatedMemoryPage(VmaPool                     pool,
-                                         VkDeviceSize                size,
-                                         VmaSuballocationType        suballocType,
-                                         uint32_t                    memTypeIndex,
-                                         const VkMemoryAllocateInfo& allocInfo,
-                                         bool                        map,
-                                         bool                        isUserDataString,
-                                         bool                        isMappingAllowed,
-                                         void*                       pUserData,
-                                         VmaAllocation*              pAllocation);
+    VkResult AllocateDedicatedMemoryPage(
+        VmaPool pool,
+        VkDeviceSize size,
+        VmaSuballocationType suballocType,
+        uint32_t memTypeIndex,
+        const VkMemoryAllocateInfo& allocInfo,
+        bool map,
+        bool isUserDataString,
+        bool isMappingAllowed,
+        void* pUserData,
+        VmaAllocation* pAllocation);
 
     // Allocates and registers new VkDeviceMemory specifically for dedicated allocations.
-    VkResult AllocateDedicatedMemory(VmaPool                     pool,
-                                     VkDeviceSize                size,
-                                     VmaSuballocationType        suballocType,
-                                     VmaDedicatedAllocationList& dedicatedAllocations,
-                                     uint32_t                    memTypeIndex,
-                                     bool                        map,
-                                     bool                        isUserDataString,
-                                     bool                        isMappingAllowed,
-                                     bool                        canAliasMemory,
-                                     void*                       pUserData,
-                                     float                       priority,
-                                     VkBuffer                    dedicatedBuffer,
-                                     VkImage                     dedicatedImage,
-                                     VkFlags                     dedicatedBufferImageUsage,
-                                     size_t                      allocationCount,
-                                     VmaAllocation*              pAllocations,
-                                     const void*                 pNextChain = nullptr);
+    VkResult AllocateDedicatedMemory(
+        VmaPool pool,
+        VkDeviceSize size,
+        VmaSuballocationType suballocType,
+        VmaDedicatedAllocationList& dedicatedAllocations,
+        uint32_t memTypeIndex,
+        bool map,
+        bool isUserDataString,
+        bool isMappingAllowed,
+        bool canAliasMemory,
+        void* pUserData,
+        float priority,
+        VkBuffer dedicatedBuffer,
+        VkImage dedicatedImage,
+        VkFlags dedicatedBufferImageUsage,
+        size_t allocationCount,
+        VmaAllocation* pAllocations,
+        const void* pNextChain = nullptr);
 
     void FreeDedicatedMemory(const VmaAllocation allocation);
 
-    VkResult CalcMemTypeParams(VmaAllocationCreateInfo& outCreateInfo,
-                               uint32_t                 memTypeIndex,
-                               VkDeviceSize             size,
-                               size_t                   allocationCount);
-    VkResult
-    CalcAllocationParams(VmaAllocationCreateInfo& outCreateInfo, bool dedicatedRequired, bool dedicatedPreferred);
+    VkResult CalcMemTypeParams(
+        VmaAllocationCreateInfo& outCreateInfo,
+        uint32_t memTypeIndex,
+        VkDeviceSize size,
+        size_t allocationCount);
+    VkResult CalcAllocationParams(
+        VmaAllocationCreateInfo& outCreateInfo,
+        bool dedicatedRequired,
+        bool dedicatedPreferred);
 
     /*
     Calculates and returns bit mask of memory types that can support defragmentation
@@ -11863,15 +11656,16 @@ struct VmaAllocator_T
     uint32_t CalculateGpuDefragmentationMemoryTypeBits() const;
     uint32_t CalculateGlobalMemoryTypeBits() const;
 
-    bool GetFlushOrInvalidateRange(VmaAllocation        allocation,
-                                   VkDeviceSize         offset,
-                                   VkDeviceSize         size,
-                                   VkMappedMemoryRange& outRange) const;
+    bool GetFlushOrInvalidateRange(
+        VmaAllocation allocation,
+        VkDeviceSize offset, VkDeviceSize size,
+        VkMappedMemoryRange& outRange) const;
 
 #if VMA_MEMORY_BUDGET
     void UpdateVulkanBudget();
 #endif // #if VMA_MEMORY_BUDGET
 };
+
 
 #ifndef _VMA_MEMORY_FUNCTIONS
 static void* VmaMalloc(VmaAllocator hAllocator, size_t size, size_t alignment)
@@ -11884,44 +11678,48 @@ static void VmaFree(VmaAllocator hAllocator, void* ptr)
     VmaFree(&hAllocator->m_AllocationCallbacks, ptr);
 }
 
-template <typename T>
+template<typename T>
 static T* VmaAllocate(VmaAllocator hAllocator)
 {
     return (T*)VmaMalloc(hAllocator, sizeof(T), VMA_ALIGN_OF(T));
 }
 
-template <typename T>
+template<typename T>
 static T* VmaAllocateArray(VmaAllocator hAllocator, size_t count)
 {
     return (T*)VmaMalloc(hAllocator, sizeof(T) * count, VMA_ALIGN_OF(T));
 }
 
-template <typename T>
+template<typename T>
 static void vma_delete(VmaAllocator hAllocator, T* ptr)
 {
-    if (ptr != VMA_NULL)
+    if(ptr != VMA_NULL)
     {
         ptr->~T();
         VmaFree(hAllocator, ptr);
     }
 }
 
-template <typename T>
+template<typename T>
 static void vma_delete_array(VmaAllocator hAllocator, T* ptr, size_t count)
 {
-    if (ptr != VMA_NULL)
+    if(ptr != VMA_NULL)
     {
-        for (size_t i = count; i--;) ptr[i].~T();
+        for(size_t i = count; i--; )
+            ptr[i].~T();
         VmaFree(hAllocator, ptr);
     }
 }
 #endif // _VMA_MEMORY_FUNCTIONS
 
 #ifndef _VMA_DEVICE_MEMORY_BLOCK_FUNCTIONS
-VmaDeviceMemoryBlock::VmaDeviceMemoryBlock(VmaAllocator hAllocator) :
-    m_pMetadata(VMA_NULL), m_MemoryTypeIndex(UINT32_MAX), m_Id(0), m_hMemory(VK_NULL_HANDLE), m_MapCount(0),
-    m_pMappedData(VMA_NULL)
-{}
+VmaDeviceMemoryBlock::VmaDeviceMemoryBlock(VmaAllocator hAllocator)
+    : m_pMetadata(VMA_NULL),
+    m_MemoryTypeIndex(UINT32_MAX),
+    m_Id(0),
+    m_hMemory(VK_NULL_HANDLE),
+    m_MapCount(0),
+    m_pMappedData(VMA_NULL) {}
 
 VmaDeviceMemoryBlock::~VmaDeviceMemoryBlock()
 {
@@ -11929,41 +11727,44 @@ VmaDeviceMemoryBlock::~VmaDeviceMemoryBlock()
     VMA_ASSERT(m_hMemory == VK_NULL_HANDLE);
 }
 
-void VmaDeviceMemoryBlock::Init(VmaAllocator   hAllocator,
-                                VmaPool        hParentPool,
-                                uint32_t       newMemoryTypeIndex,
-                                VkDeviceMemory newMemory,
-                                VkDeviceSize   newSize,
-                                uint32_t       id,
-                                uint32_t       algorithm,
-                                VkDeviceSize   bufferImageGranularity)
+void VmaDeviceMemoryBlock::Init(
+    VmaAllocator hAllocator,
+    VmaPool hParentPool,
+    uint32_t newMemoryTypeIndex,
+    VkDeviceMemory newMemory,
+    VkDeviceSize newSize,
+    uint32_t id,
+    uint32_t algorithm,
+    VkDeviceSize bufferImageGranularity)
 {
     VMA_ASSERT(m_hMemory == VK_NULL_HANDLE);
 
-    m_hParentPool     = hParentPool;
+    m_hParentPool = hParentPool;
     m_MemoryTypeIndex = newMemoryTypeIndex;
-    m_Id              = id;
-    m_hMemory         = newMemory;
+    m_Id = id;
+    m_hMemory = newMemory;
 
     switch (algorithm)
     {
-        case VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT:
-            m_pMetadata = vma_new(hAllocator, VmaBlockMetadata_Linear)(
-                hAllocator->GetAllocationCallbacks(), bufferImageGranularity, false); // isVirtual
-            break;
-        default:
-            VMA_ASSERT(0);
-            // Fall-through.
-        case 0:
-            m_pMetadata = vma_new(hAllocator, VmaBlockMetadata_TLSF)(
-                hAllocator->GetAllocationCallbacks(), bufferImageGranularity, false); // isVirtual
+    case 0:
+        m_pMetadata = vma_new(hAllocator, VmaBlockMetadata_TLSF)(hAllocator->GetAllocationCallbacks(),
+            bufferImageGranularity, false); // isVirtual
+        break;
+    case VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT:
+        m_pMetadata = vma_new(hAllocator, VmaBlockMetadata_Linear)(hAllocator->GetAllocationCallbacks(),
+            bufferImageGranularity, false); // isVirtual
+        break;
+    default:
+        VMA_ASSERT(0);
+        m_pMetadata = vma_new(hAllocator, VmaBlockMetadata_TLSF)(hAllocator->GetAllocationCallbacks(),
+            bufferImageGranularity, false); // isVirtual
     }
     m_pMetadata->Init(newSize);
 }
 
 void VmaDeviceMemoryBlock::Destroy(VmaAllocator allocator)
 {
-    // Define macro VMA_DEBUG_LOG to receive the list of the unfreed allocations
+    // Define macro VMA_DEBUG_LOG_FORMAT to receive the list of the unfreed allocations
     if (!m_pMetadata->IsEmpty())
         m_pMetadata->DebugLogAllAllocations();
     // This is the most important assert in the entire library.
@@ -11978,9 +11779,16 @@ void VmaDeviceMemoryBlock::Destroy(VmaAllocator allocator)
     m_pMetadata = VMA_NULL;
 }
 
+void VmaDeviceMemoryBlock::PostAlloc(VmaAllocator hAllocator)
+{
+    VmaMutexLock lock(m_MapAndBindMutex, hAllocator->m_UseMutex);
+    m_MappingHysteresis.PostAlloc();
+}
+
 void VmaDeviceMemoryBlock::PostFree(VmaAllocator hAllocator)
 {
-    if (m_MappingHysteresis.PostFree())
+    VmaMutexLock lock(m_MapAndBindMutex, hAllocator->m_UseMutex);
+    if(m_MappingHysteresis.PostFree())
     {
         VMA_ASSERT(m_MappingHysteresis.GetExtraMapping() == 0);
         if (m_MapCount == 0)
@@ -11993,15 +11801,16 @@ void VmaDeviceMemoryBlock::PostFree(VmaAllocator hAllocator)
 
 bool VmaDeviceMemoryBlock::Validate() const
 {
-    VMA_VALIDATE((m_hMemory != VK_NULL_HANDLE) && (m_pMetadata->GetSize() != 0));
+    VMA_VALIDATE((m_hMemory != VK_NULL_HANDLE) &&
+        (m_pMetadata->GetSize() != 0));
 
     return m_pMetadata->Validate();
 }
 
 VkResult VmaDeviceMemoryBlock::CheckCorruption(VmaAllocator hAllocator)
 {
-    void*    pData = nullptr;
-    VkResult res   = Map(hAllocator, 1, &pData);
+    void* pData = nullptr;
+    VkResult res = Map(hAllocator, 1, &pData);
     if (res != VK_SUCCESS)
     {
         return res;
@@ -12021,7 +11830,7 @@ VkResult VmaDeviceMemoryBlock::Map(VmaAllocator hAllocator, uint32_t count, void
         return VK_SUCCESS;
     }
 
-    VmaMutexLock   lock(m_MapAndBindMutex, hAllocator->m_UseMutex);
+    VmaMutexLock lock(m_MapAndBindMutex, hAllocator->m_UseMutex);
     const uint32_t oldTotalMapCount = m_MapCount + m_MappingHysteresis.GetExtraMapping();
     m_MappingHysteresis.PostMap();
     if (oldTotalMapCount != 0)
@@ -12036,12 +11845,13 @@ VkResult VmaDeviceMemoryBlock::Map(VmaAllocator hAllocator, uint32_t count, void
     }
     else
     {
-        VkResult result = (*hAllocator->GetVulkanFunctions().vkMapMemory)(hAllocator->m_hDevice,
-                                                                          m_hMemory,
-                                                                          0, // offset
-                                                                          VK_WHOLE_SIZE,
-                                                                          0, // flags
-                                                                          &m_pMappedData);
+        VkResult result = (*hAllocator->GetVulkanFunctions().vkMapMemory)(
+            hAllocator->m_hDevice,
+            m_hMemory,
+            0, // offset
+            VK_WHOLE_SIZE,
+            0, // flags
+            &m_pMappedData);
         if (result == VK_SUCCESS)
         {
             if (ppData != VMA_NULL)
@@ -12079,13 +11889,11 @@ void VmaDeviceMemoryBlock::Unmap(VmaAllocator hAllocator, uint32_t count)
     }
 }
 
-VkResult VmaDeviceMemoryBlock::WriteMagicValueAfterAllocation(VmaAllocator hAllocator,
-                                                              VkDeviceSize allocOffset,
-                                                              VkDeviceSize allocSize)
+VkResult VmaDeviceMemoryBlock::WriteMagicValueAfterAllocation(VmaAllocator hAllocator, VkDeviceSize allocOffset, VkDeviceSize allocSize)
 {
     VMA_ASSERT(VMA_DEBUG_MARGIN > 0 && VMA_DEBUG_MARGIN % 4 == 0 && VMA_DEBUG_DETECT_CORRUPTION);
 
-    void*    pData;
+    void* pData;
     VkResult res = Map(hAllocator, 1, &pData);
     if (res != VK_SUCCESS)
     {
@@ -12098,13 +11906,11 @@ VkResult VmaDeviceMemoryBlock::WriteMagicValueAfterAllocation(VmaAllocator hAllo
     return VK_SUCCESS;
 }
 
-VkResult VmaDeviceMemoryBlock::ValidateMagicValueAfterAllocation(VmaAllocator hAllocator,
-                                                                 VkDeviceSize allocOffset,
-                                                                 VkDeviceSize allocSize)
+VkResult VmaDeviceMemoryBlock::ValidateMagicValueAfterAllocation(VmaAllocator hAllocator, VkDeviceSize allocOffset, VkDeviceSize allocSize)
 {
     VMA_ASSERT(VMA_DEBUG_MARGIN > 0 && VMA_DEBUG_MARGIN % 4 == 0 && VMA_DEBUG_DETECT_CORRUPTION);
 
-    void*    pData;
+    void* pData;
     VkResult res = Map(hAllocator, 1, &pData);
     if (res != VK_SUCCESS)
     {
@@ -12120,48 +11926,54 @@ VkResult VmaDeviceMemoryBlock::ValidateMagicValueAfterAllocation(VmaAllocator hA
     return VK_SUCCESS;
 }
 
-VkResult VmaDeviceMemoryBlock::BindBufferMemory(const VmaAllocator  hAllocator,
-                                                const VmaAllocation hAllocation,
-                                                VkDeviceSize        allocationLocalOffset,
-                                                VkBuffer            hBuffer,
-                                                const void*         pNext)
+VkResult VmaDeviceMemoryBlock::BindBufferMemory(
+    const VmaAllocator hAllocator,
+    const VmaAllocation hAllocation,
+    VkDeviceSize allocationLocalOffset,
+    VkBuffer hBuffer,
+    const void* pNext)
 {
-    VMA_ASSERT(hAllocation->GetType() == VmaAllocation_T::ALLOCATION_TYPE_BLOCK && hAllocation->GetBlock() == this);
+    VMA_ASSERT(hAllocation->GetType() == VmaAllocation_T::ALLOCATION_TYPE_BLOCK &&
+        hAllocation->GetBlock() == this);
     VMA_ASSERT(allocationLocalOffset < hAllocation->GetSize() &&
-               "Invalid allocationLocalOffset. Did you forget that this offset is relative to the beginning of the "
-               "allocation, not the whole memory block?");
+        "Invalid allocationLocalOffset. Did you forget that this offset is relative to the beginning of the allocation, not the whole memory block?");
     const VkDeviceSize memoryOffset = hAllocation->GetOffset() + allocationLocalOffset;
-    // This lock is important so that we don't call vkBind... and/or vkMap... simultaneously on the same VkDeviceMemory
-    // from multiple threads.
+    // This lock is important so that we don't call vkBind... and/or vkMap... simultaneously on the same VkDeviceMemory from multiple threads.
     VmaMutexLock lock(m_MapAndBindMutex, hAllocator->m_UseMutex);
     return hAllocator->BindVulkanBuffer(m_hMemory, memoryOffset, hBuffer, pNext);
 }
 
-VkResult VmaDeviceMemoryBlock::BindImageMemory(const VmaAllocator  hAllocator,
-                                               const VmaAllocation hAllocation,
-                                               VkDeviceSize        allocationLocalOffset,
-                                               VkImage             hImage,
-                                               const void*         pNext)
+VkResult VmaDeviceMemoryBlock::BindImageMemory(
+    const VmaAllocator hAllocator,
+    const VmaAllocation hAllocation,
+    VkDeviceSize allocationLocalOffset,
+    VkImage hImage,
+    const void* pNext)
 {
-    VMA_ASSERT(hAllocation->GetType() == VmaAllocation_T::ALLOCATION_TYPE_BLOCK && hAllocation->GetBlock() == this);
+    VMA_ASSERT(hAllocation->GetType() == VmaAllocation_T::ALLOCATION_TYPE_BLOCK &&
+        hAllocation->GetBlock() == this);
     VMA_ASSERT(allocationLocalOffset < hAllocation->GetSize() &&
-               "Invalid allocationLocalOffset. Did you forget that this offset is relative to the beginning of the "
-               "allocation, not the whole memory block?");
+        "Invalid allocationLocalOffset. Did you forget that this offset is relative to the beginning of the allocation, not the whole memory block?");
     const VkDeviceSize memoryOffset = hAllocation->GetOffset() + allocationLocalOffset;
-    // This lock is important so that we don't call vkBind... and/or vkMap... simultaneously on the same VkDeviceMemory
-    // from multiple threads.
+    // This lock is important so that we don't call vkBind... and/or vkMap... simultaneously on the same VkDeviceMemory from multiple threads.
     VmaMutexLock lock(m_MapAndBindMutex, hAllocator->m_UseMutex);
     return hAllocator->BindVulkanImage(m_hMemory, memoryOffset, hImage, pNext);
 }
 #endif // _VMA_DEVICE_MEMORY_BLOCK_FUNCTIONS
 
 #ifndef _VMA_ALLOCATION_T_FUNCTIONS
-VmaAllocation_T::VmaAllocation_T(bool mappingAllowed) :
-    m_Alignment{ 1 }, m_Size{ 0 }, m_pUserData{ VMA_NULL }, m_pName{ VMA_NULL },
-    m_MemoryTypeIndex{ 0 }, m_Type{ (uint8_t)ALLOCATION_TYPE_NONE },
-    m_SuballocationType{ (uint8_t)VMA_SUBALLOCATION_TYPE_UNKNOWN }, m_MapCount{ 0 }, m_Flags{ 0 }
+VmaAllocation_T::VmaAllocation_T(bool mappingAllowed)
+    : m_Alignment{ 1 },
+    m_Size{ 0 },
+    m_pUserData{ VMA_NULL },
+    m_pName{ VMA_NULL },
+    m_MemoryTypeIndex{ 0 },
+    m_Type{ (uint8_t)ALLOCATION_TYPE_NONE },
+    m_SuballocationType{ (uint8_t)VMA_SUBALLOCATION_TYPE_UNKNOWN },
+    m_MapCount{ 0 },
+    m_Flags{ 0 }
 {
-    if (mappingAllowed)
+    if(mappingAllowed)
         m_Flags |= (uint8_t)FLAG_MAPPING_ALLOWED;
 
 #if VMA_STATS_STRING_ENABLED
@@ -12177,56 +11989,56 @@ VmaAllocation_T::~VmaAllocation_T()
     VMA_ASSERT(m_pName == VMA_NULL);
 }
 
-void VmaAllocation_T::InitBlockAllocation(VmaDeviceMemoryBlock* block,
-                                          VmaAllocHandle        allocHandle,
-                                          VkDeviceSize          alignment,
-                                          VkDeviceSize          size,
-                                          uint32_t              memoryTypeIndex,
-                                          VmaSuballocationType  suballocationType,
-                                          bool                  mapped)
+void VmaAllocation_T::InitBlockAllocation(
+    VmaDeviceMemoryBlock* block,
+    VmaAllocHandle allocHandle,
+    VkDeviceSize alignment,
+    VkDeviceSize size,
+    uint32_t memoryTypeIndex,
+    VmaSuballocationType suballocationType,
+    bool mapped)
 {
     VMA_ASSERT(m_Type == ALLOCATION_TYPE_NONE);
     VMA_ASSERT(block != VMA_NULL);
-    m_Type            = (uint8_t)ALLOCATION_TYPE_BLOCK;
-    m_Alignment       = alignment;
-    m_Size            = size;
+    m_Type = (uint8_t)ALLOCATION_TYPE_BLOCK;
+    m_Alignment = alignment;
+    m_Size = size;
     m_MemoryTypeIndex = memoryTypeIndex;
-    if (mapped)
+    if(mapped)
     {
-        VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new "
-                                         "VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
+        VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
         m_Flags |= (uint8_t)FLAG_PERSISTENT_MAP;
     }
-    m_SuballocationType             = (uint8_t)suballocationType;
-    m_BlockAllocation.m_Block       = block;
+    m_SuballocationType = (uint8_t)suballocationType;
+    m_BlockAllocation.m_Block = block;
     m_BlockAllocation.m_AllocHandle = allocHandle;
 }
 
-void VmaAllocation_T::InitDedicatedAllocation(VmaPool              hParentPool,
-                                              uint32_t             memoryTypeIndex,
-                                              VkDeviceMemory       hMemory,
-                                              VmaSuballocationType suballocationType,
-                                              void*                pMappedData,
-                                              VkDeviceSize         size)
+void VmaAllocation_T::InitDedicatedAllocation(
+    VmaPool hParentPool,
+    uint32_t memoryTypeIndex,
+    VkDeviceMemory hMemory,
+    VmaSuballocationType suballocationType,
+    void* pMappedData,
+    VkDeviceSize size)
 {
     VMA_ASSERT(m_Type == ALLOCATION_TYPE_NONE);
     VMA_ASSERT(hMemory != VK_NULL_HANDLE);
-    m_Type              = (uint8_t)ALLOCATION_TYPE_DEDICATED;
-    m_Alignment         = 0;
-    m_Size              = size;
-    m_MemoryTypeIndex   = memoryTypeIndex;
+    m_Type = (uint8_t)ALLOCATION_TYPE_DEDICATED;
+    m_Alignment = 0;
+    m_Size = size;
+    m_MemoryTypeIndex = memoryTypeIndex;
     m_SuballocationType = (uint8_t)suballocationType;
-    if (pMappedData != VMA_NULL)
+    if(pMappedData != VMA_NULL)
     {
-        VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new "
-                                         "VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
+        VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
         m_Flags |= (uint8_t)FLAG_PERSISTENT_MAP;
     }
     m_DedicatedAllocation.m_hParentPool = hParentPool;
-    m_DedicatedAllocation.m_hMemory     = hMemory;
+    m_DedicatedAllocation.m_hMemory = hMemory;
     m_DedicatedAllocation.m_pMappedData = pMappedData;
-    m_DedicatedAllocation.m_Prev        = VMA_NULL;
-    m_DedicatedAllocation.m_Next        = VMA_NULL;
+    m_DedicatedAllocation.m_Prev = VMA_NULL;
+    m_DedicatedAllocation.m_Next = VMA_NULL;
 }
 
 void VmaAllocation_T::SetName(VmaAllocator hAllocator, const char* pName)
@@ -12262,13 +12074,13 @@ VmaAllocHandle VmaAllocation_T::GetAllocHandle() const
 {
     switch (m_Type)
     {
-        case ALLOCATION_TYPE_BLOCK:
-            return m_BlockAllocation.m_AllocHandle;
-        case ALLOCATION_TYPE_DEDICATED:
-            return VK_NULL_HANDLE;
-        default:
-            VMA_ASSERT(0);
-            return VK_NULL_HANDLE;
+    case ALLOCATION_TYPE_BLOCK:
+        return m_BlockAllocation.m_AllocHandle;
+    case ALLOCATION_TYPE_DEDICATED:
+        return VK_NULL_HANDLE;
+    default:
+        VMA_ASSERT(0);
+        return VK_NULL_HANDLE;
     }
 }
 
@@ -12276,13 +12088,13 @@ VkDeviceSize VmaAllocation_T::GetOffset() const
 {
     switch (m_Type)
     {
-        case ALLOCATION_TYPE_BLOCK:
-            return m_BlockAllocation.m_Block->m_pMetadata->GetAllocationOffset(m_BlockAllocation.m_AllocHandle);
-        case ALLOCATION_TYPE_DEDICATED:
-            return 0;
-        default:
-            VMA_ASSERT(0);
-            return 0;
+    case ALLOCATION_TYPE_BLOCK:
+        return m_BlockAllocation.m_Block->m_pMetadata->GetAllocationOffset(m_BlockAllocation.m_AllocHandle);
+    case ALLOCATION_TYPE_DEDICATED:
+        return 0;
+    default:
+        VMA_ASSERT(0);
+        return 0;
     }
 }
 
@@ -12290,13 +12102,13 @@ VmaPool VmaAllocation_T::GetParentPool() const
 {
     switch (m_Type)
     {
-        case ALLOCATION_TYPE_BLOCK:
-            return m_BlockAllocation.m_Block->GetParentPool();
-        case ALLOCATION_TYPE_DEDICATED:
-            return m_DedicatedAllocation.m_hParentPool;
-        default:
-            VMA_ASSERT(0);
-            return VK_NULL_HANDLE;
+    case ALLOCATION_TYPE_BLOCK:
+        return m_BlockAllocation.m_Block->GetParentPool();
+    case ALLOCATION_TYPE_DEDICATED:
+        return m_DedicatedAllocation.m_hParentPool;
+    default:
+        VMA_ASSERT(0);
+        return VK_NULL_HANDLE;
     }
 }
 
@@ -12304,13 +12116,13 @@ VkDeviceMemory VmaAllocation_T::GetMemory() const
 {
     switch (m_Type)
     {
-        case ALLOCATION_TYPE_BLOCK:
-            return m_BlockAllocation.m_Block->GetDeviceMemory();
-        case ALLOCATION_TYPE_DEDICATED:
-            return m_DedicatedAllocation.m_hMemory;
-        default:
-            VMA_ASSERT(0);
-            return VK_NULL_HANDLE;
+    case ALLOCATION_TYPE_BLOCK:
+        return m_BlockAllocation.m_Block->GetDeviceMemory();
+    case ALLOCATION_TYPE_DEDICATED:
+        return m_DedicatedAllocation.m_hMemory;
+    default:
+        VMA_ASSERT(0);
+        return VK_NULL_HANDLE;
     }
 }
 
@@ -12318,32 +12130,31 @@ void* VmaAllocation_T::GetMappedData() const
 {
     switch (m_Type)
     {
-        case ALLOCATION_TYPE_BLOCK:
-            if (m_MapCount != 0 || IsPersistentMap())
-            {
-                void* pBlockData = m_BlockAllocation.m_Block->GetMappedData();
-                VMA_ASSERT(pBlockData != VMA_NULL);
-                return (char*)pBlockData + GetOffset();
-            }
-            else
-            {
-                return VMA_NULL;
-            }
-            break;
-        case ALLOCATION_TYPE_DEDICATED:
-            VMA_ASSERT((m_DedicatedAllocation.m_pMappedData != VMA_NULL) == (m_MapCount != 0 || IsPersistentMap()));
-            return m_DedicatedAllocation.m_pMappedData;
-        default:
-            VMA_ASSERT(0);
+    case ALLOCATION_TYPE_BLOCK:
+        if (m_MapCount != 0 || IsPersistentMap())
+        {
+            void* pBlockData = m_BlockAllocation.m_Block->GetMappedData();
+            VMA_ASSERT(pBlockData != VMA_NULL);
+            return (char*)pBlockData + GetOffset();
+        }
+        else
+        {
             return VMA_NULL;
+        }
+        break;
+    case ALLOCATION_TYPE_DEDICATED:
+        VMA_ASSERT((m_DedicatedAllocation.m_pMappedData != VMA_NULL) == (m_MapCount != 0 || IsPersistentMap()));
+        return m_DedicatedAllocation.m_pMappedData;
+    default:
+        VMA_ASSERT(0);
+        return VMA_NULL;
     }
 }
 
 void VmaAllocation_T::BlockAllocMap()
 {
     VMA_ASSERT(GetType() == ALLOCATION_TYPE_BLOCK);
-    VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new "
-                                     "VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
+    VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
 
     if (m_MapCount < 0xFF)
     {
@@ -12372,8 +12183,7 @@ void VmaAllocation_T::BlockAllocUnmap()
 VkResult VmaAllocation_T::DedicatedAllocMap(VmaAllocator hAllocator, void** ppData)
 {
     VMA_ASSERT(GetType() == ALLOCATION_TYPE_DEDICATED);
-    VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new "
-                                     "VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
+    VMA_ASSERT(IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it.");
 
     if (m_MapCount != 0 || IsPersistentMap())
     {
@@ -12392,16 +12202,17 @@ VkResult VmaAllocation_T::DedicatedAllocMap(VmaAllocator hAllocator, void** ppDa
     }
     else
     {
-        VkResult result = (*hAllocator->GetVulkanFunctions().vkMapMemory)(hAllocator->m_hDevice,
-                                                                          m_DedicatedAllocation.m_hMemory,
-                                                                          0, // offset
-                                                                          VK_WHOLE_SIZE,
-                                                                          0, // flags
-                                                                          ppData);
+        VkResult result = (*hAllocator->GetVulkanFunctions().vkMapMemory)(
+            hAllocator->m_hDevice,
+            m_DedicatedAllocation.m_hMemory,
+            0, // offset
+            VK_WHOLE_SIZE,
+            0, // flags
+            ppData);
         if (result == VK_SUCCESS)
         {
             m_DedicatedAllocation.m_pMappedData = *ppData;
-            m_MapCount                          = 1;
+            m_MapCount = 1;
         }
         return result;
     }
@@ -12417,7 +12228,9 @@ void VmaAllocation_T::DedicatedAllocUnmap(VmaAllocator hAllocator)
         if (m_MapCount == 0 && !IsPersistentMap())
         {
             m_DedicatedAllocation.m_pMappedData = VMA_NULL;
-            (*hAllocator->GetVulkanFunctions().vkUnmapMemory)(hAllocator->m_hDevice, m_DedicatedAllocation.m_hMemory);
+            (*hAllocator->GetVulkanFunctions().vkUnmapMemory)(
+                hAllocator->m_hDevice,
+                m_DedicatedAllocation.m_hMemory);
         }
     }
     else
@@ -12460,7 +12273,7 @@ void VmaAllocation_T::PrintParameters(class VmaJsonWriter& json) const
 
 void VmaAllocation_T::FreeName(VmaAllocator hAllocator)
 {
-    if (m_pName)
+    if(m_pName)
     {
         VmaFreeString(hAllocator->GetAllocationCallbacks(), m_pName);
         m_pName = VMA_NULL;
@@ -12469,29 +12282,37 @@ void VmaAllocation_T::FreeName(VmaAllocator hAllocator)
 #endif // _VMA_ALLOCATION_T_FUNCTIONS
 
 #ifndef _VMA_BLOCK_VECTOR_FUNCTIONS
-VmaBlockVector::VmaBlockVector(VmaAllocator hAllocator,
-                               VmaPool      hParentPool,
-                               uint32_t     memoryTypeIndex,
-                               VkDeviceSize preferredBlockSize,
-                               size_t       minBlockCount,
-                               size_t       maxBlockCount,
-                               VkDeviceSize bufferImageGranularity,
-                               bool         explicitBlockSize,
-                               uint32_t     algorithm,
-                               float        priority,
-                               VkDeviceSize minAllocationAlignment,
-                               void*        pMemoryAllocateNext) :
-    m_hAllocator(hAllocator),
-    m_hParentPool(hParentPool), m_MemoryTypeIndex(memoryTypeIndex), m_PreferredBlockSize(preferredBlockSize),
-    m_MinBlockCount(minBlockCount), m_MaxBlockCount(maxBlockCount), m_BufferImageGranularity(bufferImageGranularity),
-    m_ExplicitBlockSize(explicitBlockSize), m_Algorithm(algorithm), m_Priority(priority),
-    m_MinAllocationAlignment(minAllocationAlignment), m_pMemoryAllocateNext(pMemoryAllocateNext),
-    m_Blocks(VmaStlAllocator<VmaDeviceMemoryBlock*>(hAllocator->GetAllocationCallbacks())), m_NextBlockId(0)
-{}
+VmaBlockVector::VmaBlockVector(
+    VmaAllocator hAllocator,
+    VmaPool hParentPool,
+    uint32_t memoryTypeIndex,
+    VkDeviceSize preferredBlockSize,
+    size_t minBlockCount,
+    size_t maxBlockCount,
+    VkDeviceSize bufferImageGranularity,
+    bool explicitBlockSize,
+    uint32_t algorithm,
+    float priority,
+    VkDeviceSize minAllocationAlignment,
+    void* pMemoryAllocateNext)
+    : m_hAllocator(hAllocator),
+    m_hParentPool(hParentPool),
+    m_MemoryTypeIndex(memoryTypeIndex),
+    m_PreferredBlockSize(preferredBlockSize),
+    m_MinBlockCount(minBlockCount),
+    m_MaxBlockCount(maxBlockCount),
+    m_BufferImageGranularity(bufferImageGranularity),
+    m_ExplicitBlockSize(explicitBlockSize),
+    m_Algorithm(algorithm),
+    m_Priority(priority),
+    m_MinAllocationAlignment(minAllocationAlignment),
+    m_pMemoryAllocateNext(pMemoryAllocateNext),
+    m_Blocks(VmaStlAllocator<VmaDeviceMemoryBlock*>(hAllocator->GetAllocationCallbacks())),
+    m_NextBlockId(0) {}
 
 VmaBlockVector::~VmaBlockVector()
 {
-    for (size_t i = m_Blocks.size(); i--;)
+    for (size_t i = m_Blocks.size(); i--; )
     {
         m_Blocks[i]->Destroy(m_hAllocator);
         vma_delete(m_hAllocator, m_Blocks[i]);
@@ -12548,27 +12369,28 @@ bool VmaBlockVector::IsEmpty()
 bool VmaBlockVector::IsCorruptionDetectionEnabled() const
 {
     const uint32_t requiredMemFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    return (VMA_DEBUG_DETECT_CORRUPTION != 0) && (VMA_DEBUG_MARGIN > 0) &&
-           (m_Algorithm == 0 || m_Algorithm == VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT) &&
-           (m_hAllocator->m_MemProps.memoryTypes[m_MemoryTypeIndex].propertyFlags & requiredMemFlags) ==
-               requiredMemFlags;
+    return (VMA_DEBUG_DETECT_CORRUPTION != 0) &&
+        (VMA_DEBUG_MARGIN > 0) &&
+        (m_Algorithm == 0 || m_Algorithm == VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT) &&
+        (m_hAllocator->m_MemProps.memoryTypes[m_MemoryTypeIndex].propertyFlags & requiredMemFlags) == requiredMemFlags;
 }
 
-VkResult VmaBlockVector::Allocate(VkDeviceSize                   size,
-                                  VkDeviceSize                   alignment,
-                                  const VmaAllocationCreateInfo& createInfo,
-                                  VmaSuballocationType           suballocType,
-                                  size_t                         allocationCount,
-                                  VmaAllocation*                 pAllocations)
+VkResult VmaBlockVector::Allocate(
+    VkDeviceSize size,
+    VkDeviceSize alignment,
+    const VmaAllocationCreateInfo& createInfo,
+    VmaSuballocationType suballocType,
+    size_t allocationCount,
+    VmaAllocation* pAllocations)
 {
-    size_t   allocIndex;
+    size_t allocIndex;
     VkResult res = VK_SUCCESS;
 
     alignment = VMA_MAX(alignment, m_MinAllocationAlignment);
 
     if (IsCorruptionDetectionEnabled())
     {
-        size      = VmaAlignUp<VkDeviceSize>(size, sizeof(VMA_CORRUPTION_DETECTION_MAGIC_VALUE));
+        size = VmaAlignUp<VkDeviceSize>(size, sizeof(VMA_CORRUPTION_DETECTION_MAGIC_VALUE));
         alignment = VmaAlignUp<VkDeviceSize>(alignment, sizeof(VMA_CORRUPTION_DETECTION_MAGIC_VALUE));
     }
 
@@ -12576,7 +12398,12 @@ VkResult VmaBlockVector::Allocate(VkDeviceSize                   size,
         VmaMutexLockWrite lock(m_Mutex, m_hAllocator->m_UseMutex);
         for (allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
         {
-            res = AllocatePage(size, alignment, createInfo, suballocType, pAllocations + allocIndex);
+            res = AllocatePage(
+                size,
+                alignment,
+                createInfo,
+                suballocType,
+                pAllocations + allocIndex);
             if (res != VK_SUCCESS)
             {
                 break;
@@ -12587,38 +12414,42 @@ VkResult VmaBlockVector::Allocate(VkDeviceSize                   size,
     if (res != VK_SUCCESS)
     {
         // Free all already created allocations.
-        while (allocIndex--) Free(pAllocations[allocIndex]);
+        while (allocIndex--)
+            Free(pAllocations[allocIndex]);
         memset(pAllocations, 0, sizeof(VmaAllocation) * allocationCount);
     }
 
     return res;
 }
 
-VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
-                                      VkDeviceSize                   alignment,
-                                      const VmaAllocationCreateInfo& createInfo,
-                                      VmaSuballocationType           suballocType,
-                                      VmaAllocation*                 pAllocation)
+VkResult VmaBlockVector::AllocatePage(
+    VkDeviceSize size,
+    VkDeviceSize alignment,
+    const VmaAllocationCreateInfo& createInfo,
+    VmaSuballocationType suballocType,
+    VmaAllocation* pAllocation)
 {
     const bool isUpperAddress = (createInfo.flags & VMA_ALLOCATION_CREATE_UPPER_ADDRESS_BIT) != 0;
 
     VkDeviceSize freeMemory;
     {
-        const uint32_t heapIndex  = m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex);
-        VmaBudget      heapBudget = {};
+        const uint32_t heapIndex = m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex);
+        VmaBudget heapBudget = {};
         m_hAllocator->GetHeapBudgets(&heapBudget, heapIndex, 1);
         freeMemory = (heapBudget.usage < heapBudget.budget) ? (heapBudget.budget - heapBudget.usage) : 0;
     }
 
-    const bool canFallbackToDedicated =
-        !HasExplicitBlockSize() && (createInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) == 0;
-    const bool canCreateNewBlock = ((createInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) == 0) &&
-                                   (m_Blocks.size() < m_MaxBlockCount) &&
-                                   (freeMemory >= size || !canFallbackToDedicated);
+    const bool canFallbackToDedicated = !HasExplicitBlockSize() &&
+        (createInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) == 0;
+    const bool canCreateNewBlock =
+        ((createInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) == 0) &&
+        (m_Blocks.size() < m_MaxBlockCount) &&
+        (freeMemory >= size || !canFallbackToDedicated);
     uint32_t strategy = createInfo.flags & VMA_ALLOCATION_CREATE_STRATEGY_MASK;
 
     // Upper address can only be used with linear allocator and within single memory block.
-    if (isUpperAddress && (m_Algorithm != VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT || m_MaxBlockCount > 1))
+    if (isUpperAddress &&
+        (m_Algorithm != VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT || m_MaxBlockCount > 1))
     {
         return VK_ERROR_FEATURE_NOT_PRESENT;
     }
@@ -12637,17 +12468,11 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
         {
             VmaDeviceMemoryBlock* const pCurrBlock = m_Blocks.back();
             VMA_ASSERT(pCurrBlock);
-            VkResult res = AllocateFromBlock(pCurrBlock,
-                                             size,
-                                             alignment,
-                                             createInfo.flags,
-                                             createInfo.pUserData,
-                                             suballocType,
-                                             strategy,
-                                             pAllocation);
+            VkResult res = AllocateFromBlock(
+                pCurrBlock, size, alignment, createInfo.flags, createInfo.pUserData, suballocType, strategy, pAllocation);
             if (res == VK_SUCCESS)
             {
-                VMA_DEBUG_LOG("    Returned from last block #%u", pCurrBlock->GetId());
+                VMA_DEBUG_LOG_FORMAT("    Returned from last block #%u", pCurrBlock->GetId());
                 IncrementallySortBlocks();
                 return VK_SUCCESS;
             }
@@ -12657,20 +12482,19 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
     {
         if (strategy != VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT) // MIN_MEMORY or default
         {
-            const bool isHostVisible = (m_hAllocator->m_MemProps.memoryTypes[m_MemoryTypeIndex].propertyFlags &
-                                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0;
-            if (isHostVisible)
+            const bool isHostVisible =
+                (m_hAllocator->m_MemProps.memoryTypes[m_MemoryTypeIndex].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0;
+            if(isHostVisible)
             {
-                const bool isMappingAllowed =
-                    (createInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                         VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0;
+                const bool isMappingAllowed = (createInfo.flags &
+                    (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0;
                 /*
                 For non-mappable allocations, check blocks that are not mapped first.
                 For mappable allocations, check blocks that are already mapped first.
                 This way, having many blocks, we will separate mappable and non-mappable allocations,
                 hopefully limiting the number of blocks that are mapped, which will help tools like RenderDoc.
                 */
-                for (size_t mappingI = 0; mappingI < 2; ++mappingI)
+                for(size_t mappingI = 0; mappingI < 2; ++mappingI)
                 {
                     // Forward order in m_Blocks - prefer blocks with smallest amount of free space.
                     for (size_t blockIndex = 0; blockIndex < m_Blocks.size(); ++blockIndex)
@@ -12678,19 +12502,13 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
                         VmaDeviceMemoryBlock* const pCurrBlock = m_Blocks[blockIndex];
                         VMA_ASSERT(pCurrBlock);
                         const bool isBlockMapped = pCurrBlock->GetMappedData() != VMA_NULL;
-                        if ((mappingI == 0) == (isMappingAllowed == isBlockMapped))
+                        if((mappingI == 0) == (isMappingAllowed == isBlockMapped))
                         {
-                            VkResult res = AllocateFromBlock(pCurrBlock,
-                                                             size,
-                                                             alignment,
-                                                             createInfo.flags,
-                                                             createInfo.pUserData,
-                                                             suballocType,
-                                                             strategy,
-                                                             pAllocation);
+                            VkResult res = AllocateFromBlock(
+                                pCurrBlock, size, alignment, createInfo.flags, createInfo.pUserData, suballocType, strategy, pAllocation);
                             if (res == VK_SUCCESS)
                             {
-                                VMA_DEBUG_LOG("    Returned from existing block #%u", pCurrBlock->GetId());
+                                VMA_DEBUG_LOG_FORMAT("    Returned from existing block #%u", pCurrBlock->GetId());
                                 IncrementallySortBlocks();
                                 return VK_SUCCESS;
                             }
@@ -12705,17 +12523,11 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
                 {
                     VmaDeviceMemoryBlock* const pCurrBlock = m_Blocks[blockIndex];
                     VMA_ASSERT(pCurrBlock);
-                    VkResult res = AllocateFromBlock(pCurrBlock,
-                                                     size,
-                                                     alignment,
-                                                     createInfo.flags,
-                                                     createInfo.pUserData,
-                                                     suballocType,
-                                                     strategy,
-                                                     pAllocation);
+                    VkResult res = AllocateFromBlock(
+                        pCurrBlock, size, alignment, createInfo.flags, createInfo.pUserData, suballocType, strategy, pAllocation);
                     if (res == VK_SUCCESS)
                     {
-                        VMA_DEBUG_LOG("    Returned from existing block #%u", pCurrBlock->GetId());
+                        VMA_DEBUG_LOG_FORMAT("    Returned from existing block #%u", pCurrBlock->GetId());
                         IncrementallySortBlocks();
                         return VK_SUCCESS;
                     }
@@ -12725,21 +12537,14 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
         else // VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT
         {
             // Backward order in m_Blocks - prefer blocks with largest amount of free space.
-            for (size_t blockIndex = m_Blocks.size(); blockIndex--;)
+            for (size_t blockIndex = m_Blocks.size(); blockIndex--; )
             {
                 VmaDeviceMemoryBlock* const pCurrBlock = m_Blocks[blockIndex];
                 VMA_ASSERT(pCurrBlock);
-                VkResult res = AllocateFromBlock(pCurrBlock,
-                                                 size,
-                                                 alignment,
-                                                 createInfo.flags,
-                                                 createInfo.pUserData,
-                                                 suballocType,
-                                                 strategy,
-                                                 pAllocation);
+                VkResult res = AllocateFromBlock(pCurrBlock, size, alignment, createInfo.flags, createInfo.pUserData, suballocType, strategy, pAllocation);
                 if (res == VK_SUCCESS)
                 {
-                    VMA_DEBUG_LOG("    Returned from existing block #%u", pCurrBlock->GetId());
+                    VMA_DEBUG_LOG_FORMAT("    Returned from existing block #%u", pCurrBlock->GetId());
                     IncrementallySortBlocks();
                     return VK_SUCCESS;
                 }
@@ -12751,8 +12556,8 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
     if (canCreateNewBlock)
     {
         // Calculate optimal size for new block.
-        VkDeviceSize   newBlockSize             = m_PreferredBlockSize;
-        uint32_t       newBlockSizeShift        = 0;
+        VkDeviceSize newBlockSize = m_PreferredBlockSize;
+        uint32_t newBlockSizeShift = 0;
         const uint32_t NEW_BLOCK_SIZE_SHIFT_MAX = 3;
 
         if (!m_ExplicitBlockSize)
@@ -12774,10 +12579,9 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
             }
         }
 
-        size_t   newBlockIndex = 0;
-        VkResult res           = (newBlockSize <= freeMemory || !canFallbackToDedicated)
-                                     ? CreateBlock(newBlockSize, &newBlockIndex)
-                                     : VK_ERROR_OUT_OF_DEVICE_MEMORY;
+        size_t newBlockIndex = 0;
+        VkResult res = (newBlockSize <= freeMemory || !canFallbackToDedicated) ?
+            CreateBlock(newBlockSize, &newBlockIndex) : VK_ERROR_OUT_OF_DEVICE_MEMORY;
         // Allocation of this size failed? Try 1/2, 1/4, 1/8 of m_PreferredBlockSize.
         if (!m_ExplicitBlockSize)
         {
@@ -12788,9 +12592,8 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
                 {
                     newBlockSize = smallerNewBlockSize;
                     ++newBlockSizeShift;
-                    res = (newBlockSize <= freeMemory || !canFallbackToDedicated)
-                              ? CreateBlock(newBlockSize, &newBlockIndex)
-                              : VK_ERROR_OUT_OF_DEVICE_MEMORY;
+                    res = (newBlockSize <= freeMemory || !canFallbackToDedicated) ?
+                        CreateBlock(newBlockSize, &newBlockIndex) : VK_ERROR_OUT_OF_DEVICE_MEMORY;
                 }
                 else
                 {
@@ -12808,7 +12611,7 @@ VkResult VmaBlockVector::AllocatePage(VkDeviceSize                   size,
                 pBlock, size, alignment, createInfo.flags, createInfo.pUserData, suballocType, strategy, pAllocation);
             if (res == VK_SUCCESS)
             {
-                VMA_DEBUG_LOG("    Created new block #%u Size=%llu", pBlock->GetId(), newBlockSize);
+                VMA_DEBUG_LOG_FORMAT("    Created new block #%u Size=%llu", pBlock->GetId(), newBlockSize);
                 IncrementallySortBlocks();
                 return VK_SUCCESS;
             }
@@ -12829,8 +12632,8 @@ void VmaBlockVector::Free(const VmaAllocation hAllocation)
 
     bool budgetExceeded = false;
     {
-        const uint32_t heapIndex  = m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex);
-        VmaBudget      heapBudget = {};
+        const uint32_t heapIndex = m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex);
+        VmaBudget heapBudget = {};
         m_hAllocator->GetHeapBudgets(&heapBudget, heapIndex, 1);
         budgetExceeded = heapBudget.usage >= heapBudget.budget;
     }
@@ -12843,8 +12646,7 @@ void VmaBlockVector::Free(const VmaAllocation hAllocation)
 
         if (IsCorruptionDetectionEnabled())
         {
-            VkResult res = pBlock->ValidateMagicValueAfterAllocation(
-                m_hAllocator, hAllocation->GetOffset(), hAllocation->GetSize());
+            VkResult res = pBlock->ValidateMagicValueAfterAllocation(m_hAllocator, hAllocation->GetOffset(), hAllocation->GetSize());
             VMA_ASSERT(res == VK_SUCCESS && "Couldn't map block memory to validate magic value.");
         }
 
@@ -12858,7 +12660,7 @@ void VmaBlockVector::Free(const VmaAllocation hAllocation)
         pBlock->PostFree(m_hAllocator);
         VMA_HEAVY_ASSERT(pBlock->Validate());
 
-        VMA_DEBUG_LOG("  Freed from MemoryTypeIndex=%u", m_MemoryTypeIndex);
+        VMA_DEBUG_LOG_FORMAT("  Freed from MemoryTypeIndex=%u", m_MemoryTypeIndex);
 
         const bool canDeleteBlock = m_Blocks.size() > m_MinBlockCount;
         // pBlock became empty after this deallocation.
@@ -12870,8 +12672,7 @@ void VmaBlockVector::Free(const VmaAllocation hAllocation)
                 pBlockToDelete = pBlock;
                 Remove(pBlock);
             }
-            // else: We now have one empty block - leave it. A hysteresis to avoid allocating whole block back and
-            // forth.
+            // else: We now have one empty block - leave it. A hysteresis to avoid allocating whole block back and forth.
         }
         // pBlock didn't become empty, but we have another empty block - find and free that one.
         // (This is optional, heuristics.)
@@ -12892,20 +12693,19 @@ void VmaBlockVector::Free(const VmaAllocation hAllocation)
     // lock, for performance reason.
     if (pBlockToDelete != VMA_NULL)
     {
-        VMA_DEBUG_LOG("    Deleted empty block #%u", pBlockToDelete->GetId());
+        VMA_DEBUG_LOG_FORMAT("    Deleted empty block #%u", pBlockToDelete->GetId());
         pBlockToDelete->Destroy(m_hAllocator);
         vma_delete(m_hAllocator, pBlockToDelete);
     }
 
-    m_hAllocator->m_Budget.RemoveAllocation(m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex),
-                                            hAllocation->GetSize());
+    m_hAllocator->m_Budget.RemoveAllocation(m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex), hAllocation->GetSize());
     m_hAllocator->m_AllocationObjectAllocator.Free(hAllocation);
 }
 
 VkDeviceSize VmaBlockVector::CalcMaxBlockSize() const
 {
     VkDeviceSize result = 0;
-    for (size_t i = m_Blocks.size(); i--;)
+    for (size_t i = m_Blocks.size(); i--; )
     {
         result = VMA_MAX(result, m_Blocks[i]->m_pMetadata->GetSize());
         if (result >= m_PreferredBlockSize)
@@ -12949,46 +12749,54 @@ void VmaBlockVector::IncrementallySortBlocks()
 
 void VmaBlockVector::SortByFreeSize()
 {
-    VMA_SORT(m_Blocks.begin(), m_Blocks.end(), [](VmaDeviceMemoryBlock* b1, VmaDeviceMemoryBlock* b2) -> bool {
-        return b1->m_pMetadata->GetSumFreeSize() < b2->m_pMetadata->GetSumFreeSize();
-    });
+    VMA_SORT(m_Blocks.begin(), m_Blocks.end(),
+        [](VmaDeviceMemoryBlock* b1, VmaDeviceMemoryBlock* b2) -> bool
+        {
+            return b1->m_pMetadata->GetSumFreeSize() < b2->m_pMetadata->GetSumFreeSize();
+        });
 }
 
-VkResult VmaBlockVector::AllocateFromBlock(VmaDeviceMemoryBlock*    pBlock,
-                                           VkDeviceSize             size,
-                                           VkDeviceSize             alignment,
-                                           VmaAllocationCreateFlags allocFlags,
-                                           void*                    pUserData,
-                                           VmaSuballocationType     suballocType,
-                                           uint32_t                 strategy,
-                                           VmaAllocation*           pAllocation)
+VkResult VmaBlockVector::AllocateFromBlock(
+    VmaDeviceMemoryBlock* pBlock,
+    VkDeviceSize size,
+    VkDeviceSize alignment,
+    VmaAllocationCreateFlags allocFlags,
+    void* pUserData,
+    VmaSuballocationType suballocType,
+    uint32_t strategy,
+    VmaAllocation* pAllocation)
 {
     const bool isUpperAddress = (allocFlags & VMA_ALLOCATION_CREATE_UPPER_ADDRESS_BIT) != 0;
 
     VmaAllocationRequest currRequest = {};
     if (pBlock->m_pMetadata->CreateAllocationRequest(
-            size, alignment, isUpperAddress, suballocType, strategy, &currRequest))
+        size,
+        alignment,
+        isUpperAddress,
+        suballocType,
+        strategy,
+        &currRequest))
     {
-        return CommitAllocationRequest(
-            currRequest, pBlock, alignment, allocFlags, pUserData, suballocType, pAllocation);
+        return CommitAllocationRequest(currRequest, pBlock, alignment, allocFlags, pUserData, suballocType, pAllocation);
     }
     return VK_ERROR_OUT_OF_DEVICE_MEMORY;
 }
 
-VkResult VmaBlockVector::CommitAllocationRequest(VmaAllocationRequest&    allocRequest,
-                                                 VmaDeviceMemoryBlock*    pBlock,
-                                                 VkDeviceSize             alignment,
-                                                 VmaAllocationCreateFlags allocFlags,
-                                                 void*                    pUserData,
-                                                 VmaSuballocationType     suballocType,
-                                                 VmaAllocation*           pAllocation)
+VkResult VmaBlockVector::CommitAllocationRequest(
+    VmaAllocationRequest& allocRequest,
+    VmaDeviceMemoryBlock* pBlock,
+    VkDeviceSize alignment,
+    VmaAllocationCreateFlags allocFlags,
+    void* pUserData,
+    VmaSuballocationType suballocType,
+    VmaAllocation* pAllocation)
 {
-    const bool mapped           = (allocFlags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0;
+    const bool mapped = (allocFlags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0;
     const bool isUserDataString = (allocFlags & VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT) != 0;
-    const bool isMappingAllowed = (allocFlags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                                 VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0;
+    const bool isMappingAllowed = (allocFlags &
+        (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0;
 
-    pBlock->PostAlloc();
+    pBlock->PostAlloc(m_hAllocator);
     // Allocate from pCurrBlock.
     if (mapped)
     {
@@ -13001,29 +12809,27 @@ VkResult VmaBlockVector::CommitAllocationRequest(VmaAllocationRequest&    allocR
 
     *pAllocation = m_hAllocator->m_AllocationObjectAllocator.Allocate(isMappingAllowed);
     pBlock->m_pMetadata->Alloc(allocRequest, suballocType, *pAllocation);
-    (*pAllocation)
-        ->InitBlockAllocation(pBlock,
-                              allocRequest.allocHandle,
-                              alignment,
-                              allocRequest.size, // Not size, as actual allocation size may be larger than requested!
-                              m_MemoryTypeIndex,
-                              suballocType,
-                              mapped);
+    (*pAllocation)->InitBlockAllocation(
+        pBlock,
+        allocRequest.allocHandle,
+        alignment,
+        allocRequest.size, // Not size, as actual allocation size may be larger than requested!
+        m_MemoryTypeIndex,
+        suballocType,
+        mapped);
     VMA_HEAVY_ASSERT(pBlock->Validate());
     if (isUserDataString)
         (*pAllocation)->SetName(m_hAllocator, (const char*)pUserData);
     else
         (*pAllocation)->SetUserData(m_hAllocator, pUserData);
-    m_hAllocator->m_Budget.AddAllocation(m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex),
-                                         allocRequest.size);
+    m_hAllocator->m_Budget.AddAllocation(m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex), allocRequest.size);
     if (VMA_DEBUG_INITIALIZE_ALLOCATIONS)
     {
         m_hAllocator->FillAllocation(*pAllocation, VMA_ALLOCATION_FILL_PATTERN_CREATED);
     }
     if (IsCorruptionDetectionEnabled())
     {
-        VkResult res =
-            pBlock->WriteMagicValueAfterAllocation(m_hAllocator, (*pAllocation)->GetOffset(), allocRequest.size);
+        VkResult res = pBlock->WriteMagicValueAfterAllocation(m_hAllocator, (*pAllocation)->GetOffset(), allocRequest.size);
         VMA_ASSERT(res == VK_SUCCESS && "Couldn't map block memory to write magic value.");
     }
     return VK_SUCCESS;
@@ -13032,13 +12838,12 @@ VkResult VmaBlockVector::CommitAllocationRequest(VmaAllocationRequest&    allocR
 VkResult VmaBlockVector::CreateBlock(VkDeviceSize blockSize, size_t* pNewBlockIndex)
 {
     VkMemoryAllocateInfo allocInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
-    allocInfo.pNext                = m_pMemoryAllocateNext;
-    allocInfo.memoryTypeIndex      = m_MemoryTypeIndex;
-    allocInfo.allocationSize       = blockSize;
+    allocInfo.pNext = m_pMemoryAllocateNext;
+    allocInfo.memoryTypeIndex = m_MemoryTypeIndex;
+    allocInfo.allocationSize = blockSize;
 
 #if VMA_BUFFER_DEVICE_ADDRESS
-    // Every standalone block can potentially contain a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT - always
-    // enable the feature.
+    // Every standalone block can potentially contain a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT - always enable the feature.
     VkMemoryAllocateFlagsInfoKHR allocFlagsInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO_KHR };
     if (m_hAllocator->m_UseKhrBufferDeviceAddress)
     {
@@ -13068,7 +12873,7 @@ VkResult VmaBlockVector::CreateBlock(VkDeviceSize blockSize, size_t* pNewBlockIn
 #endif // VMA_EXTERNAL_MEMORY
 
     VkDeviceMemory mem = VK_NULL_HANDLE;
-    VkResult       res = m_hAllocator->AllocateVulkanMemory(&allocInfo, &mem);
+    VkResult res = m_hAllocator->AllocateVulkanMemory(&allocInfo, &mem);
     if (res < 0)
     {
         return res;
@@ -13078,14 +12883,15 @@ VkResult VmaBlockVector::CreateBlock(VkDeviceSize blockSize, size_t* pNewBlockIn
 
     // Create new Allocation for it.
     VmaDeviceMemoryBlock* const pBlock = vma_new(m_hAllocator, VmaDeviceMemoryBlock)(m_hAllocator);
-    pBlock->Init(m_hAllocator,
-                 m_hParentPool,
-                 m_MemoryTypeIndex,
-                 mem,
-                 allocInfo.allocationSize,
-                 m_NextBlockId++,
-                 m_Algorithm,
-                 m_BufferImageGranularity);
+    pBlock->Init(
+        m_hAllocator,
+        m_hParentPool,
+        m_MemoryTypeIndex,
+        mem,
+        allocInfo.allocationSize,
+        m_NextBlockId++,
+        m_Algorithm,
+        m_BufferImageGranularity);
 
     m_Blocks.push_back(pBlock);
     if (pNewBlockIndex != VMA_NULL)
@@ -13113,6 +12919,7 @@ bool VmaBlockVector::HasEmptyBlock()
 void VmaBlockVector::PrintDetailedMap(class VmaJsonWriter& json)
 {
     VmaMutexLockRead lock(m_Mutex, m_hAllocator->m_UseMutex);
+
 
     json.BeginObject();
     for (size_t i = 0; i < m_Blocks.size(); ++i)
@@ -13156,26 +12963,29 @@ VkResult VmaBlockVector::CheckCorruption()
 #endif // _VMA_BLOCK_VECTOR_FUNCTIONS
 
 #ifndef _VMA_DEFRAGMENTATION_CONTEXT_FUNCTIONS
-VmaDefragmentationContext_T::VmaDefragmentationContext_T(VmaAllocator hAllocator, const VmaDefragmentationInfo& info) :
-    m_MaxPassBytes(info.maxBytesPerPass == 0 ? VK_WHOLE_SIZE : info.maxBytesPerPass),
+VmaDefragmentationContext_T::VmaDefragmentationContext_T(
+    VmaAllocator hAllocator,
+    const VmaDefragmentationInfo& info)
+    : m_MaxPassBytes(info.maxBytesPerPass == 0 ? VK_WHOLE_SIZE : info.maxBytesPerPass),
     m_MaxPassAllocations(info.maxAllocationsPerPass == 0 ? UINT32_MAX : info.maxAllocationsPerPass),
-    m_MoveAllocator(hAllocator->GetAllocationCallbacks()), m_Moves(m_MoveAllocator)
+    m_MoveAllocator(hAllocator->GetAllocationCallbacks()),
+    m_Moves(m_MoveAllocator)
 {
     m_Algorithm = info.flags & VMA_DEFRAGMENTATION_FLAG_ALGORITHM_MASK;
 
     if (info.pool != VMA_NULL)
     {
         m_BlockVectorCount = 1;
-        m_PoolBlockVector  = &info.pool->m_BlockVector;
-        m_pBlockVectors    = &m_PoolBlockVector;
+        m_PoolBlockVector = &info.pool->m_BlockVector;
+        m_pBlockVectors = &m_PoolBlockVector;
         m_PoolBlockVector->SetIncrementalSort(false);
         m_PoolBlockVector->SortByFreeSize();
     }
     else
     {
         m_BlockVectorCount = hAllocator->GetMemoryTypeCount();
-        m_PoolBlockVector  = VMA_NULL;
-        m_pBlockVectors    = hAllocator->m_pBlockVectors;
+        m_PoolBlockVector = VMA_NULL;
+        m_pBlockVectors = hAllocator->m_pBlockVectors;
         for (uint32_t i = 0; i < m_BlockVectorCount; ++i)
         {
             VmaBlockVector* vector = m_pBlockVectors[i];
@@ -13189,21 +12999,19 @@ VmaDefragmentationContext_T::VmaDefragmentationContext_T(VmaAllocator hAllocator
 
     switch (m_Algorithm)
     {
-        case 0: // Default algorithm
-            m_Algorithm = VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT;
-        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT:
+    case 0: // Default algorithm
+        m_Algorithm = VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT;
+        m_AlgorithmState = vma_new_array(hAllocator, StateBalanced, m_BlockVectorCount);
+        break;
+    case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT:
+        m_AlgorithmState = vma_new_array(hAllocator, StateBalanced, m_BlockVectorCount);
+        break;
+    case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
+        if (hAllocator->GetBufferImageGranularity() > 1)
         {
-            m_AlgorithmState = vma_new_array(hAllocator, StateBalanced, m_BlockVectorCount);
-            break;
+            m_AlgorithmState = vma_new_array(hAllocator, StateExtensive, m_BlockVectorCount);
         }
-        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
-        {
-            if (hAllocator->GetBufferImageGranularity() > 1)
-            {
-                m_AlgorithmState = vma_new_array(hAllocator, StateExtensive, m_BlockVectorCount);
-            }
-            break;
-        }
+        break;
     }
 }
 
@@ -13227,18 +13035,14 @@ VmaDefragmentationContext_T::~VmaDefragmentationContext_T()
     {
         switch (m_Algorithm)
         {
-            case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT:
-                vma_delete_array(m_MoveAllocator.m_pCallbacks,
-                                 reinterpret_cast<StateBalanced*>(m_AlgorithmState),
-                                 m_BlockVectorCount);
-                break;
-            case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
-                vma_delete_array(m_MoveAllocator.m_pCallbacks,
-                                 reinterpret_cast<StateExtensive*>(m_AlgorithmState),
-                                 m_BlockVectorCount);
-                break;
-            default:
-                VMA_ASSERT(0);
+        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT:
+            vma_delete_array(m_MoveAllocator.m_pCallbacks, reinterpret_cast<StateBalanced*>(m_AlgorithmState), m_BlockVectorCount);
+            break;
+        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
+            vma_delete_array(m_MoveAllocator.m_pCallbacks, reinterpret_cast<StateExtensive*>(m_AlgorithmState), m_BlockVectorCount);
+            break;
+        default:
+            VMA_ASSERT(0);
         }
     }
 }
@@ -13291,124 +13095,124 @@ VkResult VmaDefragmentationContext_T::DefragmentPassEnd(VmaDefragmentationPassMo
 {
     VMA_ASSERT(moveInfo.moveCount > 0 ? moveInfo.pMoves != VMA_NULL : true);
 
-    VkResult                                                     result = VK_SUCCESS;
-    VmaStlAllocator<FragmentedBlock>                             blockAllocator(m_MoveAllocator.m_pCallbacks);
+    VkResult result = VK_SUCCESS;
+    VmaStlAllocator<FragmentedBlock> blockAllocator(m_MoveAllocator.m_pCallbacks);
     VmaVector<FragmentedBlock, VmaStlAllocator<FragmentedBlock>> immovableBlocks(blockAllocator);
     VmaVector<FragmentedBlock, VmaStlAllocator<FragmentedBlock>> mappedBlocks(blockAllocator);
 
     VmaAllocator allocator = VMA_NULL;
     for (uint32_t i = 0; i < moveInfo.moveCount; ++i)
     {
-        VmaDefragmentationMove& move      = moveInfo.pMoves[i];
-        size_t                  prevCount = 0, currentCount = 0;
-        VkDeviceSize            freedBlockSize = 0;
+        VmaDefragmentationMove& move = moveInfo.pMoves[i];
+        size_t prevCount = 0, currentCount = 0;
+        VkDeviceSize freedBlockSize = 0;
 
-        uint32_t        vectorIndex;
+        uint32_t vectorIndex;
         VmaBlockVector* vector;
         if (m_PoolBlockVector != VMA_NULL)
         {
             vectorIndex = 0;
-            vector      = m_PoolBlockVector;
+            vector = m_PoolBlockVector;
         }
         else
         {
             vectorIndex = move.srcAllocation->GetMemoryTypeIndex();
-            vector      = m_pBlockVectors[vectorIndex];
+            vector = m_pBlockVectors[vectorIndex];
             VMA_ASSERT(vector != VMA_NULL);
         }
 
         switch (move.operation)
         {
-            case VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY:
+        case VMA_DEFRAGMENTATION_MOVE_OPERATION_COPY:
+        {
+            uint8_t mapCount = move.srcAllocation->SwapBlockAllocation(vector->m_hAllocator, move.dstTmpAllocation);
+            if (mapCount > 0)
             {
-                uint8_t mapCount = move.srcAllocation->SwapBlockAllocation(vector->m_hAllocator, move.dstTmpAllocation);
-                if (mapCount > 0)
+                allocator = vector->m_hAllocator;
+                VmaDeviceMemoryBlock* newMapBlock = move.srcAllocation->GetBlock();
+                bool notPresent = true;
+                for (FragmentedBlock& block : mappedBlocks)
                 {
-                    allocator                         = vector->m_hAllocator;
-                    VmaDeviceMemoryBlock* newMapBlock = move.srcAllocation->GetBlock();
-                    bool                  notPresent  = true;
-                    for (FragmentedBlock& block : mappedBlocks)
-                    {
-                        if (block.block == newMapBlock)
-                        {
-                            notPresent = false;
-                            block.data += mapCount;
-                            break;
-                        }
-                    }
-                    if (notPresent)
-                        mappedBlocks.push_back({ mapCount, newMapBlock });
-                }
-
-                // Scope for locks, Free have it's own lock
-                {
-                    VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
-                    prevCount      = vector->GetBlockCount();
-                    freedBlockSize = move.dstTmpAllocation->GetBlock()->m_pMetadata->GetSize();
-                }
-                vector->Free(move.dstTmpAllocation);
-                {
-                    VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
-                    currentCount = vector->GetBlockCount();
-                }
-
-                result = VK_INCOMPLETE;
-                break;
-            }
-            case VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE:
-            {
-                m_PassStats.bytesMoved -= move.srcAllocation->GetSize();
-                --m_PassStats.allocationsMoved;
-                vector->Free(move.dstTmpAllocation);
-
-                VmaDeviceMemoryBlock* newBlock   = move.srcAllocation->GetBlock();
-                bool                  notPresent = true;
-                for (const FragmentedBlock& block : immovableBlocks)
-                {
-                    if (block.block == newBlock)
+                    if (block.block == newMapBlock)
                     {
                         notPresent = false;
+                        block.data += mapCount;
                         break;
                     }
                 }
                 if (notPresent)
-                    immovableBlocks.push_back({ vectorIndex, newBlock });
-                break;
+                    mappedBlocks.push_back({ mapCount, newMapBlock });
             }
-            case VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY:
+
+            // Scope for locks, Free have it's own lock
             {
-                m_PassStats.bytesMoved -= move.srcAllocation->GetSize();
-                --m_PassStats.allocationsMoved;
-                // Scope for locks, Free have it's own lock
-                {
-                    VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
-                    prevCount      = vector->GetBlockCount();
-                    freedBlockSize = move.srcAllocation->GetBlock()->m_pMetadata->GetSize();
-                }
-                vector->Free(move.srcAllocation);
-                {
-                    VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
-                    currentCount = vector->GetBlockCount();
-                }
-                freedBlockSize *= prevCount - currentCount;
-
-                VkDeviceSize dstBlockSize;
-                {
-                    VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
-                    dstBlockSize = move.dstTmpAllocation->GetBlock()->m_pMetadata->GetSize();
-                }
-                vector->Free(move.dstTmpAllocation);
-                {
-                    VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
-                    freedBlockSize += dstBlockSize * (currentCount - vector->GetBlockCount());
-                    currentCount = vector->GetBlockCount();
-                }
-
-                result = VK_INCOMPLETE;
-                break;
+                VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+                prevCount = vector->GetBlockCount();
+                freedBlockSize = move.dstTmpAllocation->GetBlock()->m_pMetadata->GetSize();
             }
-            default:
-                VMA_ASSERT(0);
+            vector->Free(move.dstTmpAllocation);
+            {
+                VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+                currentCount = vector->GetBlockCount();
+            }
+
+            result = VK_INCOMPLETE;
+            break;
+        }
+        case VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE:
+        {
+            m_PassStats.bytesMoved -= move.srcAllocation->GetSize();
+            --m_PassStats.allocationsMoved;
+            vector->Free(move.dstTmpAllocation);
+
+            VmaDeviceMemoryBlock* newBlock = move.srcAllocation->GetBlock();
+            bool notPresent = true;
+            for (const FragmentedBlock& block : immovableBlocks)
+            {
+                if (block.block == newBlock)
+                {
+                    notPresent = false;
+                    break;
+                }
+            }
+            if (notPresent)
+                immovableBlocks.push_back({ vectorIndex, newBlock });
+            break;
+        }
+        case VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY:
+        {
+            m_PassStats.bytesMoved -= move.srcAllocation->GetSize();
+            --m_PassStats.allocationsMoved;
+            // Scope for locks, Free have it's own lock
+            {
+                VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+                prevCount = vector->GetBlockCount();
+                freedBlockSize = move.srcAllocation->GetBlock()->m_pMetadata->GetSize();
+            }
+            vector->Free(move.srcAllocation);
+            {
+                VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+                currentCount = vector->GetBlockCount();
+            }
+            freedBlockSize *= prevCount - currentCount;
+
+            VkDeviceSize dstBlockSize;
+            {
+                VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+                dstBlockSize = move.dstTmpAllocation->GetBlock()->m_pMetadata->GetSize();
+            }
+            vector->Free(move.dstTmpAllocation);
+            {
+                VmaMutexLockRead lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+                freedBlockSize += dstBlockSize * (currentCount - vector->GetBlockCount());
+                currentCount = vector->GetBlockCount();
+            }
+
+            result = VK_INCOMPLETE;
+            break;
+        }
+        default:
+            VMA_ASSERT(0);
         }
 
         if (prevCount > currentCount)
@@ -13418,33 +13222,27 @@ VkResult VmaDefragmentationContext_T::DefragmentPassEnd(VmaDefragmentationPassMo
             m_PassStats.bytesFreed += freedBlockSize;
         }
 
-        switch (m_Algorithm)
+        if(m_Algorithm == VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT &&
+            m_AlgorithmState != VMA_NULL)
         {
-            case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
+            // Avoid unnecessary tries to allocate when new free block is available
+            StateExtensive& state = reinterpret_cast<StateExtensive*>(m_AlgorithmState)[vectorIndex];
+            if (state.firstFreeBlock != SIZE_MAX)
             {
-                if (m_AlgorithmState != VMA_NULL)
+                const size_t diff = prevCount - currentCount;
+                if (state.firstFreeBlock >= diff)
                 {
-                    // Avoid unnecessary tries to allocate when new free block is avaiable
-                    StateExtensive& state = reinterpret_cast<StateExtensive*>(m_AlgorithmState)[vectorIndex];
-                    if (state.firstFreeBlock != SIZE_MAX)
-                    {
-                        const size_t diff = prevCount - currentCount;
-                        if (state.firstFreeBlock >= diff)
-                        {
-                            state.firstFreeBlock -= diff;
-                            if (state.firstFreeBlock != 0)
-                                state.firstFreeBlock -=
-                                    vector->GetBlock(state.firstFreeBlock - 1)->m_pMetadata->IsEmpty();
-                        }
-                        else
-                            state.firstFreeBlock = 0;
-                    }
+                    state.firstFreeBlock -= diff;
+                    if (state.firstFreeBlock != 0)
+                        state.firstFreeBlock -= vector->GetBlock(state.firstFreeBlock - 1)->m_pMetadata->IsEmpty();
                 }
+                else
+                    state.firstFreeBlock = 0;
             }
         }
     }
     moveInfo.moveCount = 0;
-    moveInfo.pMoves    = VMA_NULL;
+    moveInfo.pMoves = VMA_NULL;
     m_Moves.clear();
 
     // Update stats
@@ -13457,9 +13255,9 @@ VkResult VmaDefragmentationContext_T::DefragmentPassEnd(VmaDefragmentationPassMo
     // Move blocks with immovable allocations according to algorithm
     if (immovableBlocks.size() > 0)
     {
-        switch (m_Algorithm)
+        do
         {
-            case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
+            if(m_Algorithm == VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT)
             {
                 if (m_AlgorithmState != VMA_NULL)
                 {
@@ -13470,15 +13268,14 @@ VkResult VmaDefragmentationContext_T::DefragmentPassEnd(VmaDefragmentationPassMo
                         StateExtensive& state = reinterpret_cast<StateExtensive*>(m_AlgorithmState)[block.data];
                         if (state.operation != StateExtensive::Operation::Cleanup)
                         {
-                            VmaBlockVector*   vector = m_pBlockVectors[block.data];
+                            VmaBlockVector* vector = m_pBlockVectors[block.data];
                             VmaMutexLockWrite lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
 
                             for (size_t i = 0, count = vector->GetBlockCount() - m_ImmovableBlockCount; i < count; ++i)
                             {
                                 if (vector->GetBlock(i) == block.block)
                                 {
-                                    VMA_SWAP(vector->m_Blocks[i],
-                                             vector->m_Blocks[vector->GetBlockCount() - ++m_ImmovableBlockCount]);
+                                    VMA_SWAP(vector->m_Blocks[i], vector->m_Blocks[vector->GetBlockCount() - ++m_ImmovableBlockCount]);
                                     if (state.firstFreeBlock != SIZE_MAX)
                                     {
                                         if (i + 1 < state.firstFreeBlock)
@@ -13500,26 +13297,23 @@ VkResult VmaDefragmentationContext_T::DefragmentPassEnd(VmaDefragmentationPassMo
                     break;
                 }
             }
-            default:
-            {
-                // Move to the begining
-                for (const FragmentedBlock& block : immovableBlocks)
-                {
-                    VmaBlockVector*   vector = m_pBlockVectors[block.data];
-                    VmaMutexLockWrite lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
 
-                    for (size_t i = m_ImmovableBlockCount; i < vector->GetBlockCount(); ++i)
+            // Move to the beginning
+            for (const FragmentedBlock& block : immovableBlocks)
+            {
+                VmaBlockVector* vector = m_pBlockVectors[block.data];
+                VmaMutexLockWrite lock(vector->GetMutex(), vector->GetAllocator()->m_UseMutex);
+
+                for (size_t i = m_ImmovableBlockCount; i < vector->GetBlockCount(); ++i)
+                {
+                    if (vector->GetBlock(i) == block.block)
                     {
-                        if (vector->GetBlock(i) == block.block)
-                        {
-                            VMA_SWAP(vector->m_Blocks[i], vector->m_Blocks[m_ImmovableBlockCount++]);
-                            break;
-                        }
+                        VMA_SWAP(vector->m_Blocks[i], vector->m_Blocks[m_ImmovableBlockCount++]);
+                        break;
                     }
                 }
-                break;
             }
-        }
+        } while (false);
     }
 
     // Bulk-map destination blocks
@@ -13535,34 +13329,34 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation(VmaBlockVector& vector,
 {
     switch (m_Algorithm)
     {
-        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FAST_BIT:
-            return ComputeDefragmentation_Fast(vector);
-        default:
-            VMA_ASSERT(0);
-        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT:
-            return ComputeDefragmentation_Balanced(vector, index, true);
-        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT:
-            return ComputeDefragmentation_Full(vector);
-        case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
-            return ComputeDefragmentation_Extensive(vector, index);
+    case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FAST_BIT:
+        return ComputeDefragmentation_Fast(vector);
+    case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED_BIT:
+        return ComputeDefragmentation_Balanced(vector, index, true);
+    case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_FULL_BIT:
+        return ComputeDefragmentation_Full(vector);
+    case VMA_DEFRAGMENTATION_FLAG_ALGORITHM_EXTENSIVE_BIT:
+        return ComputeDefragmentation_Extensive(vector, index);
+    default:
+        VMA_ASSERT(0);
+        return ComputeDefragmentation_Balanced(vector, index, true);
     }
 }
 
-VmaDefragmentationContext_T::MoveAllocationData VmaDefragmentationContext_T::GetMoveData(VmaAllocHandle    handle,
-                                                                                         VmaBlockMetadata* metadata)
+VmaDefragmentationContext_T::MoveAllocationData VmaDefragmentationContext_T::GetMoveData(
+    VmaAllocHandle handle, VmaBlockMetadata* metadata)
 {
     MoveAllocationData moveData;
     moveData.move.srcAllocation = (VmaAllocation)metadata->GetAllocationUserData(handle);
-    moveData.size               = moveData.move.srcAllocation->GetSize();
-    moveData.alignment          = moveData.move.srcAllocation->GetAlignment();
-    moveData.type               = moveData.move.srcAllocation->GetSuballocationType();
-    moveData.flags              = 0;
+    moveData.size = moveData.move.srcAllocation->GetSize();
+    moveData.alignment = moveData.move.srcAllocation->GetAlignment();
+    moveData.type = moveData.move.srcAllocation->GetSuballocationType();
+    moveData.flags = 0;
 
     if (moveData.move.srcAllocation->IsPersistentMap())
         moveData.flags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
     if (moveData.move.srcAllocation->IsMappingAllowed())
-        moveData.flags |=
-            VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
+        moveData.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
 
     return moveData;
 }
@@ -13577,6 +13371,8 @@ VmaDefragmentationContext_T::CounterStatus VmaDefragmentationContext_T::CheckCou
         else
             return CounterStatus::End;
     }
+    else
+        m_IgnoredAllocs = 0;
     return CounterStatus::Pass;
 }
 
@@ -13586,8 +13382,8 @@ bool VmaDefragmentationContext_T::IncrementCounters(VkDeviceSize bytes)
     // Early return when max found
     if (++m_PassStats.allocationsMoved >= m_MaxPassAllocations || m_PassStats.bytesMoved >= m_MaxPassBytes)
     {
-        VMA_ASSERT(m_PassStats.allocationsMoved == m_MaxPassAllocations ||
-                   m_PassStats.bytesMoved == m_MaxPassBytes && "Exceeded maximal pass threshold!");
+        VMA_ASSERT((m_PassStats.allocationsMoved == m_MaxPassAllocations ||
+            m_PassStats.bytesMoved == m_MaxPassBytes) && "Exceeded maximal pass threshold!");
         return true;
     }
     return false;
@@ -13597,8 +13393,9 @@ bool VmaDefragmentationContext_T::ReallocWithinBlock(VmaBlockVector& vector, Vma
 {
     VmaBlockMetadata* metadata = block->m_pMetadata;
 
-    for (VmaAllocHandle handle = metadata->GetAllocationListBegin(); handle != VK_NULL_HANDLE;
-         handle                = metadata->GetNextAllocation(handle))
+    for (VmaAllocHandle handle = metadata->GetAllocationListBegin();
+        handle != VK_NULL_HANDLE;
+        handle = metadata->GetNextAllocation(handle))
     {
         MoveAllocationData moveData = GetMoveData(handle, metadata);
         // Ignore newly created allocations by defragmentation algorithm
@@ -13606,36 +13403,38 @@ bool VmaDefragmentationContext_T::ReallocWithinBlock(VmaBlockVector& vector, Vma
             continue;
         switch (CheckCounters(moveData.move.srcAllocation->GetSize()))
         {
-            case CounterStatus::Ignore:
-                continue;
-            case CounterStatus::End:
-                return true;
-            default:
-                VMA_ASSERT(0);
-            case CounterStatus::Pass:
-                break;
+        case CounterStatus::Ignore:
+            continue;
+        case CounterStatus::End:
+            return true;
+        case CounterStatus::Pass:
+            break;
+        default:
+            VMA_ASSERT(0);
         }
 
         VkDeviceSize offset = moveData.move.srcAllocation->GetOffset();
         if (offset != 0 && metadata->GetSumFreeSize() >= moveData.size)
         {
             VmaAllocationRequest request = {};
-            if (metadata->CreateAllocationRequest(moveData.size,
-                                                  moveData.alignment,
-                                                  false,
-                                                  moveData.type,
-                                                  VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
-                                                  &request))
+            if (metadata->CreateAllocationRequest(
+                moveData.size,
+                moveData.alignment,
+                false,
+                moveData.type,
+                VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
+                &request))
             {
                 if (metadata->GetAllocationOffset(request.allocHandle) < offset)
                 {
-                    if (vector.CommitAllocationRequest(request,
-                                                       block,
-                                                       moveData.alignment,
-                                                       moveData.flags,
-                                                       this,
-                                                       moveData.type,
-                                                       &moveData.move.dstTmpAllocation) == VK_SUCCESS)
+                    if (vector.CommitAllocationRequest(
+                        request,
+                        block,
+                        moveData.alignment,
+                        moveData.flags,
+                        this,
+                        moveData.type,
+                        &moveData.move.dstTmpAllocation) == VK_SUCCESS)
                     {
                         m_Moves.push_back(moveData.move);
                         if (IncrementCounters(moveData.size))
@@ -13648,19 +13447,21 @@ bool VmaDefragmentationContext_T::ReallocWithinBlock(VmaBlockVector& vector, Vma
     return false;
 }
 
-bool VmaDefragmentationContext_T::AllocInOtherBlock(size_t              start,
-                                                    size_t              end,
-                                                    MoveAllocationData& data,
-                                                    VmaBlockVector&     vector)
+bool VmaDefragmentationContext_T::AllocInOtherBlock(size_t start, size_t end, MoveAllocationData& data, VmaBlockVector& vector)
 {
     for (; start < end; ++start)
     {
         VmaDeviceMemoryBlock* dstBlock = vector.GetBlock(start);
         if (dstBlock->m_pMetadata->GetSumFreeSize() >= data.size)
         {
-            if (vector.AllocateFromBlock(
-                    dstBlock, data.size, data.alignment, data.flags, this, data.type, 0, &data.move.dstTmpAllocation) ==
-                VK_SUCCESS)
+            if (vector.AllocateFromBlock(dstBlock,
+                data.size,
+                data.alignment,
+                data.flags,
+                this,
+                data.type,
+                0,
+                &data.move.dstTmpAllocation) == VK_SUCCESS)
             {
                 m_Moves.push_back(data.move);
                 if (IncrementCounters(data.size))
@@ -13681,8 +13482,9 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Fast(VmaBlockVector& ve
     {
         VmaBlockMetadata* metadata = vector.GetBlock(i)->m_pMetadata;
 
-        for (VmaAllocHandle handle = metadata->GetAllocationListBegin(); handle != VK_NULL_HANDLE;
-             handle                = metadata->GetNextAllocation(handle))
+        for (VmaAllocHandle handle = metadata->GetAllocationListBegin();
+            handle != VK_NULL_HANDLE;
+            handle = metadata->GetNextAllocation(handle))
         {
             MoveAllocationData moveData = GetMoveData(handle, metadata);
             // Ignore newly created allocations by defragmentation algorithm
@@ -13690,14 +13492,14 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Fast(VmaBlockVector& ve
                 continue;
             switch (CheckCounters(moveData.move.srcAllocation->GetSize()))
             {
-                case CounterStatus::Ignore:
-                    continue;
-                case CounterStatus::End:
-                    return true;
-                default:
-                    VMA_ASSERT(0);
-                case CounterStatus::Pass:
-                    break;
+            case CounterStatus::Ignore:
+                continue;
+            case CounterStatus::End:
+                return true;
+            case CounterStatus::Pass:
+                break;
+            default:
+                VMA_ASSERT(0);
             }
 
             // Check all previous blocks for free space
@@ -13712,23 +13514,24 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Balanced(VmaBlockVector
 {
     // Go over every allocation and try to fit it in previous blocks at lowest offsets,
     // if not possible: realloc within single block to minimize offset (exclude offset == 0),
-    // but only if there are noticable gaps between them (some heuristic, ex. average size of allocation in block)
+    // but only if there are noticeable gaps between them (some heuristic, ex. average size of allocation in block)
     VMA_ASSERT(m_AlgorithmState != VMA_NULL);
 
     StateBalanced& vectorState = reinterpret_cast<StateBalanced*>(m_AlgorithmState)[index];
     if (update && vectorState.avgAllocSize == UINT64_MAX)
         UpdateVectorStatistics(vector, vectorState);
 
-    const size_t startMoveCount    = m_Moves.size();
+    const size_t startMoveCount = m_Moves.size();
     VkDeviceSize minimalFreeRegion = vectorState.avgFreeSize / 2;
     for (size_t i = vector.GetBlockCount() - 1; i > m_ImmovableBlockCount; --i)
     {
-        VmaDeviceMemoryBlock* block              = vector.GetBlock(i);
-        VmaBlockMetadata*     metadata           = block->m_pMetadata;
-        VkDeviceSize          prevFreeRegionSize = 0;
+        VmaDeviceMemoryBlock* block = vector.GetBlock(i);
+        VmaBlockMetadata* metadata = block->m_pMetadata;
+        VkDeviceSize prevFreeRegionSize = 0;
 
-        for (VmaAllocHandle handle = metadata->GetAllocationListBegin(); handle != VK_NULL_HANDLE;
-             handle                = metadata->GetNextAllocation(handle))
+        for (VmaAllocHandle handle = metadata->GetAllocationListBegin();
+            handle != VK_NULL_HANDLE;
+            handle = metadata->GetNextAllocation(handle))
         {
             MoveAllocationData moveData = GetMoveData(handle, metadata);
             // Ignore newly created allocations by defragmentation algorithm
@@ -13736,14 +13539,14 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Balanced(VmaBlockVector
                 continue;
             switch (CheckCounters(moveData.move.srcAllocation->GetSize()))
             {
-                case CounterStatus::Ignore:
-                    continue;
-                case CounterStatus::End:
-                    return true;
-                default:
-                    VMA_ASSERT(0);
-                case CounterStatus::Pass:
-                    break;
+            case CounterStatus::Ignore:
+                continue;
+            case CounterStatus::End:
+                return true;
+            case CounterStatus::Pass:
+                break;
+            default:
+                VMA_ASSERT(0);
             }
 
             // Check all previous blocks for free space
@@ -13757,26 +13560,30 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Balanced(VmaBlockVector
             if (prevMoveCount == m_Moves.size() && offset != 0 && metadata->GetSumFreeSize() >= moveData.size)
             {
                 // Check if realloc will make sense
-                if (prevFreeRegionSize >= minimalFreeRegion || nextFreeRegionSize >= minimalFreeRegion ||
-                    moveData.size <= vectorState.avgFreeSize || moveData.size <= vectorState.avgAllocSize)
+                if (prevFreeRegionSize >= minimalFreeRegion ||
+                    nextFreeRegionSize >= minimalFreeRegion ||
+                    moveData.size <= vectorState.avgFreeSize ||
+                    moveData.size <= vectorState.avgAllocSize)
                 {
                     VmaAllocationRequest request = {};
-                    if (metadata->CreateAllocationRequest(moveData.size,
-                                                          moveData.alignment,
-                                                          false,
-                                                          moveData.type,
-                                                          VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
-                                                          &request))
+                    if (metadata->CreateAllocationRequest(
+                        moveData.size,
+                        moveData.alignment,
+                        false,
+                        moveData.type,
+                        VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
+                        &request))
                     {
                         if (metadata->GetAllocationOffset(request.allocHandle) < offset)
                         {
-                            if (vector.CommitAllocationRequest(request,
-                                                               block,
-                                                               moveData.alignment,
-                                                               moveData.flags,
-                                                               this,
-                                                               moveData.type,
-                                                               &moveData.move.dstTmpAllocation) == VK_SUCCESS)
+                            if (vector.CommitAllocationRequest(
+                                request,
+                                block,
+                                moveData.alignment,
+                                moveData.flags,
+                                this,
+                                moveData.type,
+                                &moveData.move.dstTmpAllocation) == VK_SUCCESS)
                             {
                                 m_Moves.push_back(moveData.move);
                                 if (IncrementCounters(moveData.size))
@@ -13790,7 +13597,7 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Balanced(VmaBlockVector
         }
     }
 
-    // No moves perfomed, update statistics to current vector state
+    // No moves performed, update statistics to current vector state
     if (startMoveCount == m_Moves.size() && !update)
     {
         vectorState.avgAllocSize = UINT64_MAX;
@@ -13806,11 +13613,12 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Full(VmaBlockVector& ve
 
     for (size_t i = vector.GetBlockCount() - 1; i > m_ImmovableBlockCount; --i)
     {
-        VmaDeviceMemoryBlock* block    = vector.GetBlock(i);
-        VmaBlockMetadata*     metadata = block->m_pMetadata;
+        VmaDeviceMemoryBlock* block = vector.GetBlock(i);
+        VmaBlockMetadata* metadata = block->m_pMetadata;
 
-        for (VmaAllocHandle handle = metadata->GetAllocationListBegin(); handle != VK_NULL_HANDLE;
-             handle                = metadata->GetNextAllocation(handle))
+        for (VmaAllocHandle handle = metadata->GetAllocationListBegin();
+            handle != VK_NULL_HANDLE;
+            handle = metadata->GetNextAllocation(handle))
         {
             MoveAllocationData moveData = GetMoveData(handle, metadata);
             // Ignore newly created allocations by defragmentation algorithm
@@ -13818,14 +13626,14 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Full(VmaBlockVector& ve
                 continue;
             switch (CheckCounters(moveData.move.srcAllocation->GetSize()))
             {
-                case CounterStatus::Ignore:
-                    continue;
-                case CounterStatus::End:
-                    return true;
-                default:
-                    VMA_ASSERT(0);
-                case CounterStatus::Pass:
-                    break;
+            case CounterStatus::Ignore:
+                continue;
+            case CounterStatus::End:
+                return true;
+            case CounterStatus::Pass:
+                break;
+            default:
+                VMA_ASSERT(0);
             }
 
             // Check all previous blocks for free space
@@ -13838,22 +13646,24 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Full(VmaBlockVector& ve
             if (prevMoveCount == m_Moves.size() && offset != 0 && metadata->GetSumFreeSize() >= moveData.size)
             {
                 VmaAllocationRequest request = {};
-                if (metadata->CreateAllocationRequest(moveData.size,
-                                                      moveData.alignment,
-                                                      false,
-                                                      moveData.type,
-                                                      VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
-                                                      &request))
+                if (metadata->CreateAllocationRequest(
+                    moveData.size,
+                    moveData.alignment,
+                    false,
+                    moveData.type,
+                    VMA_ALLOCATION_CREATE_STRATEGY_MIN_OFFSET_BIT,
+                    &request))
                 {
                     if (metadata->GetAllocationOffset(request.allocHandle) < offset)
                     {
-                        if (vector.CommitAllocationRequest(request,
-                                                           block,
-                                                           moveData.alignment,
-                                                           moveData.flags,
-                                                           this,
-                                                           moveData.type,
-                                                           &moveData.move.dstTmpAllocation) == VK_SUCCESS)
+                        if (vector.CommitAllocationRequest(
+                            request,
+                            block,
+                            moveData.alignment,
+                            moveData.flags,
+                            this,
+                            moveData.type,
+                            &moveData.move.dstTmpAllocation) == VK_SUCCESS)
                         {
                             m_Moves.push_back(moveData.move);
                             if (IncrementCounters(moveData.size))
@@ -13882,171 +13692,161 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Extensive(VmaBlockVecto
     bool texturePresent = false, bufferPresent = false, otherPresent = false;
     switch (vectorState.operation)
     {
-        case StateExtensive::Operation::Done: // Vector defragmented
-            return false;
-        case StateExtensive::Operation::FindFreeBlockBuffer:
-        case StateExtensive::Operation::FindFreeBlockTexture:
-        case StateExtensive::Operation::FindFreeBlockAll:
+    case StateExtensive::Operation::Done: // Vector defragmented
+        return false;
+    case StateExtensive::Operation::FindFreeBlockBuffer:
+    case StateExtensive::Operation::FindFreeBlockTexture:
+    case StateExtensive::Operation::FindFreeBlockAll:
+    {
+        // No more blocks to free, just perform fast realloc and move to cleanup
+        if (vectorState.firstFreeBlock == 0)
         {
-            // No more blocks to free, just perform fast realloc and move to cleanup
-            if (vectorState.firstFreeBlock == 0)
+            vectorState.operation = StateExtensive::Operation::Cleanup;
+            return ComputeDefragmentation_Fast(vector);
+        }
+
+        // No free blocks, have to clear last one
+        size_t last = (vectorState.firstFreeBlock == SIZE_MAX ? vector.GetBlockCount() : vectorState.firstFreeBlock) - 1;
+        VmaBlockMetadata* freeMetadata = vector.GetBlock(last)->m_pMetadata;
+
+        const size_t prevMoveCount = m_Moves.size();
+        for (VmaAllocHandle handle = freeMetadata->GetAllocationListBegin();
+            handle != VK_NULL_HANDLE;
+            handle = freeMetadata->GetNextAllocation(handle))
+        {
+            MoveAllocationData moveData = GetMoveData(handle, freeMetadata);
+            switch (CheckCounters(moveData.move.srcAllocation->GetSize()))
             {
-                vectorState.operation = StateExtensive::Operation::Cleanup;
-                return ComputeDefragmentation_Fast(vector);
+            case CounterStatus::Ignore:
+                continue;
+            case CounterStatus::End:
+                return true;
+            case CounterStatus::Pass:
+                break;
+            default:
+                VMA_ASSERT(0);
             }
 
-            // No free blocks, have to clear last one
-            size_t last =
-                (vectorState.firstFreeBlock == SIZE_MAX ? vector.GetBlockCount() : vectorState.firstFreeBlock) - 1;
-            VmaBlockMetadata* freeMetadata = vector.GetBlock(last)->m_pMetadata;
-
-            const size_t prevMoveCount = m_Moves.size();
-            for (VmaAllocHandle handle = freeMetadata->GetAllocationListBegin(); handle != VK_NULL_HANDLE;
-                 handle                = freeMetadata->GetNextAllocation(handle))
+            // Check all previous blocks for free space
+            if (AllocInOtherBlock(0, last, moveData, vector))
             {
-                MoveAllocationData moveData = GetMoveData(handle, freeMetadata);
-                switch (CheckCounters(moveData.move.srcAllocation->GetSize()))
-                {
-                    case CounterStatus::Ignore:
-                        continue;
-                    case CounterStatus::End:
-                        return true;
-                    default:
-                        VMA_ASSERT(0);
-                    case CounterStatus::Pass:
-                        break;
-                }
+                // Full clear performed already
+                if (prevMoveCount != m_Moves.size() && freeMetadata->GetNextAllocation(handle) == VK_NULL_HANDLE)
+                    vectorState.firstFreeBlock = last;
+                return true;
+            }
+        }
 
-                // Check all previous blocks for free space
-                if (AllocInOtherBlock(0, last, moveData, vector))
+        if (prevMoveCount == m_Moves.size())
+        {
+            // Cannot perform full clear, have to move data in other blocks around
+            if (last != 0)
+            {
+                for (size_t i = last - 1; i; --i)
                 {
-                    // Full clear performed already
-                    if (prevMoveCount != m_Moves.size() && freeMetadata->GetNextAllocation(handle) == VK_NULL_HANDLE)
-                        reinterpret_cast<size_t*>(m_AlgorithmState)[index] = last;
-                    return true;
+                    if (ReallocWithinBlock(vector, vector.GetBlock(i)))
+                        return true;
                 }
             }
 
             if (prevMoveCount == m_Moves.size())
             {
-                // Cannot perform full clear, have to move data in other blocks around
-                if (last != 0)
-                {
-                    for (size_t i = last - 1; i; --i)
-                    {
-                        if (ReallocWithinBlock(vector, vector.GetBlock(i)))
-                            return true;
-                    }
-                }
-
-                if (prevMoveCount == m_Moves.size())
-                {
-                    // No possible reallocs within blocks, try to move them around fast
-                    return ComputeDefragmentation_Fast(vector);
-                }
+                // No possible reallocs within blocks, try to move them around fast
+                return ComputeDefragmentation_Fast(vector);
             }
-            else
+        }
+        else
+        {
+            switch (vectorState.operation)
             {
-                switch (vectorState.operation)
-                {
-                    case StateExtensive::Operation::FindFreeBlockBuffer:
-                        vectorState.operation = StateExtensive::Operation::MoveBuffers;
-                        break;
-                    default:
-                        VMA_ASSERT(0);
-                    case StateExtensive::Operation::FindFreeBlockTexture:
-                        vectorState.operation = StateExtensive::Operation::MoveTextures;
-                        break;
-                    case StateExtensive::Operation::FindFreeBlockAll:
-                        vectorState.operation = StateExtensive::Operation::MoveAll;
-                        break;
-                }
-                vectorState.firstFreeBlock = last;
-                // Nothing done, block found without reallocations, can perform another reallocs in same pass
+            case StateExtensive::Operation::FindFreeBlockBuffer:
+                vectorState.operation = StateExtensive::Operation::MoveBuffers;
+                break;
+            case StateExtensive::Operation::FindFreeBlockTexture:
+                vectorState.operation = StateExtensive::Operation::MoveTextures;
+                break;
+            case StateExtensive::Operation::FindFreeBlockAll:
+                vectorState.operation = StateExtensive::Operation::MoveAll;
+                break;
+            default:
+                VMA_ASSERT(0);
+                vectorState.operation = StateExtensive::Operation::MoveTextures;
+            }
+            vectorState.firstFreeBlock = last;
+            // Nothing done, block found without reallocations, can perform another reallocs in same pass
+            return ComputeDefragmentation_Extensive(vector, index);
+        }
+        break;
+    }
+    case StateExtensive::Operation::MoveTextures:
+    {
+        if (MoveDataToFreeBlocks(VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL, vector,
+            vectorState.firstFreeBlock, texturePresent, bufferPresent, otherPresent))
+        {
+            if (texturePresent)
+            {
+                vectorState.operation = StateExtensive::Operation::FindFreeBlockTexture;
                 return ComputeDefragmentation_Extensive(vector, index);
             }
-            break;
-        }
-        case StateExtensive::Operation::MoveTextures:
-        {
-            if (MoveDataToFreeBlocks(VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL,
-                                     vector,
-                                     vectorState.firstFreeBlock,
-                                     texturePresent,
-                                     bufferPresent,
-                                     otherPresent))
+
+            if (!bufferPresent && !otherPresent)
             {
-                if (texturePresent)
-                {
-                    vectorState.operation = StateExtensive::Operation::FindFreeBlockTexture;
-                    return ComputeDefragmentation_Extensive(vector, index);
-                }
-
-                if (!bufferPresent && !otherPresent)
-                {
-                    vectorState.operation = StateExtensive::Operation::Cleanup;
-                    break;
-                }
-
-                // No more textures to move, check buffers
-                vectorState.operation = StateExtensive::Operation::MoveBuffers;
-                bufferPresent         = false;
-                otherPresent          = false;
-            }
-            else
-                break;
-        }
-        case StateExtensive::Operation::MoveBuffers:
-        {
-            if (MoveDataToFreeBlocks(VMA_SUBALLOCATION_TYPE_BUFFER,
-                                     vector,
-                                     vectorState.firstFreeBlock,
-                                     texturePresent,
-                                     bufferPresent,
-                                     otherPresent))
-            {
-                if (bufferPresent)
-                {
-                    vectorState.operation = StateExtensive::Operation::FindFreeBlockBuffer;
-                    return ComputeDefragmentation_Extensive(vector, index);
-                }
-
-                if (!otherPresent)
-                {
-                    vectorState.operation = StateExtensive::Operation::Cleanup;
-                    break;
-                }
-
-                // No more buffers to move, check all others
-                vectorState.operation = StateExtensive::Operation::MoveAll;
-                otherPresent          = false;
-            }
-            else
-                break;
-        }
-        case StateExtensive::Operation::MoveAll:
-        {
-            if (MoveDataToFreeBlocks(VMA_SUBALLOCATION_TYPE_FREE,
-                                     vector,
-                                     vectorState.firstFreeBlock,
-                                     texturePresent,
-                                     bufferPresent,
-                                     otherPresent))
-            {
-                if (otherPresent)
-                {
-                    vectorState.operation = StateExtensive::Operation::FindFreeBlockBuffer;
-                    return ComputeDefragmentation_Extensive(vector, index);
-                }
-                // Everything moved
                 vectorState.operation = StateExtensive::Operation::Cleanup;
+                break;
             }
-            break;
+
+            // No more textures to move, check buffers
+            vectorState.operation = StateExtensive::Operation::MoveBuffers;
+            bufferPresent = false;
+            otherPresent = false;
         }
-        case StateExtensive::Operation::Cleanup:
-            // Cleanup is handled below so that other operations may reuse the cleanup code. This case is here to
-            // prevent the unhandled enum value warning (C4062).
+        else
             break;
+        VMA_FALLTHROUGH; // Fallthrough
+    }
+    case StateExtensive::Operation::MoveBuffers:
+    {
+        if (MoveDataToFreeBlocks(VMA_SUBALLOCATION_TYPE_BUFFER, vector,
+            vectorState.firstFreeBlock, texturePresent, bufferPresent, otherPresent))
+        {
+            if (bufferPresent)
+            {
+                vectorState.operation = StateExtensive::Operation::FindFreeBlockBuffer;
+                return ComputeDefragmentation_Extensive(vector, index);
+            }
+
+            if (!otherPresent)
+            {
+                vectorState.operation = StateExtensive::Operation::Cleanup;
+                break;
+            }
+
+            // No more buffers to move, check all others
+            vectorState.operation = StateExtensive::Operation::MoveAll;
+            otherPresent = false;
+        }
+        else
+            break;
+        VMA_FALLTHROUGH; // Fallthrough
+    }
+    case StateExtensive::Operation::MoveAll:
+    {
+        if (MoveDataToFreeBlocks(VMA_SUBALLOCATION_TYPE_FREE, vector,
+            vectorState.firstFreeBlock, texturePresent, bufferPresent, otherPresent))
+        {
+            if (otherPresent)
+            {
+                vectorState.operation = StateExtensive::Operation::FindFreeBlockBuffer;
+                return ComputeDefragmentation_Extensive(vector, index);
+            }
+            // Everything moved
+            vectorState.operation = StateExtensive::Operation::Cleanup;
+        }
+        break;
+    }
+    case StateExtensive::Operation::Cleanup:
+        // Cleanup is handled below so that other operations may reuse the cleanup code. This case is here to prevent the unhandled enum value warning (C4062).
+        break;
     }
 
     if (vectorState.operation == StateExtensive::Operation::Cleanup)
@@ -14067,9 +13867,9 @@ bool VmaDefragmentationContext_T::ComputeDefragmentation_Extensive(VmaBlockVecto
 
 void VmaDefragmentationContext_T::UpdateVectorStatistics(VmaBlockVector& vector, StateBalanced& state)
 {
-    size_t allocCount  = 0;
-    size_t freeCount   = 0;
-    state.avgFreeSize  = 0;
+    size_t allocCount = 0;
+    size_t freeCount = 0;
+    state.avgFreeSize = 0;
     state.avgAllocSize = 0;
 
     for (size_t i = 0; i < vector.GetBlockCount(); ++i)
@@ -14087,20 +13887,18 @@ void VmaDefragmentationContext_T::UpdateVectorStatistics(VmaBlockVector& vector,
 }
 
 bool VmaDefragmentationContext_T::MoveDataToFreeBlocks(VmaSuballocationType currentType,
-                                                       VmaBlockVector&      vector,
-                                                       size_t               firstFreeBlock,
-                                                       bool&                texturePresent,
-                                                       bool&                bufferPresent,
-                                                       bool&                otherPresent)
+    VmaBlockVector& vector, size_t firstFreeBlock,
+    bool& texturePresent, bool& bufferPresent, bool& otherPresent)
 {
     const size_t prevMoveCount = m_Moves.size();
-    for (size_t i = firstFreeBlock; i;)
+    for (size_t i = firstFreeBlock ; i;)
     {
-        VmaDeviceMemoryBlock* block    = vector.GetBlock(--i);
-        VmaBlockMetadata*     metadata = block->m_pMetadata;
+        VmaDeviceMemoryBlock* block = vector.GetBlock(--i);
+        VmaBlockMetadata* metadata = block->m_pMetadata;
 
-        for (VmaAllocHandle handle = metadata->GetAllocationListBegin(); handle != VK_NULL_HANDLE;
-             handle                = metadata->GetNextAllocation(handle))
+        for (VmaAllocHandle handle = metadata->GetAllocationListBegin();
+            handle != VK_NULL_HANDLE;
+            handle = metadata->GetNextAllocation(handle))
         {
             MoveAllocationData moveData = GetMoveData(handle, metadata);
             // Ignore newly created allocations by defragmentation algorithm
@@ -14108,14 +13906,14 @@ bool VmaDefragmentationContext_T::MoveDataToFreeBlocks(VmaSuballocationType curr
                 continue;
             switch (CheckCounters(moveData.move.srcAllocation->GetSize()))
             {
-                case CounterStatus::Ignore:
-                    continue;
-                case CounterStatus::End:
-                    return true;
-                default:
-                    VMA_ASSERT(0);
-                case CounterStatus::Pass:
-                    break;
+            case CounterStatus::Ignore:
+                continue;
+            case CounterStatus::End:
+                return true;
+            case CounterStatus::Pass:
+                break;
+            default:
+                VMA_ASSERT(0);
             }
 
             // Move only single type of resources at once
@@ -14139,24 +13937,25 @@ bool VmaDefragmentationContext_T::MoveDataToFreeBlocks(VmaSuballocationType curr
 #endif // _VMA_DEFRAGMENTATION_CONTEXT_FUNCTIONS
 
 #ifndef _VMA_POOL_T_FUNCTIONS
-VmaPool_T::VmaPool_T(VmaAllocator hAllocator, const VmaPoolCreateInfo& createInfo, VkDeviceSize preferredBlockSize) :
-    m_BlockVector(
+VmaPool_T::VmaPool_T(
+    VmaAllocator hAllocator,
+    const VmaPoolCreateInfo& createInfo,
+    VkDeviceSize preferredBlockSize)
+    : m_BlockVector(
         hAllocator,
         this, // hParentPool
         createInfo.memoryTypeIndex,
         createInfo.blockSize != 0 ? createInfo.blockSize : preferredBlockSize,
         createInfo.minBlockCount,
         createInfo.maxBlockCount,
-        (createInfo.flags & VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT) != 0
-            ? 1
-            : hAllocator->GetBufferImageGranularity(),
-        createInfo.blockSize != 0,                         // explicitBlockSize
+        (createInfo.flags& VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT) != 0 ? 1 : hAllocator->GetBufferImageGranularity(),
+        createInfo.blockSize != 0, // explicitBlockSize
         createInfo.flags & VMA_POOL_CREATE_ALGORITHM_MASK, // algorithm
         createInfo.priority,
         VMA_MAX(hAllocator->GetMemoryTypeMinAlignment(createInfo.memoryTypeIndex), createInfo.minAllocationAlignment),
         createInfo.pMemoryAllocateNext),
-    m_Id(0), m_Name(VMA_NULL)
-{}
+    m_Id(0),
+    m_Name(VMA_NULL) {}
 
 VmaPool_T::~VmaPool_T()
 {
@@ -14189,86 +13988,87 @@ VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo) :
     m_UseAmdDeviceCoherentMemory((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_AMD_DEVICE_COHERENT_MEMORY_BIT) != 0),
     m_UseKhrBufferDeviceAddress((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT) != 0),
     m_UseExtMemoryPriority((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT) != 0),
-    m_hDevice(pCreateInfo->device), m_hInstance(pCreateInfo->instance),
+    m_hDevice(pCreateInfo->device),
+    m_hInstance(pCreateInfo->instance),
     m_AllocationCallbacksSpecified(pCreateInfo->pAllocationCallbacks != VMA_NULL),
-    m_AllocationCallbacks(pCreateInfo->pAllocationCallbacks ? *pCreateInfo->pAllocationCallbacks
-                                                            : VmaEmptyAllocationCallbacks),
-    m_AllocationObjectAllocator(&m_AllocationCallbacks), m_HeapSizeLimitMask(0), m_DeviceMemoryCount(0),
-    m_PreferredLargeHeapBlockSize(0), m_PhysicalDevice(pCreateInfo->physicalDevice),
-    m_GpuDefragmentationMemoryTypeBits(UINT32_MAX), m_NextPoolId(0), m_GlobalMemoryTypeBits(UINT32_MAX)
+    m_AllocationCallbacks(pCreateInfo->pAllocationCallbacks ?
+        *pCreateInfo->pAllocationCallbacks : VmaEmptyAllocationCallbacks),
+    m_AllocationObjectAllocator(&m_AllocationCallbacks),
+    m_HeapSizeLimitMask(0),
+    m_DeviceMemoryCount(0),
+    m_PreferredLargeHeapBlockSize(0),
+    m_PhysicalDevice(pCreateInfo->physicalDevice),
+    m_GpuDefragmentationMemoryTypeBits(UINT32_MAX),
+    m_NextPoolId(0),
+    m_GlobalMemoryTypeBits(UINT32_MAX)
 {
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
         m_UseKhrDedicatedAllocation = false;
-        m_UseKhrBindMemory2         = false;
+        m_UseKhrBindMemory2 = false;
     }
 
-    if (VMA_DEBUG_DETECT_CORRUPTION)
+    if(VMA_DEBUG_DETECT_CORRUPTION)
     {
-        // Needs to be multiply of uint32_t size because we are going to write VMA_CORRUPTION_DETECTION_MAGIC_VALUE to
-        // it.
+        // Needs to be multiply of uint32_t size because we are going to write VMA_CORRUPTION_DETECTION_MAGIC_VALUE to it.
         VMA_ASSERT(VMA_DEBUG_MARGIN % sizeof(uint32_t) == 0);
     }
 
     VMA_ASSERT(pCreateInfo->physicalDevice && pCreateInfo->device && pCreateInfo->instance);
 
-    if (m_VulkanApiVersion < VK_MAKE_VERSION(1, 1, 0))
+    if(m_VulkanApiVersion < VK_MAKE_VERSION(1, 1, 0))
     {
 #if !(VMA_DEDICATED_ALLOCATION)
-        if ((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT) != 0)
+        if((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT) != 0)
         {
-            VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT set but required extensions are "
-                            "disabled by preprocessor macros.");
+            VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT set but required extensions are disabled by preprocessor macros.");
         }
 #endif
 #if !(VMA_BIND_MEMORY2)
-        if ((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT) != 0)
+        if((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT) != 0)
         {
-            VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT set but required extension is disabled by "
-                            "preprocessor macros.");
+            VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_KHR_BIND_MEMORY2_BIT set but required extension is disabled by preprocessor macros.");
         }
 #endif
     }
 #if !(VMA_MEMORY_BUDGET)
-    if ((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT) != 0)
+    if((pCreateInfo->flags & VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT) != 0)
     {
-        VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT set but required extension is disabled by "
-                        "preprocessor macros.");
+        VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT set but required extension is disabled by preprocessor macros.");
     }
 #endif
 #if !(VMA_BUFFER_DEVICE_ADDRESS)
-    if (m_UseKhrBufferDeviceAddress)
+    if(m_UseKhrBufferDeviceAddress)
     {
-        VMA_ASSERT(0 &&
-                   "VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT is set but required extension or Vulkan 1.2 is not "
-                   "available in your Vulkan header or its support in VMA has been disabled by a preprocessor macro.");
+        VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT is set but required extension or Vulkan 1.2 is not available in your Vulkan header or its support in VMA has been disabled by a preprocessor macro.");
+    }
+#endif
+#if VMA_VULKAN_VERSION < 1003000
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 3, 0))
+    {
+        VMA_ASSERT(0 && "vulkanApiVersion >= VK_API_VERSION_1_3 but required Vulkan version is disabled by preprocessor macros.");
     }
 #endif
 #if VMA_VULKAN_VERSION < 1002000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 2, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 2, 0))
     {
-        VMA_ASSERT(
-            0 &&
-            "vulkanApiVersion >= VK_API_VERSION_1_2 but required Vulkan version is disabled by preprocessor macros.");
+        VMA_ASSERT(0 && "vulkanApiVersion >= VK_API_VERSION_1_2 but required Vulkan version is disabled by preprocessor macros.");
     }
 #endif
 #if VMA_VULKAN_VERSION < 1001000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
-        VMA_ASSERT(
-            0 &&
-            "vulkanApiVersion >= VK_API_VERSION_1_1 but required Vulkan version is disabled by preprocessor macros.");
+        VMA_ASSERT(0 && "vulkanApiVersion >= VK_API_VERSION_1_1 but required Vulkan version is disabled by preprocessor macros.");
     }
 #endif
 #if !(VMA_MEMORY_PRIORITY)
-    if (m_UseExtMemoryPriority)
+    if(m_UseExtMemoryPriority)
     {
-        VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT is set but required extension is not available "
-                        "in your Vulkan header or its support in VMA has been disabled by a preprocessor macro.");
+        VMA_ASSERT(0 && "VMA_ALLOCATOR_CREATE_EXT_MEMORY_PRIORITY_BIT is set but required extension is not available in your Vulkan header or its support in VMA has been disabled by a preprocessor macro.");
     }
 #endif
 
-    memset(&m_DeviceMemoryCallbacks, 0, sizeof(m_DeviceMemoryCallbacks));
+    memset(&m_DeviceMemoryCallbacks, 0 ,sizeof(m_DeviceMemoryCallbacks));
     memset(&m_PhysicalDeviceProperties, 0, sizeof(m_PhysicalDeviceProperties));
     memset(&m_MemProps, 0, sizeof(m_MemProps));
 
@@ -14279,11 +14079,11 @@ VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo) :
     memset(&m_TypeExternalMemoryHandleTypes, 0, sizeof(m_TypeExternalMemoryHandleTypes));
 #endif // #if VMA_EXTERNAL_MEMORY
 
-    if (pCreateInfo->pDeviceMemoryCallbacks != VMA_NULL)
+    if(pCreateInfo->pDeviceMemoryCallbacks != VMA_NULL)
     {
-        m_DeviceMemoryCallbacks.pUserData   = pCreateInfo->pDeviceMemoryCallbacks->pUserData;
+        m_DeviceMemoryCallbacks.pUserData = pCreateInfo->pDeviceMemoryCallbacks->pUserData;
         m_DeviceMemoryCallbacks.pfnAllocate = pCreateInfo->pDeviceMemoryCallbacks->pfnAllocate;
-        m_DeviceMemoryCallbacks.pfnFree     = pCreateInfo->pDeviceMemoryCallbacks->pfnFree;
+        m_DeviceMemoryCallbacks.pfnFree = pCreateInfo->pDeviceMemoryCallbacks->pfnFree;
     }
 
     ImportVulkanFunctions(pCreateInfo->pVulkanFunctions);
@@ -14296,30 +14096,28 @@ VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo) :
     VMA_ASSERT(VmaIsPow2(m_PhysicalDeviceProperties.limits.bufferImageGranularity));
     VMA_ASSERT(VmaIsPow2(m_PhysicalDeviceProperties.limits.nonCoherentAtomSize));
 
-    m_PreferredLargeHeapBlockSize = (pCreateInfo->preferredLargeHeapBlockSize != 0)
-                                        ? pCreateInfo->preferredLargeHeapBlockSize
-                                        : static_cast<VkDeviceSize>(VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE);
+    m_PreferredLargeHeapBlockSize = (pCreateInfo->preferredLargeHeapBlockSize != 0) ?
+        pCreateInfo->preferredLargeHeapBlockSize : static_cast<VkDeviceSize>(VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE);
 
     m_GlobalMemoryTypeBits = CalculateGlobalMemoryTypeBits();
 
 #if VMA_EXTERNAL_MEMORY
-    if (pCreateInfo->pTypeExternalMemoryHandleTypes != VMA_NULL)
+    if(pCreateInfo->pTypeExternalMemoryHandleTypes != VMA_NULL)
     {
-        memcpy(m_TypeExternalMemoryHandleTypes,
-               pCreateInfo->pTypeExternalMemoryHandleTypes,
-               sizeof(VkExternalMemoryHandleTypeFlagsKHR) * GetMemoryTypeCount());
+        memcpy(m_TypeExternalMemoryHandleTypes, pCreateInfo->pTypeExternalMemoryHandleTypes,
+            sizeof(VkExternalMemoryHandleTypeFlagsKHR) * GetMemoryTypeCount());
     }
 #endif // #if VMA_EXTERNAL_MEMORY
 
-    if (pCreateInfo->pHeapSizeLimit != VMA_NULL)
+    if(pCreateInfo->pHeapSizeLimit != VMA_NULL)
     {
-        for (uint32_t heapIndex = 0; heapIndex < GetMemoryHeapCount(); ++heapIndex)
+        for(uint32_t heapIndex = 0; heapIndex < GetMemoryHeapCount(); ++heapIndex)
         {
             const VkDeviceSize limit = pCreateInfo->pHeapSizeLimit[heapIndex];
-            if (limit != VK_WHOLE_SIZE)
+            if(limit != VK_WHOLE_SIZE)
             {
                 m_HeapSizeLimitMask |= 1u << heapIndex;
-                if (limit < m_MemProps.memoryHeaps[heapIndex].size)
+                if(limit < m_MemProps.memoryHeaps[heapIndex].size)
                 {
                     m_MemProps.memoryHeaps[heapIndex].size = limit;
                 }
@@ -14327,25 +14125,25 @@ VmaAllocator_T::VmaAllocator_T(const VmaAllocatorCreateInfo* pCreateInfo) :
         }
     }
 
-    for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
+    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
     {
         // Create only supported types
-        if ((m_GlobalMemoryTypeBits & (1u << memTypeIndex)) != 0)
+        if((m_GlobalMemoryTypeBits & (1u << memTypeIndex)) != 0)
         {
             const VkDeviceSize preferredBlockSize = CalcPreferredBlockSize(memTypeIndex);
-            m_pBlockVectors[memTypeIndex] =
-                vma_new(this, VmaBlockVector)(this,
-                                              VK_NULL_HANDLE, // hParentPool
-                                              memTypeIndex,
-                                              preferredBlockSize,
-                                              0,
-                                              SIZE_MAX,
-                                              GetBufferImageGranularity(),
-                                              false, // explicitBlockSize
-                                              0,     // algorithm
-                                              0.5f,  // priority (0.5 is the default per Vulkan spec)
-                                              GetMemoryTypeMinAlignment(memTypeIndex), // minAllocationAlignment
-                                              VMA_NULL);                               // // pMemoryAllocateNext
+            m_pBlockVectors[memTypeIndex] = vma_new(this, VmaBlockVector)(
+                this,
+                VK_NULL_HANDLE, // hParentPool
+                memTypeIndex,
+                preferredBlockSize,
+                0,
+                SIZE_MAX,
+                GetBufferImageGranularity(),
+                false, // explicitBlockSize
+                0, // algorithm
+                0.5f, // priority (0.5 is the default per Vulkan spec)
+                GetMemoryTypeMinAlignment(memTypeIndex), // minAllocationAlignment
+                VMA_NULL); // // pMemoryAllocateNext
             // No need to call m_pBlockVectors[memTypeIndex][blockVectorTypeIndex]->CreateMinBlocks here,
             // becase minBlockCount is 0.
         }
@@ -14357,7 +14155,7 @@ VkResult VmaAllocator_T::Init(const VmaAllocatorCreateInfo* pCreateInfo)
     VkResult res = VK_SUCCESS;
 
 #if VMA_MEMORY_BUDGET
-    if (m_UseExtMemoryBudget)
+    if(m_UseExtMemoryBudget)
     {
         UpdateVulkanBudget();
     }
@@ -14370,7 +14168,7 @@ VmaAllocator_T::~VmaAllocator_T()
 {
     VMA_ASSERT(m_Pools.IsEmpty());
 
-    for (size_t memTypeIndex = GetMemoryTypeCount(); memTypeIndex--;)
+    for(size_t memTypeIndex = GetMemoryTypeCount(); memTypeIndex--; )
     {
         vma_delete(this, m_pBlockVectors[memTypeIndex]);
     }
@@ -14382,7 +14180,7 @@ void VmaAllocator_T::ImportVulkanFunctions(const VmaVulkanFunctions* pVulkanFunc
     ImportVulkanFunctions_Static();
 #endif
 
-    if (pVulkanFunctions != VMA_NULL)
+    if(pVulkanFunctions != VMA_NULL)
     {
         ImportVulkanFunctions_Custom(pVulkanFunctions);
     }
@@ -14399,50 +14197,49 @@ void VmaAllocator_T::ImportVulkanFunctions(const VmaVulkanFunctions* pVulkanFunc
 void VmaAllocator_T::ImportVulkanFunctions_Static()
 {
     // Vulkan 1.0
-    m_VulkanFunctions.vkGetInstanceProcAddr         = (PFN_vkGetInstanceProcAddr)vkGetInstanceProcAddr;
-    m_VulkanFunctions.vkGetDeviceProcAddr           = (PFN_vkGetDeviceProcAddr)vkGetDeviceProcAddr;
+    m_VulkanFunctions.vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)vkGetInstanceProcAddr;
+    m_VulkanFunctions.vkGetDeviceProcAddr = (PFN_vkGetDeviceProcAddr)vkGetDeviceProcAddr;
     m_VulkanFunctions.vkGetPhysicalDeviceProperties = (PFN_vkGetPhysicalDeviceProperties)vkGetPhysicalDeviceProperties;
-    m_VulkanFunctions.vkGetPhysicalDeviceMemoryProperties =
-        (PFN_vkGetPhysicalDeviceMemoryProperties)vkGetPhysicalDeviceMemoryProperties;
-    m_VulkanFunctions.vkAllocateMemory          = (PFN_vkAllocateMemory)vkAllocateMemory;
-    m_VulkanFunctions.vkFreeMemory              = (PFN_vkFreeMemory)vkFreeMemory;
-    m_VulkanFunctions.vkMapMemory               = (PFN_vkMapMemory)vkMapMemory;
-    m_VulkanFunctions.vkUnmapMemory             = (PFN_vkUnmapMemory)vkUnmapMemory;
+    m_VulkanFunctions.vkGetPhysicalDeviceMemoryProperties = (PFN_vkGetPhysicalDeviceMemoryProperties)vkGetPhysicalDeviceMemoryProperties;
+    m_VulkanFunctions.vkAllocateMemory = (PFN_vkAllocateMemory)vkAllocateMemory;
+    m_VulkanFunctions.vkFreeMemory = (PFN_vkFreeMemory)vkFreeMemory;
+    m_VulkanFunctions.vkMapMemory = (PFN_vkMapMemory)vkMapMemory;
+    m_VulkanFunctions.vkUnmapMemory = (PFN_vkUnmapMemory)vkUnmapMemory;
     m_VulkanFunctions.vkFlushMappedMemoryRanges = (PFN_vkFlushMappedMemoryRanges)vkFlushMappedMemoryRanges;
-    m_VulkanFunctions.vkInvalidateMappedMemoryRanges =
-        (PFN_vkInvalidateMappedMemoryRanges)vkInvalidateMappedMemoryRanges;
-    m_VulkanFunctions.vkBindBufferMemory            = (PFN_vkBindBufferMemory)vkBindBufferMemory;
-    m_VulkanFunctions.vkBindImageMemory             = (PFN_vkBindImageMemory)vkBindImageMemory;
+    m_VulkanFunctions.vkInvalidateMappedMemoryRanges = (PFN_vkInvalidateMappedMemoryRanges)vkInvalidateMappedMemoryRanges;
+    m_VulkanFunctions.vkBindBufferMemory = (PFN_vkBindBufferMemory)vkBindBufferMemory;
+    m_VulkanFunctions.vkBindImageMemory = (PFN_vkBindImageMemory)vkBindImageMemory;
     m_VulkanFunctions.vkGetBufferMemoryRequirements = (PFN_vkGetBufferMemoryRequirements)vkGetBufferMemoryRequirements;
-    m_VulkanFunctions.vkGetImageMemoryRequirements  = (PFN_vkGetImageMemoryRequirements)vkGetImageMemoryRequirements;
-    m_VulkanFunctions.vkCreateBuffer                = (PFN_vkCreateBuffer)vkCreateBuffer;
-    m_VulkanFunctions.vkDestroyBuffer               = (PFN_vkDestroyBuffer)vkDestroyBuffer;
-    m_VulkanFunctions.vkCreateImage                 = (PFN_vkCreateImage)vkCreateImage;
-    m_VulkanFunctions.vkDestroyImage                = (PFN_vkDestroyImage)vkDestroyImage;
-    m_VulkanFunctions.vkCmdCopyBuffer               = (PFN_vkCmdCopyBuffer)vkCmdCopyBuffer;
+    m_VulkanFunctions.vkGetImageMemoryRequirements = (PFN_vkGetImageMemoryRequirements)vkGetImageMemoryRequirements;
+    m_VulkanFunctions.vkCreateBuffer = (PFN_vkCreateBuffer)vkCreateBuffer;
+    m_VulkanFunctions.vkDestroyBuffer = (PFN_vkDestroyBuffer)vkDestroyBuffer;
+    m_VulkanFunctions.vkCreateImage = (PFN_vkCreateImage)vkCreateImage;
+    m_VulkanFunctions.vkDestroyImage = (PFN_vkDestroyImage)vkDestroyImage;
+    m_VulkanFunctions.vkCmdCopyBuffer = (PFN_vkCmdCopyBuffer)vkCmdCopyBuffer;
 
     // Vulkan 1.1
 #if VMA_VULKAN_VERSION >= 1001000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
-        m_VulkanFunctions.vkGetBufferMemoryRequirements2KHR =
-            (PFN_vkGetBufferMemoryRequirements2)vkGetBufferMemoryRequirements2;
-        m_VulkanFunctions.vkGetImageMemoryRequirements2KHR =
-            (PFN_vkGetImageMemoryRequirements2)vkGetImageMemoryRequirements2;
+        m_VulkanFunctions.vkGetBufferMemoryRequirements2KHR = (PFN_vkGetBufferMemoryRequirements2)vkGetBufferMemoryRequirements2;
+        m_VulkanFunctions.vkGetImageMemoryRequirements2KHR = (PFN_vkGetImageMemoryRequirements2)vkGetImageMemoryRequirements2;
         m_VulkanFunctions.vkBindBufferMemory2KHR = (PFN_vkBindBufferMemory2)vkBindBufferMemory2;
-        m_VulkanFunctions.vkBindImageMemory2KHR  = (PFN_vkBindImageMemory2)vkBindImageMemory2;
-        m_VulkanFunctions.vkGetPhysicalDeviceMemoryProperties2KHR =
-            (PFN_vkGetPhysicalDeviceMemoryProperties2)vkGetPhysicalDeviceMemoryProperties2;
+        m_VulkanFunctions.vkBindImageMemory2KHR = (PFN_vkBindImageMemory2)vkBindImageMemory2;
+    }
+#endif
+
+#if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    {
+        m_VulkanFunctions.vkGetPhysicalDeviceMemoryProperties2KHR = (PFN_vkGetPhysicalDeviceMemoryProperties2)vkGetPhysicalDeviceMemoryProperties2;
     }
 #endif
 
 #if VMA_VULKAN_VERSION >= 1003000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 3, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 3, 0))
     {
-        m_VulkanFunctions.vkGetDeviceBufferMemoryRequirements =
-            (PFN_vkGetDeviceBufferMemoryRequirements)vkGetDeviceBufferMemoryRequirements;
-        m_VulkanFunctions.vkGetDeviceImageMemoryRequirements =
-            (PFN_vkGetDeviceImageMemoryRequirements)vkGetDeviceImageMemoryRequirements;
+        m_VulkanFunctions.vkGetDeviceBufferMemoryRequirements = (PFN_vkGetDeviceBufferMemoryRequirements)vkGetDeviceBufferMemoryRequirements;
+        m_VulkanFunctions.vkGetDeviceImageMemoryRequirements = (PFN_vkGetDeviceImageMemoryRequirements)vkGetDeviceImageMemoryRequirements;
     }
 #endif
 }
@@ -14453,9 +14250,8 @@ void VmaAllocator_T::ImportVulkanFunctions_Custom(const VmaVulkanFunctions* pVul
 {
     VMA_ASSERT(pVulkanFunctions != VMA_NULL);
 
-#define VMA_COPY_IF_NOT_NULL(funcName)          \
-    if (pVulkanFunctions->funcName != VMA_NULL) \
-        m_VulkanFunctions.funcName = pVulkanFunctions->funcName;
+#define VMA_COPY_IF_NOT_NULL(funcName) \
+    if(pVulkanFunctions->funcName != VMA_NULL) m_VulkanFunctions.funcName = pVulkanFunctions->funcName;
 
     VMA_COPY_IF_NOT_NULL(vkGetInstanceProcAddr);
     VMA_COPY_IF_NOT_NULL(vkGetDeviceProcAddr);
@@ -14487,7 +14283,7 @@ void VmaAllocator_T::ImportVulkanFunctions_Custom(const VmaVulkanFunctions* pVul
     VMA_COPY_IF_NOT_NULL(vkBindImageMemory2KHR);
 #endif
 
-#if VMA_MEMORY_BUDGET
+#if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
     VMA_COPY_IF_NOT_NULL(vkGetPhysicalDeviceMemoryProperties2KHR);
 #endif
 
@@ -14504,38 +14300,31 @@ void VmaAllocator_T::ImportVulkanFunctions_Custom(const VmaVulkanFunctions* pVul
 void VmaAllocator_T::ImportVulkanFunctions_Dynamic()
 {
     VMA_ASSERT(m_VulkanFunctions.vkGetInstanceProcAddr && m_VulkanFunctions.vkGetDeviceProcAddr &&
-               "To use VMA_DYNAMIC_VULKAN_FUNCTIONS in new versions of VMA you now have to pass "
-               "VmaVulkanFunctions::vkGetInstanceProcAddr and vkGetDeviceProcAddr as "
-               "VmaAllocatorCreateInfo::pVulkanFunctions. "
-               "Other members can be null.");
+        "To use VMA_DYNAMIC_VULKAN_FUNCTIONS in new versions of VMA you now have to pass "
+        "VmaVulkanFunctions::vkGetInstanceProcAddr and vkGetDeviceProcAddr as VmaAllocatorCreateInfo::pVulkanFunctions. "
+        "Other members can be null.");
 
 #define VMA_FETCH_INSTANCE_FUNC(memberName, functionPointerType, functionNameString) \
-    if (m_VulkanFunctions.memberName == VMA_NULL)                                    \
-        m_VulkanFunctions.memberName =                                               \
+    if(m_VulkanFunctions.memberName == VMA_NULL) \
+        m_VulkanFunctions.memberName = \
             (functionPointerType)m_VulkanFunctions.vkGetInstanceProcAddr(m_hInstance, functionNameString);
 #define VMA_FETCH_DEVICE_FUNC(memberName, functionPointerType, functionNameString) \
-    if (m_VulkanFunctions.memberName == VMA_NULL)                                  \
-        m_VulkanFunctions.memberName =                                             \
+    if(m_VulkanFunctions.memberName == VMA_NULL) \
+        m_VulkanFunctions.memberName = \
             (functionPointerType)m_VulkanFunctions.vkGetDeviceProcAddr(m_hDevice, functionNameString);
 
-    VMA_FETCH_INSTANCE_FUNC(
-        vkGetPhysicalDeviceProperties, PFN_vkGetPhysicalDeviceProperties, "vkGetPhysicalDeviceProperties");
-    VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties,
-                            PFN_vkGetPhysicalDeviceMemoryProperties,
-                            "vkGetPhysicalDeviceMemoryProperties");
+    VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceProperties, PFN_vkGetPhysicalDeviceProperties, "vkGetPhysicalDeviceProperties");
+    VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties, PFN_vkGetPhysicalDeviceMemoryProperties, "vkGetPhysicalDeviceMemoryProperties");
     VMA_FETCH_DEVICE_FUNC(vkAllocateMemory, PFN_vkAllocateMemory, "vkAllocateMemory");
     VMA_FETCH_DEVICE_FUNC(vkFreeMemory, PFN_vkFreeMemory, "vkFreeMemory");
     VMA_FETCH_DEVICE_FUNC(vkMapMemory, PFN_vkMapMemory, "vkMapMemory");
     VMA_FETCH_DEVICE_FUNC(vkUnmapMemory, PFN_vkUnmapMemory, "vkUnmapMemory");
     VMA_FETCH_DEVICE_FUNC(vkFlushMappedMemoryRanges, PFN_vkFlushMappedMemoryRanges, "vkFlushMappedMemoryRanges");
-    VMA_FETCH_DEVICE_FUNC(
-        vkInvalidateMappedMemoryRanges, PFN_vkInvalidateMappedMemoryRanges, "vkInvalidateMappedMemoryRanges");
+    VMA_FETCH_DEVICE_FUNC(vkInvalidateMappedMemoryRanges, PFN_vkInvalidateMappedMemoryRanges, "vkInvalidateMappedMemoryRanges");
     VMA_FETCH_DEVICE_FUNC(vkBindBufferMemory, PFN_vkBindBufferMemory, "vkBindBufferMemory");
     VMA_FETCH_DEVICE_FUNC(vkBindImageMemory, PFN_vkBindImageMemory, "vkBindImageMemory");
-    VMA_FETCH_DEVICE_FUNC(
-        vkGetBufferMemoryRequirements, PFN_vkGetBufferMemoryRequirements, "vkGetBufferMemoryRequirements");
-    VMA_FETCH_DEVICE_FUNC(
-        vkGetImageMemoryRequirements, PFN_vkGetImageMemoryRequirements, "vkGetImageMemoryRequirements");
+    VMA_FETCH_DEVICE_FUNC(vkGetBufferMemoryRequirements, PFN_vkGetBufferMemoryRequirements, "vkGetBufferMemoryRequirements");
+    VMA_FETCH_DEVICE_FUNC(vkGetImageMemoryRequirements, PFN_vkGetImageMemoryRequirements, "vkGetImageMemoryRequirements");
     VMA_FETCH_DEVICE_FUNC(vkCreateBuffer, PFN_vkCreateBuffer, "vkCreateBuffer");
     VMA_FETCH_DEVICE_FUNC(vkDestroyBuffer, PFN_vkDestroyBuffer, "vkDestroyBuffer");
     VMA_FETCH_DEVICE_FUNC(vkCreateImage, PFN_vkCreateImage, "vkCreateImage");
@@ -14543,57 +14332,58 @@ void VmaAllocator_T::ImportVulkanFunctions_Dynamic()
     VMA_FETCH_DEVICE_FUNC(vkCmdCopyBuffer, PFN_vkCmdCopyBuffer, "vkCmdCopyBuffer");
 
 #if VMA_VULKAN_VERSION >= 1001000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
-        VMA_FETCH_DEVICE_FUNC(
-            vkGetBufferMemoryRequirements2KHR, PFN_vkGetBufferMemoryRequirements2, "vkGetBufferMemoryRequirements2");
-        VMA_FETCH_DEVICE_FUNC(
-            vkGetImageMemoryRequirements2KHR, PFN_vkGetImageMemoryRequirements2, "vkGetImageMemoryRequirements2");
+        VMA_FETCH_DEVICE_FUNC(vkGetBufferMemoryRequirements2KHR, PFN_vkGetBufferMemoryRequirements2, "vkGetBufferMemoryRequirements2");
+        VMA_FETCH_DEVICE_FUNC(vkGetImageMemoryRequirements2KHR, PFN_vkGetImageMemoryRequirements2, "vkGetImageMemoryRequirements2");
         VMA_FETCH_DEVICE_FUNC(vkBindBufferMemory2KHR, PFN_vkBindBufferMemory2, "vkBindBufferMemory2");
         VMA_FETCH_DEVICE_FUNC(vkBindImageMemory2KHR, PFN_vkBindImageMemory2, "vkBindImageMemory2");
-        VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties2KHR,
-                                PFN_vkGetPhysicalDeviceMemoryProperties2,
-                                "vkGetPhysicalDeviceMemoryProperties2");
+    }
+#endif
+
+#if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    {
+        VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties2KHR, PFN_vkGetPhysicalDeviceMemoryProperties2, "vkGetPhysicalDeviceMemoryProperties2");
+    }
+    else if(m_UseExtMemoryBudget)
+    {
+        VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties2KHR, PFN_vkGetPhysicalDeviceMemoryProperties2, "vkGetPhysicalDeviceMemoryProperties2KHR");
     }
 #endif
 
 #if VMA_DEDICATED_ALLOCATION
-    if (m_UseKhrDedicatedAllocation)
+    if(m_UseKhrDedicatedAllocation)
     {
-        VMA_FETCH_DEVICE_FUNC(vkGetBufferMemoryRequirements2KHR,
-                              PFN_vkGetBufferMemoryRequirements2KHR,
-                              "vkGetBufferMemoryRequirements2KHR");
-        VMA_FETCH_DEVICE_FUNC(
-            vkGetImageMemoryRequirements2KHR, PFN_vkGetImageMemoryRequirements2KHR, "vkGetImageMemoryRequirements2KHR");
+        VMA_FETCH_DEVICE_FUNC(vkGetBufferMemoryRequirements2KHR, PFN_vkGetBufferMemoryRequirements2KHR, "vkGetBufferMemoryRequirements2KHR");
+        VMA_FETCH_DEVICE_FUNC(vkGetImageMemoryRequirements2KHR, PFN_vkGetImageMemoryRequirements2KHR, "vkGetImageMemoryRequirements2KHR");
     }
 #endif
 
 #if VMA_BIND_MEMORY2
-    if (m_UseKhrBindMemory2)
+    if(m_UseKhrBindMemory2)
     {
         VMA_FETCH_DEVICE_FUNC(vkBindBufferMemory2KHR, PFN_vkBindBufferMemory2KHR, "vkBindBufferMemory2KHR");
         VMA_FETCH_DEVICE_FUNC(vkBindImageMemory2KHR, PFN_vkBindImageMemory2KHR, "vkBindImageMemory2KHR");
     }
 #endif // #if VMA_BIND_MEMORY2
 
-#if VMA_MEMORY_BUDGET
-    if (m_UseExtMemoryBudget)
+#if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
-        VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties2KHR,
-                                PFN_vkGetPhysicalDeviceMemoryProperties2KHR,
-                                "vkGetPhysicalDeviceMemoryProperties2KHR");
+        VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties2KHR, PFN_vkGetPhysicalDeviceMemoryProperties2KHR, "vkGetPhysicalDeviceMemoryProperties2");
+    }
+    else if(m_UseExtMemoryBudget)
+    {
+        VMA_FETCH_INSTANCE_FUNC(vkGetPhysicalDeviceMemoryProperties2KHR, PFN_vkGetPhysicalDeviceMemoryProperties2KHR, "vkGetPhysicalDeviceMemoryProperties2KHR");
     }
 #endif // #if VMA_MEMORY_BUDGET
 
 #if VMA_VULKAN_VERSION >= 1003000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 3, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 3, 0))
     {
-        VMA_FETCH_DEVICE_FUNC(vkGetDeviceBufferMemoryRequirements,
-                              PFN_vkGetDeviceBufferMemoryRequirements,
-                              "vkGetDeviceBufferMemoryRequirements");
-        VMA_FETCH_DEVICE_FUNC(vkGetDeviceImageMemoryRequirements,
-                              PFN_vkGetDeviceImageMemoryRequirements,
-                              "vkGetDeviceImageMemoryRequirements");
+        VMA_FETCH_DEVICE_FUNC(vkGetDeviceBufferMemoryRequirements, PFN_vkGetDeviceBufferMemoryRequirements, "vkGetDeviceBufferMemoryRequirements");
+        VMA_FETCH_DEVICE_FUNC(vkGetDeviceImageMemoryRequirements, PFN_vkGetDeviceImageMemoryRequirements, "vkGetDeviceImageMemoryRequirements");
     }
 #endif
 
@@ -14624,7 +14414,7 @@ void VmaAllocator_T::ValidateVulkanFunctions()
     VMA_ASSERT(m_VulkanFunctions.vkCmdCopyBuffer != VMA_NULL);
 
 #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0) || m_UseKhrDedicatedAllocation)
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0) || m_UseKhrDedicatedAllocation)
     {
         VMA_ASSERT(m_VulkanFunctions.vkGetBufferMemoryRequirements2KHR != VMA_NULL);
         VMA_ASSERT(m_VulkanFunctions.vkGetImageMemoryRequirements2KHR != VMA_NULL);
@@ -14632,7 +14422,7 @@ void VmaAllocator_T::ValidateVulkanFunctions()
 #endif
 
 #if VMA_BIND_MEMORY2 || VMA_VULKAN_VERSION >= 1001000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0) || m_UseKhrBindMemory2)
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0) || m_UseKhrBindMemory2)
     {
         VMA_ASSERT(m_VulkanFunctions.vkBindBufferMemory2KHR != VMA_NULL);
         VMA_ASSERT(m_VulkanFunctions.vkBindImageMemory2KHR != VMA_NULL);
@@ -14640,14 +14430,14 @@ void VmaAllocator_T::ValidateVulkanFunctions()
 #endif
 
 #if VMA_MEMORY_BUDGET || VMA_VULKAN_VERSION >= 1001000
-    if (m_UseExtMemoryBudget || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    if(m_UseExtMemoryBudget || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
         VMA_ASSERT(m_VulkanFunctions.vkGetPhysicalDeviceMemoryProperties2KHR != VMA_NULL);
     }
 #endif
 
 #if VMA_VULKAN_VERSION >= 1003000
-    if (m_VulkanApiVersion >= VK_MAKE_VERSION(1, 3, 0))
+    if(m_VulkanApiVersion >= VK_MAKE_VERSION(1, 3, 0))
     {
         VMA_ASSERT(m_VulkanFunctions.vkGetDeviceBufferMemoryRequirements != VMA_NULL);
         VMA_ASSERT(m_VulkanFunctions.vkGetDeviceImageMemoryRequirements != VMA_NULL);
@@ -14657,37 +14447,41 @@ void VmaAllocator_T::ValidateVulkanFunctions()
 
 VkDeviceSize VmaAllocator_T::CalcPreferredBlockSize(uint32_t memTypeIndex)
 {
-    const uint32_t     heapIndex   = MemoryTypeIndexToHeapIndex(memTypeIndex);
-    const VkDeviceSize heapSize    = m_MemProps.memoryHeaps[heapIndex].size;
-    const bool         isSmallHeap = heapSize <= VMA_SMALL_HEAP_MAX_SIZE;
+    const uint32_t heapIndex = MemoryTypeIndexToHeapIndex(memTypeIndex);
+    const VkDeviceSize heapSize = m_MemProps.memoryHeaps[heapIndex].size;
+    const bool isSmallHeap = heapSize <= VMA_SMALL_HEAP_MAX_SIZE;
     return VmaAlignUp(isSmallHeap ? (heapSize / 8) : m_PreferredLargeHeapBlockSize, (VkDeviceSize)32);
 }
 
-VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        pool,
-                                              VkDeviceSize                   size,
-                                              VkDeviceSize                   alignment,
-                                              bool                           dedicatedPreferred,
-                                              VkBuffer                       dedicatedBuffer,
-                                              VkImage                        dedicatedImage,
-                                              VkFlags                        dedicatedBufferImageUsage,
-                                              const VmaAllocationCreateInfo& createInfo,
-                                              uint32_t                       memTypeIndex,
-                                              VmaSuballocationType           suballocType,
-                                              VmaDedicatedAllocationList&    dedicatedAllocations,
-                                              VmaBlockVector&                blockVector,
-                                              size_t                         allocationCount,
-                                              VmaAllocation*                 pAllocations)
+VkResult VmaAllocator_T::AllocateMemoryOfType(
+    VmaPool pool,
+    VkDeviceSize size,
+    VkDeviceSize alignment,
+    bool dedicatedPreferred,
+    VkBuffer dedicatedBuffer,
+    VkImage dedicatedImage,
+    VkFlags dedicatedBufferImageUsage,
+    const VmaAllocationCreateInfo& createInfo,
+    uint32_t memTypeIndex,
+    VmaSuballocationType suballocType,
+    VmaDedicatedAllocationList& dedicatedAllocations,
+    VmaBlockVector& blockVector,
+    size_t allocationCount,
+    VmaAllocation* pAllocations)
 {
     VMA_ASSERT(pAllocations != VMA_NULL);
-    VMA_DEBUG_LOG(
-        "  AllocateMemory: MemoryTypeIndex=%u, AllocationCount=%zu, Size=%llu", memTypeIndex, allocationCount, size);
+    VMA_DEBUG_LOG_FORMAT("  AllocateMemory: MemoryTypeIndex=%u, AllocationCount=%zu, Size=%llu", memTypeIndex, allocationCount, size);
 
     VmaAllocationCreateInfo finalCreateInfo = createInfo;
-    VkResult                res             = CalcMemTypeParams(finalCreateInfo, memTypeIndex, size, allocationCount);
-    if (res != VK_SUCCESS)
+    VkResult res = CalcMemTypeParams(
+        finalCreateInfo,
+        memTypeIndex,
+        size,
+        allocationCount);
+    if(res != VK_SUCCESS)
         return res;
 
-    if ((finalCreateInfo.flags & VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT) != 0)
+    if((finalCreateInfo.flags & VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT) != 0)
     {
         return AllocateDedicatedMemory(
             pool,
@@ -14697,8 +14491,8 @@ VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        poo
             memTypeIndex,
             (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0,
             (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT) != 0,
-            (finalCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                      VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0,
+            (finalCreateInfo.flags &
+                (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0,
             (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT) != 0,
             finalCreateInfo.pUserData,
             finalCreateInfo.priority,
@@ -14711,25 +14505,27 @@ VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        poo
     }
     else
     {
-        const bool canAllocateDedicated = (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) == 0 &&
-                                          (pool == VK_NULL_HANDLE || !blockVector.HasExplicitBlockSize());
+        const bool canAllocateDedicated =
+            (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) == 0 &&
+            (pool == VK_NULL_HANDLE || !blockVector.HasExplicitBlockSize());
 
-        if (canAllocateDedicated)
+        if(canAllocateDedicated)
         {
             // Heuristics: Allocate dedicated memory if requested size if greater than half of preferred block size.
-            if (size > blockVector.GetPreferredBlockSize() / 2)
+            if(size > blockVector.GetPreferredBlockSize() / 2)
             {
                 dedicatedPreferred = true;
             }
             // Protection against creating each allocation as dedicated when we reach or exceed heap size/budget,
             // which can quickly deplete maxMemoryAllocationCount: Don't prefer dedicated allocations when above
             // 3/4 of the maximum allocation count.
-            if (m_DeviceMemoryCount.load() > m_PhysicalDeviceProperties.limits.maxMemoryAllocationCount * 3 / 4)
+            if(m_PhysicalDeviceProperties.limits.maxMemoryAllocationCount < UINT32_MAX / 4 &&
+                m_DeviceMemoryCount.load() > m_PhysicalDeviceProperties.limits.maxMemoryAllocationCount * 3 / 4)
             {
                 dedicatedPreferred = false;
             }
 
-            if (dedicatedPreferred)
+            if(dedicatedPreferred)
             {
                 res = AllocateDedicatedMemory(
                     pool,
@@ -14739,8 +14535,8 @@ VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        poo
                     memTypeIndex,
                     (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0,
                     (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT) != 0,
-                    (finalCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                              VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0,
+                    (finalCreateInfo.flags &
+                        (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0,
                     (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT) != 0,
                     finalCreateInfo.pUserData,
                     finalCreateInfo.priority,
@@ -14750,21 +14546,27 @@ VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        poo
                     allocationCount,
                     pAllocations,
                     blockVector.GetAllocationNextPtr());
-                if (res == VK_SUCCESS)
+                if(res == VK_SUCCESS)
                 {
-                    // Succeeded: AllocateDedicatedMemory function already filld pMemory, nothing more to do here.
+                    // Succeeded: AllocateDedicatedMemory function already filled pMemory, nothing more to do here.
                     VMA_DEBUG_LOG("    Allocated as DedicatedMemory");
                     return VK_SUCCESS;
                 }
             }
         }
 
-        res = blockVector.Allocate(size, alignment, finalCreateInfo, suballocType, allocationCount, pAllocations);
-        if (res == VK_SUCCESS)
+        res = blockVector.Allocate(
+            size,
+            alignment,
+            finalCreateInfo,
+            suballocType,
+            allocationCount,
+            pAllocations);
+        if(res == VK_SUCCESS)
             return VK_SUCCESS;
 
         // Try dedicated memory.
-        if (canAllocateDedicated && !dedicatedPreferred)
+        if(canAllocateDedicated && !dedicatedPreferred)
         {
             res = AllocateDedicatedMemory(
                 pool,
@@ -14774,8 +14576,8 @@ VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        poo
                 memTypeIndex,
                 (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0,
                 (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT) != 0,
-                (finalCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                          VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0,
+                (finalCreateInfo.flags &
+                    (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0,
                 (finalCreateInfo.flags & VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT) != 0,
                 finalCreateInfo.pUserData,
                 finalCreateInfo.priority,
@@ -14785,9 +14587,9 @@ VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        poo
                 allocationCount,
                 pAllocations,
                 blockVector.GetAllocationNextPtr());
-            if (res == VK_SUCCESS)
+            if(res == VK_SUCCESS)
             {
-                // Succeeded: AllocateDedicatedMemory function already filld pMemory, nothing more to do here.
+                // Succeeded: AllocateDedicatedMemory function already filled pMemory, nothing more to do here.
                 VMA_DEBUG_LOG("    Allocated as DedicatedMemory");
                 return VK_SUCCESS;
             }
@@ -14798,44 +14600,45 @@ VkResult VmaAllocator_T::AllocateMemoryOfType(VmaPool                        poo
     }
 }
 
-VkResult VmaAllocator_T::AllocateDedicatedMemory(VmaPool                     pool,
-                                                 VkDeviceSize                size,
-                                                 VmaSuballocationType        suballocType,
-                                                 VmaDedicatedAllocationList& dedicatedAllocations,
-                                                 uint32_t                    memTypeIndex,
-                                                 bool                        map,
-                                                 bool                        isUserDataString,
-                                                 bool                        isMappingAllowed,
-                                                 bool                        canAliasMemory,
-                                                 void*                       pUserData,
-                                                 float                       priority,
-                                                 VkBuffer                    dedicatedBuffer,
-                                                 VkImage                     dedicatedImage,
-                                                 VkFlags                     dedicatedBufferImageUsage,
-                                                 size_t                      allocationCount,
-                                                 VmaAllocation*              pAllocations,
-                                                 const void*                 pNextChain)
+VkResult VmaAllocator_T::AllocateDedicatedMemory(
+    VmaPool pool,
+    VkDeviceSize size,
+    VmaSuballocationType suballocType,
+    VmaDedicatedAllocationList& dedicatedAllocations,
+    uint32_t memTypeIndex,
+    bool map,
+    bool isUserDataString,
+    bool isMappingAllowed,
+    bool canAliasMemory,
+    void* pUserData,
+    float priority,
+    VkBuffer dedicatedBuffer,
+    VkImage dedicatedImage,
+    VkFlags dedicatedBufferImageUsage,
+    size_t allocationCount,
+    VmaAllocation* pAllocations,
+    const void* pNextChain)
 {
     VMA_ASSERT(allocationCount > 0 && pAllocations);
 
     VkMemoryAllocateInfo allocInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };
-    allocInfo.memoryTypeIndex      = memTypeIndex;
-    allocInfo.allocationSize       = size;
-    allocInfo.pNext                = pNextChain;
+    allocInfo.memoryTypeIndex = memTypeIndex;
+    allocInfo.allocationSize = size;
+    allocInfo.pNext = pNextChain;
 
 #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
     VkMemoryDedicatedAllocateInfoKHR dedicatedAllocInfo = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR };
-    if (!canAliasMemory)
+    if(!canAliasMemory)
     {
-        if (m_UseKhrDedicatedAllocation || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+        if(m_UseKhrDedicatedAllocation || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
         {
-            if (dedicatedBuffer != VK_NULL_HANDLE)
+            if(dedicatedBuffer != VK_NULL_HANDLE)
             {
                 VMA_ASSERT(dedicatedImage == VK_NULL_HANDLE);
                 dedicatedAllocInfo.buffer = dedicatedBuffer;
                 VmaPnextChainPushFront(&allocInfo, &dedicatedAllocInfo);
             }
-            else if (dedicatedImage != VK_NULL_HANDLE)
+            else if(dedicatedImage != VK_NULL_HANDLE)
             {
                 dedicatedAllocInfo.image = dedicatedImage;
                 VmaPnextChainPushFront(&allocInfo, &dedicatedAllocInfo);
@@ -14846,20 +14649,19 @@ VkResult VmaAllocator_T::AllocateDedicatedMemory(VmaPool                     poo
 
 #if VMA_BUFFER_DEVICE_ADDRESS
     VkMemoryAllocateFlagsInfoKHR allocFlagsInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO_KHR };
-    if (m_UseKhrBufferDeviceAddress)
+    if(m_UseKhrBufferDeviceAddress)
     {
         bool canContainBufferWithDeviceAddress = true;
-        if (dedicatedBuffer != VK_NULL_HANDLE)
+        if(dedicatedBuffer != VK_NULL_HANDLE)
         {
-            canContainBufferWithDeviceAddress =
-                dedicatedBufferImageUsage == UINT32_MAX || // Usage flags unknown
+            canContainBufferWithDeviceAddress = dedicatedBufferImageUsage == UINT32_MAX || // Usage flags unknown
                 (dedicatedBufferImageUsage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_EXT) != 0;
         }
-        else if (dedicatedImage != VK_NULL_HANDLE)
+        else if(dedicatedImage != VK_NULL_HANDLE)
         {
             canContainBufferWithDeviceAddress = false;
         }
-        if (canContainBufferWithDeviceAddress)
+        if(canContainBufferWithDeviceAddress)
         {
             allocFlagsInfo.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
             VmaPnextChainPushFront(&allocInfo, &allocFlagsInfo);
@@ -14869,7 +14671,7 @@ VkResult VmaAllocator_T::AllocateDedicatedMemory(VmaPool                     poo
 
 #if VMA_MEMORY_PRIORITY
     VkMemoryPriorityAllocateInfoEXT priorityInfo = { VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT };
-    if (m_UseExtMemoryPriority)
+    if(m_UseExtMemoryPriority)
     {
         VMA_ASSERT(priority >= 0.f && priority <= 1.f);
         priorityInfo.priority = priority;
@@ -14880,48 +14682,49 @@ VkResult VmaAllocator_T::AllocateDedicatedMemory(VmaPool                     poo
 #if VMA_EXTERNAL_MEMORY
     // Attach VkExportMemoryAllocateInfoKHR if necessary.
     VkExportMemoryAllocateInfoKHR exportMemoryAllocInfo = { VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR };
-    exportMemoryAllocInfo.handleTypes                   = GetExternalMemoryHandleTypeFlags(memTypeIndex);
-    if (exportMemoryAllocInfo.handleTypes != 0)
+    exportMemoryAllocInfo.handleTypes = GetExternalMemoryHandleTypeFlags(memTypeIndex);
+    if(exportMemoryAllocInfo.handleTypes != 0)
     {
         VmaPnextChainPushFront(&allocInfo, &exportMemoryAllocInfo);
     }
 #endif // #if VMA_EXTERNAL_MEMORY
 
-    size_t   allocIndex;
+    size_t allocIndex;
     VkResult res = VK_SUCCESS;
-    for (allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
+    for(allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
     {
-        res = AllocateDedicatedMemoryPage(pool,
-                                          size,
-                                          suballocType,
-                                          memTypeIndex,
-                                          allocInfo,
-                                          map,
-                                          isUserDataString,
-                                          isMappingAllowed,
-                                          pUserData,
-                                          pAllocations + allocIndex);
-        if (res != VK_SUCCESS)
+        res = AllocateDedicatedMemoryPage(
+            pool,
+            size,
+            suballocType,
+            memTypeIndex,
+            allocInfo,
+            map,
+            isUserDataString,
+            isMappingAllowed,
+            pUserData,
+            pAllocations + allocIndex);
+        if(res != VK_SUCCESS)
         {
             break;
         }
     }
 
-    if (res == VK_SUCCESS)
+    if(res == VK_SUCCESS)
     {
         for (allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
         {
             dedicatedAllocations.Register(pAllocations[allocIndex]);
         }
-        VMA_DEBUG_LOG("    Allocated DedicatedMemory Count=%zu, MemoryTypeIndex=#%u", allocationCount, memTypeIndex);
+        VMA_DEBUG_LOG_FORMAT("    Allocated DedicatedMemory Count=%zu, MemoryTypeIndex=#%u", allocationCount, memTypeIndex);
     }
     else
     {
         // Free all already created allocations.
-        while (allocIndex--)
+        while(allocIndex--)
         {
-            VmaAllocation  currAlloc = pAllocations[allocIndex];
-            VkDeviceMemory hMemory   = currAlloc->GetMemory();
+            VmaAllocation currAlloc = pAllocations[allocIndex];
+            VkDeviceMemory hMemory = currAlloc->GetMemory();
 
             /*
             There is no need to call this, because Vulkan spec allows to skip vkUnmapMemory
@@ -14944,30 +14747,37 @@ VkResult VmaAllocator_T::AllocateDedicatedMemory(VmaPool                     poo
     return res;
 }
 
-VkResult VmaAllocator_T::AllocateDedicatedMemoryPage(VmaPool                     pool,
-                                                     VkDeviceSize                size,
-                                                     VmaSuballocationType        suballocType,
-                                                     uint32_t                    memTypeIndex,
-                                                     const VkMemoryAllocateInfo& allocInfo,
-                                                     bool                        map,
-                                                     bool                        isUserDataString,
-                                                     bool                        isMappingAllowed,
-                                                     void*                       pUserData,
-                                                     VmaAllocation*              pAllocation)
+VkResult VmaAllocator_T::AllocateDedicatedMemoryPage(
+    VmaPool pool,
+    VkDeviceSize size,
+    VmaSuballocationType suballocType,
+    uint32_t memTypeIndex,
+    const VkMemoryAllocateInfo& allocInfo,
+    bool map,
+    bool isUserDataString,
+    bool isMappingAllowed,
+    void* pUserData,
+    VmaAllocation* pAllocation)
 {
     VkDeviceMemory hMemory = VK_NULL_HANDLE;
-    VkResult       res     = AllocateVulkanMemory(&allocInfo, &hMemory);
-    if (res < 0)
+    VkResult res = AllocateVulkanMemory(&allocInfo, &hMemory);
+    if(res < 0)
     {
         VMA_DEBUG_LOG("    vkAllocateMemory FAILED");
         return res;
     }
 
     void* pMappedData = VMA_NULL;
-    if (map)
+    if(map)
     {
-        res = (*m_VulkanFunctions.vkMapMemory)(m_hDevice, hMemory, 0, VK_WHOLE_SIZE, 0, &pMappedData);
-        if (res < 0)
+        res = (*m_VulkanFunctions.vkMapMemory)(
+            m_hDevice,
+            hMemory,
+            0,
+            VK_WHOLE_SIZE,
+            0,
+            &pMappedData);
+        if(res < 0)
         {
             VMA_DEBUG_LOG("    vkMapMemory FAILED");
             FreeVulkanMemory(memTypeIndex, size, hMemory);
@@ -14982,7 +14792,7 @@ VkResult VmaAllocator_T::AllocateDedicatedMemoryPage(VmaPool                    
     else
         (*pAllocation)->SetUserData(this, pUserData);
     m_Budget.AddAllocation(MemoryTypeIndexToHeapIndex(memTypeIndex), size);
-    if (VMA_DEBUG_INITIALIZE_ALLOCATIONS)
+    if(VMA_DEBUG_INITIALIZE_ALLOCATIONS)
     {
         FillAllocation(*pAllocation, VMA_ALLOCATION_FILL_PATTERN_CREATED);
     }
@@ -14990,16 +14800,17 @@ VkResult VmaAllocator_T::AllocateDedicatedMemoryPage(VmaPool                    
     return VK_SUCCESS;
 }
 
-void VmaAllocator_T::GetBufferMemoryRequirements(VkBuffer              hBuffer,
-                                                 VkMemoryRequirements& memReq,
-                                                 bool&                 requiresDedicatedAllocation,
-                                                 bool&                 prefersDedicatedAllocation) const
+void VmaAllocator_T::GetBufferMemoryRequirements(
+    VkBuffer hBuffer,
+    VkMemoryRequirements& memReq,
+    bool& requiresDedicatedAllocation,
+    bool& prefersDedicatedAllocation) const
 {
 #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
-    if (m_UseKhrDedicatedAllocation || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    if(m_UseKhrDedicatedAllocation || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
         VkBufferMemoryRequirementsInfo2KHR memReqInfo = { VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR };
-        memReqInfo.buffer                             = hBuffer;
+        memReqInfo.buffer = hBuffer;
 
         VkMemoryDedicatedRequirementsKHR memDedicatedReq = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR };
 
@@ -15008,9 +14819,9 @@ void VmaAllocator_T::GetBufferMemoryRequirements(VkBuffer              hBuffer,
 
         (*m_VulkanFunctions.vkGetBufferMemoryRequirements2KHR)(m_hDevice, &memReqInfo, &memReq2);
 
-        memReq                      = memReq2.memoryRequirements;
+        memReq = memReq2.memoryRequirements;
         requiresDedicatedAllocation = (memDedicatedReq.requiresDedicatedAllocation != VK_FALSE);
-        prefersDedicatedAllocation  = (memDedicatedReq.prefersDedicatedAllocation != VK_FALSE);
+        prefersDedicatedAllocation  = (memDedicatedReq.prefersDedicatedAllocation  != VK_FALSE);
     }
     else
 #endif // #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
@@ -15021,16 +14832,17 @@ void VmaAllocator_T::GetBufferMemoryRequirements(VkBuffer              hBuffer,
     }
 }
 
-void VmaAllocator_T::GetImageMemoryRequirements(VkImage               hImage,
-                                                VkMemoryRequirements& memReq,
-                                                bool&                 requiresDedicatedAllocation,
-                                                bool&                 prefersDedicatedAllocation) const
+void VmaAllocator_T::GetImageMemoryRequirements(
+    VkImage hImage,
+    VkMemoryRequirements& memReq,
+    bool& requiresDedicatedAllocation,
+    bool& prefersDedicatedAllocation) const
 {
 #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
-    if (m_UseKhrDedicatedAllocation || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
+    if(m_UseKhrDedicatedAllocation || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0))
     {
         VkImageMemoryRequirementsInfo2KHR memReqInfo = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR };
-        memReqInfo.image                             = hImage;
+        memReqInfo.image = hImage;
 
         VkMemoryDedicatedRequirementsKHR memDedicatedReq = { VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR };
 
@@ -15039,9 +14851,9 @@ void VmaAllocator_T::GetImageMemoryRequirements(VkImage               hImage,
 
         (*m_VulkanFunctions.vkGetImageMemoryRequirements2KHR)(m_hDevice, &memReqInfo, &memReq2);
 
-        memReq                      = memReq2.memoryRequirements;
+        memReq = memReq2.memoryRequirements;
         requiresDedicatedAllocation = (memDedicatedReq.requiresDedicatedAllocation != VK_FALSE);
-        prefersDedicatedAllocation  = (memDedicatedReq.prefersDedicatedAllocation != VK_FALSE);
+        prefersDedicatedAllocation  = (memDedicatedReq.prefersDedicatedAllocation  != VK_FALSE);
     }
     else
 #endif // #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
@@ -15052,45 +14864,51 @@ void VmaAllocator_T::GetImageMemoryRequirements(VkImage               hImage,
     }
 }
 
-VkResult VmaAllocator_T::FindMemoryTypeIndex(uint32_t                       memoryTypeBits,
-                                             const VmaAllocationCreateInfo* pAllocationCreateInfo,
-                                             VkFlags                        bufImgUsage,
-                                             uint32_t*                      pMemoryTypeIndex) const
+VkResult VmaAllocator_T::FindMemoryTypeIndex(
+    uint32_t memoryTypeBits,
+    const VmaAllocationCreateInfo* pAllocationCreateInfo,
+    VkFlags bufImgUsage,
+    uint32_t* pMemoryTypeIndex) const
 {
     memoryTypeBits &= GetGlobalMemoryTypeBits();
 
-    if (pAllocationCreateInfo->memoryTypeBits != 0)
+    if(pAllocationCreateInfo->memoryTypeBits != 0)
     {
         memoryTypeBits &= pAllocationCreateInfo->memoryTypeBits;
     }
 
     VkMemoryPropertyFlags requiredFlags = 0, preferredFlags = 0, notPreferredFlags = 0;
-    if (!FindMemoryPreferences(
-            IsIntegratedGpu(), *pAllocationCreateInfo, bufImgUsage, requiredFlags, preferredFlags, notPreferredFlags))
+    if(!FindMemoryPreferences(
+        IsIntegratedGpu(),
+        *pAllocationCreateInfo,
+        bufImgUsage,
+        requiredFlags, preferredFlags, notPreferredFlags))
     {
         return VK_ERROR_FEATURE_NOT_PRESENT;
     }
 
     *pMemoryTypeIndex = UINT32_MAX;
-    uint32_t minCost  = UINT32_MAX;
-    for (uint32_t memTypeIndex = 0, memTypeBit = 1; memTypeIndex < GetMemoryTypeCount();
-         ++memTypeIndex, memTypeBit <<= 1)
+    uint32_t minCost = UINT32_MAX;
+    for(uint32_t memTypeIndex = 0, memTypeBit = 1;
+        memTypeIndex < GetMemoryTypeCount();
+        ++memTypeIndex, memTypeBit <<= 1)
     {
         // This memory type is acceptable according to memoryTypeBits bitmask.
-        if ((memTypeBit & memoryTypeBits) != 0)
+        if((memTypeBit & memoryTypeBits) != 0)
         {
-            const VkMemoryPropertyFlags currFlags = m_MemProps.memoryTypes[memTypeIndex].propertyFlags;
+            const VkMemoryPropertyFlags currFlags =
+                m_MemProps.memoryTypes[memTypeIndex].propertyFlags;
             // This memory type contains requiredFlags.
-            if ((requiredFlags & ~currFlags) == 0)
+            if((requiredFlags & ~currFlags) == 0)
             {
                 // Calculate cost as number of bits from preferredFlags not present in this memory type.
-                uint32_t currCost =
-                    VMA_COUNT_BITS_SET(preferredFlags & ~currFlags) + VMA_COUNT_BITS_SET(currFlags & notPreferredFlags);
+                uint32_t currCost = VMA_COUNT_BITS_SET(preferredFlags & ~currFlags) +
+                    VMA_COUNT_BITS_SET(currFlags & notPreferredFlags);
                 // Remember memory type with lowest cost.
-                if (currCost < minCost)
+                if(currCost < minCost)
                 {
                     *pMemoryTypeIndex = memTypeIndex;
-                    if (currCost == 0)
+                    if(currCost == 0)
                     {
                         return VK_SUCCESS;
                     }
@@ -15102,25 +14920,26 @@ VkResult VmaAllocator_T::FindMemoryTypeIndex(uint32_t                       memo
     return (*pMemoryTypeIndex != UINT32_MAX) ? VK_SUCCESS : VK_ERROR_FEATURE_NOT_PRESENT;
 }
 
-VkResult VmaAllocator_T::CalcMemTypeParams(VmaAllocationCreateInfo& inoutCreateInfo,
-                                           uint32_t                 memTypeIndex,
-                                           VkDeviceSize             size,
-                                           size_t                   allocationCount)
+VkResult VmaAllocator_T::CalcMemTypeParams(
+    VmaAllocationCreateInfo& inoutCreateInfo,
+    uint32_t memTypeIndex,
+    VkDeviceSize size,
+    size_t allocationCount)
 {
     // If memory type is not HOST_VISIBLE, disable MAPPED.
-    if ((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0 &&
+    if((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0 &&
         (m_MemProps.memoryTypes[memTypeIndex].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0)
     {
         inoutCreateInfo.flags &= ~VMA_ALLOCATION_CREATE_MAPPED_BIT;
     }
 
-    if ((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT) != 0 &&
+    if((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT) != 0 &&
         (inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_WITHIN_BUDGET_BIT) != 0)
     {
-        const uint32_t heapIndex  = MemoryTypeIndexToHeapIndex(memTypeIndex);
-        VmaBudget      heapBudget = {};
+        const uint32_t heapIndex = MemoryTypeIndexToHeapIndex(memTypeIndex);
+        VmaBudget heapBudget = {};
         GetHeapBudgets(&heapBudget, heapIndex, 1);
-        if (heapBudget.usage + size * allocationCount > heapBudget.budget)
+        if(heapBudget.usage + size * allocationCount > heapBudget.budget)
         {
             return VK_ERROR_OUT_OF_DEVICE_MEMORY;
         }
@@ -15128,63 +14947,54 @@ VkResult VmaAllocator_T::CalcMemTypeParams(VmaAllocationCreateInfo& inoutCreateI
     return VK_SUCCESS;
 }
 
-VkResult VmaAllocator_T::CalcAllocationParams(VmaAllocationCreateInfo& inoutCreateInfo,
-                                              bool                     dedicatedRequired,
-                                              bool                     dedicatedPreferred)
+VkResult VmaAllocator_T::CalcAllocationParams(
+    VmaAllocationCreateInfo& inoutCreateInfo,
+    bool dedicatedRequired,
+    bool dedicatedPreferred)
 {
-    VMA_ASSERT(
-        (inoutCreateInfo.flags &
-         (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) !=
-            (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT) &&
-        "Specifying both flags VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT and "
-        "VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT is incorrect.");
-    VMA_ASSERT(
-        (((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT) == 0 ||
-          (inoutCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                    VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0)) &&
-        "Specifying VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT requires also "
-        "VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT.");
-    if (inoutCreateInfo.usage == VMA_MEMORY_USAGE_AUTO ||
-        inoutCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE ||
-        inoutCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_HOST)
+    VMA_ASSERT((inoutCreateInfo.flags &
+        (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) !=
+        (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT) &&
+        "Specifying both flags VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT and VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT is incorrect.");
+    VMA_ASSERT((((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT) == 0 ||
+        (inoutCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0)) &&
+        "Specifying VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT requires also VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT.");
+    if(inoutCreateInfo.usage == VMA_MEMORY_USAGE_AUTO || inoutCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE || inoutCreateInfo.usage == VMA_MEMORY_USAGE_AUTO_PREFER_HOST)
     {
-        if ((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0)
+        if((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0)
         {
-            VMA_ASSERT((inoutCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                                 VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0 &&
-                       "When using VMA_ALLOCATION_CREATE_MAPPED_BIT and usage = VMA_MEMORY_USAGE_AUTO*, you must also "
-                       "specify VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or "
-                       "VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT.");
+            VMA_ASSERT((inoutCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) != 0 &&
+                "When using VMA_ALLOCATION_CREATE_MAPPED_BIT and usage = VMA_MEMORY_USAGE_AUTO*, you must also specify VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT.");
         }
     }
 
     // If memory is lazily allocated, it should be always dedicated.
-    if (dedicatedRequired || inoutCreateInfo.usage == VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED)
+    if(dedicatedRequired ||
+        inoutCreateInfo.usage == VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED)
     {
         inoutCreateInfo.flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
     }
 
-    if (inoutCreateInfo.pool != VK_NULL_HANDLE)
+    if(inoutCreateInfo.pool != VK_NULL_HANDLE)
     {
-        if (inoutCreateInfo.pool->m_BlockVector.HasExplicitBlockSize() &&
+        if(inoutCreateInfo.pool->m_BlockVector.HasExplicitBlockSize() &&
             (inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT) != 0)
         {
-            VMA_ASSERT(0 && "Specifying VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT while current custom pool doesn't "
-                            "support dedicated allocations.");
+            VMA_ASSERT(0 && "Specifying VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT while current custom pool doesn't support dedicated allocations.");
             return VK_ERROR_FEATURE_NOT_PRESENT;
         }
         inoutCreateInfo.priority = inoutCreateInfo.pool->m_BlockVector.GetPriority();
     }
 
-    if ((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT) != 0 &&
+    if((inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT) != 0 &&
         (inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) != 0)
     {
-        VMA_ASSERT(0 && "Specifying VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT together with "
-                        "VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT makes no sense.");
+        VMA_ASSERT(0 && "Specifying VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT together with VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT makes no sense.");
         return VK_ERROR_FEATURE_NOT_PRESENT;
     }
 
-    if (VMA_DEBUG_ALWAYS_DEDICATED_MEMORY && (inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) != 0)
+    if(VMA_DEBUG_ALWAYS_DEDICATED_MEMORY &&
+        (inoutCreateInfo.flags & VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT) != 0)
     {
         inoutCreateInfo.flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
     }
@@ -15193,12 +15003,11 @@ VkResult VmaAllocator_T::CalcAllocationParams(VmaAllocationCreateInfo& inoutCrea
     // And so does VMA_MEMORY_USAGE_UNKNOWN because it is used with custom pools.
     // Which specific flag is used doesn't matter. They change things only when used with VMA_MEMORY_USAGE_AUTO*.
     // Otherwise they just protect from assert on mapping.
-    if (inoutCreateInfo.usage != VMA_MEMORY_USAGE_AUTO &&
+    if(inoutCreateInfo.usage != VMA_MEMORY_USAGE_AUTO &&
         inoutCreateInfo.usage != VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE &&
         inoutCreateInfo.usage != VMA_MEMORY_USAGE_AUTO_PREFER_HOST)
     {
-        if ((inoutCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                      VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) == 0)
+        if((inoutCreateInfo.flags & (VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT)) == 0)
         {
             inoutCreateInfo.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
         }
@@ -15207,85 +15016,88 @@ VkResult VmaAllocator_T::CalcAllocationParams(VmaAllocationCreateInfo& inoutCrea
     return VK_SUCCESS;
 }
 
-VkResult VmaAllocator_T::AllocateMemory(const VkMemoryRequirements&    vkMemReq,
-                                        bool                           requiresDedicatedAllocation,
-                                        bool                           prefersDedicatedAllocation,
-                                        VkBuffer                       dedicatedBuffer,
-                                        VkImage                        dedicatedImage,
-                                        VkFlags                        dedicatedBufferImageUsage,
-                                        const VmaAllocationCreateInfo& createInfo,
-                                        VmaSuballocationType           suballocType,
-                                        size_t                         allocationCount,
-                                        VmaAllocation*                 pAllocations)
+VkResult VmaAllocator_T::AllocateMemory(
+    const VkMemoryRequirements& vkMemReq,
+    bool requiresDedicatedAllocation,
+    bool prefersDedicatedAllocation,
+    VkBuffer dedicatedBuffer,
+    VkImage dedicatedImage,
+    VkFlags dedicatedBufferImageUsage,
+    const VmaAllocationCreateInfo& createInfo,
+    VmaSuballocationType suballocType,
+    size_t allocationCount,
+    VmaAllocation* pAllocations)
 {
     memset(pAllocations, 0, sizeof(VmaAllocation) * allocationCount);
 
     VMA_ASSERT(VmaIsPow2(vkMemReq.alignment));
 
-    if (vkMemReq.size == 0)
+    if(vkMemReq.size == 0)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
     VmaAllocationCreateInfo createInfoFinal = createInfo;
     VkResult res = CalcAllocationParams(createInfoFinal, requiresDedicatedAllocation, prefersDedicatedAllocation);
-    if (res != VK_SUCCESS)
+    if(res != VK_SUCCESS)
         return res;
 
-    if (createInfoFinal.pool != VK_NULL_HANDLE)
+    if(createInfoFinal.pool != VK_NULL_HANDLE)
     {
         VmaBlockVector& blockVector = createInfoFinal.pool->m_BlockVector;
-        return AllocateMemoryOfType(createInfoFinal.pool,
-                                    vkMemReq.size,
-                                    vkMemReq.alignment,
-                                    prefersDedicatedAllocation,
-                                    dedicatedBuffer,
-                                    dedicatedImage,
-                                    dedicatedBufferImageUsage,
-                                    createInfoFinal,
-                                    blockVector.GetMemoryTypeIndex(),
-                                    suballocType,
-                                    createInfoFinal.pool->m_DedicatedAllocations,
-                                    blockVector,
-                                    allocationCount,
-                                    pAllocations);
+        return AllocateMemoryOfType(
+            createInfoFinal.pool,
+            vkMemReq.size,
+            vkMemReq.alignment,
+            prefersDedicatedAllocation,
+            dedicatedBuffer,
+            dedicatedImage,
+            dedicatedBufferImageUsage,
+            createInfoFinal,
+            blockVector.GetMemoryTypeIndex(),
+            suballocType,
+            createInfoFinal.pool->m_DedicatedAllocations,
+            blockVector,
+            allocationCount,
+            pAllocations);
     }
     else
     {
         // Bit mask of memory Vulkan types acceptable for this allocation.
         uint32_t memoryTypeBits = vkMemReq.memoryTypeBits;
-        uint32_t memTypeIndex   = UINT32_MAX;
+        uint32_t memTypeIndex = UINT32_MAX;
         res = FindMemoryTypeIndex(memoryTypeBits, &createInfoFinal, dedicatedBufferImageUsage, &memTypeIndex);
         // Can't find any single memory type matching requirements. res is VK_ERROR_FEATURE_NOT_PRESENT.
-        if (res != VK_SUCCESS)
+        if(res != VK_SUCCESS)
             return res;
         do
         {
             VmaBlockVector* blockVector = m_pBlockVectors[memTypeIndex];
             VMA_ASSERT(blockVector && "Trying to use unsupported memory type!");
-            res = AllocateMemoryOfType(VK_NULL_HANDLE,
-                                       vkMemReq.size,
-                                       vkMemReq.alignment,
-                                       requiresDedicatedAllocation || prefersDedicatedAllocation,
-                                       dedicatedBuffer,
-                                       dedicatedImage,
-                                       dedicatedBufferImageUsage,
-                                       createInfoFinal,
-                                       memTypeIndex,
-                                       suballocType,
-                                       m_DedicatedAllocations[memTypeIndex],
-                                       *blockVector,
-                                       allocationCount,
-                                       pAllocations);
+            res = AllocateMemoryOfType(
+                VK_NULL_HANDLE,
+                vkMemReq.size,
+                vkMemReq.alignment,
+                requiresDedicatedAllocation || prefersDedicatedAllocation,
+                dedicatedBuffer,
+                dedicatedImage,
+                dedicatedBufferImageUsage,
+                createInfoFinal,
+                memTypeIndex,
+                suballocType,
+                m_DedicatedAllocations[memTypeIndex],
+                *blockVector,
+                allocationCount,
+                pAllocations);
             // Allocation succeeded
-            if (res == VK_SUCCESS)
+            if(res == VK_SUCCESS)
                 return VK_SUCCESS;
 
             // Remove old memTypeIndex from list of possibilities.
             memoryTypeBits &= ~(1u << memTypeIndex);
             // Find alternative memTypeIndex.
             res = FindMemoryTypeIndex(memoryTypeBits, &createInfoFinal, dedicatedBufferImageUsage, &memTypeIndex);
-        } while (res == VK_SUCCESS);
+        } while(res == VK_SUCCESS);
 
         // No other matching memory type index could be found.
         // Not returning res, which is VK_ERROR_FEATURE_NOT_PRESENT, because we already failed to allocate once.
@@ -15293,47 +15105,49 @@ VkResult VmaAllocator_T::AllocateMemory(const VkMemoryRequirements&    vkMemReq,
     }
 }
 
-void VmaAllocator_T::FreeMemory(size_t allocationCount, const VmaAllocation* pAllocations)
+void VmaAllocator_T::FreeMemory(
+    size_t allocationCount,
+    const VmaAllocation* pAllocations)
 {
     VMA_ASSERT(pAllocations);
 
-    for (size_t allocIndex = allocationCount; allocIndex--;)
+    for(size_t allocIndex = allocationCount; allocIndex--; )
     {
         VmaAllocation allocation = pAllocations[allocIndex];
 
-        if (allocation != VK_NULL_HANDLE)
+        if(allocation != VK_NULL_HANDLE)
         {
-            if (VMA_DEBUG_INITIALIZE_ALLOCATIONS)
+            if(VMA_DEBUG_INITIALIZE_ALLOCATIONS)
             {
                 FillAllocation(allocation, VMA_ALLOCATION_FILL_PATTERN_DESTROYED);
             }
 
             allocation->FreeName(this);
 
-            switch (allocation->GetType())
+            switch(allocation->GetType())
             {
-                case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+            case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
                 {
                     VmaBlockVector* pBlockVector = VMA_NULL;
-                    VmaPool         hPool        = allocation->GetParentPool();
-                    if (hPool != VK_NULL_HANDLE)
+                    VmaPool hPool = allocation->GetParentPool();
+                    if(hPool != VK_NULL_HANDLE)
                     {
                         pBlockVector = &hPool->m_BlockVector;
                     }
                     else
                     {
                         const uint32_t memTypeIndex = allocation->GetMemoryTypeIndex();
-                        pBlockVector                = m_pBlockVectors[memTypeIndex];
+                        pBlockVector = m_pBlockVectors[memTypeIndex];
                         VMA_ASSERT(pBlockVector && "Trying to free memory of unsupported type!");
                     }
                     pBlockVector->Free(allocation);
                 }
                 break;
-                case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
-                    FreeDedicatedMemory(allocation);
-                    break;
-                default:
-                    VMA_ASSERT(0);
+            case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+                FreeDedicatedMemory(allocation);
+                break;
+            default:
+                VMA_ASSERT(0);
             }
         }
     }
@@ -15343,11 +15157,13 @@ void VmaAllocator_T::CalculateStatistics(VmaTotalStatistics* pStats)
 {
     // Initialize.
     VmaClearDetailedStatistics(pStats->total);
-    for (uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; ++i) VmaClearDetailedStatistics(pStats->memoryType[i]);
-    for (uint32_t i = 0; i < VK_MAX_MEMORY_HEAPS; ++i) VmaClearDetailedStatistics(pStats->memoryHeap[i]);
+    for(uint32_t i = 0; i < VK_MAX_MEMORY_TYPES; ++i)
+        VmaClearDetailedStatistics(pStats->memoryType[i]);
+    for(uint32_t i = 0; i < VK_MAX_MEMORY_HEAPS; ++i)
+        VmaClearDetailedStatistics(pStats->memoryHeap[i]);
 
     // Process default pools.
-    for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
+    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
     {
         VmaBlockVector* const pBlockVector = m_pBlockVectors[memTypeIndex];
         if (pBlockVector != VMA_NULL)
@@ -15357,60 +15173,59 @@ void VmaAllocator_T::CalculateStatistics(VmaTotalStatistics* pStats)
     // Process custom pools.
     {
         VmaMutexLockRead lock(m_PoolsMutex, m_UseMutex);
-        for (VmaPool pool = m_Pools.Front(); pool != VMA_NULL; pool = m_Pools.GetNext(pool))
+        for(VmaPool pool = m_Pools.Front(); pool != VMA_NULL; pool = m_Pools.GetNext(pool))
         {
-            VmaBlockVector& blockVector  = pool->m_BlockVector;
-            const uint32_t  memTypeIndex = blockVector.GetMemoryTypeIndex();
+            VmaBlockVector& blockVector = pool->m_BlockVector;
+            const uint32_t memTypeIndex = blockVector.GetMemoryTypeIndex();
             blockVector.AddDetailedStatistics(pStats->memoryType[memTypeIndex]);
             pool->m_DedicatedAllocations.AddDetailedStatistics(pStats->memoryType[memTypeIndex]);
         }
     }
 
     // Process dedicated allocations.
-    for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
+    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
     {
         m_DedicatedAllocations[memTypeIndex].AddDetailedStatistics(pStats->memoryType[memTypeIndex]);
     }
 
     // Sum from memory types to memory heaps.
-    for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
+    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
     {
         const uint32_t memHeapIndex = m_MemProps.memoryTypes[memTypeIndex].heapIndex;
         VmaAddDetailedStatistics(pStats->memoryHeap[memHeapIndex], pStats->memoryType[memTypeIndex]);
     }
 
     // Sum from memory heaps to total.
-    for (uint32_t memHeapIndex = 0; memHeapIndex < GetMemoryHeapCount(); ++memHeapIndex)
+    for(uint32_t memHeapIndex = 0; memHeapIndex < GetMemoryHeapCount(); ++memHeapIndex)
         VmaAddDetailedStatistics(pStats->total, pStats->memoryHeap[memHeapIndex]);
 
     VMA_ASSERT(pStats->total.statistics.allocationCount == 0 ||
-               pStats->total.allocationSizeMax >= pStats->total.allocationSizeMin);
+        pStats->total.allocationSizeMax >= pStats->total.allocationSizeMin);
     VMA_ASSERT(pStats->total.unusedRangeCount == 0 ||
-               pStats->total.unusedRangeSizeMax >= pStats->total.unusedRangeSizeMin);
+        pStats->total.unusedRangeSizeMax >= pStats->total.unusedRangeSizeMin);
 }
 
 void VmaAllocator_T::GetHeapBudgets(VmaBudget* outBudgets, uint32_t firstHeap, uint32_t heapCount)
 {
 #if VMA_MEMORY_BUDGET
-    if (m_UseExtMemoryBudget)
+    if(m_UseExtMemoryBudget)
     {
-        if (m_Budget.m_OperationsSinceBudgetFetch < 30)
+        if(m_Budget.m_OperationsSinceBudgetFetch < 30)
         {
             VmaMutexLockRead lockRead(m_Budget.m_BudgetMutex, m_UseMutex);
-            for (uint32_t i = 0; i < heapCount; ++i, ++outBudgets)
+            for(uint32_t i = 0; i < heapCount; ++i, ++outBudgets)
             {
                 const uint32_t heapIndex = firstHeap + i;
 
-                outBudgets->statistics.blockCount      = m_Budget.m_BlockCount[heapIndex];
+                outBudgets->statistics.blockCount = m_Budget.m_BlockCount[heapIndex];
                 outBudgets->statistics.allocationCount = m_Budget.m_AllocationCount[heapIndex];
-                outBudgets->statistics.blockBytes      = m_Budget.m_BlockBytes[heapIndex];
+                outBudgets->statistics.blockBytes = m_Budget.m_BlockBytes[heapIndex];
                 outBudgets->statistics.allocationBytes = m_Budget.m_AllocationBytes[heapIndex];
 
-                if (m_Budget.m_VulkanUsage[heapIndex] + outBudgets->statistics.blockBytes >
-                    m_Budget.m_BlockBytesAtBudgetFetch[heapIndex])
+                if(m_Budget.m_VulkanUsage[heapIndex] + outBudgets->statistics.blockBytes > m_Budget.m_BlockBytesAtBudgetFetch[heapIndex])
                 {
-                    outBudgets->usage = m_Budget.m_VulkanUsage[heapIndex] + outBudgets->statistics.blockBytes -
-                                        m_Budget.m_BlockBytesAtBudgetFetch[heapIndex];
+                    outBudgets->usage = m_Budget.m_VulkanUsage[heapIndex] +
+                        outBudgets->statistics.blockBytes - m_Budget.m_BlockBytesAtBudgetFetch[heapIndex];
                 }
                 else
                 {
@@ -15418,29 +15233,29 @@ void VmaAllocator_T::GetHeapBudgets(VmaBudget* outBudgets, uint32_t firstHeap, u
                 }
 
                 // Have to take MIN with heap size because explicit HeapSizeLimit is included in it.
-                outBudgets->budget =
-                    VMA_MIN(m_Budget.m_VulkanBudget[heapIndex], m_MemProps.memoryHeaps[heapIndex].size);
+                outBudgets->budget = VMA_MIN(
+                    m_Budget.m_VulkanBudget[heapIndex], m_MemProps.memoryHeaps[heapIndex].size);
             }
         }
         else
         {
-            UpdateVulkanBudget();                             // Outside of mutex lock
+            UpdateVulkanBudget(); // Outside of mutex lock
             GetHeapBudgets(outBudgets, firstHeap, heapCount); // Recursion
         }
     }
     else
 #endif
     {
-        for (uint32_t i = 0; i < heapCount; ++i, ++outBudgets)
+        for(uint32_t i = 0; i < heapCount; ++i, ++outBudgets)
         {
             const uint32_t heapIndex = firstHeap + i;
 
-            outBudgets->statistics.blockCount      = m_Budget.m_BlockCount[heapIndex];
+            outBudgets->statistics.blockCount = m_Budget.m_BlockCount[heapIndex];
             outBudgets->statistics.allocationCount = m_Budget.m_AllocationCount[heapIndex];
-            outBudgets->statistics.blockBytes      = m_Budget.m_BlockBytes[heapIndex];
+            outBudgets->statistics.blockBytes = m_Budget.m_BlockBytes[heapIndex];
             outBudgets->statistics.allocationBytes = m_Budget.m_AllocationBytes[heapIndex];
 
-            outBudgets->usage  = outBudgets->statistics.blockBytes;
+            outBudgets->usage = outBudgets->statistics.blockBytes;
             outBudgets->budget = m_MemProps.memoryHeaps[heapIndex].size * 8 / 10; // 80% heuristics.
         }
     }
@@ -15448,43 +15263,42 @@ void VmaAllocator_T::GetHeapBudgets(VmaBudget* outBudgets, uint32_t firstHeap, u
 
 void VmaAllocator_T::GetAllocationInfo(VmaAllocation hAllocation, VmaAllocationInfo* pAllocationInfo)
 {
-    pAllocationInfo->memoryType   = hAllocation->GetMemoryTypeIndex();
+    pAllocationInfo->memoryType = hAllocation->GetMemoryTypeIndex();
     pAllocationInfo->deviceMemory = hAllocation->GetMemory();
-    pAllocationInfo->offset       = hAllocation->GetOffset();
-    pAllocationInfo->size         = hAllocation->GetSize();
-    pAllocationInfo->pMappedData  = hAllocation->GetMappedData();
-    pAllocationInfo->pUserData    = hAllocation->GetUserData();
-    pAllocationInfo->pName        = hAllocation->GetName();
+    pAllocationInfo->offset = hAllocation->GetOffset();
+    pAllocationInfo->size = hAllocation->GetSize();
+    pAllocationInfo->pMappedData = hAllocation->GetMappedData();
+    pAllocationInfo->pUserData = hAllocation->GetUserData();
+    pAllocationInfo->pName = hAllocation->GetName();
 }
 
 VkResult VmaAllocator_T::CreatePool(const VmaPoolCreateInfo* pCreateInfo, VmaPool* pPool)
 {
-    VMA_DEBUG_LOG("  CreatePool: MemoryTypeIndex=%u, flags=%u", pCreateInfo->memoryTypeIndex, pCreateInfo->flags);
+    VMA_DEBUG_LOG_FORMAT("  CreatePool: MemoryTypeIndex=%u, flags=%u", pCreateInfo->memoryTypeIndex, pCreateInfo->flags);
 
     VmaPoolCreateInfo newCreateInfo = *pCreateInfo;
 
-    // Protection against uninitialized new structure member. If garbage data are left there, this pointer dereference
-    // would crash.
-    if (pCreateInfo->pMemoryAllocateNext)
+    // Protection against uninitialized new structure member. If garbage data are left there, this pointer dereference would crash.
+    if(pCreateInfo->pMemoryAllocateNext)
     {
         VMA_ASSERT(((const VkBaseInStructure*)pCreateInfo->pMemoryAllocateNext)->sType != 0);
     }
 
-    if (newCreateInfo.maxBlockCount == 0)
+    if(newCreateInfo.maxBlockCount == 0)
     {
         newCreateInfo.maxBlockCount = SIZE_MAX;
     }
-    if (newCreateInfo.minBlockCount > newCreateInfo.maxBlockCount)
+    if(newCreateInfo.minBlockCount > newCreateInfo.maxBlockCount)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
     // Memory type index out of range or forbidden.
-    if (pCreateInfo->memoryTypeIndex >= GetMemoryTypeCount() ||
+    if(pCreateInfo->memoryTypeIndex >= GetMemoryTypeCount() ||
         ((1u << pCreateInfo->memoryTypeIndex) & m_GlobalMemoryTypeBits) == 0)
     {
         return VK_ERROR_FEATURE_NOT_PRESENT;
     }
-    if (newCreateInfo.minAllocationAlignment > 0)
+    if(newCreateInfo.minAllocationAlignment > 0)
     {
         VMA_ASSERT(VmaIsPow2(newCreateInfo.minAllocationAlignment));
     }
@@ -15494,7 +15308,7 @@ VkResult VmaAllocator_T::CreatePool(const VmaPoolCreateInfo* pCreateInfo, VmaPoo
     *pPool = vma_new(this, VmaPool_T)(this, newCreateInfo, preferredBlockSize);
 
     VkResult res = (*pPool)->m_BlockVector.CreateMinBlocks();
-    if (res != VK_SUCCESS)
+    if(res != VK_SUCCESS)
     {
         vma_delete(this, *pPool);
         *pPool = VMA_NULL;
@@ -15541,7 +15355,7 @@ void VmaAllocator_T::SetCurrentFrameIndex(uint32_t frameIndex)
     m_CurrentFrameIndex.store(frameIndex);
 
 #if VMA_MEMORY_BUDGET
-    if (m_UseExtMemoryBudget)
+    if(m_UseExtMemoryBudget)
     {
         UpdateVulkanBudget();
     }
@@ -15558,21 +15372,21 @@ VkResult VmaAllocator_T::CheckCorruption(uint32_t memoryTypeBits)
     VkResult finalRes = VK_ERROR_FEATURE_NOT_PRESENT;
 
     // Process default pools.
-    for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
+    for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
     {
         VmaBlockVector* const pBlockVector = m_pBlockVectors[memTypeIndex];
-        if (pBlockVector != VMA_NULL)
+        if(pBlockVector != VMA_NULL)
         {
             VkResult localRes = pBlockVector->CheckCorruption();
-            switch (localRes)
+            switch(localRes)
             {
-                case VK_ERROR_FEATURE_NOT_PRESENT:
-                    break;
-                case VK_SUCCESS:
-                    finalRes = VK_SUCCESS;
-                    break;
-                default:
-                    return localRes;
+            case VK_ERROR_FEATURE_NOT_PRESENT:
+                break;
+            case VK_SUCCESS:
+                finalRes = VK_SUCCESS;
+                break;
+            default:
+                return localRes;
             }
         }
     }
@@ -15580,20 +15394,20 @@ VkResult VmaAllocator_T::CheckCorruption(uint32_t memoryTypeBits)
     // Process custom pools.
     {
         VmaMutexLockRead lock(m_PoolsMutex, m_UseMutex);
-        for (VmaPool pool = m_Pools.Front(); pool != VMA_NULL; pool = m_Pools.GetNext(pool))
+        for(VmaPool pool = m_Pools.Front(); pool != VMA_NULL; pool = m_Pools.GetNext(pool))
         {
-            if (((1u << pool->m_BlockVector.GetMemoryTypeIndex()) & memoryTypeBits) != 0)
+            if(((1u << pool->m_BlockVector.GetMemoryTypeIndex()) & memoryTypeBits) != 0)
             {
                 VkResult localRes = pool->m_BlockVector.CheckCorruption();
-                switch (localRes)
+                switch(localRes)
                 {
-                    case VK_ERROR_FEATURE_NOT_PRESENT:
-                        break;
-                    case VK_SUCCESS:
-                        finalRes = VK_SUCCESS;
-                        break;
-                    default:
-                        return localRes;
+                case VK_ERROR_FEATURE_NOT_PRESENT:
+                    break;
+                case VK_SUCCESS:
+                    finalRes = VK_SUCCESS;
+                    break;
+                default:
+                    return localRes;
                 }
             }
         }
@@ -15604,10 +15418,10 @@ VkResult VmaAllocator_T::CheckCorruption(uint32_t memoryTypeBits)
 
 VkResult VmaAllocator_T::AllocateVulkanMemory(const VkMemoryAllocateInfo* pAllocateInfo, VkDeviceMemory* pMemory)
 {
-    AtomicTransactionalIncrement<uint32_t> deviceMemoryCountIncrement;
+    AtomicTransactionalIncrement<VMA_ATOMIC_UINT32> deviceMemoryCountIncrement;
     const uint64_t prevDeviceMemoryCount = deviceMemoryCountIncrement.Increment(&m_DeviceMemoryCount);
 #if VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT
-    if (prevDeviceMemoryCount >= m_PhysicalDeviceProperties.limits.maxMemoryAllocationCount)
+    if(prevDeviceMemoryCount >= m_PhysicalDeviceProperties.limits.maxMemoryAllocationCount)
     {
         return VK_ERROR_TOO_MANY_OBJECTS;
     }
@@ -15616,18 +15430,18 @@ VkResult VmaAllocator_T::AllocateVulkanMemory(const VkMemoryAllocateInfo* pAlloc
     const uint32_t heapIndex = MemoryTypeIndexToHeapIndex(pAllocateInfo->memoryTypeIndex);
 
     // HeapSizeLimit is in effect for this heap.
-    if ((m_HeapSizeLimitMask & (1u << heapIndex)) != 0)
+    if((m_HeapSizeLimitMask & (1u << heapIndex)) != 0)
     {
-        const VkDeviceSize heapSize   = m_MemProps.memoryHeaps[heapIndex].size;
-        VkDeviceSize       blockBytes = m_Budget.m_BlockBytes[heapIndex];
-        for (;;)
+        const VkDeviceSize heapSize = m_MemProps.memoryHeaps[heapIndex].size;
+        VkDeviceSize blockBytes = m_Budget.m_BlockBytes[heapIndex];
+        for(;;)
         {
             const VkDeviceSize blockBytesAfterAllocation = blockBytes + pAllocateInfo->allocationSize;
-            if (blockBytesAfterAllocation > heapSize)
+            if(blockBytesAfterAllocation > heapSize)
             {
                 return VK_ERROR_OUT_OF_DEVICE_MEMORY;
             }
-            if (m_Budget.m_BlockBytes[heapIndex].compare_exchange_strong(blockBytes, blockBytesAfterAllocation))
+            if(m_Budget.m_BlockBytes[heapIndex].compare_exchange_strong(blockBytes, blockBytesAfterAllocation))
             {
                 break;
             }
@@ -15642,20 +15456,16 @@ VkResult VmaAllocator_T::AllocateVulkanMemory(const VkMemoryAllocateInfo* pAlloc
     // VULKAN CALL vkAllocateMemory.
     VkResult res = (*m_VulkanFunctions.vkAllocateMemory)(m_hDevice, pAllocateInfo, GetAllocationCallbacks(), pMemory);
 
-    if (res == VK_SUCCESS)
+    if(res == VK_SUCCESS)
     {
 #if VMA_MEMORY_BUDGET
         ++m_Budget.m_OperationsSinceBudgetFetch;
 #endif
 
         // Informative callback.
-        if (m_DeviceMemoryCallbacks.pfnAllocate != VMA_NULL)
+        if(m_DeviceMemoryCallbacks.pfnAllocate != VMA_NULL)
         {
-            (*m_DeviceMemoryCallbacks.pfnAllocate)(this,
-                                                   pAllocateInfo->memoryTypeIndex,
-                                                   *pMemory,
-                                                   pAllocateInfo->allocationSize,
-                                                   m_DeviceMemoryCallbacks.pUserData);
+            (*m_DeviceMemoryCallbacks.pfnAllocate)(this, pAllocateInfo->memoryTypeIndex, *pMemory, pAllocateInfo->allocationSize, m_DeviceMemoryCallbacks.pUserData);
         }
 
         deviceMemoryCountIncrement.Commit();
@@ -15672,7 +15482,7 @@ VkResult VmaAllocator_T::AllocateVulkanMemory(const VkMemoryAllocateInfo* pAlloc
 void VmaAllocator_T::FreeVulkanMemory(uint32_t memoryType, VkDeviceSize size, VkDeviceMemory hMemory)
 {
     // Informative callback.
-    if (m_DeviceMemoryCallbacks.pfnFree != VMA_NULL)
+    if(m_DeviceMemoryCallbacks.pfnFree != VMA_NULL)
     {
         (*m_DeviceMemoryCallbacks.pfnFree)(this, memoryType, hMemory, size, m_DeviceMemoryCallbacks.pUserData);
     }
@@ -15687,20 +15497,23 @@ void VmaAllocator_T::FreeVulkanMemory(uint32_t memoryType, VkDeviceSize size, Vk
     --m_DeviceMemoryCount;
 }
 
-VkResult
-VmaAllocator_T::BindVulkanBuffer(VkDeviceMemory memory, VkDeviceSize memoryOffset, VkBuffer buffer, const void* pNext)
+VkResult VmaAllocator_T::BindVulkanBuffer(
+    VkDeviceMemory memory,
+    VkDeviceSize memoryOffset,
+    VkBuffer buffer,
+    const void* pNext)
 {
-    if (pNext != VMA_NULL)
+    if(pNext != VMA_NULL)
     {
 #if VMA_VULKAN_VERSION >= 1001000 || VMA_BIND_MEMORY2
-        if ((m_UseKhrBindMemory2 || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0)) &&
+        if((m_UseKhrBindMemory2 || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0)) &&
             m_VulkanFunctions.vkBindBufferMemory2KHR != VMA_NULL)
         {
             VkBindBufferMemoryInfoKHR bindBufferMemoryInfo = { VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHR };
-            bindBufferMemoryInfo.pNext                     = pNext;
-            bindBufferMemoryInfo.buffer                    = buffer;
-            bindBufferMemoryInfo.memory                    = memory;
-            bindBufferMemoryInfo.memoryOffset              = memoryOffset;
+            bindBufferMemoryInfo.pNext = pNext;
+            bindBufferMemoryInfo.buffer = buffer;
+            bindBufferMemoryInfo.memory = memory;
+            bindBufferMemoryInfo.memoryOffset = memoryOffset;
             return (*m_VulkanFunctions.vkBindBufferMemory2KHR)(m_hDevice, 1, &bindBufferMemoryInfo);
         }
         else
@@ -15715,20 +15528,23 @@ VmaAllocator_T::BindVulkanBuffer(VkDeviceMemory memory, VkDeviceSize memoryOffse
     }
 }
 
-VkResult
-VmaAllocator_T::BindVulkanImage(VkDeviceMemory memory, VkDeviceSize memoryOffset, VkImage image, const void* pNext)
+VkResult VmaAllocator_T::BindVulkanImage(
+    VkDeviceMemory memory,
+    VkDeviceSize memoryOffset,
+    VkImage image,
+    const void* pNext)
 {
-    if (pNext != VMA_NULL)
+    if(pNext != VMA_NULL)
     {
 #if VMA_VULKAN_VERSION >= 1001000 || VMA_BIND_MEMORY2
-        if ((m_UseKhrBindMemory2 || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0)) &&
+        if((m_UseKhrBindMemory2 || m_VulkanApiVersion >= VK_MAKE_VERSION(1, 1, 0)) &&
             m_VulkanFunctions.vkBindImageMemory2KHR != VMA_NULL)
         {
             VkBindImageMemoryInfoKHR bindBufferMemoryInfo = { VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHR };
-            bindBufferMemoryInfo.pNext                    = pNext;
-            bindBufferMemoryInfo.image                    = image;
-            bindBufferMemoryInfo.memory                   = memory;
-            bindBufferMemoryInfo.memoryOffset             = memoryOffset;
+            bindBufferMemoryInfo.pNext = pNext;
+            bindBufferMemoryInfo.image = image;
+            bindBufferMemoryInfo.memory = memory;
+            bindBufferMemoryInfo.memoryOffset = memoryOffset;
             return (*m_VulkanFunctions.vkBindImageMemory2KHR)(m_hDevice, 1, &bindBufferMemoryInfo);
         }
         else
@@ -15745,160 +15561,159 @@ VmaAllocator_T::BindVulkanImage(VkDeviceMemory memory, VkDeviceSize memoryOffset
 
 VkResult VmaAllocator_T::Map(VmaAllocation hAllocation, void** ppData)
 {
-    switch (hAllocation->GetType())
+    switch(hAllocation->GetType())
     {
-        case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+    case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
         {
             VmaDeviceMemoryBlock* const pBlock = hAllocation->GetBlock();
-            char*                       pBytes = VMA_NULL;
-            VkResult                    res    = pBlock->Map(this, 1, (void**)&pBytes);
-            if (res == VK_SUCCESS)
+            char *pBytes = VMA_NULL;
+            VkResult res = pBlock->Map(this, 1, (void**)&pBytes);
+            if(res == VK_SUCCESS)
             {
                 *ppData = pBytes + (ptrdiff_t)hAllocation->GetOffset();
                 hAllocation->BlockAllocMap();
             }
             return res;
         }
-        case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
-            return hAllocation->DedicatedAllocMap(this, ppData);
-        default:
-            VMA_ASSERT(0);
-            return VK_ERROR_MEMORY_MAP_FAILED;
+        VMA_FALLTHROUGH; // Fallthrough
+    case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+        return hAllocation->DedicatedAllocMap(this, ppData);
+    default:
+        VMA_ASSERT(0);
+        return VK_ERROR_MEMORY_MAP_FAILED;
     }
 }
 
 void VmaAllocator_T::Unmap(VmaAllocation hAllocation)
 {
-    switch (hAllocation->GetType())
+    switch(hAllocation->GetType())
     {
-        case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+    case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
         {
             VmaDeviceMemoryBlock* const pBlock = hAllocation->GetBlock();
             hAllocation->BlockAllocUnmap();
             pBlock->Unmap(this, 1);
         }
         break;
-        case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
-            hAllocation->DedicatedAllocUnmap(this);
-            break;
-        default:
-            VMA_ASSERT(0);
+    case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+        hAllocation->DedicatedAllocUnmap(this);
+        break;
+    default:
+        VMA_ASSERT(0);
     }
 }
 
-VkResult VmaAllocator_T::BindBufferMemory(VmaAllocation hAllocation,
-                                          VkDeviceSize  allocationLocalOffset,
-                                          VkBuffer      hBuffer,
-                                          const void*   pNext)
+VkResult VmaAllocator_T::BindBufferMemory(
+    VmaAllocation hAllocation,
+    VkDeviceSize allocationLocalOffset,
+    VkBuffer hBuffer,
+    const void* pNext)
 {
-    VkResult res = VK_SUCCESS;
-    switch (hAllocation->GetType())
+    VkResult res = VK_ERROR_UNKNOWN;
+    switch(hAllocation->GetType())
     {
-        case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
-            res = BindVulkanBuffer(hAllocation->GetMemory(), allocationLocalOffset, hBuffer, pNext);
-            break;
-        case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
-        {
-            VmaDeviceMemoryBlock* const pBlock = hAllocation->GetBlock();
-            VMA_ASSERT(pBlock && "Binding buffer to allocation that doesn't belong to any block.");
-            res = pBlock->BindBufferMemory(this, hAllocation, allocationLocalOffset, hBuffer, pNext);
-            break;
-        }
-        default:
-            VMA_ASSERT(0);
+    case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+        res = BindVulkanBuffer(hAllocation->GetMemory(), allocationLocalOffset, hBuffer, pNext);
+        break;
+    case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+    {
+        VmaDeviceMemoryBlock* const pBlock = hAllocation->GetBlock();
+        VMA_ASSERT(pBlock && "Binding buffer to allocation that doesn't belong to any block.");
+        res = pBlock->BindBufferMemory(this, hAllocation, allocationLocalOffset, hBuffer, pNext);
+        break;
+    }
+    default:
+        VMA_ASSERT(0);
     }
     return res;
 }
 
-VkResult VmaAllocator_T::BindImageMemory(VmaAllocation hAllocation,
-                                         VkDeviceSize  allocationLocalOffset,
-                                         VkImage       hImage,
-                                         const void*   pNext)
+VkResult VmaAllocator_T::BindImageMemory(
+    VmaAllocation hAllocation,
+    VkDeviceSize allocationLocalOffset,
+    VkImage hImage,
+    const void* pNext)
 {
-    VkResult res = VK_SUCCESS;
-    switch (hAllocation->GetType())
+    VkResult res = VK_ERROR_UNKNOWN;
+    switch(hAllocation->GetType())
     {
-        case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
-            res = BindVulkanImage(hAllocation->GetMemory(), allocationLocalOffset, hImage, pNext);
-            break;
-        case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
-        {
-            VmaDeviceMemoryBlock* pBlock = hAllocation->GetBlock();
-            VMA_ASSERT(pBlock && "Binding image to allocation that doesn't belong to any block.");
-            res = pBlock->BindImageMemory(this, hAllocation, allocationLocalOffset, hImage, pNext);
-            break;
-        }
-        default:
-            VMA_ASSERT(0);
+    case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+        res = BindVulkanImage(hAllocation->GetMemory(), allocationLocalOffset, hImage, pNext);
+        break;
+    case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+    {
+        VmaDeviceMemoryBlock* pBlock = hAllocation->GetBlock();
+        VMA_ASSERT(pBlock && "Binding image to allocation that doesn't belong to any block.");
+        res = pBlock->BindImageMemory(this, hAllocation, allocationLocalOffset, hImage, pNext);
+        break;
+    }
+    default:
+        VMA_ASSERT(0);
     }
     return res;
 }
 
-VkResult VmaAllocator_T::FlushOrInvalidateAllocation(VmaAllocation       hAllocation,
-                                                     VkDeviceSize        offset,
-                                                     VkDeviceSize        size,
-                                                     VMA_CACHE_OPERATION op)
+VkResult VmaAllocator_T::FlushOrInvalidateAllocation(
+    VmaAllocation hAllocation,
+    VkDeviceSize offset, VkDeviceSize size,
+    VMA_CACHE_OPERATION op)
 {
     VkResult res = VK_SUCCESS;
 
     VkMappedMemoryRange memRange = {};
-    if (GetFlushOrInvalidateRange(hAllocation, offset, size, memRange))
+    if(GetFlushOrInvalidateRange(hAllocation, offset, size, memRange))
     {
-        switch (op)
+        switch(op)
         {
-            case VMA_CACHE_FLUSH:
-                res = (*GetVulkanFunctions().vkFlushMappedMemoryRanges)(m_hDevice, 1, &memRange);
-                break;
-            case VMA_CACHE_INVALIDATE:
-                res = (*GetVulkanFunctions().vkInvalidateMappedMemoryRanges)(m_hDevice, 1, &memRange);
-                break;
-            default:
-                VMA_ASSERT(0);
+        case VMA_CACHE_FLUSH:
+            res = (*GetVulkanFunctions().vkFlushMappedMemoryRanges)(m_hDevice, 1, &memRange);
+            break;
+        case VMA_CACHE_INVALIDATE:
+            res = (*GetVulkanFunctions().vkInvalidateMappedMemoryRanges)(m_hDevice, 1, &memRange);
+            break;
+        default:
+            VMA_ASSERT(0);
         }
     }
     // else: Just ignore this call.
     return res;
 }
 
-VkResult VmaAllocator_T::FlushOrInvalidateAllocations(uint32_t             allocationCount,
-                                                      const VmaAllocation* allocations,
-                                                      const VkDeviceSize*  offsets,
-                                                      const VkDeviceSize*  sizes,
-                                                      VMA_CACHE_OPERATION  op)
+VkResult VmaAllocator_T::FlushOrInvalidateAllocations(
+    uint32_t allocationCount,
+    const VmaAllocation* allocations,
+    const VkDeviceSize* offsets, const VkDeviceSize* sizes,
+    VMA_CACHE_OPERATION op)
 {
-    typedef VmaStlAllocator<VkMappedMemoryRange>                    RangeAllocator;
+    typedef VmaStlAllocator<VkMappedMemoryRange> RangeAllocator;
     typedef VmaSmallVector<VkMappedMemoryRange, RangeAllocator, 16> RangeVector;
     RangeVector ranges = RangeVector(RangeAllocator(GetAllocationCallbacks()));
 
-    for (uint32_t allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
+    for(uint32_t allocIndex = 0; allocIndex < allocationCount; ++allocIndex)
     {
-        const VmaAllocation alloc  = allocations[allocIndex];
-        const VkDeviceSize  offset = offsets != VMA_NULL ? offsets[allocIndex] : 0;
-        const VkDeviceSize  size   = sizes != VMA_NULL ? sizes[allocIndex] : VK_WHOLE_SIZE;
+        const VmaAllocation alloc = allocations[allocIndex];
+        const VkDeviceSize offset = offsets != VMA_NULL ? offsets[allocIndex] : 0;
+        const VkDeviceSize size = sizes != VMA_NULL ? sizes[allocIndex] : VK_WHOLE_SIZE;
         VkMappedMemoryRange newRange;
-        if (GetFlushOrInvalidateRange(alloc, offset, size, newRange))
+        if(GetFlushOrInvalidateRange(alloc, offset, size, newRange))
         {
             ranges.push_back(newRange);
         }
     }
 
     VkResult res = VK_SUCCESS;
-    if (!ranges.empty())
+    if(!ranges.empty())
     {
-        switch (op)
+        switch(op)
         {
-            case VMA_CACHE_FLUSH:
-                res = (*GetVulkanFunctions().vkFlushMappedMemoryRanges)(m_hDevice,
-                                                                        (uint32_t)ranges.size(),
-                                                                        ranges.data());
-                break;
-            case VMA_CACHE_INVALIDATE:
-                res = (*GetVulkanFunctions().vkInvalidateMappedMemoryRanges)(m_hDevice,
-                                                                             (uint32_t)ranges.size(),
-                                                                             ranges.data());
-                break;
-            default:
-                VMA_ASSERT(0);
+        case VMA_CACHE_FLUSH:
+            res = (*GetVulkanFunctions().vkFlushMappedMemoryRanges)(m_hDevice, (uint32_t)ranges.size(), ranges.data());
+            break;
+        case VMA_CACHE_INVALIDATE:
+            res = (*GetVulkanFunctions().vkInvalidateMappedMemoryRanges)(m_hDevice, (uint32_t)ranges.size(), ranges.data());
+            break;
+        default:
+            VMA_ASSERT(0);
         }
     }
     // else: Just ignore this call.
@@ -15910,8 +15725,8 @@ void VmaAllocator_T::FreeDedicatedMemory(const VmaAllocation allocation)
     VMA_ASSERT(allocation && allocation->GetType() == VmaAllocation_T::ALLOCATION_TYPE_DEDICATED);
 
     const uint32_t memTypeIndex = allocation->GetMemoryTypeIndex();
-    VmaPool        parentPool   = allocation->GetParentPool();
-    if (parentPool == VK_NULL_HANDLE)
+    VmaPool parentPool = allocation->GetParentPool();
+    if(parentPool == VK_NULL_HANDLE)
     {
         // Default pool
         m_DedicatedAllocations[memTypeIndex].Unregister(allocation);
@@ -15939,7 +15754,7 @@ void VmaAllocator_T::FreeDedicatedMemory(const VmaAllocation allocation)
     m_Budget.RemoveAllocation(MemoryTypeIndexToHeapIndex(allocation->GetMemoryTypeIndex()), allocation->GetSize());
     m_AllocationObjectAllocator.Free(allocation);
 
-    VMA_DEBUG_LOG("    Freed DedicatedMemory MemoryTypeIndex=%u", memTypeIndex);
+    VMA_DEBUG_LOG_FORMAT("    Freed DedicatedMemory MemoryTypeIndex=%u", memTypeIndex);
 }
 
 uint32_t VmaAllocator_T::CalculateGpuDefragmentationMemoryTypeBits() const
@@ -15951,9 +15766,9 @@ uint32_t VmaAllocator_T::CalculateGpuDefragmentationMemoryTypeBits() const
 
     // Create buffer.
     VkBuffer buf = VK_NULL_HANDLE;
-    VkResult res =
-        (*GetVulkanFunctions().vkCreateBuffer)(m_hDevice, &dummyBufCreateInfo, GetAllocationCallbacks(), &buf);
-    if (res == VK_SUCCESS)
+    VkResult res = (*GetVulkanFunctions().vkCreateBuffer)(
+        m_hDevice, &dummyBufCreateInfo, GetAllocationCallbacks(), &buf);
+    if(res == VK_SUCCESS)
     {
         // Query for supported memory types.
         VkMemoryRequirements memReq;
@@ -15974,13 +15789,12 @@ uint32_t VmaAllocator_T::CalculateGlobalMemoryTypeBits() const
 
     uint32_t memoryTypeBits = UINT32_MAX;
 
-    if (!m_UseAmdDeviceCoherentMemory)
+    if(!m_UseAmdDeviceCoherentMemory)
     {
         // Exclude memory types that have VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD.
-        for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
+        for(uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
         {
-            if ((m_MemProps.memoryTypes[memTypeIndex].propertyFlags &
-                 VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY) != 0)
+            if((m_MemProps.memoryTypes[memTypeIndex].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY) != 0)
             {
                 memoryTypeBits &= ~(1u << memTypeIndex);
             }
@@ -15990,62 +15804,63 @@ uint32_t VmaAllocator_T::CalculateGlobalMemoryTypeBits() const
     return memoryTypeBits;
 }
 
-bool VmaAllocator_T::GetFlushOrInvalidateRange(VmaAllocation        allocation,
-                                               VkDeviceSize         offset,
-                                               VkDeviceSize         size,
-                                               VkMappedMemoryRange& outRange) const
+bool VmaAllocator_T::GetFlushOrInvalidateRange(
+    VmaAllocation allocation,
+    VkDeviceSize offset, VkDeviceSize size,
+    VkMappedMemoryRange& outRange) const
 {
     const uint32_t memTypeIndex = allocation->GetMemoryTypeIndex();
-    if (size > 0 && IsMemoryTypeNonCoherent(memTypeIndex))
+    if(size > 0 && IsMemoryTypeNonCoherent(memTypeIndex))
     {
         const VkDeviceSize nonCoherentAtomSize = m_PhysicalDeviceProperties.limits.nonCoherentAtomSize;
-        const VkDeviceSize allocationSize      = allocation->GetSize();
+        const VkDeviceSize allocationSize = allocation->GetSize();
         VMA_ASSERT(offset <= allocationSize);
 
-        outRange.sType  = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
-        outRange.pNext  = VMA_NULL;
+        outRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+        outRange.pNext = VMA_NULL;
         outRange.memory = allocation->GetMemory();
 
-        switch (allocation->GetType())
+        switch(allocation->GetType())
         {
-            case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
-                outRange.offset = VmaAlignDown(offset, nonCoherentAtomSize);
-                if (size == VK_WHOLE_SIZE)
-                {
-                    outRange.size = allocationSize - outRange.offset;
-                }
-                else
-                {
-                    VMA_ASSERT(offset + size <= allocationSize);
-                    outRange.size = VMA_MIN(VmaAlignUp(size + (offset - outRange.offset), nonCoherentAtomSize),
-                                            allocationSize - outRange.offset);
-                }
-                break;
-            case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+        case VmaAllocation_T::ALLOCATION_TYPE_DEDICATED:
+            outRange.offset = VmaAlignDown(offset, nonCoherentAtomSize);
+            if(size == VK_WHOLE_SIZE)
             {
-                // 1. Still within this allocation.
-                outRange.offset = VmaAlignDown(offset, nonCoherentAtomSize);
-                if (size == VK_WHOLE_SIZE)
-                {
-                    size = allocationSize - offset;
-                }
-                else
-                {
-                    VMA_ASSERT(offset + size <= allocationSize);
-                }
-                outRange.size = VmaAlignUp(size + (offset - outRange.offset), nonCoherentAtomSize);
-
-                // 2. Adjust to whole block.
-                const VkDeviceSize allocationOffset = allocation->GetOffset();
-                VMA_ASSERT(allocationOffset % nonCoherentAtomSize == 0);
-                const VkDeviceSize blockSize = allocation->GetBlock()->m_pMetadata->GetSize();
-                outRange.offset += allocationOffset;
-                outRange.size = VMA_MIN(outRange.size, blockSize - outRange.offset);
-
-                break;
+                outRange.size = allocationSize - outRange.offset;
             }
-            default:
-                VMA_ASSERT(0);
+            else
+            {
+                VMA_ASSERT(offset + size <= allocationSize);
+                outRange.size = VMA_MIN(
+                    VmaAlignUp(size + (offset - outRange.offset), nonCoherentAtomSize),
+                    allocationSize - outRange.offset);
+            }
+            break;
+        case VmaAllocation_T::ALLOCATION_TYPE_BLOCK:
+        {
+            // 1. Still within this allocation.
+            outRange.offset = VmaAlignDown(offset, nonCoherentAtomSize);
+            if(size == VK_WHOLE_SIZE)
+            {
+                size = allocationSize - offset;
+            }
+            else
+            {
+                VMA_ASSERT(offset + size <= allocationSize);
+            }
+            outRange.size = VmaAlignUp(size + (offset - outRange.offset), nonCoherentAtomSize);
+
+            // 2. Adjust to whole block.
+            const VkDeviceSize allocationOffset = allocation->GetOffset();
+            VMA_ASSERT(allocationOffset % nonCoherentAtomSize == 0);
+            const VkDeviceSize blockSize = allocation->GetBlock()->m_pMetadata->GetSize();
+            outRange.offset += allocationOffset;
+            outRange.size = VMA_MIN(outRange.size, blockSize - outRange.offset);
+
+            break;
+        }
+        default:
+            VMA_ASSERT(0);
         }
         return true;
     }
@@ -16059,9 +15874,7 @@ void VmaAllocator_T::UpdateVulkanBudget()
 
     VkPhysicalDeviceMemoryProperties2KHR memProps = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR };
 
-    VkPhysicalDeviceMemoryBudgetPropertiesEXT budgetProps = {
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT
-    };
+    VkPhysicalDeviceMemoryBudgetPropertiesEXT budgetProps = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT };
     VmaPnextChainPushFront(&memProps, &budgetProps);
 
     GetVulkanFunctions().vkGetPhysicalDeviceMemoryProperties2KHR(m_PhysicalDevice, &memProps);
@@ -16069,22 +15882,22 @@ void VmaAllocator_T::UpdateVulkanBudget()
     {
         VmaMutexLockWrite lockWrite(m_Budget.m_BudgetMutex, m_UseMutex);
 
-        for (uint32_t heapIndex = 0; heapIndex < GetMemoryHeapCount(); ++heapIndex)
+        for(uint32_t heapIndex = 0; heapIndex < GetMemoryHeapCount(); ++heapIndex)
         {
-            m_Budget.m_VulkanUsage[heapIndex]             = budgetProps.heapUsage[heapIndex];
-            m_Budget.m_VulkanBudget[heapIndex]            = budgetProps.heapBudget[heapIndex];
+            m_Budget.m_VulkanUsage[heapIndex] = budgetProps.heapUsage[heapIndex];
+            m_Budget.m_VulkanBudget[heapIndex] = budgetProps.heapBudget[heapIndex];
             m_Budget.m_BlockBytesAtBudgetFetch[heapIndex] = m_Budget.m_BlockBytes[heapIndex].load();
 
             // Some bugged drivers return the budget incorrectly, e.g. 0 or much bigger than heap size.
-            if (m_Budget.m_VulkanBudget[heapIndex] == 0)
+            if(m_Budget.m_VulkanBudget[heapIndex] == 0)
             {
                 m_Budget.m_VulkanBudget[heapIndex] = m_MemProps.memoryHeaps[heapIndex].size * 8 / 10; // 80% heuristics.
             }
-            else if (m_Budget.m_VulkanBudget[heapIndex] > m_MemProps.memoryHeaps[heapIndex].size)
+            else if(m_Budget.m_VulkanBudget[heapIndex] > m_MemProps.memoryHeaps[heapIndex].size)
             {
                 m_Budget.m_VulkanBudget[heapIndex] = m_MemProps.memoryHeaps[heapIndex].size;
             }
-            if (m_Budget.m_VulkanUsage[heapIndex] == 0 && m_Budget.m_BlockBytesAtBudgetFetch[heapIndex] > 0)
+            if(m_Budget.m_VulkanUsage[heapIndex] == 0 && m_Budget.m_BlockBytesAtBudgetFetch[heapIndex] > 0)
             {
                 m_Budget.m_VulkanUsage[heapIndex] = m_Budget.m_BlockBytesAtBudgetFetch[heapIndex];
             }
@@ -16096,13 +15909,13 @@ void VmaAllocator_T::UpdateVulkanBudget()
 
 void VmaAllocator_T::FillAllocation(const VmaAllocation hAllocation, uint8_t pattern)
 {
-    if (VMA_DEBUG_INITIALIZE_ALLOCATIONS && hAllocation->IsMappingAllowed() &&
-        (m_MemProps.memoryTypes[hAllocation->GetMemoryTypeIndex()].propertyFlags &
-         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0)
+    if(VMA_DEBUG_INITIALIZE_ALLOCATIONS &&
+        hAllocation->IsMappingAllowed() &&
+        (m_MemProps.memoryTypes[hAllocation->GetMemoryTypeIndex()].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0)
     {
-        void*    pData = VMA_NULL;
-        VkResult res   = Map(hAllocation, &pData);
-        if (res == VK_SUCCESS)
+        void* pData = VMA_NULL;
+        VkResult res = Map(hAllocation, &pData);
+        if(res == VK_SUCCESS)
         {
             memset(pData, (int)pattern, (size_t)hAllocation->GetSize());
             FlushOrInvalidateAllocation(hAllocation, 0, VK_WHOLE_SIZE, VMA_CACHE_FLUSH);
@@ -16118,7 +15931,7 @@ void VmaAllocator_T::FillAllocation(const VmaAllocation hAllocation, uint8_t pat
 uint32_t VmaAllocator_T::GetGpuDefragmentationMemoryTypeBits()
 {
     uint32_t memoryTypeBits = m_GpuDefragmentationMemoryTypeBits.load();
-    if (memoryTypeBits == UINT32_MAX)
+    if(memoryTypeBits == UINT32_MAX)
     {
         memoryTypeBits = CalculateGpuDefragmentationMemoryTypeBits();
         m_GpuDefragmentationMemoryTypeBits.store(memoryTypeBits);
@@ -16134,7 +15947,7 @@ void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
     {
         for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
         {
-            VmaBlockVector*             pBlockVector       = m_pBlockVectors[memTypeIndex];
+            VmaBlockVector* pBlockVector = m_pBlockVectors[memTypeIndex];
             VmaDedicatedAllocationList& dedicatedAllocList = m_DedicatedAllocations[memTypeIndex];
             if (pBlockVector != VMA_NULL)
             {
@@ -16166,8 +15979,8 @@ void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
         {
             for (uint32_t memTypeIndex = 0; memTypeIndex < GetMemoryTypeCount(); ++memTypeIndex)
             {
-                bool   displayType = true;
-                size_t index       = 0;
+                bool displayType = true;
+                size_t index = 0;
                 for (VmaPool pool = m_Pools.Front(); pool != VMA_NULL; pool = m_Pools.GetNext(pool))
                 {
                     VmaBlockVector& blockVector = pool->m_BlockVector;
@@ -16186,7 +15999,7 @@ void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
                         {
                             json.WriteString("Name");
                             json.BeginString();
-                            json.ContinueString_Size(index++);
+                            json.ContinueString((uint64_t)index++);
                             if (pool->GetName())
                             {
                                 json.ContinueString(" - ");
@@ -16217,17 +16030,19 @@ void VmaAllocator_T::PrintDetailedMap(VmaJsonWriter& json)
 #endif // VMA_STATS_STRING_ENABLED
 #endif // _VMA_ALLOCATOR_T_FUNCTIONS
 
+
 #ifndef _VMA_PUBLIC_INTERFACE
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAllocator(const VmaAllocatorCreateInfo* pCreateInfo,
-                                                       VmaAllocator*                 pAllocator)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAllocator(
+    const VmaAllocatorCreateInfo* pCreateInfo,
+    VmaAllocator* pAllocator)
 {
     VMA_ASSERT(pCreateInfo && pAllocator);
-    VMA_ASSERT(pCreateInfo->vulkanApiVersion == 0 || (VK_VERSION_MAJOR(pCreateInfo->vulkanApiVersion) == 1 &&
-                                                      VK_VERSION_MINOR(pCreateInfo->vulkanApiVersion) <= 3));
+    VMA_ASSERT(pCreateInfo->vulkanApiVersion == 0 ||
+        (VK_VERSION_MAJOR(pCreateInfo->vulkanApiVersion) == 1 && VK_VERSION_MINOR(pCreateInfo->vulkanApiVersion) <= 3));
     VMA_DEBUG_LOG("vmaCreateAllocator");
-    *pAllocator     = vma_new(pCreateInfo->pAllocationCallbacks, VmaAllocator_T)(pCreateInfo);
+    *pAllocator = vma_new(pCreateInfo->pAllocationCallbacks, VmaAllocator_T)(pCreateInfo);
     VkResult result = (*pAllocator)->Init(pCreateInfo);
-    if (result < 0)
+    if(result < 0)
     {
         vma_delete(pCreateInfo->pAllocationCallbacks, *pAllocator);
         *pAllocator = VK_NULL_HANDLE;
@@ -16235,13 +16050,13 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAllocator(const VmaAllocatorCreateI
     return result;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaDestroyAllocator(VmaAllocator allocator)
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyAllocator(
+    VmaAllocator allocator)
 {
-    if (allocator != VK_NULL_HANDLE)
+    if(allocator != VK_NULL_HANDLE)
     {
         VMA_DEBUG_LOG("vmaDestroyAllocator");
-        VkAllocationCallbacks allocationCallbacks =
-            allocator->m_AllocationCallbacks; // Have to copy the callbacks when destroying.
+        VkAllocationCallbacks allocationCallbacks = allocator->m_AllocationCallbacks; // Have to copy the callbacks when destroying.
         vma_delete(&allocationCallbacks, allocator);
     }
 }
@@ -16249,35 +16064,40 @@ VMA_CALL_PRE void VMA_CALL_POST vmaDestroyAllocator(VmaAllocator allocator)
 VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocatorInfo(VmaAllocator allocator, VmaAllocatorInfo* pAllocatorInfo)
 {
     VMA_ASSERT(allocator && pAllocatorInfo);
-    pAllocatorInfo->instance       = allocator->m_hInstance;
+    pAllocatorInfo->instance = allocator->m_hInstance;
     pAllocatorInfo->physicalDevice = allocator->GetPhysicalDevice();
-    pAllocatorInfo->device         = allocator->m_hDevice;
+    pAllocatorInfo->device = allocator->m_hDevice;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST
-vmaGetPhysicalDeviceProperties(VmaAllocator allocator, const VkPhysicalDeviceProperties** ppPhysicalDeviceProperties)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetPhysicalDeviceProperties(
+    VmaAllocator allocator,
+    const VkPhysicalDeviceProperties **ppPhysicalDeviceProperties)
 {
     VMA_ASSERT(allocator && ppPhysicalDeviceProperties);
     *ppPhysicalDeviceProperties = &allocator->m_PhysicalDeviceProperties;
 }
 
 VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryProperties(
-    VmaAllocator allocator, const VkPhysicalDeviceMemoryProperties** ppPhysicalDeviceMemoryProperties)
+    VmaAllocator allocator,
+    const VkPhysicalDeviceMemoryProperties** ppPhysicalDeviceMemoryProperties)
 {
     VMA_ASSERT(allocator && ppPhysicalDeviceMemoryProperties);
     *ppPhysicalDeviceMemoryProperties = &allocator->m_MemProps;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryTypeProperties(VmaAllocator           allocator,
-                                                           uint32_t               memoryTypeIndex,
-                                                           VkMemoryPropertyFlags* pFlags)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryTypeProperties(
+    VmaAllocator allocator,
+    uint32_t memoryTypeIndex,
+    VkMemoryPropertyFlags* pFlags)
 {
     VMA_ASSERT(allocator && pFlags);
     VMA_ASSERT(memoryTypeIndex < allocator->GetMemoryTypeCount());
     *pFlags = allocator->m_MemProps.memoryTypes[memoryTypeIndex].propertyFlags;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaSetCurrentFrameIndex(VmaAllocator allocator, uint32_t frameIndex)
+VMA_CALL_PRE void VMA_CALL_POST vmaSetCurrentFrameIndex(
+    VmaAllocator allocator,
+    uint32_t frameIndex)
 {
     VMA_ASSERT(allocator);
 
@@ -16286,14 +16106,18 @@ VMA_CALL_PRE void VMA_CALL_POST vmaSetCurrentFrameIndex(VmaAllocator allocator, 
     allocator->SetCurrentFrameIndex(frameIndex);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaCalculateStatistics(VmaAllocator allocator, VmaTotalStatistics* pStats)
+VMA_CALL_PRE void VMA_CALL_POST vmaCalculateStatistics(
+    VmaAllocator allocator,
+    VmaTotalStatistics* pStats)
 {
     VMA_ASSERT(allocator && pStats);
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
     allocator->CalculateStatistics(pStats);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaGetHeapBudgets(VmaAllocator allocator, VmaBudget* pBudgets)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetHeapBudgets(
+    VmaAllocator allocator,
+    VmaBudget* pBudgets)
 {
     VMA_ASSERT(allocator && pBudgets);
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
@@ -16302,7 +16126,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaGetHeapBudgets(VmaAllocator allocator, VmaBud
 
 #if VMA_STATS_STRING_ENABLED
 
-VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char** ppStatsString, VkBool32 detailedMap)
+VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(
+    VmaAllocator allocator,
+    char** ppStatsString,
+    VkBool32 detailedMap)
 {
     VMA_ASSERT(allocator && ppStatsString);
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
@@ -16321,7 +16148,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char
             json.WriteString("General");
             json.BeginObject();
             {
-                const VkPhysicalDeviceProperties&       deviceProperties = allocator->m_PhysicalDeviceProperties;
+                const VkPhysicalDeviceProperties& deviceProperties = allocator->m_PhysicalDeviceProperties;
                 const VkPhysicalDeviceMemoryProperties& memoryProperties = allocator->m_MemProps;
 
                 json.WriteString("API");
@@ -16329,11 +16156,11 @@ VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char
 
                 json.WriteString("apiVersion");
                 json.BeginString();
-                json.ContinueString(VK_API_VERSION_MAJOR(deviceProperties.apiVersion));
+                json.ContinueString(VK_VERSION_MAJOR(deviceProperties.apiVersion));
                 json.ContinueString(".");
-                json.ContinueString(VK_API_VERSION_MINOR(deviceProperties.apiVersion));
+                json.ContinueString(VK_VERSION_MINOR(deviceProperties.apiVersion));
                 json.ContinueString(".");
-                json.ContinueString(VK_API_VERSION_PATCH(deviceProperties.apiVersion));
+                json.ContinueString(VK_VERSION_PATCH(deviceProperties.apiVersion));
                 json.EndString();
 
                 json.WriteString("GPU");
@@ -16376,16 +16203,17 @@ VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char
                         {
                             if (heapInfo.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
                                 json.WriteString("DEVICE_LOCAL");
-#if VMA_VULKAN_VERSION >= 1001000
+                        #if VMA_VULKAN_VERSION >= 1001000
                             if (heapInfo.flags & VK_MEMORY_HEAP_MULTI_INSTANCE_BIT)
                                 json.WriteString("MULTI_INSTANCE");
-#endif
+                        #endif
 
-                            VkMemoryHeapFlags flags = heapInfo.flags & ~(VK_MEMORY_HEAP_DEVICE_LOCAL_BIT
-#if VMA_VULKAN_VERSION >= 1001000
-                                                                         | VK_MEMORY_HEAP_MULTI_INSTANCE_BIT
-#endif
-                                                                       );
+                            VkMemoryHeapFlags flags = heapInfo.flags &
+                                ~(VK_MEMORY_HEAP_DEVICE_LOCAL_BIT
+                        #if VMA_VULKAN_VERSION >= 1001000
+                                    | VK_MEMORY_HEAP_MULTI_INSTANCE_BIT
+                        #endif
+                                    );
                             if (flags != 0)
                                 json.WriteNumber(flags);
                         }
@@ -16422,8 +16250,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char
                                         json.WriteString("Flags");
                                         json.BeginArray(true);
                                         {
-                                            VkMemoryPropertyFlags flags =
-                                                allocator->m_MemProps.memoryTypes[typeIndex].propertyFlags;
+                                            VkMemoryPropertyFlags flags = allocator->m_MemProps.memoryTypes[typeIndex].propertyFlags;
                                             if (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
                                                 json.WriteString("DEVICE_LOCAL");
                                             if (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
@@ -16434,28 +16261,28 @@ VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char
                                                 json.WriteString("HOST_CACHED");
                                             if (flags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
                                                 json.WriteString("LAZILY_ALLOCATED");
-#if VMA_VULKAN_VERSION >= 1001000
+                                        #if VMA_VULKAN_VERSION >= 1001000
                                             if (flags & VK_MEMORY_PROPERTY_PROTECTED_BIT)
                                                 json.WriteString("PROTECTED");
-#endif
-#if VK_AMD_device_coherent_memory
+                                        #endif
+                                        #if VK_AMD_device_coherent_memory
                                             if (flags & VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY)
                                                 json.WriteString("DEVICE_COHERENT_AMD");
                                             if (flags & VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD_COPY)
                                                 json.WriteString("DEVICE_UNCACHED_AMD");
-#endif
+                                        #endif
 
                                             flags &= ~(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
-#if VMA_VULKAN_VERSION >= 1001000
-                                                       | VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT
-#endif
-#if VK_AMD_device_coherent_memory
-                                                       | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY |
-                                                       VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD_COPY
-#endif
-                                                       | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                                       VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
-                                                       VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
+                                        #if VMA_VULKAN_VERSION >= 1001000
+                                                | VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT
+                                        #endif
+                                        #if VK_AMD_device_coherent_memory
+                                                | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD_COPY
+                                                | VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD_COPY
+                                        #endif
+                                                | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
+                                                | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
+                                                | VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
                                             if (flags != 0)
                                                 json.WriteNumber(flags);
                                         }
@@ -16467,6 +16294,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char
                                     json.EndObject();
                                 }
                             }
+
                         }
                         json.EndObject();
                     }
@@ -16485,9 +16313,11 @@ VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator allocator, char
     *ppStatsString = VmaCreateStringCopy(allocator->GetAllocationCallbacks(), sb.GetData(), sb.GetLength());
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(VmaAllocator allocator, char* pStatsString)
+VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
+    VmaAllocator allocator,
+    char* pStatsString)
 {
-    if (pStatsString != VMA_NULL)
+    if(pStatsString != VMA_NULL)
     {
         VMA_ASSERT(allocator);
         VmaFreeString(allocator->GetAllocationCallbacks(), pStatsString);
@@ -16499,10 +16329,11 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(VmaAllocator allocator, char*
 /*
 This function is not protected by any mutex because it just reads immutable data.
 */
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndex(VmaAllocator                   allocator,
-                                                           uint32_t                       memoryTypeBits,
-                                                           const VmaAllocationCreateInfo* pAllocationCreateInfo,
-                                                           uint32_t*                      pMemoryTypeIndex)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndex(
+    VmaAllocator allocator,
+    uint32_t memoryTypeBits,
+    const VmaAllocationCreateInfo* pAllocationCreateInfo,
+    uint32_t* pMemoryTypeIndex)
 {
     VMA_ASSERT(allocator != VK_NULL_HANDLE);
     VMA_ASSERT(pAllocationCreateInfo != VMA_NULL);
@@ -16511,43 +16342,42 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndex(VmaAllocator         
     return allocator->FindMemoryTypeIndex(memoryTypeBits, pAllocationCreateInfo, UINT32_MAX, pMemoryTypeIndex);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST
-vmaFindMemoryTypeIndexForBufferInfo(VmaAllocator                   allocator,
-                                    const VkBufferCreateInfo*      pBufferCreateInfo,
-                                    const VmaAllocationCreateInfo* pAllocationCreateInfo,
-                                    uint32_t*                      pMemoryTypeIndex)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndexForBufferInfo(
+    VmaAllocator allocator,
+    const VkBufferCreateInfo* pBufferCreateInfo,
+    const VmaAllocationCreateInfo* pAllocationCreateInfo,
+    uint32_t* pMemoryTypeIndex)
 {
     VMA_ASSERT(allocator != VK_NULL_HANDLE);
     VMA_ASSERT(pBufferCreateInfo != VMA_NULL);
     VMA_ASSERT(pAllocationCreateInfo != VMA_NULL);
     VMA_ASSERT(pMemoryTypeIndex != VMA_NULL);
 
-    const VkDevice            hDev  = allocator->m_hDevice;
+    const VkDevice hDev = allocator->m_hDevice;
     const VmaVulkanFunctions* funcs = &allocator->GetVulkanFunctions();
-    VkResult                  res;
+    VkResult res;
 
 #if VMA_VULKAN_VERSION >= 1003000
-    if (funcs->vkGetDeviceBufferMemoryRequirements)
+    if(funcs->vkGetDeviceBufferMemoryRequirements)
     {
         // Can query straight from VkBufferCreateInfo :)
-        VkDeviceBufferMemoryRequirements devBufMemReq = { VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS };
-        devBufMemReq.pCreateInfo                      = pBufferCreateInfo;
+        VkDeviceBufferMemoryRequirements devBufMemReq = {VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS};
+        devBufMemReq.pCreateInfo = pBufferCreateInfo;
 
-        VkMemoryRequirements2 memReq = { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2 };
+        VkMemoryRequirements2 memReq = {VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2};
         (*funcs->vkGetDeviceBufferMemoryRequirements)(hDev, &devBufMemReq, &memReq);
 
-        res = allocator->FindMemoryTypeIndex(memReq.memoryRequirements.memoryTypeBits,
-                                             pAllocationCreateInfo,
-                                             pBufferCreateInfo->usage,
-                                             pMemoryTypeIndex);
+        res = allocator->FindMemoryTypeIndex(
+            memReq.memoryRequirements.memoryTypeBits, pAllocationCreateInfo, pBufferCreateInfo->usage, pMemoryTypeIndex);
     }
     else
 #endif // #if VMA_VULKAN_VERSION >= 1003000
     {
         // Must create a dummy buffer to query :(
         VkBuffer hBuffer = VK_NULL_HANDLE;
-        res = funcs->vkCreateBuffer(hDev, pBufferCreateInfo, allocator->GetAllocationCallbacks(), &hBuffer);
-        if (res == VK_SUCCESS)
+        res = funcs->vkCreateBuffer(
+            hDev, pBufferCreateInfo, allocator->GetAllocationCallbacks(), &hBuffer);
+        if(res == VK_SUCCESS)
         {
             VkMemoryRequirements memReq = {};
             funcs->vkGetBufferMemoryRequirements(hDev, hBuffer, &memReq);
@@ -16555,39 +16385,38 @@ vmaFindMemoryTypeIndexForBufferInfo(VmaAllocator                   allocator,
             res = allocator->FindMemoryTypeIndex(
                 memReq.memoryTypeBits, pAllocationCreateInfo, pBufferCreateInfo->usage, pMemoryTypeIndex);
 
-            funcs->vkDestroyBuffer(hDev, hBuffer, allocator->GetAllocationCallbacks());
+            funcs->vkDestroyBuffer(
+                hDev, hBuffer, allocator->GetAllocationCallbacks());
         }
     }
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST
-vmaFindMemoryTypeIndexForImageInfo(VmaAllocator                   allocator,
-                                   const VkImageCreateInfo*       pImageCreateInfo,
-                                   const VmaAllocationCreateInfo* pAllocationCreateInfo,
-                                   uint32_t*                      pMemoryTypeIndex)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFindMemoryTypeIndexForImageInfo(
+    VmaAllocator allocator,
+    const VkImageCreateInfo* pImageCreateInfo,
+    const VmaAllocationCreateInfo* pAllocationCreateInfo,
+    uint32_t* pMemoryTypeIndex)
 {
     VMA_ASSERT(allocator != VK_NULL_HANDLE);
     VMA_ASSERT(pImageCreateInfo != VMA_NULL);
     VMA_ASSERT(pAllocationCreateInfo != VMA_NULL);
     VMA_ASSERT(pMemoryTypeIndex != VMA_NULL);
 
-    const VkDevice            hDev  = allocator->m_hDevice;
+    const VkDevice hDev = allocator->m_hDevice;
     const VmaVulkanFunctions* funcs = &allocator->GetVulkanFunctions();
-    VkResult                  res;
+    VkResult res;
 
 #if VMA_VULKAN_VERSION >= 1003000
-    if (funcs->vkGetDeviceImageMemoryRequirements)
+    if(funcs->vkGetDeviceImageMemoryRequirements)
     {
         // Can query straight from VkImageCreateInfo :)
-        VkDeviceImageMemoryRequirements devImgMemReq = { VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS };
-        devImgMemReq.pCreateInfo                     = pImageCreateInfo;
-        VMA_ASSERT(pImageCreateInfo->tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT_COPY &&
-                   (pImageCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT_COPY) == 0 &&
-                   "Cannot use this VkImageCreateInfo with vmaFindMemoryTypeIndexForImageInfo as I don't know what to "
-                   "pass as VkDeviceImageMemoryRequirements::planeAspect.");
+        VkDeviceImageMemoryRequirements devImgMemReq = {VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS};
+        devImgMemReq.pCreateInfo = pImageCreateInfo;
+        VMA_ASSERT(pImageCreateInfo->tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT_COPY && (pImageCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT_COPY) == 0 &&
+            "Cannot use this VkImageCreateInfo with vmaFindMemoryTypeIndexForImageInfo as I don't know what to pass as VkDeviceImageMemoryRequirements::planeAspect.");
 
-        VkMemoryRequirements2 memReq = { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2 };
+        VkMemoryRequirements2 memReq = {VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2};
         (*funcs->vkGetDeviceImageMemoryRequirements)(hDev, &devImgMemReq, &memReq);
 
         res = allocator->FindMemoryTypeIndex(
@@ -16598,8 +16427,9 @@ vmaFindMemoryTypeIndexForImageInfo(VmaAllocator                   allocator,
     {
         // Must create a dummy image to query :(
         VkImage hImage = VK_NULL_HANDLE;
-        res            = funcs->vkCreateImage(hDev, pImageCreateInfo, allocator->GetAllocationCallbacks(), &hImage);
-        if (res == VK_SUCCESS)
+        res = funcs->vkCreateImage(
+            hDev, pImageCreateInfo, allocator->GetAllocationCallbacks(), &hImage);
+        if(res == VK_SUCCESS)
         {
             VkMemoryRequirements memReq = {};
             funcs->vkGetImageMemoryRequirements(hDev, hImage, &memReq);
@@ -16607,15 +16437,17 @@ vmaFindMemoryTypeIndexForImageInfo(VmaAllocator                   allocator,
             res = allocator->FindMemoryTypeIndex(
                 memReq.memoryTypeBits, pAllocationCreateInfo, pImageCreateInfo->usage, pMemoryTypeIndex);
 
-            funcs->vkDestroyImage(hDev, hImage, allocator->GetAllocationCallbacks());
+            funcs->vkDestroyImage(
+                hDev, hImage, allocator->GetAllocationCallbacks());
         }
     }
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreatePool(VmaAllocator             allocator,
-                                                  const VmaPoolCreateInfo* pCreateInfo,
-                                                  VmaPool*                 pPool)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreatePool(
+    VmaAllocator allocator,
+    const VmaPoolCreateInfo* pCreateInfo,
+    VmaPool* pPool)
 {
     VMA_ASSERT(allocator && pCreateInfo && pPool);
 
@@ -16626,11 +16458,13 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreatePool(VmaAllocator             alloc
     return allocator->CreatePool(pCreateInfo, pPool);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaDestroyPool(VmaAllocator allocator, VmaPool pool)
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyPool(
+    VmaAllocator allocator,
+    VmaPool pool)
 {
     VMA_ASSERT(allocator);
 
-    if (pool == VK_NULL_HANDLE)
+    if(pool == VK_NULL_HANDLE)
     {
         return;
     }
@@ -16642,7 +16476,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaDestroyPool(VmaAllocator allocator, VmaPool p
     allocator->DestroyPool(pool);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolStatistics(VmaAllocator allocator, VmaPool pool, VmaStatistics* pPoolStats)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolStatistics(
+    VmaAllocator allocator,
+    VmaPool pool,
+    VmaStatistics* pPoolStats)
 {
     VMA_ASSERT(allocator && pool && pPoolStats);
 
@@ -16651,9 +16488,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolStatistics(VmaAllocator allocator, Vma
     allocator->GetPoolStatistics(pool, pPoolStats);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaCalculatePoolStatistics(VmaAllocator           allocator,
-                                                           VmaPool                pool,
-                                                           VmaDetailedStatistics* pPoolStats)
+VMA_CALL_PRE void VMA_CALL_POST vmaCalculatePoolStatistics(
+    VmaAllocator allocator,
+    VmaPool pool,
+    VmaDetailedStatistics* pPoolStats)
 {
     VMA_ASSERT(allocator && pool && pPoolStats);
 
@@ -16673,7 +16511,10 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckPoolCorruption(VmaAllocator allocato
     return allocator->CheckPoolCorruption(pool);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolName(VmaAllocator allocator, VmaPool pool, const char** ppName)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolName(
+    VmaAllocator allocator,
+    VmaPool pool,
+    const char** ppName)
 {
     VMA_ASSERT(allocator && pool && ppName);
 
@@ -16684,7 +16525,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolName(VmaAllocator allocator, VmaPool p
     *ppName = pool->GetName();
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaSetPoolName(VmaAllocator allocator, VmaPool pool, const char* pName)
+VMA_CALL_PRE void VMA_CALL_POST vmaSetPoolName(
+    VmaAllocator allocator,
+    VmaPool pool,
+    const char* pName)
 {
     VMA_ASSERT(allocator && pool);
 
@@ -16695,11 +16539,12 @@ VMA_CALL_PRE void VMA_CALL_POST vmaSetPoolName(VmaAllocator allocator, VmaPool p
     pool->SetName(pName);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemory(VmaAllocator                   allocator,
-                                                      const VkMemoryRequirements*    pVkMemoryRequirements,
-                                                      const VmaAllocationCreateInfo* pCreateInfo,
-                                                      VmaAllocation*                 pAllocation,
-                                                      VmaAllocationInfo*             pAllocationInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemory(
+    VmaAllocator allocator,
+    const VkMemoryRequirements* pVkMemoryRequirements,
+    const VmaAllocationCreateInfo* pCreateInfo,
+    VmaAllocation* pAllocation,
+    VmaAllocationInfo* pAllocationInfo)
 {
     VMA_ASSERT(allocator && pVkMemoryRequirements && pCreateInfo && pAllocation);
 
@@ -16707,18 +16552,19 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemory(VmaAllocator              
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    VkResult result = allocator->AllocateMemory(*pVkMemoryRequirements,
-                                                false,          // requiresDedicatedAllocation
-                                                false,          // prefersDedicatedAllocation
-                                                VK_NULL_HANDLE, // dedicatedBuffer
-                                                VK_NULL_HANDLE, // dedicatedImage
-                                                UINT32_MAX,     // dedicatedBufferImageUsage
-                                                *pCreateInfo,
-                                                VMA_SUBALLOCATION_TYPE_UNKNOWN,
-                                                1, // allocationCount
-                                                pAllocation);
+    VkResult result = allocator->AllocateMemory(
+        *pVkMemoryRequirements,
+        false, // requiresDedicatedAllocation
+        false, // prefersDedicatedAllocation
+        VK_NULL_HANDLE, // dedicatedBuffer
+        VK_NULL_HANDLE, // dedicatedImage
+        UINT32_MAX, // dedicatedBufferImageUsage
+        *pCreateInfo,
+        VMA_SUBALLOCATION_TYPE_UNKNOWN,
+        1, // allocationCount
+        pAllocation);
 
-    if (pAllocationInfo != VMA_NULL && result == VK_SUCCESS)
+    if(pAllocationInfo != VMA_NULL && result == VK_SUCCESS)
     {
         allocator->GetAllocationInfo(*pAllocation, pAllocationInfo);
     }
@@ -16726,14 +16572,15 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemory(VmaAllocator              
     return result;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryPages(VmaAllocator                   allocator,
-                                                           const VkMemoryRequirements*    pVkMemoryRequirements,
-                                                           const VmaAllocationCreateInfo* pCreateInfo,
-                                                           size_t                         allocationCount,
-                                                           VmaAllocation*                 pAllocations,
-                                                           VmaAllocationInfo*             pAllocationInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryPages(
+    VmaAllocator allocator,
+    const VkMemoryRequirements* pVkMemoryRequirements,
+    const VmaAllocationCreateInfo* pCreateInfo,
+    size_t allocationCount,
+    VmaAllocation* pAllocations,
+    VmaAllocationInfo* pAllocationInfo)
 {
-    if (allocationCount == 0)
+    if(allocationCount == 0)
     {
         return VK_SUCCESS;
     }
@@ -16744,20 +16591,21 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryPages(VmaAllocator         
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    VkResult result = allocator->AllocateMemory(*pVkMemoryRequirements,
-                                                false,          // requiresDedicatedAllocation
-                                                false,          // prefersDedicatedAllocation
-                                                VK_NULL_HANDLE, // dedicatedBuffer
-                                                VK_NULL_HANDLE, // dedicatedImage
-                                                UINT32_MAX,     // dedicatedBufferImageUsage
-                                                *pCreateInfo,
-                                                VMA_SUBALLOCATION_TYPE_UNKNOWN,
-                                                allocationCount,
-                                                pAllocations);
+    VkResult result = allocator->AllocateMemory(
+        *pVkMemoryRequirements,
+        false, // requiresDedicatedAllocation
+        false, // prefersDedicatedAllocation
+        VK_NULL_HANDLE, // dedicatedBuffer
+        VK_NULL_HANDLE, // dedicatedImage
+        UINT32_MAX, // dedicatedBufferImageUsage
+        *pCreateInfo,
+        VMA_SUBALLOCATION_TYPE_UNKNOWN,
+        allocationCount,
+        pAllocations);
 
-    if (pAllocationInfo != VMA_NULL && result == VK_SUCCESS)
+    if(pAllocationInfo != VMA_NULL && result == VK_SUCCESS)
     {
-        for (size_t i = 0; i < allocationCount; ++i)
+        for(size_t i = 0; i < allocationCount; ++i)
         {
             allocator->GetAllocationInfo(pAllocations[i], pAllocationInfo + i);
         }
@@ -16766,11 +16614,12 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryPages(VmaAllocator         
     return result;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForBuffer(VmaAllocator                   allocator,
-                                                               VkBuffer                       buffer,
-                                                               const VmaAllocationCreateInfo* pCreateInfo,
-                                                               VmaAllocation*                 pAllocation,
-                                                               VmaAllocationInfo*             pAllocationInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForBuffer(
+    VmaAllocator allocator,
+    VkBuffer buffer,
+    const VmaAllocationCreateInfo* pCreateInfo,
+    VmaAllocation* pAllocation,
+    VmaAllocationInfo* pAllocationInfo)
 {
     VMA_ASSERT(allocator && buffer != VK_NULL_HANDLE && pCreateInfo && pAllocation);
 
@@ -16778,23 +16627,26 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForBuffer(VmaAllocator     
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    VkMemoryRequirements vkMemReq                    = {};
-    bool                 requiresDedicatedAllocation = false;
-    bool                 prefersDedicatedAllocation  = false;
-    allocator->GetBufferMemoryRequirements(buffer, vkMemReq, requiresDedicatedAllocation, prefersDedicatedAllocation);
+    VkMemoryRequirements vkMemReq = {};
+    bool requiresDedicatedAllocation = false;
+    bool prefersDedicatedAllocation = false;
+    allocator->GetBufferMemoryRequirements(buffer, vkMemReq,
+        requiresDedicatedAllocation,
+        prefersDedicatedAllocation);
 
-    VkResult result = allocator->AllocateMemory(vkMemReq,
-                                                requiresDedicatedAllocation,
-                                                prefersDedicatedAllocation,
-                                                buffer,         // dedicatedBuffer
-                                                VK_NULL_HANDLE, // dedicatedImage
-                                                UINT32_MAX,     // dedicatedBufferImageUsage
-                                                *pCreateInfo,
-                                                VMA_SUBALLOCATION_TYPE_BUFFER,
-                                                1, // allocationCount
-                                                pAllocation);
+    VkResult result = allocator->AllocateMemory(
+        vkMemReq,
+        requiresDedicatedAllocation,
+        prefersDedicatedAllocation,
+        buffer, // dedicatedBuffer
+        VK_NULL_HANDLE, // dedicatedImage
+        UINT32_MAX, // dedicatedBufferImageUsage
+        *pCreateInfo,
+        VMA_SUBALLOCATION_TYPE_BUFFER,
+        1, // allocationCount
+        pAllocation);
 
-    if (pAllocationInfo && result == VK_SUCCESS)
+    if(pAllocationInfo && result == VK_SUCCESS)
     {
         allocator->GetAllocationInfo(*pAllocation, pAllocationInfo);
     }
@@ -16802,11 +16654,12 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForBuffer(VmaAllocator     
     return result;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForImage(VmaAllocator                   allocator,
-                                                              VkImage                        image,
-                                                              const VmaAllocationCreateInfo* pCreateInfo,
-                                                              VmaAllocation*                 pAllocation,
-                                                              VmaAllocationInfo*             pAllocationInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForImage(
+    VmaAllocator allocator,
+    VkImage image,
+    const VmaAllocationCreateInfo* pCreateInfo,
+    VmaAllocation* pAllocation,
+    VmaAllocationInfo* pAllocationInfo)
 {
     VMA_ASSERT(allocator && image != VK_NULL_HANDLE && pCreateInfo && pAllocation);
 
@@ -16814,23 +16667,25 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForImage(VmaAllocator      
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    VkMemoryRequirements vkMemReq                    = {};
-    bool                 requiresDedicatedAllocation = false;
-    bool                 prefersDedicatedAllocation  = false;
-    allocator->GetImageMemoryRequirements(image, vkMemReq, requiresDedicatedAllocation, prefersDedicatedAllocation);
+    VkMemoryRequirements vkMemReq = {};
+    bool requiresDedicatedAllocation = false;
+    bool prefersDedicatedAllocation  = false;
+    allocator->GetImageMemoryRequirements(image, vkMemReq,
+        requiresDedicatedAllocation, prefersDedicatedAllocation);
 
-    VkResult result = allocator->AllocateMemory(vkMemReq,
-                                                requiresDedicatedAllocation,
-                                                prefersDedicatedAllocation,
-                                                VK_NULL_HANDLE, // dedicatedBuffer
-                                                image,          // dedicatedImage
-                                                UINT32_MAX,     // dedicatedBufferImageUsage
-                                                *pCreateInfo,
-                                                VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN,
-                                                1, // allocationCount
-                                                pAllocation);
+    VkResult result = allocator->AllocateMemory(
+        vkMemReq,
+        requiresDedicatedAllocation,
+        prefersDedicatedAllocation,
+        VK_NULL_HANDLE, // dedicatedBuffer
+        image, // dedicatedImage
+        UINT32_MAX, // dedicatedBufferImageUsage
+        *pCreateInfo,
+        VMA_SUBALLOCATION_TYPE_IMAGE_UNKNOWN,
+        1, // allocationCount
+        pAllocation);
 
-    if (pAllocationInfo && result == VK_SUCCESS)
+    if(pAllocationInfo && result == VK_SUCCESS)
     {
         allocator->GetAllocationInfo(*pAllocation, pAllocationInfo);
     }
@@ -16838,11 +16693,13 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaAllocateMemoryForImage(VmaAllocator      
     return result;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemory(VmaAllocator allocator, VmaAllocation allocation)
+VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemory(
+    VmaAllocator allocator,
+    VmaAllocation allocation)
 {
     VMA_ASSERT(allocator);
 
-    if (allocation == VK_NULL_HANDLE)
+    if(allocation == VK_NULL_HANDLE)
     {
         return;
     }
@@ -16851,15 +16708,17 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemory(VmaAllocator allocator, VmaAllocat
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    allocator->FreeMemory(1, // allocationCount
-                          &allocation);
+    allocator->FreeMemory(
+        1, // allocationCount
+        &allocation);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemoryPages(VmaAllocator         allocator,
-                                                   size_t               allocationCount,
-                                                   const VmaAllocation* pAllocations)
+VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemoryPages(
+    VmaAllocator allocator,
+    size_t allocationCount,
+    const VmaAllocation* pAllocations)
 {
-    if (allocationCount == 0)
+    if(allocationCount == 0)
     {
         return;
     }
@@ -16873,9 +16732,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemoryPages(VmaAllocator         allocato
     allocator->FreeMemory(allocationCount, pAllocations);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationInfo(VmaAllocator       allocator,
-                                                     VmaAllocation      allocation,
-                                                     VmaAllocationInfo* pAllocationInfo)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationInfo(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    VmaAllocationInfo* pAllocationInfo)
 {
     VMA_ASSERT(allocator && allocation && pAllocationInfo);
 
@@ -16884,9 +16744,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationInfo(VmaAllocator       allocato
     allocator->GetAllocationInfo(allocation, pAllocationInfo);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationUserData(VmaAllocator  allocator,
-                                                         VmaAllocation allocation,
-                                                         void*         pUserData)
+VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationUserData(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    void* pUserData)
 {
     VMA_ASSERT(allocator && allocation);
 
@@ -16895,23 +16756,28 @@ VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationUserData(VmaAllocator  allocator
     allocation->SetUserData(allocator, pUserData);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationName(VmaAllocator VMA_NOT_NULL  allocator,
-                                                     VmaAllocation VMA_NOT_NULL allocation,
-                                                     const char* VMA_NULLABLE   pName)
+VMA_CALL_PRE void VMA_CALL_POST vmaSetAllocationName(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    const char* VMA_NULLABLE pName)
 {
     allocation->SetName(allocator, pName);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationMemoryProperties(VmaAllocator VMA_NOT_NULL           allocator,
-                                                                 VmaAllocation VMA_NOT_NULL          allocation,
-                                                                 VkMemoryPropertyFlags* VMA_NOT_NULL pFlags)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetAllocationMemoryProperties(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkMemoryPropertyFlags* VMA_NOT_NULL pFlags)
 {
     VMA_ASSERT(allocator && allocation && pFlags);
     const uint32_t memTypeIndex = allocation->GetMemoryTypeIndex();
-    *pFlags                     = allocator->m_MemProps.memoryTypes[memTypeIndex].propertyFlags;
+    *pFlags = allocator->m_MemProps.memoryTypes[memTypeIndex].propertyFlags;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaMapMemory(VmaAllocator allocator, VmaAllocation allocation, void** ppData)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaMapMemory(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    void** ppData)
 {
     VMA_ASSERT(allocator && allocation && ppData);
 
@@ -16920,7 +16786,9 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaMapMemory(VmaAllocator allocator, VmaAllo
     return allocator->Map(allocation, ppData);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaUnmapMemory(VmaAllocator allocator, VmaAllocation allocation)
+VMA_CALL_PRE void VMA_CALL_POST vmaUnmapMemory(
+    VmaAllocator allocator,
+    VmaAllocation allocation)
 {
     VMA_ASSERT(allocator && allocation);
 
@@ -16929,10 +16797,11 @@ VMA_CALL_PRE void VMA_CALL_POST vmaUnmapMemory(VmaAllocator allocator, VmaAlloca
     allocator->Unmap(allocation);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocation(VmaAllocator  allocator,
-                                                       VmaAllocation allocation,
-                                                       VkDeviceSize  offset,
-                                                       VkDeviceSize  size)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocation(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    VkDeviceSize offset,
+    VkDeviceSize size)
 {
     VMA_ASSERT(allocator && allocation);
 
@@ -16945,10 +16814,11 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocation(VmaAllocator  allocator,
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocation(VmaAllocator  allocator,
-                                                            VmaAllocation allocation,
-                                                            VkDeviceSize  offset,
-                                                            VkDeviceSize  size)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocation(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    VkDeviceSize offset,
+    VkDeviceSize size)
 {
     VMA_ASSERT(allocator && allocation);
 
@@ -16961,15 +16831,16 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocation(VmaAllocator  alloca
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocations(VmaAllocator         allocator,
-                                                        uint32_t             allocationCount,
-                                                        const VmaAllocation* allocations,
-                                                        const VkDeviceSize*  offsets,
-                                                        const VkDeviceSize*  sizes)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocations(
+    VmaAllocator allocator,
+    uint32_t allocationCount,
+    const VmaAllocation* allocations,
+    const VkDeviceSize* offsets,
+    const VkDeviceSize* sizes)
 {
     VMA_ASSERT(allocator);
 
-    if (allocationCount == 0)
+    if(allocationCount == 0)
     {
         return VK_SUCCESS;
     }
@@ -16980,21 +16851,21 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaFlushAllocations(VmaAllocator         all
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    const VkResult res =
-        allocator->FlushOrInvalidateAllocations(allocationCount, allocations, offsets, sizes, VMA_CACHE_FLUSH);
+    const VkResult res = allocator->FlushOrInvalidateAllocations(allocationCount, allocations, offsets, sizes, VMA_CACHE_FLUSH);
 
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocations(VmaAllocator         allocator,
-                                                             uint32_t             allocationCount,
-                                                             const VmaAllocation* allocations,
-                                                             const VkDeviceSize*  offsets,
-                                                             const VkDeviceSize*  sizes)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocations(
+    VmaAllocator allocator,
+    uint32_t allocationCount,
+    const VmaAllocation* allocations,
+    const VkDeviceSize* offsets,
+    const VkDeviceSize* sizes)
 {
     VMA_ASSERT(allocator);
 
-    if (allocationCount == 0)
+    if(allocationCount == 0)
     {
         return VK_SUCCESS;
     }
@@ -17005,13 +16876,14 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocations(VmaAllocator       
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    const VkResult res =
-        allocator->FlushOrInvalidateAllocations(allocationCount, allocations, offsets, sizes, VMA_CACHE_INVALIDATE);
+    const VkResult res = allocator->FlushOrInvalidateAllocations(allocationCount, allocations, offsets, sizes, VMA_CACHE_INVALIDATE);
 
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckCorruption(VmaAllocator allocator, uint32_t memoryTypeBits)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckCorruption(
+    VmaAllocator allocator,
+    uint32_t memoryTypeBits)
 {
     VMA_ASSERT(allocator);
 
@@ -17022,9 +16894,10 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCheckCorruption(VmaAllocator allocator, u
     return allocator->CheckCorruption(memoryTypeBits);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentation(VmaAllocator                  allocator,
-                                                            const VmaDefragmentationInfo* pInfo,
-                                                            VmaDefragmentationContext*    pContext)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentation(
+    VmaAllocator allocator,
+    const VmaDefragmentationInfo* pInfo,
+    VmaDefragmentationContext* pContext)
 {
     VMA_ASSERT(allocator && pInfo && pContext);
 
@@ -17043,9 +16916,10 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentation(VmaAllocator        
     return VK_SUCCESS;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaEndDefragmentation(VmaAllocator              allocator,
-                                                      VmaDefragmentationContext context,
-                                                      VmaDefragmentationStats*  pStats)
+VMA_CALL_PRE void VMA_CALL_POST vmaEndDefragmentation(
+    VmaAllocator allocator,
+    VmaDefragmentationContext context,
+    VmaDefragmentationStats* pStats)
 {
     VMA_ASSERT(allocator && context);
 
@@ -17058,9 +16932,10 @@ VMA_CALL_PRE void VMA_CALL_POST vmaEndDefragmentation(VmaAllocator              
     vma_delete(allocator, context);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentationPass(VmaAllocator VMA_NOT_NULL                    allocator,
-                                                                VmaDefragmentationContext VMA_NOT_NULL       context,
-                                                                VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentationPass(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaDefragmentationContext VMA_NOT_NULL context,
+    VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo)
 {
     VMA_ASSERT(context && pPassInfo);
 
@@ -17071,9 +16946,10 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaBeginDefragmentationPass(VmaAllocator VMA
     return context->DefragmentPassBegin(*pPassInfo);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaEndDefragmentationPass(VmaAllocator VMA_NOT_NULL                    allocator,
-                                                              VmaDefragmentationContext VMA_NOT_NULL       context,
-                                                              VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaEndDefragmentationPass(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaDefragmentationContext VMA_NOT_NULL context,
+    VmaDefragmentationPassMoveInfo* VMA_NOT_NULL pPassInfo)
 {
     VMA_ASSERT(context && pPassInfo);
 
@@ -17084,9 +16960,10 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaEndDefragmentationPass(VmaAllocator VMA_N
     return context->DefragmentPassEnd(*pPassInfo);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory(VmaAllocator  allocator,
-                                                        VmaAllocation allocation,
-                                                        VkBuffer      buffer)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    VkBuffer buffer)
 {
     VMA_ASSERT(allocator && allocation && buffer);
 
@@ -17097,11 +16974,12 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory(VmaAllocator  allocator,
     return allocator->BindBufferMemory(allocation, 0, buffer, VMA_NULL);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory2(VmaAllocator  allocator,
-                                                         VmaAllocation allocation,
-                                                         VkDeviceSize  allocationLocalOffset,
-                                                         VkBuffer      buffer,
-                                                         const void*   pNext)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory2(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    VkDeviceSize allocationLocalOffset,
+    VkBuffer buffer,
+    const void* pNext)
 {
     VMA_ASSERT(allocator && allocation && buffer);
 
@@ -17112,7 +16990,10 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindBufferMemory2(VmaAllocator  allocator
     return allocator->BindBufferMemory(allocation, allocationLocalOffset, buffer, pNext);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory(VmaAllocator allocator, VmaAllocation allocation, VkImage image)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    VkImage image)
 {
     VMA_ASSERT(allocator && allocation && image);
 
@@ -17123,11 +17004,12 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory(VmaAllocator allocator, V
     return allocator->BindImageMemory(allocation, 0, image, VMA_NULL);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory2(VmaAllocator  allocator,
-                                                        VmaAllocation allocation,
-                                                        VkDeviceSize  allocationLocalOffset,
-                                                        VkImage       image,
-                                                        const void*   pNext)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory2(
+    VmaAllocator allocator,
+    VmaAllocation allocation,
+    VkDeviceSize allocationLocalOffset,
+    VkImage image,
+    const void* pNext)
 {
     VMA_ASSERT(allocator && allocation && image);
 
@@ -17135,27 +17017,27 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaBindImageMemory2(VmaAllocator  allocator,
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    return allocator->BindImageMemory(allocation, allocationLocalOffset, image, pNext);
+        return allocator->BindImageMemory(allocation, allocationLocalOffset, image, pNext);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBuffer(VmaAllocator                   allocator,
-                                                    const VkBufferCreateInfo*      pBufferCreateInfo,
-                                                    const VmaAllocationCreateInfo* pAllocationCreateInfo,
-                                                    VkBuffer*                      pBuffer,
-                                                    VmaAllocation*                 pAllocation,
-                                                    VmaAllocationInfo*             pAllocationInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBuffer(
+    VmaAllocator allocator,
+    const VkBufferCreateInfo* pBufferCreateInfo,
+    const VmaAllocationCreateInfo* pAllocationCreateInfo,
+    VkBuffer* pBuffer,
+    VmaAllocation* pAllocation,
+    VmaAllocationInfo* pAllocationInfo)
 {
     VMA_ASSERT(allocator && pBufferCreateInfo && pAllocationCreateInfo && pBuffer && pAllocation);
 
-    if (pBufferCreateInfo->size == 0)
+    if(pBufferCreateInfo->size == 0)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
-    if ((pBufferCreateInfo->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_COPY) != 0 &&
+    if((pBufferCreateInfo->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_COPY) != 0 &&
         !allocator->m_UseKhrBufferDeviceAddress)
     {
-        VMA_ASSERT(0 && "Creating a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT is not valid if "
-                        "VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT was not used.");
+        VMA_ASSERT(0 && "Creating a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT is not valid if VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT was not used.");
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -17163,91 +17045,91 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBuffer(VmaAllocator                
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    *pBuffer     = VK_NULL_HANDLE;
+    *pBuffer = VK_NULL_HANDLE;
     *pAllocation = VK_NULL_HANDLE;
 
     // 1. Create VkBuffer.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(allocator->m_hDevice,
-                                                                     pBufferCreateInfo,
-                                                                     allocator->GetAllocationCallbacks(),
-                                                                     pBuffer);
-    if (res >= 0)
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(
+        allocator->m_hDevice,
+        pBufferCreateInfo,
+        allocator->GetAllocationCallbacks(),
+        pBuffer);
+    if(res >= 0)
     {
         // 2. vkGetBufferMemoryRequirements.
-        VkMemoryRequirements vkMemReq                    = {};
-        bool                 requiresDedicatedAllocation = false;
-        bool                 prefersDedicatedAllocation  = false;
-        allocator->GetBufferMemoryRequirements(
-            *pBuffer, vkMemReq, requiresDedicatedAllocation, prefersDedicatedAllocation);
+        VkMemoryRequirements vkMemReq = {};
+        bool requiresDedicatedAllocation = false;
+        bool prefersDedicatedAllocation  = false;
+        allocator->GetBufferMemoryRequirements(*pBuffer, vkMemReq,
+            requiresDedicatedAllocation, prefersDedicatedAllocation);
 
         // 3. Allocate memory using allocator.
-        res = allocator->AllocateMemory(vkMemReq,
-                                        requiresDedicatedAllocation,
-                                        prefersDedicatedAllocation,
-                                        *pBuffer,                 // dedicatedBuffer
-                                        VK_NULL_HANDLE,           // dedicatedImage
-                                        pBufferCreateInfo->usage, // dedicatedBufferImageUsage
-                                        *pAllocationCreateInfo,
-                                        VMA_SUBALLOCATION_TYPE_BUFFER,
-                                        1, // allocationCount
-                                        pAllocation);
+        res = allocator->AllocateMemory(
+            vkMemReq,
+            requiresDedicatedAllocation,
+            prefersDedicatedAllocation,
+            *pBuffer, // dedicatedBuffer
+            VK_NULL_HANDLE, // dedicatedImage
+            pBufferCreateInfo->usage, // dedicatedBufferImageUsage
+            *pAllocationCreateInfo,
+            VMA_SUBALLOCATION_TYPE_BUFFER,
+            1, // allocationCount
+            pAllocation);
 
-        if (res >= 0)
+        if(res >= 0)
         {
             // 3. Bind buffer with memory.
-            if ((pAllocationCreateInfo->flags & VMA_ALLOCATION_CREATE_DONT_BIND_BIT) == 0)
+            if((pAllocationCreateInfo->flags & VMA_ALLOCATION_CREATE_DONT_BIND_BIT) == 0)
             {
                 res = allocator->BindBufferMemory(*pAllocation, 0, *pBuffer, VMA_NULL);
             }
-            if (res >= 0)
+            if(res >= 0)
             {
-// All steps succeeded.
-#if VMA_STATS_STRING_ENABLED
-                (*pAllocation)->InitBufferImageUsage(pBufferCreateInfo->usage);
-#endif
-                if (pAllocationInfo != VMA_NULL)
+                // All steps succeeded.
+                #if VMA_STATS_STRING_ENABLED
+                    (*pAllocation)->InitBufferImageUsage(pBufferCreateInfo->usage);
+                #endif
+                if(pAllocationInfo != VMA_NULL)
                 {
                     allocator->GetAllocationInfo(*pAllocation, pAllocationInfo);
                 }
 
                 return VK_SUCCESS;
             }
-            allocator->FreeMemory(1, // allocationCount
-                                  pAllocation);
+            allocator->FreeMemory(
+                1, // allocationCount
+                pAllocation);
             *pAllocation = VK_NULL_HANDLE;
-            (*allocator->GetVulkanFunctions().vkDestroyBuffer)(
-                allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
+            (*allocator->GetVulkanFunctions().vkDestroyBuffer)(allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
             *pBuffer = VK_NULL_HANDLE;
             return res;
         }
-        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(
-            allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
+        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
         *pBuffer = VK_NULL_HANDLE;
         return res;
     }
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBufferWithAlignment(VmaAllocator                   allocator,
-                                                                 const VkBufferCreateInfo*      pBufferCreateInfo,
-                                                                 const VmaAllocationCreateInfo* pAllocationCreateInfo,
-                                                                 VkDeviceSize                   minAlignment,
-                                                                 VkBuffer*                      pBuffer,
-                                                                 VmaAllocation*                 pAllocation,
-                                                                 VmaAllocationInfo*             pAllocationInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBufferWithAlignment(
+    VmaAllocator allocator,
+    const VkBufferCreateInfo* pBufferCreateInfo,
+    const VmaAllocationCreateInfo* pAllocationCreateInfo,
+    VkDeviceSize minAlignment,
+    VkBuffer* pBuffer,
+    VmaAllocation* pAllocation,
+    VmaAllocationInfo* pAllocationInfo)
 {
-    VMA_ASSERT(allocator && pBufferCreateInfo && pAllocationCreateInfo && VmaIsPow2(minAlignment) && pBuffer &&
-               pAllocation);
+    VMA_ASSERT(allocator && pBufferCreateInfo && pAllocationCreateInfo && VmaIsPow2(minAlignment) && pBuffer && pAllocation);
 
-    if (pBufferCreateInfo->size == 0)
+    if(pBufferCreateInfo->size == 0)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
-    if ((pBufferCreateInfo->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_COPY) != 0 &&
+    if((pBufferCreateInfo->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_COPY) != 0 &&
         !allocator->m_UseKhrBufferDeviceAddress)
     {
-        VMA_ASSERT(0 && "Creating a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT is not valid if "
-                        "VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT was not used.");
+        VMA_ASSERT(0 && "Creating a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT is not valid if VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT was not used.");
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -17255,83 +17137,95 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBufferWithAlignment(VmaAllocator   
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    *pBuffer     = VK_NULL_HANDLE;
+    *pBuffer = VK_NULL_HANDLE;
     *pAllocation = VK_NULL_HANDLE;
 
     // 1. Create VkBuffer.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(allocator->m_hDevice,
-                                                                     pBufferCreateInfo,
-                                                                     allocator->GetAllocationCallbacks(),
-                                                                     pBuffer);
-    if (res >= 0)
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(
+        allocator->m_hDevice,
+        pBufferCreateInfo,
+        allocator->GetAllocationCallbacks(),
+        pBuffer);
+    if(res >= 0)
     {
         // 2. vkGetBufferMemoryRequirements.
-        VkMemoryRequirements vkMemReq                    = {};
-        bool                 requiresDedicatedAllocation = false;
-        bool                 prefersDedicatedAllocation  = false;
-        allocator->GetBufferMemoryRequirements(
-            *pBuffer, vkMemReq, requiresDedicatedAllocation, prefersDedicatedAllocation);
+        VkMemoryRequirements vkMemReq = {};
+        bool requiresDedicatedAllocation = false;
+        bool prefersDedicatedAllocation  = false;
+        allocator->GetBufferMemoryRequirements(*pBuffer, vkMemReq,
+            requiresDedicatedAllocation, prefersDedicatedAllocation);
 
         // 2a. Include minAlignment
         vkMemReq.alignment = VMA_MAX(vkMemReq.alignment, minAlignment);
 
         // 3. Allocate memory using allocator.
-        res = allocator->AllocateMemory(vkMemReq,
-                                        requiresDedicatedAllocation,
-                                        prefersDedicatedAllocation,
-                                        *pBuffer,                 // dedicatedBuffer
-                                        VK_NULL_HANDLE,           // dedicatedImage
-                                        pBufferCreateInfo->usage, // dedicatedBufferImageUsage
-                                        *pAllocationCreateInfo,
-                                        VMA_SUBALLOCATION_TYPE_BUFFER,
-                                        1, // allocationCount
-                                        pAllocation);
+        res = allocator->AllocateMemory(
+            vkMemReq,
+            requiresDedicatedAllocation,
+            prefersDedicatedAllocation,
+            *pBuffer, // dedicatedBuffer
+            VK_NULL_HANDLE, // dedicatedImage
+            pBufferCreateInfo->usage, // dedicatedBufferImageUsage
+            *pAllocationCreateInfo,
+            VMA_SUBALLOCATION_TYPE_BUFFER,
+            1, // allocationCount
+            pAllocation);
 
-        if (res >= 0)
+        if(res >= 0)
         {
             // 3. Bind buffer with memory.
-            if ((pAllocationCreateInfo->flags & VMA_ALLOCATION_CREATE_DONT_BIND_BIT) == 0)
+            if((pAllocationCreateInfo->flags & VMA_ALLOCATION_CREATE_DONT_BIND_BIT) == 0)
             {
                 res = allocator->BindBufferMemory(*pAllocation, 0, *pBuffer, VMA_NULL);
             }
-            if (res >= 0)
+            if(res >= 0)
             {
-// All steps succeeded.
-#if VMA_STATS_STRING_ENABLED
-                (*pAllocation)->InitBufferImageUsage(pBufferCreateInfo->usage);
-#endif
-                if (pAllocationInfo != VMA_NULL)
+                // All steps succeeded.
+                #if VMA_STATS_STRING_ENABLED
+                    (*pAllocation)->InitBufferImageUsage(pBufferCreateInfo->usage);
+                #endif
+                if(pAllocationInfo != VMA_NULL)
                 {
                     allocator->GetAllocationInfo(*pAllocation, pAllocationInfo);
                 }
 
                 return VK_SUCCESS;
             }
-            allocator->FreeMemory(1, // allocationCount
-                                  pAllocation);
+            allocator->FreeMemory(
+                1, // allocationCount
+                pAllocation);
             *pAllocation = VK_NULL_HANDLE;
-            (*allocator->GetVulkanFunctions().vkDestroyBuffer)(
-                allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
+            (*allocator->GetVulkanFunctions().vkDestroyBuffer)(allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
             *pBuffer = VK_NULL_HANDLE;
             return res;
         }
-        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(
-            allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
+        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
         *pBuffer = VK_NULL_HANDLE;
         return res;
     }
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST
-vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL              allocator,
-                        VmaAllocation VMA_NOT_NULL             allocation,
-                        const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
-                        VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingBuffer(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer)
+{
+    return vmaCreateAliasingBuffer2(allocator, allocation, 0, pBufferCreateInfo, pBuffer);
+}
+
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingBuffer2(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize allocationLocalOffset,
+    const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer)
 {
     VMA_ASSERT(allocator && pBufferCreateInfo && pBuffer && allocation);
+    VMA_ASSERT(allocationLocalOffset + pBufferCreateInfo->size <= allocation->GetSize());
 
-    VMA_DEBUG_LOG("vmaCreateAliasingBuffer");
+    VMA_DEBUG_LOG("vmaCreateAliasingBuffer2");
 
     *pBuffer = VK_NULL_HANDLE;
 
@@ -17342,37 +17236,39 @@ vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL              allocator,
     if ((pBufferCreateInfo->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_COPY) != 0 &&
         !allocator->m_UseKhrBufferDeviceAddress)
     {
-        VMA_ASSERT(0 && "Creating a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT is not valid if "
-                        "VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT was not used.");
+        VMA_ASSERT(0 && "Creating a buffer with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT is not valid if VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT was not used.");
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
     // 1. Create VkBuffer.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(allocator->m_hDevice,
-                                                                     pBufferCreateInfo,
-                                                                     allocator->GetAllocationCallbacks(),
-                                                                     pBuffer);
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(
+        allocator->m_hDevice,
+        pBufferCreateInfo,
+        allocator->GetAllocationCallbacks(),
+        pBuffer);
     if (res >= 0)
     {
         // 2. Bind buffer with memory.
-        res = allocator->BindBufferMemory(allocation, 0, *pBuffer, VMA_NULL);
+        res = allocator->BindBufferMemory(allocation, allocationLocalOffset, *pBuffer, VMA_NULL);
         if (res >= 0)
         {
             return VK_SUCCESS;
         }
-        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(
-            allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
+        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(allocator->m_hDevice, *pBuffer, allocator->GetAllocationCallbacks());
     }
     return res;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaDestroyBuffer(VmaAllocator allocator, VkBuffer buffer, VmaAllocation allocation)
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyBuffer(
+    VmaAllocator allocator,
+    VkBuffer buffer,
+    VmaAllocation allocation)
 {
     VMA_ASSERT(allocator);
 
-    if (buffer == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
+    if(buffer == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
     {
         return;
     }
@@ -17381,30 +17277,34 @@ VMA_CALL_PRE void VMA_CALL_POST vmaDestroyBuffer(VmaAllocator allocator, VkBuffe
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    if (buffer != VK_NULL_HANDLE)
+    if(buffer != VK_NULL_HANDLE)
     {
-        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(
-            allocator->m_hDevice, buffer, allocator->GetAllocationCallbacks());
+        (*allocator->GetVulkanFunctions().vkDestroyBuffer)(allocator->m_hDevice, buffer, allocator->GetAllocationCallbacks());
     }
 
-    if (allocation != VK_NULL_HANDLE)
+    if(allocation != VK_NULL_HANDLE)
     {
-        allocator->FreeMemory(1, // allocationCount
-                              &allocation);
+        allocator->FreeMemory(
+            1, // allocationCount
+            &allocation);
     }
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateImage(VmaAllocator                   allocator,
-                                                   const VkImageCreateInfo*       pImageCreateInfo,
-                                                   const VmaAllocationCreateInfo* pAllocationCreateInfo,
-                                                   VkImage*                       pImage,
-                                                   VmaAllocation*                 pAllocation,
-                                                   VmaAllocationInfo*             pAllocationInfo)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateImage(
+    VmaAllocator allocator,
+    const VkImageCreateInfo* pImageCreateInfo,
+    const VmaAllocationCreateInfo* pAllocationCreateInfo,
+    VkImage* pImage,
+    VmaAllocation* pAllocation,
+    VmaAllocationInfo* pAllocationInfo)
 {
     VMA_ASSERT(allocator && pImageCreateInfo && pAllocationCreateInfo && pImage && pAllocation);
 
-    if (pImageCreateInfo->extent.width == 0 || pImageCreateInfo->extent.height == 0 ||
-        pImageCreateInfo->extent.depth == 0 || pImageCreateInfo->mipLevels == 0 || pImageCreateInfo->arrayLayers == 0)
+    if(pImageCreateInfo->extent.width == 0 ||
+        pImageCreateInfo->extent.height == 0 ||
+        pImageCreateInfo->extent.depth == 0 ||
+        pImageCreateInfo->mipLevels == 0 ||
+        pImageCreateInfo->arrayLayers == 0)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
@@ -17413,87 +17313,102 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateImage(VmaAllocator                 
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    *pImage      = VK_NULL_HANDLE;
+    *pImage = VK_NULL_HANDLE;
     *pAllocation = VK_NULL_HANDLE;
 
     // 1. Create VkImage.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(allocator->m_hDevice,
-                                                                    pImageCreateInfo,
-                                                                    allocator->GetAllocationCallbacks(),
-                                                                    pImage);
-    if (res >= 0)
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(
+        allocator->m_hDevice,
+        pImageCreateInfo,
+        allocator->GetAllocationCallbacks(),
+        pImage);
+    if(res >= 0)
     {
-        VmaSuballocationType suballocType = pImageCreateInfo->tiling == VK_IMAGE_TILING_OPTIMAL
-                                                ? VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL
-                                                : VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR;
+        VmaSuballocationType suballocType = pImageCreateInfo->tiling == VK_IMAGE_TILING_OPTIMAL ?
+            VMA_SUBALLOCATION_TYPE_IMAGE_OPTIMAL :
+            VMA_SUBALLOCATION_TYPE_IMAGE_LINEAR;
 
         // 2. Allocate memory using allocator.
-        VkMemoryRequirements vkMemReq                    = {};
-        bool                 requiresDedicatedAllocation = false;
-        bool                 prefersDedicatedAllocation  = false;
-        allocator->GetImageMemoryRequirements(
-            *pImage, vkMemReq, requiresDedicatedAllocation, prefersDedicatedAllocation);
+        VkMemoryRequirements vkMemReq = {};
+        bool requiresDedicatedAllocation = false;
+        bool prefersDedicatedAllocation  = false;
+        allocator->GetImageMemoryRequirements(*pImage, vkMemReq,
+            requiresDedicatedAllocation, prefersDedicatedAllocation);
 
-        res = allocator->AllocateMemory(vkMemReq,
-                                        requiresDedicatedAllocation,
-                                        prefersDedicatedAllocation,
-                                        VK_NULL_HANDLE,          // dedicatedBuffer
-                                        *pImage,                 // dedicatedImage
-                                        pImageCreateInfo->usage, // dedicatedBufferImageUsage
-                                        *pAllocationCreateInfo,
-                                        suballocType,
-                                        1, // allocationCount
-                                        pAllocation);
+        res = allocator->AllocateMemory(
+            vkMemReq,
+            requiresDedicatedAllocation,
+            prefersDedicatedAllocation,
+            VK_NULL_HANDLE, // dedicatedBuffer
+            *pImage, // dedicatedImage
+            pImageCreateInfo->usage, // dedicatedBufferImageUsage
+            *pAllocationCreateInfo,
+            suballocType,
+            1, // allocationCount
+            pAllocation);
 
-        if (res >= 0)
+        if(res >= 0)
         {
             // 3. Bind image with memory.
-            if ((pAllocationCreateInfo->flags & VMA_ALLOCATION_CREATE_DONT_BIND_BIT) == 0)
+            if((pAllocationCreateInfo->flags & VMA_ALLOCATION_CREATE_DONT_BIND_BIT) == 0)
             {
                 res = allocator->BindImageMemory(*pAllocation, 0, *pImage, VMA_NULL);
             }
-            if (res >= 0)
+            if(res >= 0)
             {
-// All steps succeeded.
-#if VMA_STATS_STRING_ENABLED
-                (*pAllocation)->InitBufferImageUsage(pImageCreateInfo->usage);
-#endif
-                if (pAllocationInfo != VMA_NULL)
+                // All steps succeeded.
+                #if VMA_STATS_STRING_ENABLED
+                    (*pAllocation)->InitBufferImageUsage(pImageCreateInfo->usage);
+                #endif
+                if(pAllocationInfo != VMA_NULL)
                 {
                     allocator->GetAllocationInfo(*pAllocation, pAllocationInfo);
                 }
 
                 return VK_SUCCESS;
             }
-            allocator->FreeMemory(1, // allocationCount
-                                  pAllocation);
+            allocator->FreeMemory(
+                1, // allocationCount
+                pAllocation);
             *pAllocation = VK_NULL_HANDLE;
-            (*allocator->GetVulkanFunctions().vkDestroyImage)(
-                allocator->m_hDevice, *pImage, allocator->GetAllocationCallbacks());
+            (*allocator->GetVulkanFunctions().vkDestroyImage)(allocator->m_hDevice, *pImage, allocator->GetAllocationCallbacks());
             *pImage = VK_NULL_HANDLE;
             return res;
         }
-        (*allocator->GetVulkanFunctions().vkDestroyImage)(
-            allocator->m_hDevice, *pImage, allocator->GetAllocationCallbacks());
+        (*allocator->GetVulkanFunctions().vkDestroyImage)(allocator->m_hDevice, *pImage, allocator->GetAllocationCallbacks());
         *pImage = VK_NULL_HANDLE;
         return res;
     }
     return res;
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingImage(VmaAllocator VMA_NOT_NULL             allocator,
-                                                           VmaAllocation VMA_NOT_NULL            allocation,
-                                                           const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
-                                                           VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingImage(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
+    VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage)
+{
+    return vmaCreateAliasingImage2(allocator, allocation, 0, pImageCreateInfo, pImage);
+}
+
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingImage2(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VmaAllocation VMA_NOT_NULL allocation,
+    VkDeviceSize allocationLocalOffset,
+    const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
+    VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage)
 {
     VMA_ASSERT(allocator && pImageCreateInfo && pImage && allocation);
 
     *pImage = VK_NULL_HANDLE;
 
-    VMA_DEBUG_LOG("vmaCreateImage");
+    VMA_DEBUG_LOG("vmaCreateImage2");
 
-    if (pImageCreateInfo->extent.width == 0 || pImageCreateInfo->extent.height == 0 ||
-        pImageCreateInfo->extent.depth == 0 || pImageCreateInfo->mipLevels == 0 || pImageCreateInfo->arrayLayers == 0)
+    if (pImageCreateInfo->extent.width == 0 ||
+        pImageCreateInfo->extent.height == 0 ||
+        pImageCreateInfo->extent.depth == 0 ||
+        pImageCreateInfo->mipLevels == 0 ||
+        pImageCreateInfo->arrayLayers == 0)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
@@ -17501,31 +17416,32 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingImage(VmaAllocator VMA_NOT_
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
     // 1. Create VkImage.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(allocator->m_hDevice,
-                                                                    pImageCreateInfo,
-                                                                    allocator->GetAllocationCallbacks(),
-                                                                    pImage);
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(
+        allocator->m_hDevice,
+        pImageCreateInfo,
+        allocator->GetAllocationCallbacks(),
+        pImage);
     if (res >= 0)
     {
         // 2. Bind image with memory.
-        res = allocator->BindImageMemory(allocation, 0, *pImage, VMA_NULL);
+        res = allocator->BindImageMemory(allocation, allocationLocalOffset, *pImage, VMA_NULL);
         if (res >= 0)
         {
             return VK_SUCCESS;
         }
-        (*allocator->GetVulkanFunctions().vkDestroyImage)(
-            allocator->m_hDevice, *pImage, allocator->GetAllocationCallbacks());
+        (*allocator->GetVulkanFunctions().vkDestroyImage)(allocator->m_hDevice, *pImage, allocator->GetAllocationCallbacks());
     }
     return res;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(VmaAllocator VMA_NOT_NULL             allocator,
-                                                VkImage VMA_NULLABLE_NON_DISPATCHABLE image,
-                                                VmaAllocation VMA_NULLABLE            allocation)
+VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(
+    VmaAllocator VMA_NOT_NULL allocator,
+    VkImage VMA_NULLABLE_NON_DISPATCHABLE image,
+    VmaAllocation VMA_NULLABLE allocation)
 {
     VMA_ASSERT(allocator);
 
-    if (image == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
+    if(image == VK_NULL_HANDLE && allocation == VK_NULL_HANDLE)
     {
         return;
     }
@@ -17534,28 +17450,29 @@ VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(VmaAllocator VMA_NOT_NULL       
 
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
-    if (image != VK_NULL_HANDLE)
+    if(image != VK_NULL_HANDLE)
     {
-        (*allocator->GetVulkanFunctions().vkDestroyImage)(
-            allocator->m_hDevice, image, allocator->GetAllocationCallbacks());
+        (*allocator->GetVulkanFunctions().vkDestroyImage)(allocator->m_hDevice, image, allocator->GetAllocationCallbacks());
     }
-    if (allocation != VK_NULL_HANDLE)
+    if(allocation != VK_NULL_HANDLE)
     {
-        allocator->FreeMemory(1, // allocationCount
-                              &allocation);
+        allocator->FreeMemory(
+            1, // allocationCount
+            &allocation);
     }
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateVirtualBlock(const VmaVirtualBlockCreateInfo* VMA_NOT_NULL pCreateInfo,
-                                                          VmaVirtualBlock VMA_NULLABLE* VMA_NOT_NULL pVirtualBlock)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateVirtualBlock(
+    const VmaVirtualBlockCreateInfo* VMA_NOT_NULL pCreateInfo,
+    VmaVirtualBlock VMA_NULLABLE * VMA_NOT_NULL pVirtualBlock)
 {
     VMA_ASSERT(pCreateInfo && pVirtualBlock);
     VMA_ASSERT(pCreateInfo->size > 0);
     VMA_DEBUG_LOG("vmaCreateVirtualBlock");
     VMA_DEBUG_GLOBAL_MUTEX_LOCK;
     *pVirtualBlock = vma_new(pCreateInfo->pAllocationCallbacks, VmaVirtualBlock_T)(*pCreateInfo);
-    VkResult res   = (*pVirtualBlock)->Init();
-    if (res < 0)
+    VkResult res = (*pVirtualBlock)->Init();
+    if(res < 0)
     {
         vma_delete(pCreateInfo->pAllocationCallbacks, *pVirtualBlock);
         *pVirtualBlock = VK_NULL_HANDLE;
@@ -17565,12 +17482,11 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateVirtualBlock(const VmaVirtualBlockC
 
 VMA_CALL_PRE void VMA_CALL_POST vmaDestroyVirtualBlock(VmaVirtualBlock VMA_NULLABLE virtualBlock)
 {
-    if (virtualBlock != VK_NULL_HANDLE)
+    if(virtualBlock != VK_NULL_HANDLE)
     {
         VMA_DEBUG_LOG("vmaDestroyVirtualBlock");
         VMA_DEBUG_GLOBAL_MUTEX_LOCK;
-        VkAllocationCallbacks allocationCallbacks =
-            virtualBlock->m_AllocationCallbacks; // Have to copy the callbacks when destroying.
+        VkAllocationCallbacks allocationCallbacks = virtualBlock->m_AllocationCallbacks; // Have to copy the callbacks when destroying.
         vma_delete(&allocationCallbacks, virtualBlock);
     }
 }
@@ -17583,10 +17499,8 @@ VMA_CALL_PRE VkBool32 VMA_CALL_POST vmaIsVirtualBlockEmpty(VmaVirtualBlock VMA_N
     return virtualBlock->IsEmpty() ? VK_TRUE : VK_FALSE;
 }
 
-VMA_CALL_PRE void VMA_CALL_POST
-vmaGetVirtualAllocationInfo(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                            VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation,
-                            VmaVirtualAllocationInfo* VMA_NOT_NULL             pVirtualAllocInfo)
+VMA_CALL_PRE void VMA_CALL_POST vmaGetVirtualAllocationInfo(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation, VmaVirtualAllocationInfo* VMA_NOT_NULL pVirtualAllocInfo)
 {
     VMA_ASSERT(virtualBlock != VK_NULL_HANDLE && pVirtualAllocInfo != VMA_NULL);
     VMA_DEBUG_LOG("vmaGetVirtualAllocationInfo");
@@ -17594,11 +17508,9 @@ vmaGetVirtualAllocationInfo(VmaVirtualBlock VMA_NOT_NULL                       v
     virtualBlock->GetAllocationInfo(allocation, *pVirtualAllocInfo);
 }
 
-VMA_CALL_PRE VkResult VMA_CALL_POST
-vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                   const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                   VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pAllocation,
-                   VkDeviceSize* VMA_NULLABLE                                       pOffset)
+VMA_CALL_PRE VkResult VMA_CALL_POST vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL pCreateInfo, VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pAllocation,
+    VkDeviceSize* VMA_NULLABLE pOffset)
 {
     VMA_ASSERT(virtualBlock != VK_NULL_HANDLE && pCreateInfo != VMA_NULL && pAllocation != VMA_NULL);
     VMA_DEBUG_LOG("vmaVirtualAllocate");
@@ -17606,10 +17518,9 @@ vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL                       virtualBlo
     return virtualBlock->Allocate(*pCreateInfo, *pAllocation, pOffset);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaVirtualFree(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                                               VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE allocation)
+VMA_CALL_PRE void VMA_CALL_POST vmaVirtualFree(VmaVirtualBlock VMA_NOT_NULL virtualBlock, VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE allocation)
 {
-    if (allocation != VK_NULL_HANDLE)
+    if(allocation != VK_NULL_HANDLE)
     {
         VMA_ASSERT(virtualBlock != VK_NULL_HANDLE);
         VMA_DEBUG_LOG("vmaVirtualFree");
@@ -17626,10 +17537,8 @@ VMA_CALL_PRE void VMA_CALL_POST vmaClearVirtualBlock(VmaVirtualBlock VMA_NOT_NUL
     virtualBlock->Clear();
 }
 
-VMA_CALL_PRE void VMA_CALL_POST
-vmaSetVirtualAllocationUserData(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                                VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation,
-                                void* VMA_NULLABLE                                 pUserData)
+VMA_CALL_PRE void VMA_CALL_POST vmaSetVirtualAllocationUserData(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaVirtualAllocation VMA_NOT_NULL_NON_DISPATCHABLE allocation, void* VMA_NULLABLE pUserData)
 {
     VMA_ASSERT(virtualBlock != VK_NULL_HANDLE);
     VMA_DEBUG_LOG("vmaSetVirtualAllocationUserData");
@@ -17638,7 +17547,7 @@ vmaSetVirtualAllocationUserData(VmaVirtualBlock VMA_NOT_NULL                    
 }
 
 VMA_CALL_PRE void VMA_CALL_POST vmaGetVirtualBlockStatistics(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
-                                                             VmaStatistics* VMA_NOT_NULL  pStats)
+    VmaStatistics* VMA_NOT_NULL pStats)
 {
     VMA_ASSERT(virtualBlock != VK_NULL_HANDLE && pStats != VMA_NULL);
     VMA_DEBUG_LOG("vmaGetVirtualBlockStatistics");
@@ -17646,8 +17555,8 @@ VMA_CALL_PRE void VMA_CALL_POST vmaGetVirtualBlockStatistics(VmaVirtualBlock VMA
     virtualBlock->GetStatistics(*pStats);
 }
 
-VMA_CALL_PRE void VMA_CALL_POST vmaCalculateVirtualBlockStatistics(VmaVirtualBlock VMA_NOT_NULL        virtualBlock,
-                                                                   VmaDetailedStatistics* VMA_NOT_NULL pStats)
+VMA_CALL_PRE void VMA_CALL_POST vmaCalculateVirtualBlockStatistics(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VmaDetailedStatistics* VMA_NOT_NULL pStats)
 {
     VMA_ASSERT(virtualBlock != VK_NULL_HANDLE && pStats != VMA_NULL);
     VMA_DEBUG_LOG("vmaCalculateVirtualBlockStatistics");
@@ -17658,21 +17567,20 @@ VMA_CALL_PRE void VMA_CALL_POST vmaCalculateVirtualBlockStatistics(VmaVirtualBlo
 #if VMA_STATS_STRING_ENABLED
 
 VMA_CALL_PRE void VMA_CALL_POST vmaBuildVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
-                                                                char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
-                                                                VkBool32                         detailedMap)
+    char* VMA_NULLABLE * VMA_NOT_NULL ppStatsString, VkBool32 detailedMap)
 {
     VMA_ASSERT(virtualBlock != VK_NULL_HANDLE && ppStatsString != VMA_NULL);
     VMA_DEBUG_GLOBAL_MUTEX_LOCK;
     const VkAllocationCallbacks* allocationCallbacks = virtualBlock->GetAllocationCallbacks();
-    VmaStringBuilder             sb(allocationCallbacks);
+    VmaStringBuilder sb(allocationCallbacks);
     virtualBlock->BuildStatsString(detailedMap != VK_FALSE, sb);
     *ppStatsString = VmaCreateStringCopy(allocationCallbacks, sb.GetData(), sb.GetLength());
 }
 
 VMA_CALL_PRE void VMA_CALL_POST vmaFreeVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
-                                                               char* VMA_NULLABLE           pStatsString)
+    char* VMA_NULLABLE pStatsString)
 {
-    if (pStatsString != VMA_NULL)
+    if(pStatsString != VMA_NULL)
     {
         VMA_ASSERT(virtualBlock != VK_NULL_HANDLE);
         VMA_DEBUG_GLOBAL_MUTEX_LOCK;
@@ -17694,8 +17602,8 @@ You can add this file directly to your project and submit it to code repository 
 
 "Single header" doesn't mean that everything is contained in C/C++ declarations,
 like it tends to be in case of inline functions or C++ templates.
-It means that implementation is bundled with interface in a single file and needs to be extracted using preprocessor
-macro. If you don't do it properly, you will get linker errors.
+It means that implementation is bundled with interface in a single file and needs to be extracted using preprocessor macro.
+If you don't do it properly, you will get linker errors.
 
 To do it properly:
 
@@ -17720,7 +17628,7 @@ them before every `#include` of this library.
 This library is written in C++, but has C-compatible interface.
 Thus you can include and use vk_mem_alloc.h in C or C++ code, but full
 implementation with `VMA_IMPLEMENTATION` macro must be compiled as C++, NOT as C.
-Some features of C++14 used. STL containers, RTTI, or C++ exceptions are not used.
+Some features of C++14 are used. STL containers, RTTI, or C++ exceptions are not used.
 
 
 \section quick_start_initialization Initialization
@@ -17734,8 +17642,36 @@ At program startup:
 Only members `physicalDevice`, `device`, `instance` are required.
 However, you should inform the library which Vulkan version do you use by setting
 VmaAllocatorCreateInfo::vulkanApiVersion and which extensions did you enable
-by setting VmaAllocatorCreateInfo::flags (like #VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT for
-VK_KHR_buffer_device_address). Otherwise, VMA would use only features of Vulkan 1.0 core with no extensions.
+by setting VmaAllocatorCreateInfo::flags (like #VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT for VK_KHR_buffer_device_address).
+Otherwise, VMA would use only features of Vulkan 1.0 core with no extensions.
+
+\subsection quick_start_initialization_selecting_vulkan_version Selecting Vulkan version
+
+VMA supports Vulkan version down to 1.0, for backward compatibility.
+If you want to use higher version, you need to inform the library about it.
+This is a two-step process.
+
+<b>Step 1: Compile time.</b> By default, VMA compiles with code supporting the highest
+Vulkan version found in the included `<vulkan/vulkan.h>` that is also supported by the library.
+If this is OK, you don't need to do anything.
+However, if you want to compile VMA as if only some lower Vulkan version was available,
+define macro `VMA_VULKAN_VERSION` before every `#include "vk_mem_alloc.h"`.
+It should have decimal numeric value in form of ABBBCCC, where A = major, BBB = minor, CCC = patch Vulkan version.
+For example, to compile against Vulkan 1.2:
+
+\code
+#define VMA_VULKAN_VERSION 1002000 // Vulkan 1.2
+#include "vk_mem_alloc.h"
+\endcode
+
+<b>Step 2: Runtime.</b> Even when compiled with higher Vulkan version available,
+VMA can use only features of a lower version, which is configurable during creation of the #VmaAllocator object.
+By default, only Vulkan 1.0 is used.
+To initialize the allocator with support for higher Vulkan version, you need to set member
+VmaAllocatorCreateInfo::vulkanApiVersion to an appropriate value, e.g. using constants like `VK_API_VERSION_1_2`.
+See code sample below.
+
+\subsection quick_start_initialization_importing_vulkan_functions Importing Vulkan functions
 
 You may need to configure importing Vulkan functions. There are 3 ways to do this:
 
@@ -17753,7 +17689,15 @@ You may need to configure importing Vulkan functions. There are 3 ways to do thi
    - Define `VMA_STATIC_VULKAN_FUNCTIONS` and `VMA_DYNAMIC_VULKAN_FUNCTIONS` to 0.
    - Pass these pointers via structure #VmaVulkanFunctions.
 
+Example for case 2:
+
 \code
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
+#include "vk_mem_alloc.h"
+
+...
+
 VmaVulkanFunctions vulkanFunctions = {};
 vulkanFunctions.vkGetInstanceProcAddr = &vkGetInstanceProcAddr;
 vulkanFunctions.vkGetDeviceProcAddr = &vkGetDeviceProcAddr;
@@ -17842,8 +17786,7 @@ It is valid, although not very useful.
 The easiest way to specify memory requirements is to fill member
 VmaAllocationCreateInfo::usage using one of the values of enum #VmaMemoryUsage.
 It defines high level, common usage types.
-Since version 3 of the library, it is recommended to use #VMA_MEMORY_USAGE_AUTO to let it select best memory type for
-your resource automatically.
+Since version 3 of the library, it is recommended to use #VMA_MEMORY_USAGE_AUTO to let it select best memory type for your resource automatically.
 
 For example, if you want to create a uniform buffer that will be filled using
 transfer only once or infrequently and then used for rendering every frame as a uniform buffer, you can
@@ -17874,8 +17817,8 @@ This will help the library decide about preferred memory type to ensure it has `
 so you can map it.
 
 For example, a staging buffer that will be filled via mapped pointer and then
-used as a source of transfer to the buffer decribed previously can be created like this.
-It will likely and up in a memory type that is `HOST_VISIBLE` and `HOST_COHERENT`
+used as a source of transfer to the buffer described previously can be created like this.
+It will likely end up in a memory type that is `HOST_VISIBLE` and `HOST_COHERENT`
 but not `HOST_CACHED` (meaning uncached, write-combined) and not `DEVICE_LOCAL` (meaning system RAM).
 
 \code
@@ -17898,7 +17841,7 @@ Usage values `VMA_MEMORY_USAGE_AUTO*` are legal to use only when the library kno
 about the resource being created by having `VkBufferCreateInfo` / `VkImageCreateInfo` passed,
 so they work with functions like: vmaCreateBuffer(), vmaCreateImage(), vmaFindMemoryTypeIndexForBufferInfo() etc.
 If you allocate raw memory using function vmaAllocateMemory(), you have to use other means of selecting
-memory type, as decribed below.
+memory type, as described below.
 
 \note
 Old usage values (`VMA_MEMORY_USAGE_GPU_ONLY`, `VMA_MEMORY_USAGE_CPU_ONLY`,
@@ -18036,8 +17979,7 @@ vmaUnmapMemory(allocator, constantBufferAllocation);
 
 When mapping, you may see a warning from Vulkan validation layer similar to this one:
 
-<i>Mapping an image with layout VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL can result in undefined behavior if
-this memory is used by the device. Only GENERAL or PREINITIALIZED should be used.</i>
+<i>Mapping an image with layout VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL can result in undefined behavior if this memory is used by the device. Only GENERAL or PREINITIALIZED should be used.</i>
 
 It happens because the library maps entire `VkDeviceMemory` block, where different
 types of images and buffers may end up together, especially on GPUs with unified memory like Intel.
@@ -18047,7 +17989,7 @@ object that you wanted to map.
 
 \section memory_mapping_persistently_mapped_memory Persistently mapped memory
 
-Kepping your memory persistently mapped is generally OK in Vulkan.
+Keeping your memory persistently mapped is generally OK in Vulkan.
 You don't need to unmap it before using its data on the GPU.
 The library provides a special feature designed for that:
 Allocations made with #VMA_ALLOCATION_CREATE_MAPPED_BIT flag set in
@@ -18079,8 +18021,8 @@ memcpy(allocInfo.pMappedData, &constantBufferData, sizeof(constantBufferData));
 in a mappable memory type.
 For this, you need to also specify #VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT or
 #VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT.
-#VMA_ALLOCATION_CREATE_MAPPED_BIT only guarantees that if the memory is `HOST_VISIBLE`, the allocation will be mapped on
-creation. For an example of how to make use of this fact, see section \ref usage_patterns_advanced_data_uploading.
+#VMA_ALLOCATION_CREATE_MAPPED_BIT only guarantees that if the memory is `HOST_VISIBLE`, the allocation will be mapped on creation.
+For an example of how to make use of this fact, see section \ref usage_patterns_advanced_data_uploading.
 
 \section memory_mapping_cache_control Cache flush and invalidate
 
@@ -18268,6 +18210,12 @@ vkDestroyImage(allocator, img2, nullptr);
 vkDestroyImage(allocator, img1, nullptr);
 \endcode
 
+VMA also provides convenience functions that create a buffer or image and bind it to memory
+represented by an existing #VmaAllocation:
+vmaCreateAliasingBuffer(), vmaCreateAliasingBuffer2(),
+vmaCreateAliasingImage(), vmaCreateAliasingImage2().
+Versions with "2" offer additional parameter `allocationLocalOffset`.
+
 Remember that using resources that alias in memory requires proper synchronization.
 You need to issue a memory barrier to make sure commands that use `img1` and `img2`
 don't overlap on GPU timeline.
@@ -18403,9 +18351,9 @@ poolCreateInfo.memoryTypeIndex = memTypeIndex;
 When creating buffers/images allocated in that pool, provide following parameters:
 
 - `VkBufferCreateInfo`: Prefer to pass same parameters as above.
-  Otherwise you risk creating resources in a memory type that is not suitable for them, which may result in undefined
-behavior. Using different `VK_BUFFER_USAGE_` flags may work, but you shouldn't create images in a pool intended for
-buffers or the other way around.
+  Otherwise you risk creating resources in a memory type that is not suitable for them, which may result in undefined behavior.
+  Using different `VK_BUFFER_USAGE_` flags may work, but you shouldn't create images in a pool intended for buffers
+  or the other way around.
 - VmaAllocationCreateInfo: You don't need to pass same parameters. Fill only `pool` member.
   Other members are ignored anyway.
 
@@ -18505,8 +18453,8 @@ allocations.
 To mitigate this problem, you can use defragmentation feature.
 It doesn't happen automatically though and needs your cooperation,
 because VMA is a low level library that only allocates memory.
-It cannot recreate buffers and images in a new place as it doesn't remember the contents of `VkBufferCreateInfo` /
-`VkImageCreateInfo` structures. It cannot copy their contents as it doesn't record any commands to a command buffer.
+It cannot recreate buffers and images in a new place as it doesn't remember the contents of `VkBufferCreateInfo` / `VkImageCreateInfo` structures.
+It cannot copy their contents as it doesn't record any commands to a command buffer.
 
 Example:
 
@@ -18532,7 +18480,7 @@ for(;;)
     {
         // Inspect pass.pMoves[i].srcAllocation, identify what buffer/image it represents.
         VmaAllocationInfo allocInfo;
-        vmaGetAllocationInfo(allocator, pMoves[i].srcAllocation, &allocInfo);
+        vmaGetAllocationInfo(allocator, pass.pMoves[i].srcAllocation, &allocInfo);
         MyEngineResourceData* resData = (MyEngineResourceData*)allocInfo.pUserData;
 
         // Recreate and bind this buffer/image at: pass.pMoves[i].dstMemory, pass.pMoves[i].dstOffset.
@@ -18540,7 +18488,7 @@ for(;;)
         VkImage newImg;
         res = vkCreateImage(device, &imgCreateInfo, nullptr, &newImg);
         // Check res...
-        res = vmaBindImageMemory(allocator, pMoves[i].dstTmpAllocation, newImg);
+        res = vmaBindImageMemory(allocator, pass.pMoves[i].dstTmpAllocation, newImg);
         // Check res...
 
         // Issue a vkCmdCopyBuffer/vkCmdCopyImage to copy its content to the new place.
@@ -18592,31 +18540,29 @@ In each pass:
    - Modifies source #VmaAllocation objects that are moved to point to the destination reserved memory.
    - Frees `VkDeviceMemory` blocks that became empty.
 
-Unlike in previous iterations of the defragmentation API, there is no list of "movable" allocations passed as a
-parameter. Defragmentation algorithm tries to move all suitable allocations. You can, however, refuse to move some of
-them inside a defragmentation pass, by setting `pass.pMoves[i].operation` to #VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE.
+Unlike in previous iterations of the defragmentation API, there is no list of "movable" allocations passed as a parameter.
+Defragmentation algorithm tries to move all suitable allocations.
+You can, however, refuse to move some of them inside a defragmentation pass, by setting
+`pass.pMoves[i].operation` to #VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE.
 This is not recommended and may result in suboptimal packing of the allocations after defragmentation.
 If you cannot ensure any allocation can be moved, it is better to keep movable allocations separate in a custom pool.
 
 Inside a pass, for each allocation that should be moved:
 
-- You should copy its data from the source to the destination place by calling e.g. `vkCmdCopyBuffer()`,
-`vkCmdCopyImage()`.
-  - You need to make sure these commands finished executing before destroying the source buffers/images and before
-calling vmaEndDefragmentationPass().
+- You should copy its data from the source to the destination place by calling e.g. `vkCmdCopyBuffer()`, `vkCmdCopyImage()`.
+  - You need to make sure these commands finished executing before destroying the source buffers/images and before calling vmaEndDefragmentationPass().
 - If a resource doesn't contain any meaningful data, e.g. it is a transient color attachment image to be cleared,
   filled, and used temporarily in each rendering frame, you can just recreate this image
   without copying its data.
 - If the resource is in `HOST_VISIBLE` and `HOST_CACHED` memory, you can copy its data on the CPU
   using `memcpy()`.
-- If you cannot move the allocation, you can set `pass.pMoves[i].operation` to
-#VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE. This will cancel the move.
+- If you cannot move the allocation, you can set `pass.pMoves[i].operation` to #VMA_DEFRAGMENTATION_MOVE_OPERATION_IGNORE.
+  This will cancel the move.
   - vmaEndDefragmentationPass() will then free the destination memory
     not the source memory of the allocation, leaving it unchanged.
 - If you decide the allocation is unimportant and can be destroyed instead of moved (e.g. it wasn't used for long time),
   you can set `pass.pMoves[i].operation` to #VMA_DEFRAGMENTATION_MOVE_OPERATION_DESTROY.
-  - vmaEndDefragmentationPass() will then free both source and destination memory, and will destroy the source
-#VmaAllocation object.
+  - vmaEndDefragmentationPass() will then free both source and destination memory, and will destroy the source #VmaAllocation object.
 
 You can defragment a specific custom pool by setting VmaDefragmentationInfo::pool
 (like in the example above) or all the default pools by setting this member to null.
@@ -18624,9 +18570,8 @@ You can defragment a specific custom pool by setting VmaDefragmentationInfo::poo
 Defragmentation is always performed in each pool separately.
 Allocations are never moved between different Vulkan memory types.
 The size of the destination memory reserved for a moved allocation is the same as the original one.
-Alignment of an allocation as it was determined using `vkGetBufferMemoryRequirements()` etc. is also respected after
-defragmentation. Buffers/images should be recreated with the same `VkBufferCreateInfo` / `VkImageCreateInfo` parameters
-as the original ones.
+Alignment of an allocation as it was determined using `vkGetBufferMemoryRequirements()` etc. is also respected after defragmentation.
+Buffers/images should be recreated with the same `VkBufferCreateInfo` / `VkImageCreateInfo` parameters as the original ones.
 
 You can perform the defragmentation incrementally to limit the number of allocations and bytes to be moved
 in each pass, e.g. to call it in sync with render frames and not to experience too big hitches.
@@ -18653,7 +18598,7 @@ especially the amount of memory allocated from Vulkan.
 
 If you need to obtain basic statistics about memory usage per heap, together with current budget,
 you can call function vmaGetHeapBudgets() and inspect structure #VmaBudget.
-This is useful to keep track of memory usage and stay withing budget
+This is useful to keep track of memory usage and stay within budget
 (see also \ref staying_within_budget).
 Example:
 
@@ -18715,7 +18660,7 @@ To do that, fill VmaAllocationCreateInfo::pUserData field when creating
 an allocation. It is an opaque `void*` pointer. You can use it e.g. as a pointer,
 some handle, index, key, ordinal number or any other value that would associate
 the allocation with your custom metadata.
-It it useful to identify appropriate data structures in your engine given #VmaAllocation,
+It is useful to identify appropriate data structures in your engine given #VmaAllocation,
 e.g. when doing \ref defragmentation.
 
 \code
@@ -18767,17 +18712,16 @@ You must do it manually using an extension like VK_EXT_debug_utils, which is ind
 
 \page virtual_allocator Virtual allocator
 
-As an extra feature, the core allocation algorithm of the library is exposed through a simple and convenient API of
-"virtual allocator". It doesn't allocate any real GPU memory. It just keeps track of used and free regions of a "virtual
-block". You can use it to allocate your own memory or other objects, even completely unrelated to Vulkan. A common use
-case is sub-allocation of pieces of one large GPU buffer.
+As an extra feature, the core allocation algorithm of the library is exposed through a simple and convenient API of "virtual allocator".
+It doesn't allocate any real GPU memory. It just keeps track of used and free regions of a "virtual block".
+You can use it to allocate your own memory or other objects, even completely unrelated to Vulkan.
+A common use case is sub-allocation of pieces of one large GPU buffer.
 
 \section virtual_allocator_creating_virtual_block Creating virtual block
 
 To use this functionality, there is no main "allocator" object.
 You don't need to have #VmaAllocator object created.
-All you need to do is to create a separate #VmaVirtualBlock object for each block of memory you want to be managed by
-the allocator:
+All you need to do is to create a separate #VmaVirtualBlock object for each block of memory you want to be managed by the allocator:
 
 -# Fill in #VmaVirtualBlockCreateInfo structure.
 -# Call vmaCreateVirtualBlock(). Get new #VmaVirtualBlock object.
@@ -18797,7 +18741,7 @@ VkResult res = vmaCreateVirtualBlock(&blockCreateInfo, &block);
 #VmaVirtualBlock object contains internal data structure that keeps track of free and occupied regions
 using the same code as the main Vulkan memory allocator.
 Similarly to #VmaAllocation for standard GPU allocations, there is #VmaVirtualAllocation type
-that represents an opaque handle to an allocation withing the virtual block.
+that represents an opaque handle to an allocation within the virtual block.
 
 In order to make such allocation:
 
@@ -18832,8 +18776,8 @@ called for the same #VmaVirtualBlock.
 
 When whole block is no longer needed, the block object can be released by calling vmaDestroyVirtualBlock().
 All allocations must be freed before the block is destroyed, which is checked internally by an assert.
-However, if you don't want to call vmaVirtualFree() for each allocation, you can use vmaClearVirtualBlock() to free them
-all at once - a feature not available in normal Vulkan memory allocator. Example:
+However, if you don't want to call vmaVirtualFree() for each allocation, you can use vmaClearVirtualBlock() to free them all at once -
+a feature not available in normal Vulkan memory allocator. Example:
 
 \code
 vmaVirtualFree(block, alloc);
@@ -18844,8 +18788,8 @@ vmaDestroyVirtualBlock(block);
 
 You can attach a custom pointer to each allocation by using vmaSetVirtualAllocationUserData().
 Its default value is null.
-It can be used to store any data that needs to be associated with that allocation - e.g. an index, a handle, or a
-pointer to some larger data structure containing more information. Example:
+It can be used to store any data that needs to be associated with that allocation - e.g. an index, a handle, or a pointer to some
+larger data structure containing more information. Example:
 
 \code
 struct CustomAllocData
@@ -18859,8 +18803,8 @@ vmaSetVirtualAllocationUserData(block, alloc, allocData);
 
 The pointer can later be fetched, along with allocation offset and size, by passing the allocation handle to function
 vmaGetVirtualAllocationInfo() and inspecting returned structure #VmaVirtualAllocationInfo.
-If you allocated a new object to be used as the custom pointer, don't forget to delete that object before freeing the
-allocation! Example:
+If you allocated a new object to be used as the custom pointer, don't forget to delete that object before freeing the allocation!
+Example:
 
 \code
 VmaVirtualAllocationInfo allocInfo;
@@ -18873,8 +18817,8 @@ vmaVirtualFree(block, alloc);
 \section virtual_allocator_alignment_and_units Alignment and units
 
 It feels natural to express sizes and offsets in bytes.
-If an offset of an allocation needs to be aligned to a multiply of some number (e.g. 4 bytes), you can fill optional
-member VmaVirtualAllocationCreateInfo::alignment to request it. Example:
+If an offset of an allocation needs to be aligned to a multiply of some number (e.g. 4 bytes), you can fill optional member
+VmaVirtualAllocationCreateInfo::alignment to request it. Example:
 
 \code
 VmaVirtualAllocationCreateInfo allocCreateInfo = {};
@@ -18899,8 +18843,8 @@ It might be more convenient, but you need to make sure to use this new unit cons
 You can obtain statistics of a virtual block using vmaGetVirtualBlockStatistics()
 (to get brief statistics that are fast to calculate)
 or vmaCalculateVirtualBlockStatistics() (to get more detailed statistics, slower to calculate).
-The functions fill structures #VmaStatistics, #VmaDetailedStatistics respectively - same as used by the normal Vulkan
-memory allocator. Example:
+The functions fill structures #VmaStatistics, #VmaDetailedStatistics respectively - same as used by the normal Vulkan memory allocator.
+Example:
 
 \code
 VmaStatistics stats;
@@ -18921,11 +18865,10 @@ Keeping track of a whole collection of blocks, allocating new ones when out of f
 deleting empty ones, and deciding which one to try first for a new allocation must be implemented by the user.
 
 Alternative allocation algorithms are supported, just like in custom pools of the real GPU memory.
-See enum #VmaVirtualBlockCreateFlagBits to learn how to specify them (e.g.
-#VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT). You can find their description in chapter \ref custom_memory_pools.
+See enum #VmaVirtualBlockCreateFlagBits to learn how to specify them (e.g. #VMA_VIRTUAL_BLOCK_CREATE_LINEAR_ALGORITHM_BIT).
+You can find their description in chapter \ref custom_memory_pools.
 Allocation strategies are also supported.
-See enum #VmaVirtualAllocationCreateFlagBits to learn how to specify them (e.g.
-#VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT).
+See enum #VmaVirtualAllocationCreateFlagBits to learn how to specify them (e.g. #VMA_VIRTUAL_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT).
 
 Following features are supported only by the allocator of the real GPU memory and not by virtual allocations:
 buffer-image granularity, `VMA_DEBUG_MARGIN`, `VMA_MIN_ALIGNMENT`.
@@ -18939,9 +18882,9 @@ you can use debug features of this library to verify this.
 
 \section debugging_memory_usage_initialization Memory initialization
 
-If you experience a bug with incorrect and nondeterministic data in your program and you suspect uninitialized memory to
-be used, you can enable automatic memory initialization to verify this. To do it, define macro
-`VMA_DEBUG_INITIALIZE_ALLOCATIONS` to 1.
+If you experience a bug with incorrect and nondeterministic data in your program and you suspect uninitialized memory to be used,
+you can enable automatic memory initialization to verify this.
+To do it, define macro `VMA_DEBUG_INITIALIZE_ALLOCATIONS` to 1.
 
 \code
 #define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
@@ -19030,13 +18973,13 @@ VMA provides some features that help with interoperability with OpenGL.
 
 \section opengl_interop_exporting_memory Exporting memory
 
-If you want to attach `VkExportMemoryAllocateInfoKHR` structure to `pNext` chain of memory allocations made by the
-library:
+If you want to attach `VkExportMemoryAllocateInfoKHR` structure to `pNext` chain of memory allocations made by the library:
 
 It is recommended to create \ref custom_memory_pools for such allocations.
-Define and fill in your `VkExportMemoryAllocateInfoKHR` structure and attach it to
-VmaPoolCreateInfo::pMemoryAllocateNext while creating the custom pool. Please note that the structure must remain alive
-and unchanged for the whole lifetime of the #VmaPool, not only while creating it, as no copy of the structure is made,
+Define and fill in your `VkExportMemoryAllocateInfoKHR` structure and attach it to VmaPoolCreateInfo::pMemoryAllocateNext
+while creating the custom pool.
+Please note that the structure must remain alive and unchanged for the whole lifetime of the #VmaPool,
+not only while creating it, as no copy of the structure is made,
 but its original pointer is used for each allocation instead.
 
 If you want to export all memory allocated by the library from certain memory types,
@@ -19047,8 +18990,7 @@ through `VkExportMemoryAllocateInfoKHR` on each allocation made from a specific 
 Please note that new versions of the library also support dedicated allocations created in custom pools.
 
 You should not mix these two methods in a way that allows to apply both to the same memory type.
-Otherwise, `VkExportMemoryAllocateInfoKHR` structure would be attached twice to the `pNext` chain of
-`VkMemoryAllocateInfo`.
+Otherwise, `VkExportMemoryAllocateInfoKHR` structure would be attached twice to the `pNext` chain of `VkMemoryAllocateInfo`.
 
 
 \section opengl_interop_custom_alignment Custom alignment
@@ -19060,16 +19002,15 @@ To impose such alignment:
 It is recommended to create \ref custom_memory_pools for such allocations.
 Set VmaPoolCreateInfo::minAllocationAlignment member to the minimum alignment required for each allocation
 to be made out of this pool.
-The alignment actually used will be the maximum of this member and the alignment returned for the specific buffer or
-image from a function like `vkGetBufferMemoryRequirements`, which is called by VMA automatically.
+The alignment actually used will be the maximum of this member and the alignment returned for the specific buffer or image
+from a function like `vkGetBufferMemoryRequirements`, which is called by VMA automatically.
 
 If you want to create a buffer with a specific minimum alignment out of default pools,
 use special function vmaCreateBufferWithAlignment(), which takes additional parameter `minAlignment`.
 
 Note the problem of alignment affects only resources placed inside bigger `VkDeviceMemory` blocks and not dedicated
-allocations, as these, by definition, always have alignment = 0 because the resource is bound to the beginning of its
-dedicated block. Contrary to Direct3D 12, Vulkan doesn't have a concept of alignment of the entire memory block passed
-on its allocation.
+allocations, as these, by definition, always have alignment = 0 because the resource is bound to the beginning of its dedicated block.
+Contrary to Direct3D 12, Vulkan doesn't have a concept of alignment of the entire memory block passed on its allocation.
 
 
 \page usage_patterns Recommended usage patterns
@@ -19078,8 +19019,7 @@ Vulkan gives great flexibility in memory allocation.
 This chapter shows the most common patterns.
 
 See also slides from talk:
-[Sawicki, Adam. Advanced Graphics Techniques Tutorial: Memory management in Vulkan and DX12. Game Developers Conference,
-2018](https://www.gdcvault.com/play/1025458/Advanced-Graphics-Techniques-Tutorial-New)
+[Sawicki, Adam. Advanced Graphics Techniques Tutorial: Memory management in Vulkan and DX12. Game Developers Conference, 2018](https://www.gdcvault.com/play/1025458/Advanced-Graphics-Techniques-Tutorial-New)
 
 
 \section usage_patterns_gpu_only GPU-only resource
@@ -19127,7 +19067,7 @@ to decrease chances to be evicted to system memory by the operating system.
 \section usage_patterns_staging_copy_upload Staging copy for upload
 
 <b>When:</b>
-A "staging" buffer than you want to map and fill from CPU code, then use as a source od transfer
+A "staging" buffer than you want to map and fill from CPU code, then use as a source of transfer
 to some GPU resource.
 
 <b>What to do:</b>
@@ -19194,13 +19134,13 @@ const float* downloadedData = (const float*)allocInfo.pMappedData;
 \section usage_patterns_advanced_data_uploading Advanced data uploading
 
 For resources that you frequently write on CPU via mapped pointer and
-freqnently read on GPU e.g. as a uniform buffer (also called "dynamic"), multiple options are possible:
+frequently read on GPU e.g. as a uniform buffer (also called "dynamic"), multiple options are possible:
 
 -# Easiest solution is to have one copy of the resource in `HOST_VISIBLE` memory,
    even if it means system RAM (not `DEVICE_LOCAL`) on systems with a discrete graphics card,
    and make the device reach out to that resource directly.
    - Reads performed by the device will then go through PCI Express bus.
-     The performace of this access may be limited, but it may be fine depending on the size
+     The performance of this access may be limited, but it may be fine depending on the size
      of this resource (whether it is small enough to quickly end up in GPU cache) and the sparsity
      of access.
 -# On systems with unified memory (e.g. AMD APU or Intel integrated graphics, mobile chips),
@@ -19273,6 +19213,7 @@ else
 
     // [Executed in runtime]:
     memcpy(stagingAllocInfo.pMappedData, myData, myDataSize);
+    vmaFlushAllocation(allocator, stagingAlloc, 0, VK_WHOLE_SIZE);
     //vkCmdPipelineBarrier: VK_ACCESS_HOST_WRITE_BIT --> VK_ACCESS_TRANSFER_READ_BIT
     VkBufferCopy bufCopy = {
         0, // srcOffset
@@ -19422,8 +19363,7 @@ buffer using vmaCreateBuffer() or image using vmaCreateImage().
 When using the extension together with Vulkan Validation Layer, you will receive
 warnings like this:
 
-_vkBindBufferMemory(): Binding memory to buffer 0x33 but vkGetBufferMemoryRequirements() has not been called on that
-buffer._
+_vkBindBufferMemory(): Binding memory to buffer 0x33 but vkGetBufferMemoryRequirements() has not been called on that buffer._
 
 It is OK, you should just ignore it. It happens because you use function
 `vkGetBufferMemoryRequirements2KHR()` instead of standard
@@ -19432,8 +19372,7 @@ unaware of it.
 
 To learn more about this extension, see:
 
-- [VK_KHR_dedicated_allocation in Vulkan
-specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap50.html#VK_KHR_dedicated_allocation)
+- [VK_KHR_dedicated_allocation in Vulkan specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap50.html#VK_KHR_dedicated_allocation)
 - [VK_KHR_dedicated_allocation unofficial manual](http://asawicki.info/articles/VK_KHR_dedicated_allocation.php5)
 
 
@@ -19457,9 +19396,8 @@ If you want to use this extension in connection with VMA, follow these steps:
 Check if the extension is supported - if returned array of `VkExtensionProperties` contains "VK_EXT_memory_priority".
 
 2) Call `vkGetPhysicalDeviceFeatures2` for the physical device instead of old `vkGetPhysicalDeviceFeatures`.
-Attach additional structure `VkPhysicalDeviceMemoryPriorityFeaturesEXT` to `VkPhysicalDeviceFeatures2::pNext` to be
-returned. Check if the device feature is really supported - check if
-`VkPhysicalDeviceMemoryPriorityFeaturesEXT::memoryPriority` is true.
+Attach additional structure `VkPhysicalDeviceMemoryPriorityFeaturesEXT` to `VkPhysicalDeviceFeatures2::pNext` to be returned.
+Check if the device feature is really supported - check if `VkPhysicalDeviceMemoryPriorityFeaturesEXT::memoryPriority` is true.
 
 3) While creating device with `vkCreateDevice`, enable this extension - add "VK_EXT_memory_priority"
 to the list passed as `VkDeviceCreateInfo::ppEnabledExtensionNames`.
@@ -19477,8 +19415,7 @@ to VmaAllocatorCreateInfo::flags.
 
 When using this extension, you should initialize following member:
 
-- VmaAllocationCreateInfo::priority when creating a dedicated allocation with
-#VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
+- VmaAllocationCreateInfo::priority when creating a dedicated allocation with #VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT.
 - VmaPoolCreateInfo::priority when creating a custom pool.
 
 It should be a floating-point value between `0.0f` and `1.0f`, where recommended default is `0.5f`.
@@ -19538,13 +19475,11 @@ If you want to use this extension in connection with VMA, follow these steps:
 \section vk_amd_device_coherent_memory_initialization Initialization
 
 1) Call `vkEnumerateDeviceExtensionProperties` for the physical device.
-Check if the extension is supported - if returned array of `VkExtensionProperties` contains
-"VK_AMD_device_coherent_memory".
+Check if the extension is supported - if returned array of `VkExtensionProperties` contains "VK_AMD_device_coherent_memory".
 
 2) Call `vkGetPhysicalDeviceFeatures2` for the physical device instead of old `vkGetPhysicalDeviceFeatures`.
-Attach additional structure `VkPhysicalDeviceCoherentMemoryFeaturesAMD` to `VkPhysicalDeviceFeatures2::pNext` to be
-returned. Check if the device feature is really supported - check if
-`VkPhysicalDeviceCoherentMemoryFeaturesAMD::deviceCoherentMemory` is true.
+Attach additional structure `VkPhysicalDeviceCoherentMemoryFeaturesAMD` to `VkPhysicalDeviceFeatures2::pNext` to be returned.
+Check if the device feature is really supported - check if `VkPhysicalDeviceCoherentMemoryFeaturesAMD::deviceCoherentMemory` is true.
 
 3) While creating device with `vkCreateDevice`, enable this extension - add "VK_AMD_device_coherent_memory"
 to the list passed as `VkDeviceCreateInfo::ppEnabledExtensionNames`.
@@ -19573,8 +19508,7 @@ devices. There are multiple ways to do it, for example:
 
 \section vk_amd_device_coherent_memory_more_information More information
 
-To learn more about this extension, see [VK_AMD_device_coherent_memory in Vulkan
-specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_AMD_device_coherent_memory.html)
+To learn more about this extension, see [VK_AMD_device_coherent_memory in Vulkan specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_AMD_device_coherent_memory.html)
 
 Example use of this extension can be found in the code of the sample and test suite
 accompanying this library.
@@ -19595,9 +19529,8 @@ Check if the extension is supported - if returned array of `VkExtensionPropertie
 "VK_KHR_buffer_device_address".
 
 2) Call `vkGetPhysicalDeviceFeatures2` for the physical device instead of old `vkGetPhysicalDeviceFeatures`.
-Attach additional structure `VkPhysicalDeviceBufferDeviceAddressFeatures*` to `VkPhysicalDeviceFeatures2::pNext` to be
-returned. Check if the device feature is really supported - check if
-`VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress` is true.
+Attach additional structure `VkPhysicalDeviceBufferDeviceAddressFeatures*` to `VkPhysicalDeviceFeatures2::pNext` to be returned.
+Check if the device feature is really supported - check if `VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress` is true.
 
 3) (For Vulkan version < 1.2) While creating device with `vkCreateDevice`, enable this extension - add
 "VK_KHR_buffer_device_address" to the list passed as `VkDeviceCreateInfo::ppEnabledExtensionNames`.
@@ -19613,9 +19546,9 @@ to VmaAllocatorCreateInfo::flags.
 
 \section enabling_buffer_device_address_usage Usage
 
-After following steps described above, you can create buffers with `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT*` using
-VMA. The library automatically adds `VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT*` to allocated memory blocks wherever it
-might be needed.
+After following steps described above, you can create buffers with `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT*` using VMA.
+The library automatically adds `VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT*` to
+allocated memory blocks wherever it might be needed.
 
 Please note that the library supports only `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT*`.
 The second part of this functionality related to "capture and replay" is not supported,
@@ -19623,8 +19556,7 @@ as it is intended for usage in debugging tools like RenderDoc, not in everyday V
 
 \section enabling_buffer_device_address_more_information More information
 
-To learn more about this extension, see [VK_KHR_buffer_device_address in Vulkan
-specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap46.html#VK_KHR_buffer_device_address)
+To learn more about this extension, see [VK_KHR_buffer_device_address in Vulkan specification](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap46.html#VK_KHR_buffer_device_address)
 
 Example use of this extension can be found in the code of the sample and test suite
 accompanying this library.
@@ -19665,7 +19597,7 @@ which means version numbers follow convention: Major.Minor.Patch (e.g. 2.3.0), w
 
 All changes between official releases are documented in file "CHANGELOG.md".
 
-\warning Backward compatiblity is considered on the level of C++ source code, not binary linkage.
+\warning Backward compatibility is considered on the level of C++ source code, not binary linkage.
 Adding new members to existing structures is treated as backward compatible if initializing
 the new members to binary zero results in the old behavior.
 You should always fully initialize all library structures to zeros and not rely on their
@@ -19677,12 +19609,10 @@ When using this library, you can meet following types of warnings issued by
 Vulkan validation layer. They don't necessarily indicate a bug, so you may need
 to just ignore them.
 
-- *vkBindBufferMemory(): Binding memory to buffer 0xeb8e4 but vkGetBufferMemoryRequirements() has not been called on
-that buffer.*
+- *vkBindBufferMemory(): Binding memory to buffer 0xeb8e4 but vkGetBufferMemoryRequirements() has not been called on that buffer.*
   - It happens when VK_KHR_dedicated_allocation extension is enabled.
     `vkGetBufferMemoryRequirements2KHR` function is used instead, while validation layer seems to be unaware of it.
-- *Mapping an image with layout VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL can result in undefined behavior if
-this memory is used by the device. Only GENERAL or PREINITIALIZED should be used.*
+- *Mapping an image with layout VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL can result in undefined behavior if this memory is used by the device. Only GENERAL or PREINITIALIZED should be used.*
   - It happens when you map a buffer or image, because the library maps entire
     `VkDeviceMemory` block, where different types of images and buffers may end
     up together, especially on GPUs with unified memory like Intel.
@@ -19729,6 +19659,6 @@ Features deliberately excluded from the scope of this library:
    or conditional expressions constant in some configurations.
    The code of this library should not be bigger or more complicated just to silence these warnings.
    It is recommended to disable such warnings instead.
--# This is a C++ library with C interface. **Bindings or ports to any other programming languages** are welcome as
-external projects but are not going to be included into this repository.
+-# This is a C++ library with C interface. **Bindings or ports to any other programming languages** are welcome as external projects but
+   are not going to be included into this repository.
 */


### PR DESCRIPTION
Fixing snprintf  doesn't support for some platform. However, this 3.1.0 isn't a release version. It's copied from master branch. It needs to be updated again when 3.1.0 is released.

https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator