### PR TITLE
Add trace preload option

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/descriptor_update_template_decoder.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/file_processor.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/file_processor.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/preload_file_processor.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/preload_file_processor.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/file_transformer.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/file_transformer.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/handle_pointer_decoder.h

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -24,6 +24,7 @@
 #include "application/application.h"
 #include "util/logging.h"
 #include "util/platform.h"
+#include "decode/preload_file_processor.h"
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 #include "application/win32_context.h"
@@ -149,6 +150,14 @@ void Application::Run()
                 if (fps_info_->ShouldWaitIdleBeforeFrame(frame_number))
                 {
                     file_processor_->WaitDecodersIdle();
+                }
+
+                auto preload_frames_count = fps_info_->ShouldPreloadFrames(frame_number);
+                if (preload_frames_count > 0U)
+                {
+                    auto* preload_processor = dynamic_cast<decode::PreloadFileProcessor*>(file_processor_);
+                    GFXRECON_ASSERT(preload_processor)
+                    preload_processor->PreloadNextFrames(preload_frames_count);
                 }
 
                 fps_info_->BeginFrame(frame_number);

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -61,6 +61,8 @@ target_sources(gfxrecon_decode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_object_info.h>
                     ${CMAKE_CURRENT_LIST_DIR}/file_processor.h
                     ${CMAKE_CURRENT_LIST_DIR}/file_processor.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/preload_file_processor.h
+                    ${CMAKE_CURRENT_LIST_DIR}/preload_file_processor.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/file_transformer.h
                     ${CMAKE_CURRENT_LIST_DIR}/file_transformer.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/handle_pointer_decoder.h

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -243,12 +243,7 @@ bool FileProcessor::ProcessBlocks()
 
     while (success)
     {
-        if (enable_print_block_info_ && ((block_index_from_ < 0 || block_index_to_ < 0) ||
-                                         (block_index_from_ <= block_index_ && block_index_to_ >= block_index_)))
-        {
-            GFXRECON_LOG_INFO(
-                "block info: index: %" PRIu64 ", current frame: %" PRIu64 "", block_index_, current_frame_number_);
-        }
+        PrintBlockInfo();
         success = ContinueDecoding();
 
         if (success)
@@ -2005,6 +2000,16 @@ bool FileProcessor::IsFrameDelimiter(format::ApiCallId call_id) const
                 (call_id == format::ApiCallId::ApiCall_vkFrameBoundaryANDROID) ||
                 (call_id == format::ApiCallId::ApiCall_IDXGISwapChain_Present) ||
                 (call_id == format::ApiCallId::ApiCall_IDXGISwapChain1_Present1));
+    }
+}
+
+void FileProcessor::PrintBlockInfo() const
+{
+    if (enable_print_block_info_ && ((block_index_from_ < 0 || block_index_to_ < 0) ||
+                                     (block_index_from_ <= block_index_ && block_index_to_ >= block_index_)))
+    {
+        GFXRECON_LOG_INFO(
+            "block info: index: %" PRIu64 ", current frame: %" PRIu64 "", block_index_, current_frame_number_);
     }
 }
 

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -141,6 +141,8 @@ class FileProcessor
 
     bool ProcessAnnotation(const format::BlockHeader& block_header, format::AnnotationType annotation_type);
 
+    void PrintBlockInfo() const;
+
   protected:
     FILE*                    file_descriptor_;
     uint64_t                 current_frame_number_;

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -58,6 +58,13 @@ class FileProcessor
         kErrorUnsupportedCompressionType   = -10
     };
 
+    enum BlockProcessReturn : int32_t
+    {
+        kSuccess = 0,
+        kFailure = 1,
+        kBreak   = 2,
+    };
+
   public:
     FileProcessor();
 
@@ -115,9 +122,9 @@ class FileProcessor
 
     bool SkipBytes(size_t skip_size);
 
-    bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id);
+    bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id, bool& should_break);
 
-    bool ProcessMethodCall(const format::BlockHeader& block_header, format::ApiCallId call_id);
+    bool ProcessMethodCall(const format::BlockHeader& block_header, format::ApiCallId call_id, bool& should_break);
 
     bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataId meta_data_id);
 
@@ -127,7 +134,8 @@ class FileProcessor
 
     void HandleBlockReadError(Error error_code, const char* error_message);
 
-    bool ProcessFrameMarker(const format::BlockHeader& block_header, format::MarkerType marker_type);
+    bool
+    ProcessFrameMarker(const format::BlockHeader& block_header, format::MarkerType marker_type, bool& should_break);
 
     bool ProcessStateMarker(const format::BlockHeader& block_header, format::MarkerType marker_type);
 

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -111,7 +111,7 @@ class FileProcessor
 
     bool ReadBlockHeader(format::BlockHeader* block_header);
 
