### PR TITLE
Add option to skip blit of virtual swapchain

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -922,6 +922,9 @@ optional arguments:
                         AHardwareBuffer*.  (forwarded to replay tool)
   --swapchain MODE      Choose a swapchain mode to replay. Available modes are:
                         virtual, captured, offscreen (forwarded to replay tool)
+  --vssb, --virtual-swapchain-skip-blit
+                        Skip blit to real swapchain to gain performance during
+                        replay. (forwarded to replay tool)
   --use-captured-swapchain-indices
                         Same as "--swapchain captured". Ignored if the "--swapchain" option is used.
   --mfr START-END, --measurement-frame-range START-END

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -648,6 +648,8 @@ Optional arguments:
                                         capture directly on the swapchain setup for replay.
                             offscreen   Disable creating swapchains, surfaces
                                         and windows. To see rendering, add the --screenshots option.
+  --vssb
+                        Skip blit to real swapchain to gain performance during replay.
   --use-captured-swapchain-indices
                         Same as "--swapchain captured". Ignored if the "--swapchain" option is used.
   --measurement-frame-range <start_frame>-<end_frame>

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -93,6 +93,7 @@ def CreateReplayParser():
     parser.add_argument('--flush-inside-measurement-range', action='store_true', default=False, help='If this is specified the replayer will flush and wait for all current GPU work to finish at end of each frame inside the measurement range. (forwarded to replay tool)')
     parser.add_argument('-m', '--memory-translation', metavar='MODE', choices=['none', 'remap', 'realign', 'rebind'], help='Enable memory translation for replay on GPUs with memory types that are not compatible with the capture GPU\'s memory types.  Available modes are: none, remap, realign, rebind (forwarded to replay tool)')
     parser.add_argument('--swapchain', metavar='MODE', choices=['virtual', 'captured', 'offscreen'], help='Choose a swapchain mode to replay. Available modes are: virtual, captured, offscreen (forwarded to replay tool)')
+    parser.add_argument('--vssb', '--virtual-swapchain-skip-blit', action='store_true', default=False, help='Skip blit to real swapchain to gain performance during replay.')
     parser.add_argument('--use-captured-swapchain-indices', action='store_true', default=False, help='Same as "--swapchain captured". Ignored if the "--swapchain" option is used.')
     parser.add_argument('file', nargs='?', help='File on device to play (forwarded to replay tool)')
     return parser
@@ -198,6 +199,9 @@ def MakeExtrasString(args):
     
     if args.offscreen_swapchain_frame_boundary:
         arg_list.append('--offscreen-swapchain-frame-boundary')
+
+    if args.vssb:
+        arg_list.append('--vssb')
 
     if args.memory_translation:
         arg_list.append('-m')

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -32,19 +32,17 @@ VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                       
                                                  VkFlags                             flags,
                                                  HandlePointerDecoder<VkSurfaceKHR>* surface,
                                                  const encode::VulkanInstanceTable*  instance_table,
-                                                 application::Application*           application,
-                                                 const VulkanReplayOptions&          replay_options)
+                                                 application::Application*           application)
 {
     GFXRECON_ASSERT(surface);
 
-    instance_table_        = instance_table;
-    application_           = application;
-    options_surface_index_ = replay_options.surface_index;
-    insert_frame_boundary_ = replay_options.offscreen_swapchain_frame_boundary;
+    instance_table_ = instance_table;
+    application_    = application;
 
     // For multi-surface captures, when replay is restricted to a specific surface, only create a surface for
     // the specified index.
-    if ((options_surface_index_ == -1) || (options_surface_index_ == create_surface_count_))
+    if ((swapchain_options_.select_surface_index == -1) ||
+        (swapchain_options_.select_surface_index == create_surface_count_))
     {
 
         const format::HandleId* id             = surface->GetPointer();

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -41,8 +41,7 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
                                    const encode::VulkanInstanceTable*  instance_table,
-                                   application::Application*           application,
-                                   const VulkanReplayOptions&          replay_options) override;
+                                   application::Application*           application) override;
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const InstanceInfo*          instance_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -181,6 +181,7 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
             break;
         default:
             swapchain_ = std::make_unique<VulkanVirtualSwapchain>();
