### PR TITLE
Loosen up frame range check

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -606,7 +606,7 @@ void CaptureManager::CheckContinueCaptureForWriteMode()
                 DestroyStateTracker();
                 compressor_ = nullptr;
             }
-            else if (trim_ranges_[trim_current_range_].first == current_frame_)
+            else if (trim_ranges_[trim_current_range_].first <= current_frame_)
             {
                 // Trimming was configured to capture two consecutive frames, so we need to start a new capture
                 // file for the current frame.
@@ -639,7 +639,7 @@ void CaptureManager::CheckStartCaptureForTrackMode()
 {
     if (!trim_ranges_.empty())
     {
-        if (trim_ranges_[trim_current_range_].first == current_frame_)
+        if (trim_ranges_[trim_current_range_].first <= current_frame_)
         {
             const CaptureSettings::TrimRange& trim_range = trim_ranges_[trim_current_range_];
             bool success = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));


### PR DESCRIPTION
Loosen up frame range check by instead of doing a strict equality check a less than or equal check of the starting frame