### PR TITLE
Fix Vulkan deferred operation handling errors

### DIFF
--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -75,6 +76,18 @@ class VulkanConsumerBase : public MetadataConsumerBase, public MarkerConsumerBas
                                                               format::HandleId                 descriptorSet,
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData)
+    {}
+
+    virtual void Process_vkCreateRayTracingPipelinesKHR(
+        const ApiCallInfo&                                               call_info,
+        VkResult                                                         returnValue,
+        format::HandleId                                                 device,
+        format::HandleId                                                 deferredOperation,
+        format::HandleId                                                 pipelineCache,
+        uint32_t                                                         createInfoCount,
+        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
+        HandlePointerDecoder<VkPipeline>*                                pPipelines)
     {}
 
     virtual void ProcessSetTlasToBlasRelationCommand(format::HandleId tlas, const std::vector<format::HandleId>& blases)

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019-2022 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -432,11 +433,13 @@ struct FramebufferInfo : public VulkanObjectInfo<VkFramebuffer>
 
 struct DeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR>
 {
-    VkResult join_state{ VK_NOT_READY };
+    bool pending_state{ false };
 
     // Record CreateRayTracingPipelinesKHR parameters for safety.
     std::vector<VkRayTracingPipelineCreateInfoKHR>                 record_modified_create_infos;
     std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>> record_modified_pgroups;
+    std::vector<VkPipeline>                                        replayPipelines;
+    std::vector<format::HandleId>                                  capturePipelines;
 };
 
 struct VideoSessionKHRInfo : VulkanObjectInfo<VkVideoSessionKHR>

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -178,6 +178,16 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                               format::HandleId                 descriptorSet,
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData) override;
+    virtual void Process_vkCreateRayTracingPipelinesKHR(
+        const ApiCallInfo&                                               call_info,
+        VkResult                                                         returnValue,
+        format::HandleId                                                 device,
+        format::HandleId                                                 deferredOperation,
+        format::HandleId                                                 pipelineCache,
+        uint32_t                                                         createInfoCount,
+        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
+        HandlePointerDecoder<VkPipeline>*                                pPipelines);
 
   protected:
     const VulkanObjectInfoTable& GetObjectInfoTable() const { return object_info_table_; }

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -654,8 +654,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice            
     }
 
     auto device_wrapper = GetWrapper<DeviceWrapper>(device);
-    if ((result != VK_OPERATION_DEFERRED_KHR) ||
-        (!device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay))
+    if (result != VK_OPERATION_DEFERRED_KHR)
     {
         // If the operation is not deferred by driver. or the system doesn't support
         // rayTracingPipelineShaderGroupHandleCaptureReplay, we don't need to delay writing the block of

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -687,6 +687,13 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice            
                     result, device, deferredOperation, createInfoCount, pPipelines, pCreateInfos);
         }
     }
+    else
+    {
+        GFXRECON_LOG_WARNING("The operation of vkCreateRayTracingPipelinesKHR call is deferred, so the writing of "
+                             "vkCreateRayTracingPipelinesKHR block to capture file will be delayed until the deferred "
+                             "operation (handle = 0x%" PRIx64 ") is finished.",
+                             deferredOperation);
+    }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR>::Dispatch(
         VulkanCaptureManager::Get(),

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
-** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,7 @@
 
 #include "project_version.h"
 
+#include "encode/struct_pointer_encoder.h"
 #include "encode/vulkan_capture_manager.h"
 
 #include "encode/vulkan_handle_wrapper_util.h"
@@ -1178,6 +1179,8 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
         }
         deferred_operation_wrapper->create_infos.resize(createInfoCount);
         deferred_operation_wrapper->pipelines.resize(createInfoCount);
+        deferred_operation_wrapper->pPipelines    = pPipelines;
+        deferred_operation_wrapper->pipelineCache = pipelineCache;
     }
     else
     {
@@ -1208,7 +1211,24 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                                 deferred_operation_wrapper->p_allocator,
                                                                 deferred_operation_wrapper->pipelines.data());
 