+            swapchain_->SetPerformanceMode(options.virtual_swapchain_skip_blit);
     }
     if (options_.enable_debug_device_lost)
     {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -181,8 +181,13 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
             break;
         default:
             swapchain_ = std::make_unique<VulkanVirtualSwapchain>();
-            swapchain_->SetPerformanceMode(options.virtual_swapchain_skip_blit);
     }
+
+    VulkanSwapchainOptions swapchain_options;
+    swapchain_options.skip_additional_present_blts = options.virtual_swapchain_skip_blit;
+    swapchain_options.select_surface_index         = options_.surface_index;
+    swapchain_->SetOptions(swapchain_options);
+
     if (options_.enable_debug_device_lost)
     {
         GFXRECON_LOG_WARNING("This debugging feature has not been implemented for Vulkan.");
@@ -2455,25 +2460,6 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
     else
     {
         GFXRECON_LOG_WARNING("The vkCreateInstance parameter pCreateInfo is NULL.");
-    }
-
-    if (options_.offscreen_swapchain_frame_boundary)
-    {
-        bool frameBoundaryExtensionFound = false;
-
-        for (const char* extensionName : filtered_extensions)
-        {
-            if (gfxrecon::util::platform::StringCompareNoCase(extensionName, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
-            {
-                frameBoundaryExtensionFound = true;
-                break;
-            }
-        }
-
-        if (!frameBoundaryExtensionFound)
-        {
-            filtered_extensions.push_back(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
-        }
     }
 
     // Disable layers; any layers needed for replay should be enabled for the replay app with the VK_INSTANCE_LAYERS
@@ -6338,8 +6324,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
@@ -6366,8 +6351,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -6412,8 +6396,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -6462,8 +6445,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -6512,8 +6494,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
@@ -6540,8 +6521,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
@@ -6568,8 +6548,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -6616,8 +6595,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateMetalSurfaceEXT(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get(),
-                                     options_);
+                                     application_.get());
 }
 
 void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -50,6 +50,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         use_colorspace_fallback{ false };
     bool                         offscreen_swapchain_frame_boundary{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
+    bool                         virtual_swapchain_skip_blit{ false };
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -32,11 +32,11 @@ const uint32_t kDefaultWindowHeight    = 240;
 
 void VulkanSwapchain::Clean()
 {
-    if (options_surface_index_ >= create_surface_count_)
+    if (swapchain_options_.select_surface_index >= create_surface_count_)
     {
         GFXRECON_LOG_WARNING("Rendering was restricted to surface index %u, but a surface was never created for that "
                              "index; replay created %d surface(s)",
-                             options_surface_index_,
+                             swapchain_options_.select_surface_index,
                              create_surface_count_);
     }
 
@@ -56,14 +56,12 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
                                         VkFlags                             flags,
                                         HandlePointerDecoder<VkSurfaceKHR>* surface,
                                         const encode::VulkanInstanceTable*  instance_table,
-                                        application::Application*           application,
-                                        const VulkanReplayOptions&          replay_options)
+                                        application::Application*           application)
 {
     assert(instance_info != nullptr);
 
-    instance_table_        = instance_table;
-    application_           = application;
-    options_surface_index_ = replay_options.surface_index;
+    instance_table_ = instance_table;
+    application_    = application;
 
     VkInstance    instance       = instance_info->handle;
     VkSurfaceKHR* replay_surface = nullptr;
@@ -76,7 +74,8 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
 
     // For multi-surface captures, when replay is restricted to a specific surface, only create a surface for
     // the specified index.
-    if ((options_surface_index_ == -1) || (options_surface_index_ == create_surface_count_))
+    if ((swapchain_options_.select_surface_index == -1) ||
+        (swapchain_options_.select_surface_index == create_surface_count_))
     {
         // Create a window for our surface.
         assert(application_);

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -47,6 +47,7 @@ class VulkanSwapchain
     virtual ~VulkanSwapchain() {}
 
     virtual void Clean();
+    virtual void SetPerformanceMode(bool performance_mode) {}
 
     virtual VkResult CreateSurface(VkResult                            original_result,
                                    InstanceInfo*                       instance_info,

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -41,13 +41,23 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 class ScreenshotHandler;
 
+struct VulkanSwapchainOptions
+{
+    bool    skip_additional_present_blts{ false };
+    int32_t select_surface_index{ -1 };
+};
+
 class VulkanSwapchain
 {
   public:
     virtual ~VulkanSwapchain() {}
 
     virtual void Clean();
-    virtual void SetPerformanceMode(bool performance_mode) {}
+
+    void SetOptions(VulkanSwapchainOptions& options)
+    {
+        memcpy(&swapchain_options_, &options, sizeof(VulkanSwapchainOptions));
+    }
 
     virtual VkResult CreateSurface(VkResult                            original_result,
                                    InstanceInfo*                       instance_info,
@@ -55,8 +65,7 @@ class VulkanSwapchain
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
                                    const encode::VulkanInstanceTable*  instance_table,
-                                   application::Application*           application,
-                                   const VulkanReplayOptions&          replay_options);
+                                   application::Application*           application);
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const InstanceInfo*          instance_info,
@@ -161,7 +170,7 @@ class VulkanSwapchain
     application::Application* application_{ nullptr };
     ActiveWindows             active_windows_;
     int32_t                   create_surface_count_{ 0 };
-    int32_t                   options_surface_index_{ 0 };
+    VulkanSwapchainOptions    swapchain_options_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -54,10 +54,7 @@ class VulkanSwapchain
 
     virtual void Clean();
 
-    void SetOptions(VulkanSwapchainOptions& options)
-    {
-        memcpy(&swapchain_options_, &options, sizeof(VulkanSwapchainOptions));
-    }
+    void SetOptions(VulkanSwapchainOptions& options) { swapchain_options_ = options; }
 
     virtual VkResult CreateSurface(VkResult                            original_result,
                                    InstanceInfo*                       instance_info,

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -665,6 +665,11 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
     VkQueue  queue              = queue_info->handle;
     uint32_t queue_family_index = queue_info->family_index;
 
+    if (performance_mode_)
+    {
+        return func(queue, present_info);
+    }
+
     // TODO: Note that this copy could also be used to scale the image, which would allow replay to support an option
     // for changing the window/swapchain size when the virtual swapchain mode is active.  The virtual image would
     // continue to use the captured swapchain image size, and be scaled to the replay swapchain image size with
@@ -820,15 +825,18 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
         VkExtent3D  image_extent = { swapchain_info->width, swapchain_info->height, 1 };
         VkImageCopy image_copy   = { subresource, offset, subresource, offset, image_extent };
 
-        // NOTE: vkCmdCopyImage works on Queues of types including Graphics, Compute
-        //       and Transfer.  So should work on any queues we get a vkQueuePresentKHR from.
-        device_table_->CmdCopyImage(command_buffer,
-                                    virtual_image.image,
-                                    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                    replay_image,
-                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                    1,
-                                    &image_copy);
+        if (!performance_mode_)
+        {
+            // NOTE: vkCmdCopyImage works on Queues of types including Graphics, Compute
+            //       and Transfer.  So should work on any queues we get a vkQueuePresentKHR from.
+            device_table_->CmdCopyImage(command_buffer,
+                                        virtual_image.image,
+                                        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                        replay_image,
+                                        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                        1,
+                                        &image_copy);
+        }
 
         final_barrier_virtual_image.image                         = virtual_image.image;
         final_barrier_virtual_image.subresourceRange.layerCount   = swapchain_info->image_array_layers;

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -31,6 +31,8 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanVirtualSwapchain : public VulkanSwapchain
 {
   public:
+    virtual void SetPerformanceMode(bool performance_mode) override { performance_mode_ = performance_mode; }
+
     virtual ~VulkanVirtualSwapchain() override {}
 
     virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
@@ -163,6 +165,8 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     // Create an unordered map to associate the swapchain resource data with a particular Vulkan swapchain
     std::unordered_map<VkSwapchainKHR, std::unique_ptr<SwapchainResourceData>> swapchain_resources_;
+
+    bool performance_mode_{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -31,8 +31,6 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanVirtualSwapchain : public VulkanSwapchain
 {
   public:
-    virtual void SetPerformanceMode(bool performance_mode) override { performance_mode_ = performance_mode; }
-
     virtual ~VulkanVirtualSwapchain() override {}
 
     virtual VkResult CreateSwapchainKHR(VkResult                              original_result,
@@ -165,8 +163,6 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
 
     // Create an unordered map to associate the swapchain resource data with a particular Vulkan swapchain
     std::unordered_map<VkSwapchainKHR, std::unique_ptr<SwapchainResourceData>> swapchain_resources_;
-
-    bool performance_mode_{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -27,12 +27,12 @@
 #define GFXRECON_REPLAY_SETTINGS_H
 
 const char kOptions[] =
-    "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
-    "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
+    "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--opcd|--"
+    "omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-range,--fmr|--flush-"
-    "measurement-range,--flush-inside-measurement-range,--use-captured-swapchain-indices,--dcp,--"
-    "discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,"
-    "--offscreen-swapchain-frame-boundary";
+    "measurement-range,--flush-inside-measurement-range,--vssb|--virtual-swapchain-skip-blit,--use-captured-swapchain-"
+    "indices,--dcp,--discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,--"
+    "offscreen-swapchain-frame-boundary";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -64,6 +64,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--onhb | --omit-null-hardware-buffers]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--swapchain <mode>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--vssb | --virtual-swapchain-skip-blit]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-captured-swapchain-indices]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-colorspace-fallback]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--offscreen-swapchain-frame-boundary]");
@@ -199,6 +200,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\t         \tcapture directly on the swapchain setup for replay.");
     GFXRECON_WRITE_CONSOLE("          \t\t    %s\tDisable creating swapchains, surfaces", kSwapchainOffscreen);
     GFXRECON_WRITE_CONSOLE("          \t\t         \tand windows. To see rendering, add the --screenshots option.");
+    GFXRECON_WRITE_CONSOLE("  --vssb");
+    GFXRECON_WRITE_CONSOLE("          \t\tSkip blit to real swapchain to gain performance during replay.");
     GFXRECON_WRITE_CONSOLE("  --use-captured-swapchain-indices");
     GFXRECON_WRITE_CONSOLE("          \t\tSame as \"--swapchain captured\".");
     GFXRECON_WRITE_CONSOLE("          \t\tIgnored if the \"--swapchain\" option is used.");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -107,12 +107,14 @@ const char kFlushInsideMeasurementRangeOption[]  = "--flush-inside-measurement-r
 const char kSwapchainOption[]                    = "--swapchain";
 const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
-const char kColorspaceFallback[]              = "--use-colorspace-fallback";
-const char kOffscreenSwapchainFrameBoundary[] = "--offscreen-swapchain-frame-boundary";
-const char kFormatArgument[]                  = "--format";
-const char kIncludeBinariesOption[]           = "--include-binaries";
-const char kExpandFlagsOption[]               = "--expand-flags";
-const char kFilePerFrameOption[]              = "--file-per-frame";
+const char kVirtualSwapchainSkipBlitShortOption[] = "--vssb";
+const char kVirtualSwapchainSkipBlitLongOption[]  = "--virtual-swapchain-skip-blit";
+const char kColorspaceFallback[]                  = "--use-colorspace-fallback";
+const char kOffscreenSwapchainFrameBoundary[]     = "--offscreen-swapchain-frame-boundary";
+const char kFormatArgument[]                      = "--format";
+const char kIncludeBinariesOption[]               = "--include-binaries";
+const char kExpandFlagsOption[]                   = "--expand-flags";
+const char kFilePerFrameOption[]                  = "--file-per-frame";
 #if defined(WIN32)
 const char kApiFamilyOption[]             = "--api";
 const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
@@ -903,6 +905,12 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (arg_parser.IsOptionSet(kOffscreenSwapchainFrameBoundary))
     {
         replay_options.offscreen_swapchain_frame_boundary = true;
+    }
+
+    if (arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitLongOption) ||
+        arg_parser.IsOptionSet(kVirtualSwapchainSkipBlitShortOption))
+    {
+        replay_options.virtual_swapchain_skip_blit = true;
     }
 
     replay_options.replace_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);


### PR DESCRIPTION
Add an option during replay to skip blitting virtual swapchain to real swapchain to remove the overhead of the blit. This overhead is noticeable for microbenchmarks and impacts hardware counter analysis.
The option is "--vssb" or "--virtual-swapchain-skip-blit".