### PR TITLE
Take screenshots of FB attachments for VR frames 

### DIFF
--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -82,7 +82,8 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
                                    VkImage                                 image,
                                    VkFormat                                format,
                                    uint32_t                                width,
-                                   uint32_t                                height)
+                                   uint32_t                                height,
+                                   VkImageLayout                           image_layout)
 {
     if ((device_table == nullptr) || (allocator == nullptr))
     {
@@ -193,12 +194,12 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
 
             if (result == VK_SUCCESS)
             {
-                // Transition source image to target to the TRANSFER_DST layout.
+                // Transition source image from image_layout to the TRANSFER_DST layout.
                 VkImageMemoryBarrier image_barrier            = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER };
                 image_barrier.pNext                           = nullptr;
                 image_barrier.srcAccessMask                   = 0;
                 image_barrier.dstAccessMask                   = VK_ACCESS_TRANSFER_READ_BIT;
-                image_barrier.oldLayout                       = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+                image_barrier.oldLayout                       = image_layout;
                 image_barrier.newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
                 image_barrier.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
                 image_barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
@@ -322,11 +323,11 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
                                                    1,
                                                    &copy_region);
 
-                // Transition source image to PRESENT_SOURCE layout for vkQueuePresentKHR.
+                // Transition source image back to image_layout after the screenshot.
                 image_barrier.srcAccessMask       = VK_ACCESS_TRANSFER_READ_BIT;
                 image_barrier.dstAccessMask       = 0;
                 image_barrier.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-                image_barrier.newLayout           = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+                image_barrier.newLayout           = image_layout;
                 image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
                 image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -90,6 +90,16 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
         return;
     }
 
+    if ((width == 0) || (height == 0))
+    {
+        GFXRECON_LOG_WARNING("Cannot create screenshot \"%s\" for 0 size image (width=%" PRIu32 ", height=%" PRIu32
+                             ").",
+                             filename_prefix.c_str(),
+                             width,
+                             height);
+        return;
+    }
+
     VkResult result = VK_SUCCESS;
 
     // TODO: Improved queue selection; ensure queue supports transfer operations.

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -59,7 +59,8 @@ class ScreenshotHandler : public ScreenshotHandlerBase
                     VkImage                                 image,
                     VkFormat                                format,
                     uint32_t                                width,
-                    uint32_t                                height);
+                    uint32_t                                height,
+                    VkImageLayout                           image_layout);
 
     void DestroyDeviceResources(VkDevice device, const encode::DeviceTable* device_table);
 

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -189,7 +189,6 @@ struct VulkanPoolObjectInfo : public VulkanObjectInfo<T>
 typedef VulkanObjectInfo<VkEvent>                         EventInfo;
 typedef VulkanObjectInfo<VkQueryPool>                     QueryPoolInfo;
 typedef VulkanObjectInfo<VkBufferView>                    BufferViewInfo;
-typedef VulkanObjectInfo<VkImageView>                     ImageViewInfo;
 typedef VulkanObjectInfo<VkShaderModule>                  ShaderModuleInfo;
 typedef VulkanObjectInfo<VkPipelineLayout>                PipelineLayoutInfo;
 typedef VulkanObjectInfo<VkPrivateDataSlot>               PrivateDataSlotInfo;
@@ -433,9 +432,16 @@ struct ValidationCacheEXTInfo : public VulkanObjectInfo<VkValidationCacheEXT>
     std::unordered_map<uint32_t, size_t> array_counts;
 };
 
+struct ImageViewInfo : public VulkanObjectInfo<VkImageView>
+{
+    format::HandleId image_id{ format::kNullHandleId };
+};
+
 struct FramebufferInfo : public VulkanObjectInfo<VkFramebuffer>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
+
+    std::vector<format::HandleId> attachment_image_view_ids;
 };
 
 struct DeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR>