-    bool ReadBytes(void* buffer, size_t buffer_size);
+    virtual bool ReadBytes(void* buffer, size_t buffer_size);
 
     bool SkipBytes(size_t skip_size);
 
@@ -139,6 +139,7 @@ class FileProcessor
     std::vector<ApiDecoder*> decoders_;
     AnnotationHandler*       annotation_handler_;
     Error                    error_state_;
+    uint64_t                 bytes_read_;
 
     /// @brief Incremented at the end of every block successfully processed.
     uint64_t block_index_;
@@ -163,7 +164,6 @@ class FileProcessor
     format::FileHeader                  file_header_;
     std::vector<format::FileOptionPair> file_options_;
     format::EnabledOptions              enabled_options_;
-    uint64_t                            bytes_read_;
     std::vector<uint8_t>                parameter_buffer_;
     std::vector<uint8_t>                compressed_parameter_buffer_;
     util::Compressor*                   compressor_;

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -115,12 +115,10 @@ bool PreloadFileProcessor::ProcessBlocks()
                         }
                         else
                         {
-                            success = ProcessFunctionCall(block_header, api_call_id);
-                            if (is_frame_delimiter)
+                            bool should_break = false;
+                            success           = ProcessFunctionCall(block_header, api_call_id, should_break);
+                            if (should_break)
                             {
-                                // Make sure to increment the frame number on the way out.
-                                ++current_frame_number_;
-                                ++block_index_;
                                 break;
                             }
                         }
@@ -159,12 +157,10 @@ bool PreloadFileProcessor::ProcessBlocks()
                         }
                         else
                         {
-                            success = ProcessMethodCall(block_header, api_call_id);
-                            if (is_frame_delimiter)
+                            bool should_break = false;
+                            success           = ProcessMethodCall(block_header, api_call_id, should_break);
+                            if (should_break)
                             {
-                                // Make sure to increment the frame number on the way out.
-                                ++current_frame_number_;
-                                ++block_index_;
                                 break;
                             }
                         }
