### PR TITLE
Allow ags.lib/agsd.lib for win32 replayer/optimizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,8 +190,8 @@ if(MSVC)
     
     if (${D3D12_SUPPORT})
         if (${GFXRECON_AGS_SUPPORT})
+            find_package(AGS)
             if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-                find_package(AGS)
                 if (TARGET AGS::AGS)
                     add_definitions(-DGFXRECON_AGS_SUPPORT)
                 

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -151,7 +151,7 @@ if (WAYLAND_LIBRARY)
     target_compile_definitions(gfxrecon_util PUBLIC "WAYLAND_LIBRARY=\"${WAYLAND_LIBRARY}\"")
 endif()
 
-if (${GFXRECON_AGS_SUPPORT_FINAL})
+if (${GFXRECON_AGS_SUPPORT})
     target_link_libraries(gfxrecon_util AGS::AGS)
 endif()
 


### PR DESCRIPTION
**Problem**
We may need to use AGS functions, such as agsDriverExtensionsDX12_PushMarker, through statically linking to ags.lib or agsd.lib for replay project or optimize project. Currently the required libs are included for x64 builds of the replay project and the optimize project. The AGS libs are missing for win32 builds. 

**Solution**
Adjust related AGS related flags in CMakeLists files. 

**Result**
ags.lib/agsd.lib show up in the link input list for win32 builds. 