@@ -459,7 +465,8 @@ struct ShaderEXTInfo : VulkanObjectInfo<VkShaderEXT>
 
 struct CommandBufferInfo : VulkanPoolObjectInfo<VkCommandBuffer>
 {
-    bool is_frame_boundary{ false };
+    bool                          is_frame_boundary{ false };
+    std::vector<format::HandleId> frame_buffer_ids;
 };
 
 //

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -192,7 +192,6 @@ typedef VulkanObjectInfo<VkBufferView>                    BufferViewInfo;
 typedef VulkanObjectInfo<VkShaderModule>                  ShaderModuleInfo;
 typedef VulkanObjectInfo<VkPipelineLayout>                PipelineLayoutInfo;
 typedef VulkanObjectInfo<VkPrivateDataSlot>               PrivateDataSlotInfo;
-typedef VulkanObjectInfo<VkRenderPass>                    RenderPassInfo;
 typedef VulkanObjectInfo<VkDescriptorSetLayout>           DescriptorSetLayoutInfo;
 typedef VulkanObjectInfo<VkSampler>                       SamplerInfo;
 typedef VulkanPoolObjectInfo<VkDescriptorSet>             DescriptorSetInfo;
@@ -336,6 +335,8 @@ struct ImageInfo : public VulkanObjectInfo<VkImage>
     uint32_t                            layer_count{ 0 };
     uint32_t                            level_count{ 0 };
     uint32_t                            queue_family_index{ 0 };
+
+    VkImageLayout current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
 };
 
 struct PipelineCacheInfo : public VulkanObjectInfo<VkPipelineCache>
@@ -463,10 +464,16 @@ struct ShaderEXTInfo : VulkanObjectInfo<VkShaderEXT>
     std::unordered_map<uint32_t, size_t> array_counts;
 };
 
