### PR TITLE
Add used resolutions info

### DIFF
--- a/framework/decode/vulkan_stats_consumer.h
+++ b/framework/decode/vulkan_stats_consumer.h
@@ -30,8 +30,8 @@
 #include "generated/generated_vulkan_struct_decoders.h"
 #include "generated/generated_vulkan_consumer.h"
 #include "util/defines.h"
-#include "vulkan/vulkan.hpp"
 #include "vulkan/vulkan_hash.hpp"
+#include "vulkan/vulkan_structs.hpp"
 
 #include "vulkan/vulkan.h"
 

--- a/framework/decode/vulkan_stats_consumer.h
+++ b/framework/decode/vulkan_stats_consumer.h
@@ -420,7 +420,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         gfxrecon::format::HandleId                                                                  device,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*    pAllocator,
-        gfxrecon::decode::HandlePointerDecoder<VkSwapchainKHR>*                                     pSwapchain)
+        gfxrecon::decode::HandlePointerDecoder<VkSwapchainKHR>*                                     pSwapchain) override
     {
         if (!pCreateInfo->IsNull())
         {
@@ -436,7 +436,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
                                         uint32_t                                                swapchainCount,
                                         StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfos,
                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
-                                        HandlePointerDecoder<VkSwapchainKHR>*                   pSwapchains)
+                                        HandlePointerDecoder<VkSwapchainKHR>*                   pSwapchains) override
     {
         if (!pCreateInfos->IsNull())
         {

--- a/tools/info/CMakeLists.txt
+++ b/tools/info/CMakeLists.txt
@@ -46,6 +46,7 @@ if (MSVC)
 endif()
 
 target_include_directories(gfxrecon-info PUBLIC ${CMAKE_BINARY_DIR})
+target_compile_definitions(gfxrecon_decode PUBLIC VULKAN_HPP_NO_STRUCT_SETTERS)
 
 target_link_libraries(gfxrecon-info
                       gfxrecon_decode

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -414,6 +414,12 @@ void PrintVulkanStats(const gfxrecon::decode::VulkanStatsConsumer& vulkan_stats_
         GFXRECON_WRITE_CONSOLE("\tEngine name: %s", vulkan_stats_consumer.GetEngineName().c_str());
         GFXRECON_WRITE_CONSOLE("\tEngine version: %u", vulkan_stats_consumer.GetEngineVersion());
         GFXRECON_WRITE_CONSOLE("\tTarget API version: %u (%s)", api_version, GetVersionString(api_version).c_str());
+        std::string resolutions = "\tUsed resolutions: ";
+        for (const auto& resolution : vulkan_stats_consumer.GetResolutions())
+        {
+            resolutions += std::to_string(resolution.width) + "x" + std::to_string(resolution.height) + " ";
+        }
+        GFXRECON_WRITE_CONSOLE(resolutions.c_str());
 
         // Properties for physical devices used to create logical devices.
         std::vector<const VkPhysicalDeviceProperties*> used_device_properties;

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -414,12 +414,16 @@ void PrintVulkanStats(const gfxrecon::decode::VulkanStatsConsumer& vulkan_stats_
         GFXRECON_WRITE_CONSOLE("\tEngine name: %s", vulkan_stats_consumer.GetEngineName().c_str());
         GFXRECON_WRITE_CONSOLE("\tEngine version: %u", vulkan_stats_consumer.GetEngineVersion());
         GFXRECON_WRITE_CONSOLE("\tTarget API version: %u (%s)", api_version, GetVersionString(api_version).c_str());
-        std::string resolutions = "\tUsed resolutions: ";
-        for (const auto& resolution : vulkan_stats_consumer.GetResolutions())
+
+        if (!vulkan_stats_consumer.GetResolutions().empty())
         {
-            resolutions += std::to_string(resolution.width) + "x" + std::to_string(resolution.height) + " ";
+            std::string resolutions = "\tUsed resolutions: ";
+            for (const auto& resolution : vulkan_stats_consumer.GetResolutions())
+            {
+                resolutions += std::to_string(resolution.width) + "x" + std::to_string(resolution.height) + " ";
+            }
+            GFXRECON_WRITE_CONSOLE(resolutions.c_str());
         }
-        GFXRECON_WRITE_CONSOLE(resolutions.c_str());
 
         // Properties for physical devices used to create logical devices.
         std::vector<const VkPhysicalDeviceProperties*> used_device_properties;


### PR DESCRIPTION
gfxrecon-info reports resolutions used in vulkan traces based on data provided in vkCreateSwapchainKHR and vkCreateSharedSwapchainsKHR calls.

Sample output:
```
Exe info:
        Application exe name: 
        Application version: 0.0.0.0
        Application Company name: 
        Product name: 
File info:
        Compression format: LZ4
        Total frames: 11

Application info:
        Application name: ray_queries
        Application version: 0
        Engine name: Vulkan Samples
        Engine version: 0
        Target API version: 4198400 (1.1.0)
        Used resolutions: 1280x720

Physical device info:
        Device name: NVIDIA GeForce RTX 2060
        Device ID: 0x1e89
        Vendor ID: 0x10de
        Driver version: 2181955968 (0x820e0180)
        API version: 4206797 (1.3.205)

Device memory allocation info:
        Total allocations: 12
        Min allocation size: 3932160
        Max allocation size: 134217728

Pipeline info:
        Total graphics pipelines: 2
        Total compute pipelines: 0

```
