### PR TITLE
Check Windows SDK version for D3D12 build in CMake

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -188,7 +188,7 @@ Visual Studio configuration will include support for capturing and replaying Dir
 At this point, you can build the solution from the command line or open the
 generated solution with Visual Studio.
 
-**Note: the build uses Windows 10 SDK 10.0.20348.0. Windows 11 SDK 10.0.22000.194 is not compatible at the present time. If you need to specify a Windows 10 SDK, please use `-DCMAKE_SYSTEM_VERSION=10.0.20348.0`. If Python code generation is required, the shell used to run it should have the environment variable `WindowsSDKVersion=10.0.20348.0\` set too.**
+**Note: The D3D12 build uses Windows 10 SDK 10.0.20348.0. Other Windows SDK versions may not be compatible. If you need to specify a Windows SDK, please use `-DCMAKE_SYSTEM_VERSION=10.0.20348.0`. If Python code generation is required, the shell used to run it should set the environment variable `WindowsSDKVersion=10.0.20348.0`.**
 
 When generating a native build on an ARM64 Windows host the Visual Studio
 Installer can be used to install the required Windows SDK version, `10.0.20348.0`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ if(MSVC)
     # e.g. passed through the commandline -A option: cmake -G "Visual Studio 17 2022" -A ARM64
     message(STATUS "CMAKE_GENERATOR_PLATFORM: " ${CMAKE_GENERATOR_PLATFORM})
 
+    message(STATUS "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION: " ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
+
     set(GFXR_ARM_WINDOWS_BUILD FALSE)
     if(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
         set(GFXR_ARM_WINDOWS_BUILD TRUE)
@@ -163,6 +165,17 @@ if(MSVC)
         if(${CONVERT_EXPERIMENTAL_D3D12})
             add_definitions(-DCONVERT_EXPERIMENTAL_D3D12)
         endif()
+
+        # Check Windows SDK version and print warning if there is a mismatch.
+        set(EXPECTED_WIN_SDK_VER "10.0.20348.0")
+        if (NOT ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} STREQUAL ${EXPECTED_WIN_SDK_VER})
+            message(WARNING
+                "D3D12 support is authored against Windows SDK ${EXPECTED_WIN_SDK_VER}. Windows SDK verison "
+                "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} may not be compatible. If you encounter build errors, "
+                "set D3D12_SUPPORT=OFF or configure the build with the recommended Windows SDK version. See BUILD.md "
+                "for more information.")
+        endif()
+        
     else()
         set(BUILD_LAUNCHER_AND_INTERCEPTOR OFF)
     endif()


### PR DESCRIPTION
Issue a CMake warning if the SDK version doesn't match the version D3D12 was created with.