### PR TITLE
Android capture trigger now appears in logcat

### DIFF
--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -685,11 +685,12 @@ CaptureSettings::ParseMemoryTrackingModeString(const std::string&               
     return result;
 }
 
+#if defined(__ANDROID__)
 CaptureSettings::RuntimeTriggerState
 CaptureSettings::ParseAndroidRunTimeTrimState(const std::string&                   value_string,
                                               CaptureSettings::RuntimeTriggerState default_value)
 {
-    CaptureSettings::RuntimeTriggerState result = default_value;
+    static CaptureSettings::RuntimeTriggerState result = default_value;
 
     if (value_string.empty())
     {
@@ -697,12 +698,23 @@ CaptureSettings::ParseAndroidRunTimeTrimState(const std::string&                
     }
     else
     {
-        result = gfxrecon::util::ParseBoolString(value_string, false) ? RuntimeTriggerState::kEnabled
-                                                                      : RuntimeTriggerState::kDisabled;
+        CaptureSettings::RuntimeTriggerState new_result = gfxrecon::util::ParseBoolString(value_string, false)
+                                                              ? RuntimeTriggerState::kEnabled
+                                                              : RuntimeTriggerState::kDisabled;
+
+        if (new_result != result)
+        {
+            GFXRECON_LOG_INFO("Runtime settings: Option %s was set to %s",
+                              kCaptureAndroidTriggerEnvVar,
+                              new_result == RuntimeTriggerState::kEnabled ? "enabled" : "disabled");
+
+            result = new_result;
+        }
     }
 
     return result;
 }
+#endif
 
 format::CompressionType CaptureSettings::ParseCompressionTypeString(const std::string&      value_string,
                                                                     format::CompressionType default_value)

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -165,8 +165,10 @@ class CaptureSettings
     static MemoryTrackingMode ParseMemoryTrackingModeString(const std::string& value_string,
                                                             MemoryTrackingMode default_value);
 
+#if defined(__ANDROID__)
     static RuntimeTriggerState ParseAndroidRunTimeTrimState(const std::string&  value_string,
                                                             RuntimeTriggerState default_value);
+#endif
 
     static format::CompressionType ParseCompressionTypeString(const std::string&      value_string,
                                                               format::CompressionType default_value);


### PR DESCRIPTION
When debug.gfxrecon.capture_android_trigger is switched between
true/false should now be visible in logcat