@@ -214,9 +210,9 @@ bool PreloadFileProcessor::ProcessBlocks()
 
                     if (success)
                     {
-                        const auto is_frame_delimiter = IsFrameDelimiter(block_header.type, marker_type);
                         if (status_ == PreloadStatus::kRecord)
                         {
+                            const auto is_frame_delimiter = IsFrameDelimiter(block_header.type, marker_type);
                             preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
                             preload_buffer_.Add(&block_header);
                             preload_buffer_.Add(&marker_type);
@@ -234,12 +230,11 @@ bool PreloadFileProcessor::ProcessBlocks()
                         }
                         else
                         {
-                            success = ProcessFrameMarker(block_header, marker_type);
-                            if (is_frame_delimiter)
+                            bool should_break = false;
+                            success           = ProcessFrameMarker(block_header, marker_type, should_break);
+
+                            if (should_break)
                             {
-                                // Make sure to increment the frame number on the way out.
-                                ++current_frame_number_;
-                                ++block_index_;
                                 break;
                             }
                         }

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -97,12 +97,7 @@ bool PreloadFileProcessor::ProcessBlocks()
                         const auto is_frame_delimiter = IsFrameDelimiter(api_call_id);
                         if (status_ == PreloadStatus::kRecord)
                         {
-                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
-                            preload_buffer_.Add(&block_header);
-                            preload_buffer_.Add(&api_call_id);
-                            size_t parameters_size  = block_header.size - sizeof(api_call_id);
-                            auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
-                            success                 = ReadBytes(parameter_buffer, parameters_size);
+                            success = ReadParameterBytes(block_header, api_call_id, preload_buffer_);
                             if (!success)
                             {
                                 HandleBlockReadError(kErrorReadingBlockData, "Failed to read function call block data");
@@ -139,12 +134,7 @@ bool PreloadFileProcessor::ProcessBlocks()
                         const auto is_frame_delimiter = IsFrameDelimiter(api_call_id);
                         if (status_ == PreloadStatus::kRecord)
                         {
-                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
-                            preload_buffer_.Add(&block_header);
-                            preload_buffer_.Add(&api_call_id);
-                            size_t parameters_size  = block_header.size - sizeof(api_call_id);
-                            auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
-                            success                 = ReadBytes(parameter_buffer, parameters_size);
+                            success = ReadParameterBytes(block_header, api_call_id, preload_buffer_);
                             if (!success)
                             {
                                 HandleBlockReadError(kErrorReadingBlockData,
@@ -174,11 +164,7 @@ bool PreloadFileProcessor::ProcessBlocks()
                 {
                     if (status_ == PreloadStatus::kRecord)
                     {
-                        preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
-                        preload_buffer_.Add(&block_header);
-                        size_t parameters_size  = block_header.size;
-                        auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
-                        success                 = ReadBytes(parameter_buffer, parameters_size);
+                        success = ReadParameterBytes(block_header, preload_buffer_);
                         if (!success)
                         {
                             HandleBlockReadError(kErrorReadingBlockData, "Failed to preload meta-data block");
@@ -213,12 +199,7 @@ bool PreloadFileProcessor::ProcessBlocks()
                         if (status_ == PreloadStatus::kRecord)
                         {
                             const auto is_frame_delimiter = IsFrameDelimiter(block_header.type, marker_type);
-                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
-                            preload_buffer_.Add(&block_header);
-                            preload_buffer_.Add(&marker_type);
-                            size_t parameters_size  = block_header.size - sizeof(marker_type);
-                            auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
-                            success                 = ReadBytes(parameter_buffer, parameters_size);
+                            success = ReadParameterBytes(block_header, marker_type, preload_buffer_);
                             if (!success)
                             {
                                 HandleBlockReadError(kErrorReadingBlockData, "Failed to preload frame marker block");
@@ -251,11 +232,7 @@ bool PreloadFileProcessor::ProcessBlocks()
 
                     if (status_ == PreloadStatus::kRecord)
                     {
-                        preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
-                        preload_buffer_.Add(&block_header);
-                        size_t parameters_size  = block_header.size;
-                        auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
-                        success                 = ReadBytes(parameter_buffer, parameters_size);
+                        success = ReadParameterBytes(block_header, preload_buffer_);
                         if (!success)
                         {
                             HandleBlockReadError(kErrorReadingBlockData, "Failed to preload state marker block data");
@@ -281,10 +258,7 @@ bool PreloadFileProcessor::ProcessBlocks()
                     {
                         if (status_ == PreloadStatus::kRecord)
                         {
-                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
-                            preload_buffer_.Add(&block_header);
-                            auto* parameter_buffer = preload_buffer_.Add(block_header.size);
-                            success                = ReadBytes(parameter_buffer, block_header.size);
+                            success = ReadParameterBytes(block_header, preload_buffer_);
                             if (!success)
                             {
                                 HandleBlockReadError(kErrorReadingBlockData, "Failed to preload annotation block data");

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -1,0 +1,375 @@
+/*
+** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "decode/preload_file_processor.h"
+#include "util/logging.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+PreloadFileProcessor::PreloadFileProcessor() : status_(PreloadStatus::kInactive) {}
+
+void PreloadFileProcessor::PreloadNextFrames(size_t count)
+{
+    status_ = PreloadStatus::kRecord;
+    while (--count != 0U)
+    {
+        ProcessNextFrame();
+    }
+    status_ = PreloadStatus::kReplay;
+}
+
+PreloadFileProcessor::PreloadBuffer::PreloadBuffer() : replay_offset_(0) {}
+
+void PreloadFileProcessor::PreloadBuffer::Reserve(size_t size)
+{
+    container_.reserve(container_.size() + size);
+}
+
+size_t PreloadFileProcessor::PreloadBuffer::Read(void* destination, size_t destination_size)
+{
+    auto remaining_buffer_data = container_.size() - replay_offset_;
+    auto read_size             = destination_size > remaining_buffer_data ? remaining_buffer_data : destination_size;
+    memcpy(destination, &container_[replay_offset_], read_size);
+    replay_offset_ += read_size;
+    return read_size;
+}
+
+void PreloadFileProcessor::PreloadBuffer::Reset()
+{
+    container_.clear();
+    container_.shrink_to_fit();
+    replay_offset_ = 0;
+}
+
+bool PreloadFileProcessor::ProcessBlocks()
+{
+    format::BlockHeader block_header;
+    bool                success = true;
+
+    while (success)
+    {
+        success = ContinueDecoding();
+
+        if (success)
+        {
+            success = ReadBlockHeader(&block_header);
+
+            if (status_ != PreloadStatus::kRecord)
+            {
+                // Since block_index isn't relevant during recording, skip setting it in the decoders
+                for (auto* decoder : decoders_)
+                {
+                    decoder->SetCurrentBlockIndex(block_index_);
+                }
+            }
+
+            if (success)
+            {
+                if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kFunctionCallBlock)
+                {
+                    format::ApiCallId api_call_id = format::ApiCallId::ApiCall_Unknown;
+
+                    success = ReadBytes(&api_call_id, sizeof(api_call_id));
+
+                    if (success)
+                    {
+                        const auto is_frame_delimiter = IsFrameDelimiter(api_call_id);
+                        if (status_ == PreloadStatus::kRecord)
+                        {
+                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
+                            preload_buffer_.Add(&block_header);
+                            preload_buffer_.Add(&api_call_id);
+                            size_t parameters_size  = block_header.size - sizeof(api_call_id);
+                            auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
+                            success                 = ReadBytes(parameter_buffer, parameters_size);
+                            if (!success)
+                            {
+                                HandleBlockReadError(kErrorReadingBlockData, "Failed to read function call block data");
+                            }
+
+                            if (is_frame_delimiter)
+                            {
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            success = ProcessFunctionCall(block_header, api_call_id);
+                            if (is_frame_delimiter)
+                            {
+                                // Make sure to increment the frame number on the way out.
+                                ++current_frame_number_;
+                                ++block_index_;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read function call block header");
+                    }
+                }
+                else if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kMethodCallBlock)
+                {
+                    format::ApiCallId api_call_id = format::ApiCallId::ApiCall_Unknown;
+
+                    success = ReadBytes(&api_call_id, sizeof(api_call_id));
+
+                    if (success)
+                    {
+                        const auto is_frame_delimiter = IsFrameDelimiter(api_call_id);
+                        if (status_ == PreloadStatus::kRecord)
+                        {
+                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
+                            preload_buffer_.Add(&block_header);
+                            preload_buffer_.Add(&api_call_id);
+                            size_t parameters_size  = block_header.size - sizeof(api_call_id);
+                            auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
+                            success                 = ReadBytes(parameter_buffer, parameters_size);
+                            if (!success)
+                            {
+                                HandleBlockReadError(kErrorReadingBlockData,
+                                                     "Failed to preload method call block data");
+                            }
+                            if (is_frame_delimiter)
+                            {
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            success = ProcessMethodCall(block_header, api_call_id);
+                            if (is_frame_delimiter)
+                            {
+                                // Make sure to increment the frame number on the way out.
+                                ++current_frame_number_;
+                                ++block_index_;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read function call block header");
+                    }
+                }
+                else if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kMetaDataBlock)
+                {
+                    if (status_ == PreloadStatus::kRecord)
+                    {
+                        preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
+                        preload_buffer_.Add(&block_header);
+                        size_t parameters_size  = block_header.size;
+                        auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
+                        success                 = ReadBytes(parameter_buffer, parameters_size);
+                        if (!success)
+                        {
+                            HandleBlockReadError(kErrorReadingBlockData, "Failed to preload meta-data block");
+                        }
+                    }
+                    else
+                    {
+                        format::MetaDataId meta_data_id = format::MakeMetaDataId(
+                            format::ApiFamilyId::ApiFamily_None, format::MetaDataType::kUnknownMetaDataType);
+
+                        success = ReadBytes(&meta_data_id, sizeof(meta_data_id));
+
+                        if (success)
+                        {
+                            success = ProcessMetaData(block_header, meta_data_id);
+                        }
+                        else
+                        {
+                            HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read meta-data block header");
+                        }
+                    }
+                }
+                else if (block_header.type == format::BlockType::kFrameMarkerBlock)
+                {
+                    format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
+                    uint64_t           frame_number = 0;
+
+                    success = ReadBytes(&marker_type, sizeof(marker_type));
+
+                    if (success)
+                    {
+                        const auto is_frame_delimiter = IsFrameDelimiter(block_header.type, marker_type);
+                        if (status_ == PreloadStatus::kRecord)
+                        {
+                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
+                            preload_buffer_.Add(&block_header);
+                            preload_buffer_.Add(&marker_type);
+                            size_t parameters_size  = block_header.size - sizeof(marker_type);
+                            auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
+                            success                 = ReadBytes(parameter_buffer, parameters_size);
+                            if (!success)
+                            {
+                                HandleBlockReadError(kErrorReadingBlockData, "Failed to preload frame marker block");
+                            }
+                            if (is_frame_delimiter)
+                            {
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            success = ProcessFrameMarker(block_header, marker_type);
+                            if (is_frame_delimiter)
+                            {
+                                // Make sure to increment the frame number on the way out.
+                                ++current_frame_number_;
+                                ++block_index_;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read frame marker header");
+                    }
+                }
+                else if (block_header.type == format::BlockType::kStateMarkerBlock)
+                {
+                    format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
+                    uint64_t           frame_number = 0;
+
+                    if (status_ == PreloadStatus::kRecord)
+                    {
+                        preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
+                        preload_buffer_.Add(&block_header);
+                        size_t parameters_size  = block_header.size;
+                        auto*  parameter_buffer = preload_buffer_.Add(parameters_size);
+                        success                 = ReadBytes(parameter_buffer, parameters_size);
+                        if (!success)
+                        {
+                            HandleBlockReadError(kErrorReadingBlockData, "Failed to preload state marker block data");
+                        }
+                    }
+                    else
+                    {
+                        success = ReadBytes(&marker_type, sizeof(marker_type));
+
+                        if (success)
+                        {
+                            success = ProcessStateMarker(block_header, marker_type);
+                        }
+                        else
+                        {
+                            HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read state marker header");
+                        }
+                    }
+                }
+                else if (block_header.type == format::BlockType::kAnnotation)
+                {
+                    if (annotation_handler_ != nullptr)
+                    {
+                        if (status_ == PreloadStatus::kRecord)
+                        {
+                            preload_buffer_.Reserve(sizeof(block_header) + block_header.size);
+                            preload_buffer_.Add(&block_header);
+                            auto* parameter_buffer = preload_buffer_.Add(block_header.size);
+                            success                = ReadBytes(parameter_buffer, block_header.size);
+                            if (!success)
+                            {
+                                HandleBlockReadError(kErrorReadingBlockData, "Failed to preload annotation block data");
+                            }
+                        }
+                        else
+                        {
+                            format::AnnotationType annotation_type = format::AnnotationType::kUnknown;
+
+                            success = ReadBytes(&annotation_type, sizeof(annotation_type));
+
+                            if (success)
+                            {
+                                success = ProcessAnnotation(block_header, annotation_type);
+                            }
+                            else
+                            {
+                                HandleBlockReadError(kErrorReadingBlockHeader,
+                                                     "Failed to read annotation block header");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // If there is no annotation handler to process the annotation, we can skip the annotation
+                        // block.
+                        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, block_header.size);
+                        success = SkipBytes(static_cast<size_t>(block_header.size));
+                    }
+                }
+                else
+                {
+                    // Unrecognized block type.
+                    GFXRECON_LOG_WARNING("Skipping unrecognized file block with type %u", block_header.type);
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, block_header.size);
+                    success = SkipBytes(static_cast<size_t>(block_header.size));
+                }
+            }
+            else
+            {
+                if (feof(file_descriptor_) == 0)
+                {
+                    // No data has been read for the current block, so we don't use 'HandleBlockReadError' here, as
+                    // it assumes that the block header has been successfully read and will print an incomplete
+                    // block at end of file warning when the file is at EOF without an error. For this case (the
+                    // normal EOF case) we print nothing at EOF, or print an error message and set the error code
+                    // directly when not at EOF.
+                    GFXRECON_LOG_ERROR("Failed to read block header");
+                    error_state_ = kErrorReadingBlockHeader;
+                }
+            }
+        }
+        if (status_ != PreloadStatus::kRecord)
+        {
+            ++block_index_;
+        }
+    }
+
+    return success;
+}
+
+bool PreloadFileProcessor::ReadBytes(void* buffer, size_t buffer_size)
+{
+    size_t bytes_read = 0;
+    if (status_ == PreloadStatus::kReplay)
+    {
+        bytes_read = preload_buffer_.Read(buffer, buffer_size);
+        bytes_read_ += bytes_read;
+        if (preload_buffer_.ReplayFinished())
+        {
+            status_ = PreloadStatus::kInactive;
+        }
+    }
+    else
+    {
+        bytes_read = util::platform::FileRead(buffer, 1, buffer_size, file_descriptor_);
+        bytes_read_ += bytes_read;
+    }
+    return bytes_read == buffer_size;
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/preload_file_processor.cpp
+++ b/framework/decode/preload_file_processor.cpp
@@ -69,6 +69,7 @@ bool PreloadFileProcessor::ProcessBlocks()
 
     while (success)
     {
+        PrintBlockInfo();
         success = ContinueDecoding();
 
         if (success)

--- a/framework/decode/preload_file_processor.h
+++ b/framework/decode/preload_file_processor.h
@@ -1,0 +1,94 @@
+/*
+** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_PRELOAD_FILE_PROCESSOR_H
+#define GFXRECON_DECODE_PRELOAD_FILE_PROCESSOR_H
+
+#include "decode/file_processor.h"
+#include "format/format_util.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class PreloadFileProcessor : public FileProcessor
+{
+  public:
+    PreloadFileProcessor();
+
+    // Preloads *count* frames to continuous, expandable memory buffer
+    void PreloadNextFrames(size_t count);
+
+  private:
+    class PreloadBuffer
+    {
+      public:
+        PreloadBuffer();
+
+        // Ensures the buffer can store additional *size* bytes
+        void Reserve(size_t size);
+
+        // Copies the preloaded data from the internal container into the provided destination buffer
+        // Accounts for current replay position
+        size_t Read(void* destination, size_t destination_size);
+
+        // Copies provided object of type T into the preload buffer
+        // Returns a pointer to inserted object in the container
+        template <typename T>
+        inline void* Add(T* data)
+        {
+            return &*container_.insert(
+                container_.end(), reinterpret_cast<char*>(data), reinterpret_cast<char*>(data) + sizeof(T));
+        }
+
+        // Allocates *size* bytes in the preload buffer
+        // Returns the pointer to initialized memory
+        inline void* Add(size_t size) { return &*container_.insert(container_.end(), size, 0); }
+
+        // Indicates whether the preloaded calls have been replayed in full
+        inline bool ReplayFinished() { return !container_.empty() && replay_offset_ >= container_.size(); }
+
+        // Clears the preload buffer, resets internal state
+        void Reset();
+
+      private:
+        std::vector<char> container_;
+        size_t            replay_offset_;
+
+    } preload_buffer_;
+
+    enum class PreloadStatus
+    {
+        kInactive,
+        kRecord,
+        kReplay
+    } status_;
+
+    bool ProcessBlocks() override;
+
+    bool ReadBytes(void* buffer, size_t buffer_size) override;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_PRELOAD_FILE_PROCESSOR_H

--- a/framework/decode/preload_file_processor.h
+++ b/framework/decode/preload_file_processor.h
@@ -83,6 +83,26 @@ class PreloadFileProcessor : public FileProcessor
         kReplay
     } status_;
 
+    template <typename T>
+    bool ReadParameterBytes(format::BlockHeader& block_header, T& data, PreloadBuffer& preload_buffer)
+    {
+        preload_buffer.Reserve(sizeof(block_header) + block_header.size);
+        preload_buffer.Add(&block_header);
+        preload_buffer.Add(&data);
+        size_t parameters_size  = block_header.size - sizeof(T);
+        void*  parameter_buffer = preload_buffer.Add(parameters_size);
+        return ReadBytes(parameter_buffer, parameters_size);
+    }
+
+    bool ReadParameterBytes(format::BlockHeader& block_header, PreloadBuffer& preload_buffer)
+    {
+        preload_buffer.Reserve(sizeof(block_header) + block_header.size);
+        preload_buffer.Add(&block_header);
+        size_t parameters_size  = block_header.size;
+        void*  parameter_buffer = preload_buffer.Add(parameters_size);
+        return ReadBytes(parameter_buffer, parameters_size);
+    }
+
     bool ProcessBlocks() override;
 
     bool ReadBytes(void* buffer, size_t buffer_size) override;

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -99,6 +99,8 @@ struct VulkanReplayOptions : public ReplayOptions
     bool  dump_resources_json_per_command{ false };
     bool  dump_resources_dump_immutable_resources{ false };
     bool  dump_resources_dump_all_image_subresources{ false };
+
+    bool preload_measurement_range{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -63,13 +63,14 @@ FpsInfo::FpsInfo(uint64_t               measurement_start_frame,
                  bool                   quit_after_range,
                  bool                   flush_measurement_range,
                  bool                   flush_inside_measurement_range,
+                 bool                   preload_measurement_range,
                  const std::string_view measurement_file_name) :
     measurement_start_frame_(measurement_start_frame),
     measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
     quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range),
     flush_inside_measurement_range_(flush_inside_measurement_range), has_measurement_range_(has_measurement_range),
     started_measurement_(false), ended_measurement_(false), frame_start_time_(0), frame_durations_(),
-    measurement_file_name_(measurement_file_name)
+    preload_measurement_range_(preload_measurement_range), measurement_file_name_(measurement_file_name)
 {
     if (has_measurement_range_)
     {
@@ -233,6 +234,16 @@ void FpsInfo::LogToConsole()
                                measurement_start_frame_,
                                measurement_end_frame_);
     }
+}
+
+uint64_t FpsInfo::ShouldPreloadFrames(uint64_t current_frame) const
+{
+    uint64_t result = 0;
+    if (preload_measurement_range_ && current_frame == measurement_start_frame_)
+    {
+        result = measurement_end_frame_ - measurement_start_frame_;
+    }
+    return result;
 }
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -42,18 +42,20 @@ class FpsInfo
             bool                   quit_after_range               = false,
             bool                   flush_measurement_range        = false,
             bool                   flush_inside_measurement_range = false,
+            bool                   preload_measurement_range      = false,
             const std::string_view measurement_file_name          = "");
 
     void LogToConsole();
 
-    void BeginFile();
-    bool ShouldWaitIdleBeforeFrame(uint64_t file_processor_frame);
-    bool ShouldWaitIdleAfterFrame(uint64_t file_processor_frame);
-    bool ShouldQuit(uint64_t file_processor_frame);
-    void BeginFrame(uint64_t file_processor_frame);
-    void EndFrame(uint64_t file_processor_frame);
-    void EndFile(uint64_t end_file_processor_frame);
-    void ProcessStateEndMarker(uint64_t file_processor_frame);
+    void                   BeginFile();
+    bool                   ShouldWaitIdleBeforeFrame(uint64_t file_processor_frame);
+    bool                   ShouldWaitIdleAfterFrame(uint64_t file_processor_frame);
+    bool                   ShouldQuit(uint64_t file_processor_frame);
+    void                   BeginFrame(uint64_t file_processor_frame);
+    void                   EndFrame(uint64_t file_processor_frame);
+    void                   EndFile(uint64_t end_file_processor_frame);
+    void                   ProcessStateEndMarker(uint64_t file_processor_frame);
+    [[nodiscard]] uint64_t ShouldPreloadFrames(uint64_t current_frame) const;
 
   private:
     uint64_t start_time_;
@@ -79,6 +81,8 @@ class FpsInfo
     std::vector<int64_t> frame_durations_;
 
     std::string measurement_file_name_;
+
+    bool preload_measurement_range_;
 };
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/tools/optimize/block_skipping_file_processor.cpp
+++ b/tools/optimize/block_skipping_file_processor.cpp
@@ -53,6 +53,7 @@ bool BlockSkippingFileProcessor::ProcessBlocks()
 
     while (success)
     {
+        PrintBlockInfo();
         success = ContinueDecoding();
 
         if (success)

--- a/tools/optimize/block_skipping_file_processor.cpp
+++ b/tools/optimize/block_skipping_file_processor.cpp
@@ -80,14 +80,10 @@ bool BlockSkippingFileProcessor::ProcessBlocks()
 
                     if (success)
                     {
-                        success = ProcessFunctionCall(block_header, api_call_id);
-
-                        // Break from loop on frame delimiter.
-                        if (IsFrameDelimiter(api_call_id))
+                        bool should_break = false;
+                        success           = ProcessFunctionCall(block_header, api_call_id, should_break);
+                        if (should_break)
                         {
-                            // Make sure to increment the frame number on the way out.
-                            ++current_frame_number_;
-                            ++block_index_;
                             break;
                         }
                     }
@@ -104,14 +100,11 @@ bool BlockSkippingFileProcessor::ProcessBlocks()
 
                     if (success)
                     {
-                        success = ProcessMethodCall(block_header, api_call_id);
+                        bool should_break = false;
+                        success           = ProcessMethodCall(block_header, api_call_id, should_break);
 
-                        // Break from loop on frame delimiter.
-                        if (IsFrameDelimiter(api_call_id))
+                        if (should_break)
                         {
-                            // Make sure to increment the frame number on the way out.
-                            ++current_frame_number_;
-                            ++block_index_;
                             break;
                         }
                     }
@@ -145,14 +138,11 @@ bool BlockSkippingFileProcessor::ProcessBlocks()
 
                     if (success)
                     {
-                        success = ProcessFrameMarker(block_header, marker_type);
+                        bool should_break = false;
+                        success           = ProcessFrameMarker(block_header, marker_type, should_break);
 
-                        // Break from loop on frame delimiter.
-                        if (IsFrameDelimiter(block_header.type, marker_type))
+                        if (should_break)
                         {
-                            // Make sure to increment the frame number on the way out.
-                            ++current_frame_number_;
-                            ++block_index_;
                             break;
                         }
                     }

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -26,6 +26,7 @@
 #include "application/android_context.h"
 #include "application/android_window.h"
 #include "decode/file_processor.h"
+#include "decode/preload_file_processor.h"
 #include "decode/vulkan_replay_options.h"
 #include "decode/vulkan_tracked_object_info_table.h"
 #include "format/format.h"
@@ -101,16 +102,19 @@ void android_main(struct android_app* app)
 
         try
         {
-            gfxrecon::decode::FileProcessor file_processor;
+            std::unique_ptr<gfxrecon::decode::FileProcessor> file_processor =
+                arg_parser.IsOptionSet(kPreloadMeasurementRangeOption)
+                    ? std::make_unique<gfxrecon::decode::PreloadFileProcessor>()
+                    : std::make_unique<gfxrecon::decode::FileProcessor>();
 
-            if (!file_processor.Initialize(filename))
+            if (!file_processor->Initialize(filename))
             {
                 GFXRECON_WRITE_CONSOLE("Failed to load file %s.", filename.c_str());
             }
             else
             {
                 auto application =
-                    std::make_shared<gfxrecon::application::Application>(kApplicationName, &file_processor);
+                    std::make_shared<gfxrecon::application::Application>(kApplicationName, file_processor.get());
                 application->InitializeWsiContext(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, app);
 
                 gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
@@ -142,13 +146,14 @@ void android_main(struct android_app* app)
                                                      replay_options.quit_after_measurement_frame_range,
                                                      replay_options.flush_measurement_frame_range,
                                                      replay_options.flush_inside_measurement_range,
+                                                     replay_options.preload_measurement_range,
                                                      measurement_file_name);
 
                 replay_consumer.SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
                 replay_consumer.SetFpsInfo(&fps_info);
 
                 decoder.AddConsumer(&replay_consumer);
-                file_processor.AddDecoder(&decoder);
+                file_processor->AddDecoder(&decoder);
                 application->SetPauseFrame(GetPauseFrame(arg_parser));
 
                 // Warn if the capture layer is active.
@@ -166,25 +171,25 @@ void android_main(struct android_app* app)
                 application->Run();
 
                 // Add one so that it matches the trim range frame number semantic
-                fps_info.EndFile(file_processor.GetCurrentFrameNumber() + 1);
+                fps_info.EndFile(file_processor->GetCurrentFrameNumber() + 1);
 
-                if ((file_processor.GetCurrentFrameNumber() > 0) &&
-                    (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
+                if ((file_processor->GetCurrentFrameNumber() > 0) &&
+                    (file_processor->GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
                 {
-                    if (file_processor.GetCurrentFrameNumber() < start_frame)
+                    if (file_processor->GetCurrentFrameNumber() < start_frame)
                     {
                         GFXRECON_LOG_WARNING(
                             "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                             "Measurements were never started, cannot calculate measurement range FPS.",
                             start_frame,
-                            file_processor.GetCurrentFrameNumber());
+                            file_processor->GetCurrentFrameNumber());
                     }
                     else
                     {
                         fps_info.LogToConsole();
                     }
                 }
-                else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
+                else if (file_processor->GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
                 {
                     GFXRECON_WRITE_CONSOLE("A failure has occurred during replay");
                 }

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -35,7 +35,7 @@ const char kOptions[] =
     "offscreen-swapchain-frame-boundary,--wait-before-present,--dump-resources-before-draw,"
     "--dump-resources-dump-depth-attachment,--dump-"
     "resources-dump-vertex-index-buffers,--dump-resources-json-output-per-command,--dump-resources-dump-immutable-"
-    "resources,--dump-resources-dump-all-image-subresources,--pbi-all";
+    "resources,--dump-resources-dump-all-image-subresources,--pbi-all,--preload-measurement-range";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -122,6 +122,7 @@ const char kSkipGetFenceRanges[]                  = "--skip-get-fence-ranges";
 const char kWaitBeforePresent[]                   = "--wait-before-present";
 const char kPrintBlockInfoAllOption[]             = "--pbi-all";
 const char kPrintBlockInfosArgument[]             = "--pbis";
+const char kPreloadMeasurementRangeOption[]       = "--preload-measurement-range";
 #if defined(WIN32)
 const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
 const char kDxOverrideObjectNames[]       = "--dx12-override-object-names";
@@ -1065,6 +1066,10 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (arg_parser.IsOptionSet(kWaitBeforePresent))
     {
         replay_options.wait_before_present = true;
+    }
+    if (arg_parser.IsOptionSet(kPreloadMeasurementRangeOption))
+    {
+        replay_options.preload_measurement_range = true;
     }
 
     replay_options.dump_resources              = arg_parser.GetArgumentValue(kDumpResourcesArgument);


### PR DESCRIPTION
Adds --preload-measurement-range option allowing to preload a frame range specified with --measurement-frame-range from the trace file into a continuous, expandable buffer, in order to mitigate the impact of read file commands on performance measurements.
