### PR TITLE
Track removed resource GPUVA

### DIFF
--- a/framework/encode/dx12_rv_annotator.cpp
+++ b/framework/encode/dx12_rv_annotator.cpp
@@ -35,7 +35,10 @@ void Dx12ResourceValueAnnotator::RemoveObjectGPUVA(IUnknown_Wrapper* wrapper)
     if (IsEqualGUID(riid, __uuidof(ID3D12Resource)) || IsEqualGUID(riid, __uuidof(ID3D12Resource1)) ||
         IsEqualGUID(riid, __uuidof(ID3D12Resource2)))
     {
-        RemoveGPUVA(reinterpret_cast<ID3D12Resource_Wrapper*>(wrapper)->GetObjectInfo()->gpu_va);
+        if (reinterpret_cast<ID3D12Resource_Wrapper*>(wrapper)->GetObjectInfo()->heap_wrapper == nullptr)
+        {
+            RemoveGPUVA(reinterpret_cast<ID3D12Resource_Wrapper*>(wrapper)->GetObjectInfo()->gpu_va);
+        }
     }
     else if (IsEqualGUID(riid, __uuidof(ID3D12Heap)) || IsEqualGUID(riid, __uuidof(ID3D12Heap1)))
     {


### PR DESCRIPTION
**Problem:**
If two resources were created on same heap and same offset, released one resource deleted entire GPUVA range.

**Solution:**
If released resource associated to Heap, kept GPUVA range until Heap been released.