### PR TITLE
Fixed Linking disable_popup_result for all Tools

### DIFF
--- a/tools/compress/CMakeLists.txt
+++ b/tools/compress/CMakeLists.txt
@@ -40,9 +40,9 @@ if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-compress PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-compress PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
     endif()
 endif()
 

--- a/tools/convert/CMakeLists.txt
+++ b/tools/convert/CMakeLists.txt
@@ -36,9 +36,9 @@ if (MSVC)
       # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
       # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
       if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-         target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+         target_link_options(gfxrecon-convert PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
       else()
-            target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+            target_link_options(gfxrecon-convert PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
       endif()
 endif()
 

--- a/tools/extract/CMakeLists.txt
+++ b/tools/extract/CMakeLists.txt
@@ -38,9 +38,9 @@ if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-extract PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-extract PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
     endif()
 endif()
 

--- a/tools/info/CMakeLists.txt
+++ b/tools/info/CMakeLists.txt
@@ -38,9 +38,9 @@ if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-info PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-info PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
     endif()
 endif()
 

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -48,9 +48,9 @@ if (MSVC)
     # Force inclusion of "gfxrecon_disable_popup_result" variable in linking.
     # On 32-bit windows, MSVC prefixes symbols with "_" but on 64-bit windows it doesn't.
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-optimize PUBLIC "LINKER:/Include:_gfxrecon_disable_popup_result")
     else()
-      target_link_options(gfxrecon-replay PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
+      target_link_options(gfxrecon-optimize PUBLIC "LINKER:/Include:gfxrecon_disable_popup_result")
     endif()
 endif()
 


### PR DESCRIPTION
Previously each tool's CMakeLists.txt was restating the linkage for the replay tool.