-            std::memcpy(pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
+            if (result == VK_OPERATION_NOT_DEFERRED_KHR)
+            {
+                // VK_OPERATION_NOT_DEFERRED_KHR means the operation successfully completed immediately, so here we copy
+                // the created pipelines to original array which is used to store them by target application.
+                //
+                // Note:
+                //       VK_OPERATION_DEFERRED_KHR means the operation is successfully deferred, but the pipeline
+                //       creation might not be finished. We must therefore lean on
+                //       vkDeferredOperationJoinKHR/vkGetDeferredOperationResultKHR to get the final result. If the
+                //       result indicated the operation has finished, then the created pipelines are ready for use.
+                std::memcpy(
+                    pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
+            }
+            else if (result == VK_OPERATION_DEFERRED_KHR)
+            {
+                const std::lock_guard<std::mutex> lock(deferred_operation_mutex);
+                deferred_operation_wrapper->pending_state = true;
+            }
         }
         else
         {
@@ -1240,8 +1260,18 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                                 deferred_operation_wrapper->create_infos.data(),
                                                                 deferred_operation_wrapper->p_allocator,
                                                                 deferred_operation_wrapper->pipelines.data());
-
-            std::memcpy(pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
+            if (result == VK_OPERATION_NOT_DEFERRED_KHR)
+            {
+                // If the driver doesn't defer the command, and instead completed the operation immediately, we copy the
+                // created pipelines to original array which is used to store them by target application.
+                std::memcpy(
+                    pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
+            }
+            else if (result == VK_OPERATION_DEFERRED_KHR)
+            {
+                const std::lock_guard<std::mutex> lock(deferred_operation_mutex);
+                deferred_operation_wrapper->pending_state = true;
+            }
         }
         else
         {
@@ -1254,10 +1284,11 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                                 pPipelines);
         }
     }
-    if (((result == VK_SUCCESS) || (result == VK_OPERATION_DEFERRED_KHR) ||
-         (result == VK_OPERATION_NOT_DEFERRED_KHR)) &&
-        (pPipelines != nullptr))
+
+    if (((result == VK_SUCCESS) || (result == VK_OPERATION_NOT_DEFERRED_KHR)) && (pPipelines != nullptr))
     {
+        // If the return result show the creation is successfully finished, we do the following process.
+
         CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(
             device, deferredOperation, pPipelines, createInfoCount, GetUniqueId);
 
@@ -1289,6 +1320,139 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                 }
             }
         }
