### PR TITLE
Add --gpu option to the optimizer

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -466,7 +466,6 @@ Required arguments:
 Optional arguments:
   --d3d12-pso-removal   D3D12-only: Remove creation of unreferenced PSOs.
   --dxr                 D3D12-only: Optimize for DXR replay.
-  --gpu                 D3D12-only: Optimize for DXR replay.
 
 Note: running without optional arguments will instruct the optimizer to detect API and run all available optimizations.
 ```

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -407,7 +407,7 @@ gfxrecon-optimize.exe - Produce new captures with enhanced performance character
                         For D3D12, the optimizer will improve DXR replay performance and remove unused PSOs (for all captures)
 
 Usage:
-  gfxrecon-optimize.exe [-h | --help] [--version] [--d3d12-pso-removal] [--dxr] <input-file> <output-file>
+  gfxrecon-optimize.exe [-h | --help] [--version] [--d3d12-pso-removal] [--dxr] [--gpu <index>] <input-file> <output-file>
 
 Required arguments:
   <input-file>          The path to input GFXReconstruct capture file to be processed.
@@ -418,6 +418,10 @@ Optional arguments:
   --version             Print version information and exit.
   --d3d12-pso-removal   D3D12-only: Remove creation of unreferenced PSOs.
   --dxr                 D3D12-only: Optimize for DXR replay.
+  --gpu <index>         D3D12-only: Use the specified device for the optimizer replay, where index is the zero-based index to the array 
+                        of physical devices returned by vkEnumeratePhysicalDevices or The optimizer replay may fail if the specified 
+                        device is not compatible with the IDXGIFactory1::EnumAdapters1. The optimizer replay may fail if the specified 
+                        device is not compatible with the original capture devices..
 
 Note: running without optional arguments will instruct the optimizer to detect API and run all available optimizations.
 ```
@@ -462,6 +466,7 @@ Required arguments:
 Optional arguments:
   --d3d12-pso-removal   D3D12-only: Remove creation of unreferenced PSOs.
   --dxr                 D3D12-only: Optimize for DXR replay.
+  --gpu                 D3D12-only: Optimize for DXR replay.
 
 Note: running without optional arguments will instruct the optimizer to detect API and run all available optimizations.
 ```

--- a/framework/decode/dx12_optimize_options.h
+++ b/framework/decode/dx12_optimize_options.h
@@ -32,6 +32,8 @@ struct Dx12OptimizationOptions
     bool remove_redundant_psos{ false };
     bool optimize_resource_values{ false };
     bool optimize_resource_values_experimental{ false };
+
+    int32_t override_gpu_index{ -1 };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/tools/optimize/dx12_optimize_util.cpp
+++ b/tools/optimize/dx12_optimize_util.cpp
@@ -71,9 +71,10 @@ void CreateResourceValueTrackingConsumer(
     application = std::make_shared<gfxrecon::application::Application>(app_string, file_processor);
     application->InitializeDx12WsiContext();
 
-    // Use default replay options, except dcp.
+    // Use default replay options, except dcp and gpu index.
     decode::DxReplayOptions dx_replay_options;
     dx_replay_options.discard_cached_psos = true;
+    dx_replay_options.override_gpu_index  = options.override_gpu_index;
 
     // Create the replay consumer.
     dx12_replay_consumer = std::make_unique<decode::Dx12ResourceValueTrackingConsumer>(


### PR DESCRIPTION
**Problem**
A system may have multiple GPUs. We should be able to select a GPU for the optimization, because if the trace is captured with one of the GPUs, the optimization may be performed only with the same GPU. 

**Solution**
Add the option to the optimizer. 

**Result**
Tested. It is working.