### PR TITLE
Add --flush-inside-measurement-range option

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -859,6 +859,10 @@ optional arguments:
                         If this is specified the replayer will flush and wait
                         for all current GPU work to finish at the start and end
                         of the measurement range. (forwarded to replay tool)
+  --flush-inside-measurement-range
+                        If this is specified the replayer will flush and wait
+                        for all current GPU work to finish at the end of each
+                        frame inside the measurement range. (forwarded to replay tool)
   --use-colorspace-fallback
                         Swap the swapchain color space if unsupported by replay device.
                         Check if color space is not supported by replay device and swap

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -532,6 +532,10 @@ Optional arguments:
               If this is specified the replayer will flush
               and wait for all current GPU work to finish at the
               start and end of the measurement range.
+  --flush-inside-measurement-range
+              If this is specified the replayer will flush and wait
+              for all current GPU work to finish at the end of each
+              frame inside the measurement range.
   --use-colorspace-fallback
               Swap the swapchain color space if unsupported by replay device.
               Check if color space is not supported by replay device and

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -89,6 +89,7 @@ def CreateReplayParser():
     parser.add_argument('--measurement-file', metavar='DEVICE_FILE', help='Write measurements to a file at the specified path. Default is: \'/sdcard/gfxrecon-measurements.json\' on android and \'./gfxrecon-measurements.json\' on desktop. (forwarded to replay tool)')
     parser.add_argument('--quit-after-measurement-range', action='store_true', default=False, help='If this is specified the replayer will abort when it reaches the <end_frame> specified in the --measurement-frame-range argument. (forwarded to replay tool)')
     parser.add_argument('--flush-measurement-range', action='store_true', default=False, help='If this is specified the replayer will flush and wait for all current GPU work to finish at the start and end of the measurement range. (forwarded to replay tool)')
+    parser.add_argument('--flush-inside-measurement-range', action='store_true', default=False, help='If this is specified the replayer will flush and wait for all current GPU work to finish at end of each frame inside the measurement range. (forwarded to replay tool)')
     parser.add_argument('-m', '--memory-translation', metavar='MODE', choices=['none', 'remap', 'realign', 'rebind'], help='Enable memory translation for replay on GPUs with memory types that are not compatible with the capture GPU\'s memory types.  Available modes are: none, remap, realign, rebind (forwarded to replay tool)')
     parser.add_argument('--swapchain', metavar='MODE', choices=['virtual', 'captured', 'offscreen'], help='Choose a swapchain mode to replay. Available modes are: virtual, captured, offscreen (forwarded to replay tool)')
     parser.add_argument('--use-captured-swapchain-indices', action='store_true', default=False, help='Same as "--swapchain captured". Ignored if the "--swapchain" option is used.')
@@ -185,6 +186,10 @@ def MakeExtrasString(args):
     if args.flush_measurement_range:
         arg_list.append('--flush-measurement-range')
         arg_list.append('{}'.format(args.flush_measurement_range))
+
+    if args.flush_inside_measurement_range:
+        arg_list.append('--flush-inside-measurement-range')
+        arg_list.append('{}'.format(args.flush_inside_measurement_range))
 
     if args.swapchain:
         arg_list.append('--swapchain')

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -47,6 +47,7 @@ struct ReplayOptions
     bool     omit_null_hardware_buffers{ false };
     bool     quit_after_measurement_frame_range{ false };
     bool     flush_measurement_frame_range{ false };
+    bool     flush_inside_measurement_range{ false };
     bool     force_windowed{ false };
     uint32_t windowed_width{ 0 };
     uint32_t windowed_height{ 0 };

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -62,12 +62,14 @@ FpsInfo::FpsInfo(uint64_t               measurement_start_frame,
                  bool                   has_measurement_range,
                  bool                   quit_after_range,
                  bool                   flush_measurement_range,
+                 bool                   flush_inside_measurement_range,
                  const std::string_view measurement_file_name) :
     measurement_start_frame_(measurement_start_frame),
     measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
     quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range),
