### PR TITLE
discard-cached-psos renamed to use_cached_psos

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -183,7 +183,7 @@ Usage:
                         [--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
-                        [--use-cached-psos <boolean>] [--surface-index <N>]
+                        [--use-cached-psos] [--surface-index <N>]
                         [--remove-unsupported] [--validate]
                         [--onhb | --omit-null-hardware-buffers]
                         [-m <mode> | --memory-translation <mode>]
@@ -285,9 +285,8 @@ Vulkan-only:
                                         and suballocations.
 
 D3D12-only:
-  --use-cached-psos <boolean>  Permit using cached PSOs when creating graphics or compute pipelines.
+  --use-cached-psos            Permit using cached PSOs when creating graphics or compute pipelines.
                                Disabling helps enable replay across changing driver installs.
-                               Default: disabled
   --debug-device-lost          Enables automatic injection of breadcrumbs into command buffers
                                and page fault reporting.
                                Used to debug Direct3D 12 device removed problems.

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -285,9 +285,9 @@ Vulkan-only:
                                         and suballocations.
 
 D3D12-only:
-  --use-cached-psos <boolean>  Force CachedPSO to null when creating graphics or compute PSOs.
-                               Can help enable replay across changing driver installs.
-                               Default: enabled
+  --use-cached-psos <boolean>  Permit using cached PSOs when creating graphics or compute pipelines.
+                               Disabling helps enable replay across changing driver installs.
+                               Default: disabled
   --debug-device-lost          Enables automatic injection of breadcrumbs into command buffers
                                and page fault reporting.
                                Used to debug Direct3D 12 device removed problems.

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -286,7 +286,7 @@ Vulkan-only:
 
 D3D12-only:
   --use-cached-psos            Permit using cached PSOs when creating graphics or compute pipelines.
-                               Disabling helps enable replay across changing driver installs.
+                               Using cached PSOs may reduce PSO creation time but may result in replay errors.
   --debug-device-lost          Enables automatic injection of breadcrumbs into command buffers
                                and page fault reporting.
                                Used to debug Direct3D 12 device removed problems.

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -183,7 +183,7 @@ Usage:
                         [--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
-                        [--dcp | --discard-cached-psos] [--surface-index <N>]
+                        [--use-cached-psos <boolean>] [--surface-index <N>]
                         [--remove-unsupported] [--validate]
                         [--onhb | --omit-null-hardware-buffers]
                         [-m <mode> | --memory-translation <mode>]
@@ -285,16 +285,16 @@ Vulkan-only:
                                         and suballocations.
 
 D3D12-only:
-  --dcp                 Force CachedPSO to null when creating graphics or compute PSOs.
-                        Can help enable replay across changing driver installs.
-                        (Same as --discard-cached-psos)
-  --debug-device-lost   Enables automatic injection of breadcrumbs into command buffers
-                        and page fault reporting.
-                        Used to debug Direct3D 12 device removed problems.
-  --fw <width,height>   Setup windowed and override resolution.
-                        (Same as --force-windowed)
-  --create-dummy-allocations Enables creation of dummy heaps and resources
-                             for replay validation.
+  --use-cached-psos <boolean>  Force CachedPSO to null when creating graphics or compute PSOs.
+                               Can help enable replay across changing driver installs.
+                               Default: enabled
+  --debug-device-lost          Enables automatic injection of breadcrumbs into command buffers
+                               and page fault reporting.
+                               Used to debug Direct3D 12 device removed problems.
+  --fw <width,height>          Setup windowed and override resolution.
+                               (Same as --force-windowed)
+  --create-dummy-allocations   Enables creation of dummy heaps and resources
+                               for replay validation.
   --dx12-override-object-names Generates unique names for all ID3D12Objects and
                                assigns each object the generated name.
                                This is intended to assist replay debugging.

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -2207,7 +2207,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideLoadGraphicsPipeline(
                (desc != nullptr) && (desc->GetPointer() != nullptr) && (state != nullptr));
 
         auto desc2 = desc->GetPointer();
-        if (options_.discard_cached_psos)
+        if (options_.use_cached_psos == false)
         {
             desc2->CachedPSO.pCachedBlob           = nullptr;
             desc2->CachedPSO.CachedBlobSizeInBytes = 0;
@@ -2240,7 +2240,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideLoadComputePipeline(
                (desc != nullptr) && (desc->GetPointer() != nullptr) && (state != nullptr));
 
         auto desc2 = desc->GetPointer();
-        if (options_.discard_cached_psos)
+        if (options_.use_cached_psos == false)
         {
             desc2->CachedPSO.pCachedBlob           = nullptr;
             desc2->CachedPSO.CachedBlobSizeInBytes = 0;
@@ -3101,7 +3101,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateGraphicsPipelineState(
     auto device = static_cast<ID3D12Device*>(device_object_info->object);
 
     auto pDesc2 = pDesc->GetPointer();
-    if (options_.discard_cached_psos)
+    if (options_.use_cached_psos == false)
     {
         pDesc2->CachedPSO.pCachedBlob           = nullptr;
         pDesc2->CachedPSO.CachedBlobSizeInBytes = 0;
@@ -3128,7 +3128,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateComputePipelineState(
     auto device = static_cast<ID3D12Device*>(device_object_info->object);
 
     auto pDesc2 = pDesc->GetPointer();
-    if (options_.discard_cached_psos)
+    if (options_.use_cached_psos == false)
     {
         pDesc2->CachedPSO.pCachedBlob           = nullptr;
         pDesc2->CachedPSO.CachedBlobSizeInBytes = 0;

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -2207,7 +2207,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideLoadGraphicsPipeline(
                (desc != nullptr) && (desc->GetPointer() != nullptr) && (state != nullptr));
 
         auto desc2 = desc->GetPointer();
-        if (options_.use_cached_psos == false)
+        if (!options_.use_cached_psos)
         {
             desc2->CachedPSO.pCachedBlob           = nullptr;
             desc2->CachedPSO.CachedBlobSizeInBytes = 0;
@@ -2240,7 +2240,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideLoadComputePipeline(
                (desc != nullptr) && (desc->GetPointer() != nullptr) && (state != nullptr));
 
         auto desc2 = desc->GetPointer();
-        if (options_.use_cached_psos == false)
+        if (!options_.use_cached_psos)
         {
             desc2->CachedPSO.pCachedBlob           = nullptr;
             desc2->CachedPSO.CachedBlobSizeInBytes = 0;
@@ -3101,7 +3101,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateGraphicsPipelineState(
     auto device = static_cast<ID3D12Device*>(device_object_info->object);
 
     auto pDesc2 = pDesc->GetPointer();
-    if (options_.use_cached_psos == false)
+    if (!options_.use_cached_psos)
     {
         pDesc2->CachedPSO.pCachedBlob           = nullptr;
         pDesc2->CachedPSO.CachedBlobSizeInBytes = 0;
@@ -3128,7 +3128,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateComputePipelineState(
     auto device = static_cast<ID3D12Device*>(device_object_info->object);
 
     auto pDesc2 = pDesc->GetPointer();
-    if (options_.use_cached_psos == false)
+    if (!options_.use_cached_psos)
     {
         pDesc2->CachedPSO.pCachedBlob           = nullptr;
         pDesc2->CachedPSO.CachedBlobSizeInBytes = 0;

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -40,7 +40,7 @@ struct DxReplayOptions : public ReplayOptions
 {
     bool                 enable_d3d12{ true };
     bool                 enable_d3d12_two_pass_replay{ false };
-    bool                 discard_cached_psos{ true };
+    bool                 use_cached_psos{ false };
     std::vector<int32_t> AllowedDebugMessages;
     std::vector<int32_t> DeniedDebugMessages;
     bool                 override_object_names{ false };

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -40,7 +40,7 @@ struct DxReplayOptions : public ReplayOptions
 {
     bool                 enable_d3d12{ true };
     bool                 enable_d3d12_two_pass_replay{ false };
-    bool                 discard_cached_psos{ false };
+    bool                 discard_cached_psos{ true };
     std::vector<int32_t> AllowedDebugMessages;
     std::vector<int32_t> DeniedDebugMessages;
     bool                 override_object_names{ false };

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -73,7 +73,6 @@ void CreateResourceValueTrackingConsumer(
 
     // Use default replay options, except dcp.
     decode::DxReplayOptions dx_replay_options;
-    dx_replay_options.discard_cached_psos = true;
 
     // Create the replay consumer.
     dx12_replay_consumer = std::make_unique<decode::Dx12ResourceValueTrackingConsumer>(

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -35,7 +35,8 @@ const char kOptions[] =
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
-    "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range,--fw|--force-windowed";
+    "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range,--fw|--force-windowed,"
+    "--use-cached-psos";
 
 static void PrintUsage(const char* exe_name)
 {

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -31,12 +31,11 @@ const char kOptions[] =
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
     "range,--fmr|--flush-measurement-range,--use-captured-swapchain-indices,--dcp,--discard-cached-psos,"
-    "--dx12-override-object-names";
+    "--use-cached-psos,--dx12-override-object-names";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
-    "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range,--fw|--force-windowed,"
-    "--use-cached-psos";
+    "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range,--fw|--force-windowed";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -201,8 +200,8 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12-only:")
-    GFXRECON_WRITE_CONSOLE("  --use-cached-psos <boolean>");
-    GFXRECON_WRITE_CONSOLE("          \t\tPermit using cached PSOs when creating graphics or compute pipelines.");
+    GFXRECON_WRITE_CONSOLE(
+        "  --use-cached-psos  \tPermit using cached PSOs when creating graphics or compute pipelines.");
     GFXRECON_WRITE_CONSOLE("       \t\t\tCan help enable replay across changing driver installs.");
     GFXRECON_WRITE_CONSOLE("  --debug-device-lost\tEnables automatic injection of breadcrumbs into command buffers");
     GFXRECON_WRITE_CONSOLE("            \t\tand page fault reporting.");

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -201,9 +201,9 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12-only:")
-    GFXRECON_WRITE_CONSOLE("  --dcp\t\t\tForce CachedPSO to null when creating graphics or compute PSOs.");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tCan help enable replay across changing driver installs.");
-    GFXRECON_WRITE_CONSOLE("       \t\t\t(Same as --discard-cached-psos)");
+    GFXRECON_WRITE_CONSOLE(
+        "  --use-cached-psos <boolean> Force CachedPSO to null when creating graphics or compute PSOs.");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tCan help enable replay across changing driver installs. Default true.");
     GFXRECON_WRITE_CONSOLE("  --debug-device-lost\tEnables automatic injection of breadcrumbs into command buffers");
     GFXRECON_WRITE_CONSOLE("            \t\tand page fault reporting.");
     GFXRECON_WRITE_CONSOLE("            \t\tUsed to debug Direct3D 12 device removed problems.");

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -201,9 +201,9 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("D3D12-only:")
-    GFXRECON_WRITE_CONSOLE(
-        "  --use-cached-psos <boolean> Force CachedPSO to null when creating graphics or compute PSOs.");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tCan help enable replay across changing driver installs. Default true.");
+    GFXRECON_WRITE_CONSOLE("  --use-cached-psos <boolean>");
+    GFXRECON_WRITE_CONSOLE("          \t\tPermit using cached PSOs when creating graphics or compute pipelines.");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tCan help enable replay across changing driver installs.");
     GFXRECON_WRITE_CONSOLE("  --debug-device-lost\tEnables automatic injection of breadcrumbs into command buffers");
     GFXRECON_WRITE_CONSOLE("            \t\tand page fault reporting.");
     GFXRECON_WRITE_CONSOLE("            \t\tUsed to debug Direct3D 12 device removed problems.");

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -55,7 +55,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--surface-index <N>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--use-cached-psos] [--surface-index <N>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--remove-unsupported] [--validate]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--onhb | --omit-null-hardware-buffers]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
@@ -202,7 +202,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("D3D12-only:")
     GFXRECON_WRITE_CONSOLE(
         "  --use-cached-psos  \tPermit using cached PSOs when creating graphics or compute pipelines.");
-    GFXRECON_WRITE_CONSOLE("       \t\t\tCan help enable replay across changing driver installs.");
+    GFXRECON_WRITE_CONSOLE(
+        "       \t\t\tUsing cached PSOs may reduce PSO creation time but may result in replay errors.");
     GFXRECON_WRITE_CONSOLE("  --debug-device-lost\tEnables automatic injection of breadcrumbs into command buffers");
     GFXRECON_WRITE_CONSOLE("            \t\tand page fault reporting.");
     GFXRECON_WRITE_CONSOLE("            \t\tUsed to debug Direct3D 12 device removed problems.");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -72,7 +72,7 @@ const char kSkipFailedAllocationShortOption[]    = "--sfa";
 const char kSkipFailedAllocationLongOption[]     = "--skip-failed-allocations";
 const char kDiscardCachedPsosShortOption[]       = "--dcp";
 const char kDiscardCachedPsosLongOption[]        = "--discard-cached-psos";
-const char kUseCachedPsosArgument[]              = "--use-cached-psos";
+const char kUseCachedPsosOption[]                = "--use-cached-psos";
 const char kOmitPipelineCacheDataShortOption[]   = "--opcd";
 const char kOmitPipelineCacheDataLongOption[]    = "--omit-pipeline-cache-data";
 const char kWsiArgument[]                        = "--wsi";
@@ -806,14 +806,13 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
 
     if (arg_parser.IsOptionSet(kDiscardCachedPsosLongOption) || arg_parser.IsOptionSet(kDiscardCachedPsosShortOption))
     {
-        GFXRECON_LOG_WARNING("The parameters --dcp and --discard-cached-psos have been depracated in favor for "
-                             "--use-cached-psos <boolean> (default false)");
+        GFXRECON_LOG_WARNING("The parameters --dcp and --discard-cached-psos have been deprecated in favor for "
+                             "--use-cached-psos");
     }
 
-    const auto& psos_value = arg_parser.GetArgumentValue(kUseCachedPsosArgument);
-    if (!psos_value.empty())
+    if (arg_parser.IsOptionSet(kUseCachedPsosOption))
     {
-        replay_options.use_cached_psos = gfxrecon::util::ParseBoolString(psos_value, false);
+        replay_options.use_cached_psos = true;
     }
 
     if (arg_parser.IsOptionSet(kDxOverrideObjectNames))

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -72,7 +72,7 @@ const char kSkipFailedAllocationShortOption[]    = "--sfa";
 const char kSkipFailedAllocationLongOption[]     = "--skip-failed-allocations";
 const char kDiscardCachedPsosShortOption[]       = "--dcp";
 const char kDiscardCachedPsosLongOption[]        = "--discard-cached-psos";
-const char kDiscardCachedPsosArgument[]          = "--use-cached-psos";
+const char kUseCachedPsosArgument[]              = "--use-cached-psos";
 const char kOmitPipelineCacheDataShortOption[]   = "--opcd";
 const char kOmitPipelineCacheDataLongOption[]    = "--omit-pipeline-cache-data";
 const char kWsiArgument[]                        = "--wsi";
@@ -807,13 +807,13 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     if (arg_parser.IsOptionSet(kDiscardCachedPsosLongOption) || arg_parser.IsOptionSet(kDiscardCachedPsosShortOption))
     {
         GFXRECON_LOG_WARNING("The parameters --dcp and --discard-cached-psos have been depracated in favor for "
-                             "--use-cached-psos <boolean> (default true)");
+                             "--use-cached-psos <boolean> (default false)");
     }
 
-    const auto& psos_value = arg_parser.GetArgumentValue(kDiscardCachedPsosArgument);
+    const auto& psos_value = arg_parser.GetArgumentValue(kUseCachedPsosArgument);
     if (!psos_value.empty())
     {
-        replay_options.discard_cached_psos = gfxrecon::util::ParseBoolString(psos_value, true);
+        replay_options.use_cached_psos = gfxrecon::util::ParseBoolString(psos_value, false);
     }
 
     if (arg_parser.IsOptionSet(kDxOverrideObjectNames))

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -72,6 +72,7 @@ const char kSkipFailedAllocationShortOption[]    = "--sfa";
 const char kSkipFailedAllocationLongOption[]     = "--skip-failed-allocations";
 const char kDiscardCachedPsosShortOption[]       = "--dcp";
 const char kDiscardCachedPsosLongOption[]        = "--discard-cached-psos";
+const char kDiscardCachedPsosArgument[]          = "--use-cached-psos";
 const char kOmitPipelineCacheDataShortOption[]   = "--opcd";
 const char kOmitPipelineCacheDataLongOption[]    = "--omit-pipeline-cache-data";
 const char kWsiArgument[]                        = "--wsi";
@@ -805,7 +806,14 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
 
     if (arg_parser.IsOptionSet(kDiscardCachedPsosLongOption) || arg_parser.IsOptionSet(kDiscardCachedPsosShortOption))
     {
-        replay_options.discard_cached_psos = true;
+        GFXRECON_LOG_WARNING("The parameters --dcp and --discard-cached-psos have been depracated in favor for "
+                             "--use-cached-psos <boolean> (default true)");
+    }
+
+    const auto& psos_value = arg_parser.GetArgumentValue(kDiscardCachedPsosArgument);
+    if (!psos_value.empty())
+    {
+        replay_options.discard_cached_psos = gfxrecon::util::ParseBoolString(psos_value, true);
     }
 
     if (arg_parser.IsOptionSet(kDxOverrideObjectNames))


### PR DESCRIPTION
**Problem:**
The replayer should always use 'discard-cached-psos'. Currently '--dcp' and '--discard-cached-psos' are options and could not be disabled. 

**Solution:**
Added option'--use-cached-psos' with default 'false'. 'discard_cached_psos' renamed to 'use_cached_psos' and would be set 'true' if used.

**Test:**
Tested with default, enabled and disabled. Warning issued when deprecated '--dcp' is used.