### PR TITLE
Replaced Stray "rec_command_index"

### DIFF
--- a/framework/generated/generated_vulkan_export_json_consumer.cpp
+++ b/framework/generated/generated_vulkan_export_json_consumer.cpp
@@ -9104,7 +9104,7 @@ void VulkanExportJsonConsumer::Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(
     VkImageAspectFlags                          aspectMask)
 {
     nlohmann::ordered_json& jdata = WriteApiCallStart(call_info, "vkCmdSetAttachmentFeedbackLoopEnableEXT");
-    FieldToJson(jdata["rec_command_index"], GetCommandBufferRecordIndex(commandBuffer), json_options_);
+    FieldToJson(jdata[NameCommandIndex()], GetCommandBufferRecordIndex(commandBuffer), json_options_);
     auto& args = jdata[NameArgs()];
         HandleToJson(args["commandBuffer"], commandBuffer, json_options_);
         FieldToJson(VkImageAspectFlags_t(), args["aspectMask"], aspectMask, json_options_);


### PR DESCRIPTION
This should not be here in a generated file. It must be a merge artifact from a PR made against a dev that predated the replacement of that JSON field.