-    has_measurement_range_(has_measurement_range), started_measurement_(false), ended_measurement_(false),
-    frame_start_time_(0), frame_durations_(), measurement_file_name_(measurement_file_name)
+    flush_inside_measurement_range_(flush_inside_measurement_range), has_measurement_range_(has_measurement_range),
+    started_measurement_(false), ended_measurement_(false), frame_start_time_(0), frame_durations_(),
+    measurement_file_name_(measurement_file_name)
 {
     if (has_measurement_range_)
     {
@@ -177,8 +179,9 @@ void FpsInfo::EndFrame(uint64_t frame)
 
 bool FpsInfo::ShouldWaitIdleAfterFrame(uint64_t frame)
 {
-    bool range_ended = frame == measurement_end_frame_;
-    return flush_measurement_range_ && range_ended;
+    bool range_ended  = frame == measurement_end_frame_;
+    bool inside_range = frame >= measurement_start_frame_ && frame <= measurement_end_frame_;
+    return (flush_measurement_range_ && range_ended) || (flush_inside_measurement_range_ && inside_range);
 }
 
 void FpsInfo::EndFile(uint64_t frame)

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -36,12 +36,13 @@ GFXRECON_BEGIN_NAMESPACE(graphics)
 class FpsInfo
 {
   public:
-    FpsInfo(uint64_t               measurement_start_frame = 1,
-            uint64_t               measurement_end_frame   = std::numeric_limits<uint64_t>::max(),
-            bool                   has_measurement_range   = false,
-            bool                   quit_after_range        = false,
-            bool                   flush_measurement_range = false,
-            const std::string_view measurement_file_name   = "");
+    FpsInfo(uint64_t               measurement_start_frame        = 1,
+            uint64_t               measurement_end_frame          = std::numeric_limits<uint64_t>::max(),
+            bool                   has_measurement_range          = false,
+            bool                   quit_after_range               = false,
+            bool                   flush_measurement_range        = false,
+            bool                   flush_inside_measurement_range = false,
+            const std::string_view measurement_file_name          = "");
 
     void LogToConsole();
 
@@ -69,6 +70,7 @@ class FpsInfo
     bool has_measurement_range_;
     bool quit_after_range_;
     bool flush_measurement_range_;
+    bool flush_inside_measurement_range_;
 
     bool started_measurement_;
     bool ended_measurement_;

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -131,6 +131,7 @@ void android_main(struct android_app* app)
                                                      has_mfr,
                                                      replay_options.quit_after_measurement_frame_range,
                                                      replay_options.flush_measurement_frame_range,
+                                                     replay_options.flush_inside_measurement_range,
                                                      measurement_file_name);
 
                 replay_consumer.SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -146,6 +146,7 @@ int main(int argc, const char** argv)
             bool        has_mfr                            = false;
             bool        quit_after_measurement_frame_range = false;
             bool        flush_measurement_frame_range      = false;
+            bool        flush_inside_measurement_range     = false;
             std::string measurement_file_name;
 
             if (vulkan_replay_options.enable_vulkan)
@@ -153,6 +154,7 @@ int main(int argc, const char** argv)
                 has_mfr                            = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
                 quit_after_measurement_frame_range = vulkan_replay_options.quit_after_measurement_frame_range;
                 flush_measurement_frame_range      = vulkan_replay_options.flush_measurement_frame_range;
+                flush_inside_measurement_range     = vulkan_replay_options.flush_inside_measurement_range;
             }
 
             if (has_mfr)
@@ -165,6 +167,7 @@ int main(int argc, const char** argv)
                                                  has_mfr,
                                                  quit_after_measurement_frame_range,
                                                  flush_measurement_frame_range,
+                                                 flush_inside_measurement_range,
                                                  measurement_file_name);
 
             gfxrecon::decode::VulkanReplayConsumer vulkan_replay_consumer(application, vulkan_replay_options);

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -29,9 +29,9 @@
 const char kOptions[] =
     "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
-    "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
-    "range,--fmr|--flush-measurement-range,--use-captured-swapchain-indices,--dcp,--discard-cached-psos,"
-    "--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names";
+    "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-range,--fmr|--flush-"
+    "measurement-range,--flush-inside-measurement-range,--use-captured-swapchain-indices,--dcp,--"
+    "discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -223,6 +223,10 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tIf this is specified the replayer will flush")
     GFXRECON_WRITE_CONSOLE("          \t\tand wait for all current GPU work to finish at the");
     GFXRECON_WRITE_CONSOLE("          \t\tstart and end of the measurement range.");
+    GFXRECON_WRITE_CONSOLE("  --flush-inside-measurement-range");
+    GFXRECON_WRITE_CONSOLE("          \t\tIf this is specified the replayer will flush")
+    GFXRECON_WRITE_CONSOLE("          \t\tand wait for all current GPU work to finish at the");
+    GFXRECON_WRITE_CONSOLE("          \t\tend of each frame inside the measurement range.");
     GFXRECON_WRITE_CONSOLE("  --gpu-group <index>\tUse the specified device group for replay, where index");
     GFXRECON_WRITE_CONSOLE("          \t\tis the zero-based index to the array of physical device group");
     GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDeviceGroups.  Replay may fail");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -103,6 +103,7 @@ const char kMeasurementRangeArgument[]           = "--measurement-frame-range";
 const char kMeasurementFileArgument[]            = "--measurement-file";
 const char kQuitAfterMeasurementRangeOption[]    = "--quit-after-measurement-range";
 const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
+const char kFlushInsideMeasurementRangeOption[]  = "--flush-inside-measurement-range";
 const char kSwapchainOption[]                    = "--swapchain";
 const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
@@ -808,6 +809,11 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions& options, const gfx
     if (arg_parser.IsOptionSet(kFlushMeasurementRangeOption))
     {
         options.flush_measurement_frame_range = true;
+    }
+
+    if (arg_parser.IsOptionSet(kFlushInsideMeasurementRangeOption))
+    {
+        options.flush_inside_measurement_range = true;
     }
 
     const auto& override_gpu = arg_parser.GetArgumentValue(kOverrideGpuArgument);


### PR DESCRIPTION
Add option to flush and wait all current GPU work to finish at the end of every frame inside the measurement range.

This allows to take measurements on each frame individually without jobs interleaving between two frames.
