### PR TITLE
Updated the DX12 BlockLists

### DIFF
--- a/framework/generated/dx12_generators/blacklists.json
+++ b/framework/generated/dx12_generators/blacklists.json
@@ -1,5 +1,6 @@
 {
-  "functions": [],
+  "functions-all": [],
+  "functions-encoder": [],
   "functions-decoder": [],
   "classmethods": {
     "ID3D12Device": [


### PR DESCRIPTION
Reenables Python generation for DX12.

`python3.exe generate_dx12.py` was not working for some number of previous commits since the Vulkan blocklists file was changed and the DX12 version not similarly updated.