-struct CommandBufferInfo : VulkanPoolObjectInfo<VkCommandBuffer>
+struct CommandBufferInfo : public VulkanPoolObjectInfo<VkCommandBuffer>
 {
-    bool                          is_frame_boundary{ false };
-    std::vector<format::HandleId> frame_buffer_ids;
+    bool                                                is_frame_boundary{ false };
+    std::vector<format::HandleId>                       frame_buffer_ids;
+    std::unordered_map<format::HandleId, VkImageLayout> image_layout_barriers;
+};
+
+struct RenderPassInfo : public VulkanObjectInfo<VkRenderPass>
+{
+    std::vector<VkAttachmentDescription> attachment_descriptions;
 };
 
 //

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2163,10 +2163,59 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(const Comm
     {
         if (screenshot_handler_->IsScreenshotFrame())
         {
-            GFXRECON_LOG_ERROR("Unable to take screenshot requested for frame %" PRIu32
-                               ". The frame ends with vkQueueSubmit* and screenshot requires frames to end with "
-                               "vkQueuePresent.",
-                               screenshot_handler_->GetCurrentFrame());
+            DeviceInfo* device_info = object_info_table_.GetDeviceInfo(command_buffer_info->parent_id);
+
+            auto instance_table = GetInstanceTable(device_info->parent);
+            GFXRECON_ASSERT(instance_table != nullptr);
+
+            // TODO: This should be stored in the DeviceInfo structure to avoid the need for frequent queries.
+            VkPhysicalDeviceMemoryProperties memory_properties;
+            instance_table->GetPhysicalDeviceMemoryProperties(device_info->parent, &memory_properties);
+
+            for (size_t i = 0; i < command_buffer_info->frame_buffer_ids.size(); ++i)
+            {
+                auto framebuffer_info = object_info_table_.GetFramebufferInfo(command_buffer_info->frame_buffer_ids[i]);
+
+                for (size_t j = 0; j < framebuffer_info->attachment_image_view_ids.size(); ++j)
+                {
+                    auto image_view_id   = framebuffer_info->attachment_image_view_ids[j];
+                    auto image_view_info = object_info_table_.GetImageViewInfo(image_view_id);
+                    auto image_info      = object_info_table_.GetImageInfo(image_view_info->image_id);
+
+                    // Only screenshot images that are color attachments.
+                    if ((image_info->usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) !=
+                        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+                    {
+                        continue;
+                    }
+
+                    std::string filename_prefix = screenshot_file_prefix_;
+                    filename_prefix += "_frame_";
+                    filename_prefix += std::to_string(screenshot_handler_->GetCurrentFrame());
+
+                    if (command_buffer_info->frame_buffer_ids.size() > 0)
+                    {
+                        filename_prefix += "_renderpass_";
+                        filename_prefix += std::to_string(i);
+                    }
+
+                    if (framebuffer_info->attachment_image_view_ids.size() > 0)
+                    {
+                        filename_prefix += "_attachment_";
+                        filename_prefix += std::to_string(j);
+                    }
+
+                    screenshot_handler_->WriteImage(filename_prefix,
+                                                    device_info->handle,
+                                                    GetDeviceTable(device_info->handle),
+                                                    memory_properties,
+                                                    device_info->allocator.get(),
+                                                    image_info->handle,
+                                                    image_info->format,
+                                                    image_info->extent.width,
+                                                    image_info->extent.height);
+                }
+            }
         }
         screenshot_handler_->EndFrame();
         return true;
@@ -3215,7 +3264,7 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit func,
     // Check whether any of the submitted command lists buffers are frame boundaries.
     if (screenshot_handler_ != nullptr)
     {
-        bool is_frame_boundary = false;
+        CommandBufferInfo* frame_boundary_command_buffer_info = nullptr;
         for (uint32_t i = 0; i < submitCount; ++i)
         {
             if (submit_info_data != nullptr)
@@ -6349,6 +6398,7 @@ VkResult VulkanReplayConsumerBase::OverrideGetAndroidHardwareBufferPropertiesAND
 void VulkanReplayConsumerBase::ClearCommandBufferInfo(CommandBufferInfo* command_buffer_info)
 {
     command_buffer_info->is_frame_boundary = false;
+    command_buffer_info->frame_buffer_ids.clear();
 }
 
 VkResult VulkanReplayConsumerBase::OverrideBeginCommandBuffer(
@@ -6389,6 +6439,77 @@ void VulkanReplayConsumerBase::OverrideCmdDebugMarkerInsertEXT(
         command_buffer_info->is_frame_boundary = true;
     }
 };
+
+void VulkanReplayConsumerBase::OverrideCmdBeginRenderPass(
+    PFN_vkCmdBeginRenderPass                             func,
+    CommandBufferInfo*                                   command_buffer_info,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
+    VkSubpassContents                                    contents)
+{
+    command_buffer_info->frame_buffer_ids.push_back(
+        render_pass_begin_info_decoder->GetMetaStructPointer()->framebuffer);
+
+    VkCommandBuffer command_buffer = command_buffer_info->handle;
+    return func(command_buffer, render_pass_begin_info_decoder->GetPointer(), contents);
+}
+
+VkResult VulkanReplayConsumerBase::OverrideCreateImageView(
+    PFN_vkCreateImageView                                func,
+    VkResult                                             original_result,
+    const DeviceInfo*                                    device_info,
+    StructPointerDecoder<Decoded_VkImageViewCreateInfo>* create_info_decoder,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* allocator_decoder,
+    HandlePointerDecoder<VkImageView>*                   view_decoder)
+{
+    VkDevice                     device      = device_info->handle;
+    const VkImageViewCreateInfo* create_info = create_info_decoder->GetPointer();
+    const VkAllocationCallbacks* allocator   = GetAllocationCallbacks(allocator_decoder);
+    VkImageView*                 out_view    = view_decoder->GetHandlePointer();
+
+    VkResult result = func(device, create_info, allocator, out_view);
+
+    if ((result == VK_SUCCESS) && ((*out_view) != VK_NULL_HANDLE))
+    {
+        auto image_view_info = reinterpret_cast<ImageViewInfo*>(view_decoder->GetConsumerData(0));
+        GFXRECON_ASSERT(image_view_info != nullptr);
+
+        image_view_info->image_id = create_info_decoder->GetMetaStructPointer()->image;
+    }
+
+    return result;
+}
+
+VkResult VulkanReplayConsumerBase::OverrideCreateFramebuffer(
+    PFN_vkCreateFramebuffer                                func,
+    VkResult                                               original_result,
+    const DeviceInfo*                                      device_info,
+    StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* create_info_decoder,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>*   allocator_decoder,
+    HandlePointerDecoder<VkFramebuffer>*                   frame_buffer_decoder)
+{
+    VkDevice                       device          = device_info->handle;
+    const VkFramebufferCreateInfo* create_info     = create_info_decoder->GetPointer();
+    const VkAllocationCallbacks*   allocator       = GetAllocationCallbacks(allocator_decoder);
+    VkFramebuffer*                 out_framebuffer = frame_buffer_decoder->GetHandlePointer();
+
+    VkResult result = func(device, create_info, allocator, out_framebuffer);
+
+    if ((result == VK_SUCCESS) && ((*out_framebuffer) != VK_NULL_HANDLE) && (create_info->attachmentCount > 0) &&
+        (create_info->pAttachments != nullptr) &&
+        ((create_info->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) != VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT))
+    {
+        auto framebuffer_info = reinterpret_cast<FramebufferInfo*>(frame_buffer_decoder->GetConsumerData(0));
+        GFXRECON_ASSERT(framebuffer_info != nullptr);
+
+        for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
+        {
+            framebuffer_info->attachment_image_view_ids.push_back(
+                create_info_decoder->GetMetaStructPointer()->pAttachments.GetPointer()[i]);
+        }
+    }
+
+    return result;
+}
 
 // We want to allow skipping the query for tool properties because the capture layer actually adds this extension
 // and the application may end up using the query.  However, this extension may not be present for replay, so

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -666,7 +666,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                        HandlePointerDecoder<VkRenderPass>*                          pRenderPass);
 
     void OverrideCmdPipelineBarrier(PFN_vkCmdPipelineBarrier                                   func,
-                                    const CommandBufferInfo*                                   command_buffer_info,
+                                    CommandBufferInfo*                                         command_buffer_info,
                                     VkPipelineStageFlags                                       srcStageMask,
                                     VkPipelineStageFlags                                       dstStageMask,
                                     VkDependencyFlags                                          dependencyFlags,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -936,6 +936,25 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                          CommandBufferInfo*                                        command_buffer_info,
                                          StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* marker_info_decoder);
 
+    void OverrideCmdBeginRenderPass(PFN_vkCmdBeginRenderPass                             func,
+                                    CommandBufferInfo*                                   command_buffer_info,
+                                    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* render_pass_begin_info_decoder,
+                                    VkSubpassContents                                    contents);
+
+    VkResult OverrideCreateImageView(PFN_vkCreateImageView                                func,
+                                     VkResult                                             original_result,
+                                     const DeviceInfo*                                    device_info,
+                                     StructPointerDecoder<Decoded_VkImageViewCreateInfo>* create_info_decoder,
+                                     StructPointerDecoder<Decoded_VkAllocationCallbacks>* allocator_decoder,
+                                     HandlePointerDecoder<VkImageView>*                   view_decoder);
+
+    VkResult OverrideCreateFramebuffer(PFN_vkCreateFramebuffer                                func,
+                                       VkResult                                               original_result,
+                                       const DeviceInfo*                                      device_info,
+                                       StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* create_info_decoder,
+                                       StructPointerDecoder<Decoded_VkAllocationCallbacks>*   allocator_decoder,
+                                       HandlePointerDecoder<VkFramebuffer>*                   frame_buffer_decoder);
+
   private:
     void RaiseFatalError(const char* message) const;
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -835,17 +835,17 @@ void VulkanReplayConsumer::Process_vkCreateImageView(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkImageView>*          pView)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkImageViewCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
-    MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
-    if (!pView->IsNull()) { pView->SetHandleLength(1); }
-    VkImageView* out_pView = pView->GetHandlePointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
 
-    VkResult replay_result = GetDeviceTable(in_device)->CreateImageView(in_device, in_pCreateInfo, in_pAllocator, out_pView);
+    MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
+    if (!pView->IsNull()) { pView->SetHandleLength(1); }
+    ImageViewInfo handle_info;
+    pView->SetConsumerData(0, &handle_info);
+
+    VkResult replay_result = OverrideCreateImageView(GetDeviceTable(in_device->handle)->CreateImageView, returnValue, in_device, pCreateInfo, pAllocator, pView);
     CheckResult("vkCreateImageView", returnValue, replay_result);
 
-    AddHandle<ImageViewInfo>(device, pView->GetPointer(), out_pView, &VulkanObjectInfoTable::AddImageViewInfo);
+    AddHandle<ImageViewInfo>(device, pView->GetPointer(), pView->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyImageView(
@@ -1240,17 +1240,17 @@ void VulkanReplayConsumer::Process_vkCreateFramebuffer(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFramebuffer>*        pFramebuffer)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkFramebufferCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
-    MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
-    if (!pFramebuffer->IsNull()) { pFramebuffer->SetHandleLength(1); }
-    VkFramebuffer* out_pFramebuffer = pFramebuffer->GetHandlePointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
 
-    VkResult replay_result = GetDeviceTable(in_device)->CreateFramebuffer(in_device, in_pCreateInfo, in_pAllocator, out_pFramebuffer);
+    MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
+    if (!pFramebuffer->IsNull()) { pFramebuffer->SetHandleLength(1); }
+    FramebufferInfo handle_info;
+    pFramebuffer->SetConsumerData(0, &handle_info);
+
+    VkResult replay_result = OverrideCreateFramebuffer(GetDeviceTable(in_device->handle)->CreateFramebuffer, returnValue, in_device, pCreateInfo, pAllocator, pFramebuffer);
     CheckResult("vkCreateFramebuffer", returnValue, replay_result);
 
-    AddHandle<FramebufferInfo>(device, pFramebuffer->GetPointer(), out_pFramebuffer, &VulkanObjectInfoTable::AddFramebufferInfo);
+    AddHandle<FramebufferInfo>(device, pFramebuffer->GetPointer(), pFramebuffer->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddFramebufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyFramebuffer(
@@ -2019,11 +2019,11 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass(
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     VkSubpassContents                           contents)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
-    const VkRenderPassBeginInfo* in_pRenderPassBegin = pRenderPassBegin->GetPointer();
+    auto in_commandBuffer = GetObjectInfoTable().GetCommandBufferInfo(commandBuffer);
+
     MapStructHandles(pRenderPassBegin->GetMetaStructPointer(), GetObjectInfoTable());
 
-    GetDeviceTable(in_commandBuffer)->CmdBeginRenderPass(in_commandBuffer, in_pRenderPassBegin, contents);
+    OverrideCmdBeginRenderPass(GetDeviceTable(in_commandBuffer->handle)->CmdBeginRenderPass, in_commandBuffer, pRenderPassBegin, contents);
 }
 
 void VulkanReplayConsumer::Process_vkCmdNextSubpass(

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -90,6 +90,9 @@
     "vkGetPhysicalDeviceToolPropertiesEXT": "OverrideGetPhysicalDeviceToolProperties",
     "vkBeginCommandBuffer": "OverrideBeginCommandBuffer",
     "vkResetCommandBuffer": "OverrideResetCommandBuffer",
-    "vkCmdDebugMarkerInsertEXT": "OverrideCmdDebugMarkerInsertEXT"
+    "vkCmdDebugMarkerInsertEXT": "OverrideCmdDebugMarkerInsertEXT",
+    "vkCmdBeginRenderPass": "OverrideCmdBeginRenderPass",
+    "vkCreateImageView": "OverrideCreateImageView",
+    "vkCreateFramebuffer": "OverrideCreateFramebuffer"
   }
 }


### PR DESCRIPTION
Screenshot the renderpass's framebuffer color attachments that were used
in a command buffer that marks the end of a VR frame.
