### PR TITLE
Hush Android compile warnings

### DIFF
--- a/android/layer/build.gradle
+++ b/android/layer/build.gradle
@@ -13,7 +13,7 @@ android {
         }
         externalNativeBuild {
             cmake {
-                cppFlags "-fexceptions", "-std=c++14"
+                cppFlags "-fexceptions", "-std=c++14", "-Wno-nullability-completeness"
                 arguments "-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=c++_static"
             }
         }

--- a/android/tools/replay/build.gradle
+++ b/android/tools/replay/build.gradle
@@ -14,7 +14,7 @@ android {
         }
         externalNativeBuild {
             cmake {
-                cppFlags "-fexceptions", "-std=c++14"
+                cppFlags "-fexceptions", "-std=c++14", "-Wno-nullability-completeness"
                 arguments "-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=c++_static"
             }
         }


### PR DESCRIPTION
A big deal of "warning: pointer is missing a nullability type specifier" kind of warnings were being generated from a third-party library when compiling for Android. This patch should silence those warnings