### PR TITLE
Fix agsInitialize call capture

### DIFF
--- a/framework/decode/custom_ags_replay_consumer.cpp
+++ b/framework/decode/custom_ags_replay_consumer.cpp
@@ -209,9 +209,19 @@ void AgsReplayConsumer::Process_agsInitialize(const ApiCallInfo&      call_info,
     if (ags_dll_loaded_)
     {
         captured_context_ = context;
-        AGSGPUInfo    gpu_info_replay{};
+        AGSGPUInfo gpu_info_replay{};
+
+        if (config != nullptr && (config->allocCallback != nullptr || config->freeCallback != nullptr))
+        {
+            GFXRECON_LOG_WARNING_ONCE(
+                "agsInitialize function was called with a non-null 'config' parameter during capture. "
+                "Now for replay, the parameter is set to a nullptr value, because the callback pointers can't be translated.");
+        }
+
+        AGSConfiguration* forced_config = nullptr;
+
         AGSReturnCode result =
-            ags_dispatch_table_.agsInitialize(agsVersion, config, &current_context_, &gpu_info_replay);
+            ags_dispatch_table_.agsInitialize(agsVersion, forced_config, &current_context_, &gpu_info_replay);
 
         CheckReplayResult("Process_agsInitialize", return_value, result);
     }

--- a/framework/encode/custom_ags_wrappers.cpp
+++ b/framework/encode/custom_ags_wrappers.cpp
@@ -52,25 +52,15 @@ AMD_AGS_API AGSReturnCode agsInitialize(int                     agsVersion,
             shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();
         }
 
-        if (config != nullptr && (config->allocCallback != nullptr || config->freeCallback != nullptr))
-        {
-            GFXRECON_LOG_WARNING_ONCE(
-                "The application calls agsInitialize function with a non-null 'config' parameter. "
-                "GFXR forces the parameter to be a nullptr value. "
-                "The behavior of the application may change.");
-        }
-
-        AGSConfiguration* forced_config = nullptr;
-
         CustomWrapperPreCall<format::ApiCallId::ApiCall_Ags_agsInitialize_6_0_1>::Dispatch(
-            manager, agsVersion, forced_config, context, gpuInfo);
+            manager, agsVersion, config, context, gpuInfo);
 
-        result = manager->GetAgsDispatchTable().agsInitialize(agsVersion, forced_config, context, gpuInfo);
+        result = manager->GetAgsDispatchTable().agsInitialize(agsVersion, config, context, gpuInfo);
 
-        Encode_agsInitialize(result, agsVersion, forced_config, context, gpuInfo);
+        Encode_agsInitialize(result, agsVersion, config, context, gpuInfo);
 
         CustomWrapperPostCall<format::ApiCallId::ApiCall_Ags_agsInitialize_6_0_1>::Dispatch(
-            manager, result, agsVersion, forced_config, context, gpuInfo);
+            manager, result, agsVersion, config, context, gpuInfo);
     }
     else
     {

--- a/framework/encode/custom_ags_wrappers.cpp
+++ b/framework/encode/custom_ags_wrappers.cpp
@@ -52,15 +52,25 @@ AMD_AGS_API AGSReturnCode agsInitialize(int                     agsVersion,
             shared_api_call_lock = D3D12CaptureManager::AcquireSharedApiCallLock();
         }
 
+        if (config != nullptr && (config->allocCallback != nullptr || config->freeCallback != nullptr))
+        {
+            GFXRECON_LOG_WARNING_ONCE(
+                "The application calls agsInitialize function with a non-null 'config' parameter. "
+                "GFXR forces the parameter to be a nullptr value. "
+                "The behavior of the application may change.");
+        }
+
+        AGSConfiguration* forced_config = nullptr;
+
         CustomWrapperPreCall<format::ApiCallId::ApiCall_Ags_agsInitialize_6_0_1>::Dispatch(
-            manager, agsVersion, config, context, gpuInfo);
+            manager, agsVersion, forced_config, context, gpuInfo);
 
-        result = manager->GetAgsDispatchTable().agsInitialize(agsVersion, config, context, gpuInfo);
+        result = manager->GetAgsDispatchTable().agsInitialize(agsVersion, forced_config, context, gpuInfo);
 
-        Encode_agsInitialize(result, agsVersion, config, context, gpuInfo);
+        Encode_agsInitialize(result, agsVersion, forced_config, context, gpuInfo);
 
         CustomWrapperPostCall<format::ApiCallId::ApiCall_Ags_agsInitialize_6_0_1>::Dispatch(
-            manager, result, agsVersion, config, context, gpuInfo);
+            manager, result, agsVersion, forced_config, context, gpuInfo);
     }
     else
     {


### PR DESCRIPTION
**Problem**
Some applications may call agsInitialize() with "config" parameter with callback pointer values. At replay, these callback pointer values can not be resolved and will cause replay crash. 

**Solution**
At the capture time, we will force the call with config=nullptr. The agsInitialize call will also be captured as config being nullptr. Implemented in the call wrapper, because adding log there is more straightforward. 

**Result**
Tested with an application passing in "config" parameter containing valid pointer values. The replay is still OK. 