### PR TITLE
Fix --log-file option for Android during replay

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -715,6 +715,12 @@ optional arguments:
   -h, --help            show this help message and exit
   --version             Print version information and exit (forwarded to
                         replay tool)
+  --log-level LEVEL     Specify highest level message to log. Options are:
+                        debug, info, warning, error, and fatal. Default is
+                        info. (forwarded to replay tool)
+  --log-file DEVICE_FILE
+                        Write log messages to a file at the specified path
+                        instead of logcat (forwarded to replay tool)
   --pause-frame N       Pause after replaying frame number N (forwarded to
                         replay tool)
   --paused              Pause after replaying the first frame (same as "--

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -66,6 +66,8 @@ def CreateReplayParser():
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]) + ' replay', description='Launch the replay tool.')
     parser.add_argument('-p', '--push-file', metavar='LOCAL_FILE', help='Local file to push to the location on device specified by <file>')
     parser.add_argument('--version', action='store_true', default=False, help='Print version information and exit (forwarded to replay tool)')
+    parser.add_argument('--log-level', metavar='LEVEL', help='Specify highest level message to log. Options are: debug, info, warning, error, and fatal. Default is info. (forwarded to replay tool)')
+    parser.add_argument('--log-file', metavar='DEVICE_FILE', help='Write log messages to a file at the specified path instead of logcat (forwarded to replay tool)')
     parser.add_argument('--pause-frame', metavar='N', help='Pause after replaying frame number N (forwarded to replay tool)')
     parser.add_argument('--paused', action='store_true', default=False, help='Pause after replaying the first frame (same as "--pause-frame 1"; forwarded to replay tool)')
     parser.add_argument('--screenshot-all', action='store_true', default=False, help='Generate screenshots for all frames.  When this option is specified, --screenshots is ignored (forwarded to replay tool)')
@@ -91,6 +93,14 @@ def MakeExtrasString(args):
 
     if args.version:
         arg_list.append('--version')
+
+    if args.log_level:
+        arg_list.append('--log-level')
+        arg_list.append('{}'.format(args.log_level))
+
+    if args.log_file:
+        arg_list.append('--log-file')
+        arg_list.append('{}'.format(args.log_file))
 
     if args.pause_frame:
         arg_list.append('--pause-frame')

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -84,6 +84,12 @@ void android_main(struct android_app* app)
 
     if (run)
     {
+        // Reinitialize logging with values retrieved from command line arguments
+        gfxrecon::util::Log::Settings log_settings;
+        GetLogSettings(arg_parser, log_settings);
+        gfxrecon::util::Log::Release();
+        gfxrecon::util::Log::Init(log_settings);
+
         std::string filename = kDefaultCaptureFile;
 
         if (arg_parser.GetPositionalArgumentsCount() == 1)


### PR DESCRIPTION
Add the `--log-file` and `--log-level` options for android at replay time. It is needed in android environments where logcat isn't available.