+    }
+
+    return result;
+}
+
+void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               device,
+                                                        VkDeferredOperationKHR deferredOperation,
+                                                        bool                   capture_manager_tracking)
+{
+    const std::lock_guard<std::mutex> lock(deferred_operation_mutex);
+    VkResult                          result      = VK_SUCCESS;
+    auto               deferred_operation_wrapper = GetWrapper<DeferredOperationKHRWrapper>(deferredOperation);
+    auto               device_wrapper             = GetWrapper<DeviceWrapper>(device);
+    const DeviceTable* device_table               = GetDeviceTable(device);
+
+    GFXRECON_ASSERT(device_table != nullptr);
+
+    if ((deferred_operation_wrapper != nullptr) && (deferred_operation_wrapper->pending_state))
+    {
+        deferred_operation_wrapper->pending_state = false;
+        uint32_t create_info_count                = deferred_operation_wrapper->create_infos.size();
+        std::memcpy(deferred_operation_wrapper->pPipelines,
+                    deferred_operation_wrapper->pipelines.data(),
+                    sizeof(VkPipeline) * deferred_operation_wrapper->create_infos.size());
+
+        CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(
+            device, deferredOperation, deferred_operation_wrapper->pPipelines, create_info_count, GetUniqueId);
+
+        for (uint32_t i = 0; i < create_info_count; ++i)
+        {
+            auto pipeline_wrapper = GetWrapper<PipelineWrapper>(deferred_operation_wrapper->pPipelines[i]);
+
+            if (deferred_operation_wrapper)
+            {
+                pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
+                pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
+                pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
+            }
+
+            if (device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+            {
+                const uint32_t data_size =
+                    device_wrapper->property_feature_info.property_shaderGroupHandleCaptureReplaySize *
+                    deferred_operation_wrapper->create_infos[i].groupCount;
+
+                std::vector<uint8_t> data(data_size);
+                device_table->GetRayTracingCaptureReplayShaderGroupHandlesKHR(
+                    device_wrapper->handle,
+                    pipeline_wrapper->handle,
+                    0,
+                    deferred_operation_wrapper->create_infos[i].groupCount,
+                    data_size,
+                    data.data());
+
+                WriteSetRayTracingShaderGroupHandlesCommand(
+                    device_wrapper->handle_id, pipeline_wrapper->handle_id, data_size, data.data());
+
+                if (capture_manager_tracking == true)
+                {
+                    state_tracker_->TrackRayTracingShaderGroupHandles(
+                        device, deferred_operation_wrapper->pPipelines[i], data_size, data.data());
+                }
+            }
+        }
+
+        // When the command vkCreateRayTracingPipelinesKHR is deferred at capture time, the created pipelines might not
+        // be ready on the return of the API call, because the pipeline creation workload might not be finished. But for
+        // replay time, we must guarantee the data relevant to vkGetRayTracingCaptureReplayShaderGroupHandlesKHR is
+        // ready before calling vkCreateRaytracingPipelines so shader group handles during playback are the same with
+        // capture time. The special handling needed here that when the command vkCreateRayTracingPipelinesKHR is
+        // deferred, the writing of its block will be delayed writing to file, until it is confirmed that the deferred
+        // command is finished.
+        auto encoder = BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR);
+
+        if (encoder)
+        {
+            encoder->EncodeHandleValue<DeviceWrapper>(device);
+            encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
+            encoder->EncodeHandleValue<PipelineCacheWrapper>(deferred_operation_wrapper->pipelineCache);
+            encoder->EncodeUInt32Value(create_info_count);
+            EncodeStructArray(encoder, deferred_operation_wrapper->create_infos.data(), create_info_count);
+            EncodeStructPtr(encoder, deferred_operation_wrapper->p_allocator);
+            encoder->EncodeHandleArray<PipelineWrapper>(
+                deferred_operation_wrapper->pPipelines, create_info_count, false);
+            encoder->EncodeEnumValue(VK_OPERATION_DEFERRED_KHR);
+            EndGroupCreateApiCallCapture<VkDevice,
+                                         VkDeferredOperationKHR,
+                                         PipelineWrapper,
+                                         VkRayTracingPipelineCreateInfoKHR>(
+                result,
+                device,
+                deferredOperation,
+                create_info_count,
+                deferred_operation_wrapper->pPipelines,
+                deferred_operation_wrapper->create_infos.data());
+        }
+    }
+}
+
+VkResult VulkanCaptureManager::OverrideDeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation)
+{
+    auto device_table = GetDeviceTable(device);
+    GFXRECON_ASSERT(device_table != nullptr);
+    VkResult result = device_table->DeferredOperationJoinKHR(device, operation);
+
+    if (result == VK_SUCCESS)
+    {
+        // The deferred operation done and we continue to get the deferred command return value.
+        VkResult deferred_command_result = device_table->GetDeferredOperationResultKHR(device, operation);
+
+        if (deferred_command_result == VK_SUCCESS)
+        {
+            // The deferred command return VK_SUCCESS
+            DeferredOperationPostProcess(device, operation, (GetCaptureMode() & kModeTrack) == kModeTrack);
+        }
+    }
+
+    return result;
+}
+
+VkResult VulkanCaptureManager::OverrideGetDeferredOperationResultKHR(VkDevice device, VkDeferredOperationKHR operation)
+{
+    auto device_table = GetDeviceTable(device);
+    GFXRECON_ASSERT(device_table != nullptr);
+    VkResult result = device_table->GetDeferredOperationResultKHR(device, operation);
+
+    if (result == VK_SUCCESS)
+    {
+        // There are the following two cases with VK_SUCCESS for vkGetDeferredOperationResultKHR. Both are covered by
+        // DeferredOperationPostProcess:
+        //    1. The deferred operation finished and returned VK_SUCCESS.
+        //    2. No command has been deferred on the deferred operation object.
+        DeferredOperationPostProcess(device, operation, (GetCaptureMode() & kModeTrack) == kModeTrack);
     }
 
     return result;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1200,9 +1200,10 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
         }
         if (deferred_operation_wrapper)
         {
-            std::memcpy(deferred_operation_wrapper->create_infos.data(),
-                        modified_create_infos.get(),
-                        sizeof(VkRayTracingPipelineCreateInfoKHR) * createInfoCount);
+            deferred_operation_wrapper->create_infos.clear();
+            deferred_operation_wrapper->create_infos.insert(deferred_operation_wrapper->create_infos.end(),
+                                                            &modified_create_infos.get()[0],
+                                                            &modified_create_infos.get()[createInfoCount]);
             result = device_table->CreateRayTracingPipelinesKHR(device,
                                                                 deferredOperation,
                                                                 pipelineCache,
@@ -1211,7 +1212,7 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                                 deferred_operation_wrapper->p_allocator,
                                                                 deferred_operation_wrapper->pipelines.data());
 
-            if (result == VK_OPERATION_NOT_DEFERRED_KHR)
+            if ((result == VK_OPERATION_NOT_DEFERRED_KHR) || (result == VK_SUCCESS))
             {
                 // VK_OPERATION_NOT_DEFERRED_KHR means the operation successfully completed immediately, so here we copy
                 // the created pipelines to original array which is used to store them by target application.
@@ -1221,6 +1222,12 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                 //       creation might not be finished. We must therefore lean on
                 //       vkDeferredOperationJoinKHR/vkGetDeferredOperationResultKHR to get the final result. If the
                 //       result indicated the operation has finished, then the created pipelines are ready for use.
+                //
+                //       By Vulkan doc of VK_KHR_deferred_host_operations, if deferred operation object was
+                //       provided and the operation successfully completed immediately without deferring, the
+                //       command return VK_OPERATION_NOT_DEFERRED_KHR. Some hardware/driver may return VK_SUCCESS on
+                //       such case, so same handling is proceeded with VK_SUCCESS.
+                //
                 std::memcpy(
                     pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
             }
@@ -1250,9 +1257,10 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
 
         if (deferred_operation_wrapper)
         {
-            std::memcpy(deferred_operation_wrapper->create_infos.data(),
-                        pCreateInfos_unwrapped,
-                        sizeof(VkRayTracingPipelineCreateInfoKHR) * createInfoCount);
+            deferred_operation_wrapper->create_infos.clear();
+            deferred_operation_wrapper->create_infos.insert(deferred_operation_wrapper->create_infos.end(),
+                                                            &pCreateInfos_unwrapped[0],
+                                                            &pCreateInfos_unwrapped[createInfoCount]);
             result = device_table->CreateRayTracingPipelinesKHR(device,
                                                                 deferredOperation,
                                                                 pipelineCache,
@@ -1260,7 +1268,7 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                                 deferred_operation_wrapper->create_infos.data(),
                                                                 deferred_operation_wrapper->p_allocator,
                                                                 deferred_operation_wrapper->pipelines.data());
-            if (result == VK_OPERATION_NOT_DEFERRED_KHR)
+            if ((result == VK_OPERATION_NOT_DEFERRED_KHR) || (result == VK_SUCCESS))
             {
                 // If the driver doesn't defer the command, and instead completed the operation immediately, we copy the
                 // created pipelines to original array which is used to store them by target application.
@@ -1298,6 +1306,10 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
 
             if (deferred_operation_wrapper)
             {
+                // We need to set device_id here because some hardware may not have the feature
+                // rayTracingPipelineShaderGroupHandleCaptureReplay so the device_id cannot be set by
+                // VulkanStateTracker::TrackRayTracingShaderGroupHandles
+                pipeline_wrapper->device_id                            = GetWrappedId<DeviceWrapper>(device);
                 pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
                 pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
                 pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
@@ -1354,6 +1366,10 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
 
             if (deferred_operation_wrapper)
             {
+                // We need to set device_id here because some hardware may not have the feature
+                // rayTracingPipelineShaderGroupHandleCaptureReplay so the device_id cannot be set by
+                // VulkanStateTracker::TrackRayTracingShaderGroupHandles
+                pipeline_wrapper->device_id                            = GetWrappedId<DeviceWrapper>(device);
                 pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
                 pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
                 pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
@@ -1430,9 +1446,8 @@ VkResult VulkanCaptureManager::OverrideDeferredOperationJoinKHR(VkDevice device,
         // The deferred operation done and we continue to get the deferred command return value.
         VkResult deferred_command_result = device_table->GetDeferredOperationResultKHR(device, operation);
 
-        if (deferred_command_result == VK_SUCCESS)
+        if ((deferred_command_result == VK_SUCCESS) || (deferred_command_result == VK_OPERATION_NOT_DEFERRED_KHR))
         {
-            // The deferred command return VK_SUCCESS
             DeferredOperationPostProcess(device, operation, (GetCaptureMode() & kModeTrack) == kModeTrack);
         }
     }
@@ -1446,10 +1461,11 @@ VkResult VulkanCaptureManager::OverrideGetDeferredOperationResultKHR(VkDevice de
     GFXRECON_ASSERT(device_table != nullptr);
     VkResult result = device_table->GetDeferredOperationResultKHR(device, operation);
 
-    if (result == VK_SUCCESS)
+    if ((result == VK_SUCCESS) || (result == VK_OPERATION_NOT_DEFERRED_KHR))
     {
         // There are the following two cases with VK_SUCCESS for vkGetDeferredOperationResultKHR. Both are covered by
-        // DeferredOperationPostProcess:
+        // DeferredOperationPostProcess. We also provide same handling for VK_OPERATION_NOT_DEFERRED_KHR in case some
+        // hardware/driver return VK_OPERATION_NOT_DEFERRED_KHR:
         //    1. The deferred operation finished and returned VK_SUCCESS.
         //    2. No command has been deferred on the deferred operation object.
         DeferredOperationPostProcess(device, operation, (GetCaptureMode() & kModeTrack) == kModeTrack);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
-** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -309,6 +309,14 @@ class VulkanCaptureManager : public CaptureManager
                                                   const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
                                                   const VkAllocationCallbacks*             pAllocator,
                                                   VkPipeline*                              pPipelines);
+
+    VkResult OverrideDeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation);
+
+    VkResult OverrideGetDeferredOperationResultKHR(VkDevice device, VkDeferredOperationKHR operation);
+
+    void DeferredOperationPostProcess(VkDevice               device,
+                                      VkDeferredOperationKHR deferredOperation,
+                                      bool                   capture_manager_tracking);
 
     void OverrideGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice         physicalDevice,
                                                         uint32_t*                pQueueFamilyPropertyCount,
@@ -1309,6 +1317,7 @@ class VulkanCaptureManager : public CaptureManager
     std::set<DeviceMemoryWrapper*>      mapped_memory_; // Track mapped memory for unassisted tracking mode.
     std::unique_ptr<VulkanStateTracker> state_tracker_;
     HardwareBufferMap                   hardware_buffers_;
+    std::mutex                          deferred_operation_mutex;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019-2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -346,6 +347,9 @@ struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR
     VkAllocationCallbacks                          allocator{};
     VkAllocationCallbacks*                         p_allocator{ nullptr };
     std::vector<VkPipeline>                        pipelines;
+    VkPipeline*                                    pPipelines;
+    VkPipelineCache                                pipelineCache;
+    bool                                           pending_state = false;
 };
 
 struct DescriptorUpdateTemplateWrapper : public HandleWrapper<VkDescriptorUpdateTemplate>

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -135,6 +136,8 @@ class VulkanStateWriter
     void WriteDeviceMemoryState(const VulkanStateTable& state_table);
 
     void WriteAccelerationStructureKHRState(const VulkanStateTable& state_table);
+
+    void WriteDeferredOperationJoinCommand(format::HandleId device_id, format::HandleId deferred_operation_id);
 
     void
     ProcessHardwareBuffer(format::HandleId memory_id, AHardwareBuffer* hardware_buffer, VkDeviceSize allocation_size);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -12958,7 +12958,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR>::Dispatch(manager, device, operation);
 
-    VkResult result = GetDeviceTable(device)->GetDeferredOperationResultKHR(device, operation);
+    VkResult result = manager->OverrideGetDeferredOperationResultKHR(device, operation);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR);
     if (encoder)
@@ -12994,7 +12994,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR>::Dispatch(manager, device, operation);
 
-    VkResult result = GetDeviceTable(device)->DeferredOperationJoinKHR(device, operation);
+    VkResult result = manager->OverrideDeferredOperationJoinKHR(device, operation);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR);
     if (encoder)

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -4158,17 +4158,6 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    height,
         uint32_t                                    depth) {}
 
-    virtual void Process_vkCreateRayTracingPipelinesKHR(
-        const ApiCallInfo&                          call_info,
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        format::HandleId                            pipelineCache,
-        uint32_t                                    createInfoCount,
-        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
-        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-        HandlePointerDecoder<VkPipeline>*           pPipelines) {}
-
     virtual void Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
         const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -9087,32 +9087,6 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysKHR(
     GetDeviceTable(in_commandBuffer)->CmdTraceRaysKHR(in_commandBuffer, in_pRaygenShaderBindingTable, in_pMissShaderBindingTable, in_pHitShaderBindingTable, in_pCallableShaderBindingTable, width, height, depth);
 }
 
-void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesKHR(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            deferredOperation,
-    format::HandleId                            pipelineCache,
-    uint32_t                                    createInfoCount,
-    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
-    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-    HandlePointerDecoder<VkPipeline>*           pPipelines)
-{
-    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
-    auto in_deferredOperation = GetObjectInfoTable().GetDeferredOperationKHRInfo(deferredOperation);
-    auto in_pipelineCache = GetObjectInfoTable().GetPipelineCacheInfo(pipelineCache);
-
-    MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
-    if (!pPipelines->IsNull()) { pPipelines->SetHandleLength(createInfoCount); }
-    std::vector<PipelineInfo> handle_info(createInfoCount);
-    for (size_t i = 0; i < createInfoCount; ++i) { pPipelines->SetConsumerData(i, &handle_info[i]); }
-
-    VkResult replay_result = OverrideCreateRayTracingPipelinesKHR(GetDeviceTable(in_device->handle)->CreateRayTracingPipelinesKHR, returnValue, in_device, in_deferredOperation, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
-    CheckResult("vkCreateRayTracingPipelinesKHR", returnValue, replay_result, call_info);
-
-    AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(handle_info), &VulkanObjectInfoTable::AddPipelineInfo);
-}
-
 void VulkanReplayConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
     const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -4158,17 +4158,6 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    height,
         uint32_t                                    depth) override;
 
-    virtual void Process_vkCreateRayTracingPipelinesKHR(
-        const ApiCallInfo&                          call_info,
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        format::HandleId                            pipelineCache,
-        uint32_t                                    createInfoCount,
-        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
-        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
-        HandlePointerDecoder<VkPipeline>*           pPipelines) override;
-
     virtual void Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
         const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,

--- a/framework/generated/vulkan_generators/blacklists.json
+++ b/framework/generated/vulkan_generators/blacklists.json
@@ -12,6 +12,7 @@
     "vkCmdPushDescriptorSetWithTemplateKHR",
     "vkBuildAccelerationStructuresKHR",
     "vkCopyAccelerationStructureKHR",
+    "vkCreateRayTracingPipelinesKHR",
     "vkSetLatencySleepModeNV",
     "vkLatencySleepNV",
     "vkSetLatencyMarkerNV",
@@ -25,7 +26,6 @@
     "vkCreateRayTracingPipelinesKHR"
   ],
   "functions-decoder": [
-    "vkCreateRayTracingPipelinesKHR",
     "vkDeferredOperationJoinKHR"
   ],
   "structures": [

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -7,6 +7,8 @@
         "vkAllocateMemory": "manager->OverrideAllocateMemory",
         "vkGetPhysicalDeviceToolPropertiesEXT": "manager->OverrideGetPhysicalDeviceToolPropertiesEXT",
         "vkCreateAccelerationStructureKHR": "manager->OverrideCreateAccelerationStructureKHR",
+        "vkGetDeferredOperationResultKHR": "manager->OverrideGetDeferredOperationResultKHR",
+        "vkDeferredOperationJoinKHR": "manager->OverrideDeferredOperationJoinKHR",
         "vkGetPhysicalDeviceQueueFamilyProperties": "manager->OverrideGetPhysicalDeviceQueueFamilyProperties",
         "vkGetPhysicalDeviceQueueFamilyProperties2": "manager->OverrideGetPhysicalDeviceQueueFamilyProperties2",
         "vkGetPhysicalDeviceQueueFamilyProperties2KHR": "manager->OverrideGetPhysicalDeviceQueueFamilyProperties2KHR",

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -84,7 +84,6 @@
     "vkDestroySurfaceKHR": "OverrideDestroySurfaceKHR",
     "vkCreateAccelerationStructureKHR": "OverrideCreateAccelerationStructureKHR",
     "vkGetRandROutputDisplayEXT": "OverrideGetRandROutputDisplayEXT",
-    "vkCreateRayTracingPipelinesKHR": "OverrideCreateRayTracingPipelinesKHR",
     "vkGetBufferDeviceAddress": "OverrideGetBufferDeviceAddress",
     "vkGetBufferDeviceAddressKHR": "OverrideGetBufferDeviceAddress",
     "vkGetAccelerationStructureDeviceAddressKHR": "OverrideGetAccelerationStructureDeviceAddressKHR",

--- a/framework/generated/vulkan_generators/vulkan_json_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_json_consumer_body_generator.py
@@ -140,6 +140,13 @@ class VulkanExportJsonConsumerBodyGenerator(BaseGenerator):
     def generate_feature(self):
         """Performs C++ code generation for the feature."""
         first = True
+
+        # TODO: Each code generator is passed a blacklist like framework\generated\vulkan_generators\blacklists.json
+        # of functions and structures not to generate code for. Once the feature is implemented, the following can be
+        # replaced with adding vkCreateRayTracingPipelinesKHR in corresponding blacklist.
+        if 'vkCreateRayTracingPipelinesKHR' in self.APICALL_BLACKLIST:
+            self.APICALL_BLACKLIST.remove('vkCreateRayTracingPipelinesKHR')
+
         for cmd in self.get_filtered_cmd_names():
             if not cmd in self.customImplementationRequired:
                 info = self.feature_cmd_params[cmd]

--- a/framework/generated/vulkan_generators/vulkan_json_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_json_consumer_header_generator.py
@@ -86,6 +86,13 @@ class VulkanExportJsonConsumerHeaderGenerator(VulkanConsumerHeaderGenerator):
     def generate_feature(self):
         """Performs C++ code generation for the feature."""
         first = True
+
+        # TODO: Each code generator is passed a blacklist like framework\generated\vulkan_generators\blacklists.json
+        # of functions and structures not to generate code for. Once the feature is implemented, the following can be
+        # replaced with adding vkCreateRayTracingPipelinesKHR in corresponding blacklist.
+        if 'vkCreateRayTracingPipelinesKHR' in self.APICALL_BLACKLIST:
+            self.APICALL_BLACKLIST.remove('vkCreateRayTracingPipelinesKHR')
+
         for cmd in self.get_filtered_cmd_names():
             if cmd not in self.customImplementationRequired:
                 info = self.feature_cmd_params[cmd]


### PR DESCRIPTION
**The problem**
when using deferred operation object in command vkcreateraytracingpipelines, there are two cases with the driver. One is driver proceed all workload in current thread without deferring this command, another case is deferring this command to other threads. The second case is not covered by existing handling. It cause some
title playback failure because reading wrong pipeline data and capture/playback shader group handle, it also cause trim playback failure because ray tracing pipeline creation failure.


**The solution**
The pull request is the fix for these errors. It added needed handling for deferred command and fixed related errors on pipeline reading, capture/playback shader group handle handling and trim deferred operation object handling.

**Result**
All tests passed for the target title and other applications include trim trace and full trace capture/playback, these test results show the pull-request fixed the target title playback issue caused by these deferred operation handling errors.