### PR TITLE
Print differences in supported extensions and features

### DIFF
--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -55,11 +55,12 @@ void RemoveIgnorableExtensions(const std::vector<VkExtensionProperties>& propert
                                std::vector<const char*>*                 extensions);
 
 // This is a declaration for a generated function.
-void RemoveUnsupportedFeatures(VkPhysicalDevice                 physicalDevice,
-                               PFN_vkGetPhysicalDeviceFeatures  get_device_features_proc,
-                               PFN_vkGetPhysicalDeviceFeatures2 get_device_features2_proc,
-                               const void*                      pNext,
-                               const VkPhysicalDeviceFeatures*  pEnabledFeatures);
+void CheckUnsupportedFeatures(VkPhysicalDevice                 physicalDevice,
+                              PFN_vkGetPhysicalDeviceFeatures  get_device_features_proc,
+                              PFN_vkGetPhysicalDeviceFeatures2 get_device_features2_proc,
+                              const void*                      pNext,
+                              const VkPhysicalDeviceFeatures*  pEnabledFeatures,
+                              bool                             remove_unsupported);
 
 GFXRECON_END_NAMESPACE(feature_util)
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2579,15 +2579,13 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
                 }
             }
 
-            if (options_.remove_unsupported_features)
-            {
-                // Remove enabled features that are not available from the replay device.
-                feature_util::RemoveUnsupportedFeatures(physical_device,
-                                                        table->GetPhysicalDeviceFeatures,
-                                                        table->GetPhysicalDeviceFeatures2,
-                                                        modified_create_info.pNext,
-                                                        modified_create_info.pEnabledFeatures);
-            }
+            // Remove enabled features that are not available from the replay device.
+            feature_util::CheckUnsupportedFeatures(physical_device,
+                                                   table->GetPhysicalDeviceFeatures,
+                                                   table->GetPhysicalDeviceFeatures2,
+                                                   modified_create_info.pNext,
+                                                   modified_create_info.pEnabledFeatures,
+                                                   options_.remove_unsupported_features);
         }
 
         modified_create_info.enabledExtensionCount   = static_cast<uint32_t>(modified_extensions.size());

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -34,7 +34,12 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(feature_util)
 
-void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures, PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2, const void* pNext, const VkPhysicalDeviceFeatures* pEnabledFeatures)
+void CheckUnsupportedFeatures(VkPhysicalDevice physicalDevice,
+                             PFN_vkGetPhysicalDeviceFeatures  GetPhysicalDeviceFeatures,
+                             PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2,
+                             const void*                      pNext,
+                             const VkPhysicalDeviceFeatures*  pEnabledFeatures,
+                             bool                             remove_unsupported)
 {
     // If the pNext chain includes a VkPhysicalDeviceFeatures2 structure, then pEnabledFeatures must be NULL
     const VkPhysicalDeviceFeatures* physicalDeviceFeatures = nullptr;
@@ -42,6 +47,11 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
     {
         physicalDeviceFeatures = pEnabledFeatures;
     }
+
+    bool found_unsupported = false;
+    const char* warn_message =
+        remove_unsupported ? "requested at capture is not supported by the replay device and it will not be enabled."
+                           : "requested at capture is not supported by the replay device.";
 
     if (GetPhysicalDeviceFeatures2 != nullptr)
     {
@@ -63,26 +73,34 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->storageBuffer16BitAccess == VK_TRUE) && (query.storageBuffer16BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storageBuffer16BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storageBuffer16BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storageBuffer16BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->uniformAndStorageBuffer16BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer16BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->uniformAndStorageBuffer16BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer16BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->uniformAndStorageBuffer16BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->storagePushConstant16 == VK_TRUE) && (query.storagePushConstant16 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storagePushConstant16, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storagePushConstant16 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant16 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storagePushConstant16 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->storageInputOutput16 == VK_TRUE) && (query.storageInputOutput16 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storageInputOutput16, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storageInputOutput16 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storageInputOutput16 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storageInputOutput16 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
             {
                 const VkPhysicalDeviceMultiviewFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(next);
@@ -91,21 +109,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->multiview == VK_TRUE) && (query.multiview == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiview, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiview = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiview %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiview =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multiviewGeometryShader == VK_TRUE) && (query.multiviewGeometryShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewGeometryShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiviewGeometryShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewGeometryShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiviewGeometryShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multiviewTessellationShader == VK_TRUE) && (query.multiviewTessellationShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewTessellationShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiviewTessellationShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewTessellationShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiviewTessellationShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES:
             {
                 const VkPhysicalDeviceVariablePointersFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(next);
@@ -114,16 +138,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->variablePointersStorageBuffer == VK_TRUE) && (query.variablePointersStorageBuffer == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature variablePointersStorageBuffer, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVariablePointersFeatures*>(currentNext)->variablePointersStorageBuffer = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature variablePointersStorageBuffer %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVariablePointersFeatures*>(currentNext)->variablePointersStorageBuffer =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->variablePointers == VK_TRUE) && (query.variablePointers == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature variablePointers, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVariablePointersFeatures*>(currentNext)->variablePointers = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature variablePointers %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVariablePointersFeatures*>(currentNext)->variablePointers =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
             {
                 const VkPhysicalDeviceProtectedMemoryFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(next);
@@ -132,11 +160,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->protectedMemory == VK_TRUE) && (query.protectedMemory == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature protectedMemory, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceProtectedMemoryFeatures*>(currentNext)->protectedMemory = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature protectedMemory %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceProtectedMemoryFeatures*>(currentNext)->protectedMemory =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
             {
                 const VkPhysicalDeviceSamplerYcbcrConversionFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(next);
@@ -145,11 +175,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->samplerYcbcrConversion == VK_TRUE) && (query.samplerYcbcrConversion == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature samplerYcbcrConversion, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(currentNext)->samplerYcbcrConversion = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature samplerYcbcrConversion %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(currentNext)->samplerYcbcrConversion =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES:
             {
                 const VkPhysicalDeviceShaderDrawParametersFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(next);
@@ -158,11 +190,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderDrawParameters == VK_TRUE) && (query.shaderDrawParameters == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderDrawParameters, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderDrawParametersFeatures*>(currentNext)->shaderDrawParameters = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderDrawParameters %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderDrawParametersFeatures*>(currentNext)->shaderDrawParameters =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
             {
                 const VkPhysicalDeviceVulkan11Features* currentNext = reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(next);
@@ -171,66 +205,90 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->storageBuffer16BitAccess == VK_TRUE) && (query.storageBuffer16BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storageBuffer16BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storageBuffer16BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storageBuffer16BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->uniformAndStorageBuffer16BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer16BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->uniformAndStorageBuffer16BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer16BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->uniformAndStorageBuffer16BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->storagePushConstant16 == VK_TRUE) && (query.storagePushConstant16 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storagePushConstant16, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storagePushConstant16 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant16 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storagePushConstant16 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->storageInputOutput16 == VK_TRUE) && (query.storageInputOutput16 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storageInputOutput16, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storageInputOutput16 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storageInputOutput16 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storageInputOutput16 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multiview == VK_TRUE) && (query.multiview == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiview, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiview = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiview %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiview =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multiviewGeometryShader == VK_TRUE) && (query.multiviewGeometryShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewGeometryShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiviewGeometryShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewGeometryShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiviewGeometryShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multiviewTessellationShader == VK_TRUE) && (query.multiviewTessellationShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewTessellationShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiviewTessellationShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewTessellationShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiviewTessellationShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->variablePointersStorageBuffer == VK_TRUE) && (query.variablePointersStorageBuffer == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature variablePointersStorageBuffer, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->variablePointersStorageBuffer = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature variablePointersStorageBuffer %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->variablePointersStorageBuffer =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->variablePointers == VK_TRUE) && (query.variablePointers == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature variablePointers, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->variablePointers = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature variablePointers %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->variablePointers =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->protectedMemory == VK_TRUE) && (query.protectedMemory == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature protectedMemory, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->protectedMemory = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature protectedMemory %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->protectedMemory =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->samplerYcbcrConversion == VK_TRUE) && (query.samplerYcbcrConversion == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature samplerYcbcrConversion, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->samplerYcbcrConversion = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature samplerYcbcrConversion %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->samplerYcbcrConversion =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderDrawParameters == VK_TRUE) && (query.shaderDrawParameters == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderDrawParameters, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->shaderDrawParameters = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderDrawParameters %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->shaderDrawParameters =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
             {
                 const VkPhysicalDeviceVulkan12Features* currentNext = reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(next);
@@ -239,241 +297,335 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->samplerMirrorClampToEdge == VK_TRUE) && (query.samplerMirrorClampToEdge == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature samplerMirrorClampToEdge, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->samplerMirrorClampToEdge = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature samplerMirrorClampToEdge %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->samplerMirrorClampToEdge =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->drawIndirectCount == VK_TRUE) && (query.drawIndirectCount == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature drawIndirectCount, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->drawIndirectCount = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature drawIndirectCount %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->drawIndirectCount =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->storageBuffer8BitAccess == VK_TRUE) && (query.storageBuffer8BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->storageBuffer8BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storageBuffer8BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->storageBuffer8BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->uniformAndStorageBuffer8BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer8BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->uniformAndStorageBuffer8BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer8BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->uniformAndStorageBuffer8BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->storagePushConstant8 == VK_TRUE) && (query.storagePushConstant8 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storagePushConstant8, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->storagePushConstant8 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant8 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->storagePushConstant8 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferInt64Atomics == VK_TRUE) && (query.shaderBufferInt64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferInt64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderBufferInt64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferInt64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderBufferInt64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedInt64Atomics == VK_TRUE) && (query.shaderSharedInt64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedInt64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSharedInt64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedInt64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSharedInt64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderFloat16 == VK_TRUE) && (query.shaderFloat16 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderFloat16, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderFloat16 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderFloat16 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderFloat16 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderInt8 == VK_TRUE) && (query.shaderInt8 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderInt8, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInt8 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderInt8 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInt8 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorIndexing == VK_TRUE) && (query.descriptorIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderInputAttachmentArrayDynamicIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayDynamicIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInputAttachmentArrayDynamicIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayDynamicIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInputAttachmentArrayDynamicIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderUniformTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayDynamicIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformTexelBufferArrayDynamicIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayDynamicIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformTexelBufferArrayDynamicIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayDynamicIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageTexelBufferArrayDynamicIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayDynamicIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageTexelBufferArrayDynamicIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderUniformBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSampledImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderSampledImageArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSampledImageArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSampledImageArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageImageArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageImageArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageImageArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderInputAttachmentArrayNonUniformIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInputAttachmentArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInputAttachmentArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderUniformTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformTexelBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageTexelBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingUniformBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUniformBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUniformBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingSampledImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingSampledImageUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingSampledImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingSampledImageUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingSampledImageUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingSampledImageUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingStorageImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageImageUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageImageUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageImageUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageImageUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingStorageBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingUniformTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformTexelBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUniformTexelBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformTexelBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUniformTexelBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingStorageTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageTexelBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageTexelBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageTexelBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageTexelBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingUpdateUnusedWhilePending == VK_TRUE) && (query.descriptorBindingUpdateUnusedWhilePending == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingUpdateUnusedWhilePending, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUpdateUnusedWhilePending = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUpdateUnusedWhilePending %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUpdateUnusedWhilePending =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingPartiallyBound == VK_TRUE) && (query.descriptorBindingPartiallyBound == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingPartiallyBound, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingPartiallyBound = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingPartiallyBound %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingPartiallyBound =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingVariableDescriptorCount == VK_TRUE) && (query.descriptorBindingVariableDescriptorCount == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingVariableDescriptorCount, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingVariableDescriptorCount = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingVariableDescriptorCount %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingVariableDescriptorCount =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->runtimeDescriptorArray == VK_TRUE) && (query.runtimeDescriptorArray == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature runtimeDescriptorArray, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->runtimeDescriptorArray = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature runtimeDescriptorArray %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->runtimeDescriptorArray =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->samplerFilterMinmax == VK_TRUE) && (query.samplerFilterMinmax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature samplerFilterMinmax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->samplerFilterMinmax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature samplerFilterMinmax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->samplerFilterMinmax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->scalarBlockLayout == VK_TRUE) && (query.scalarBlockLayout == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature scalarBlockLayout, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->scalarBlockLayout = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature scalarBlockLayout %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->scalarBlockLayout =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->imagelessFramebuffer == VK_TRUE) && (query.imagelessFramebuffer == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imagelessFramebuffer, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->imagelessFramebuffer = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imagelessFramebuffer %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->imagelessFramebuffer =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->uniformBufferStandardLayout == VK_TRUE) && (query.uniformBufferStandardLayout == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature uniformBufferStandardLayout, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->uniformBufferStandardLayout = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature uniformBufferStandardLayout %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->uniformBufferStandardLayout =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSubgroupExtendedTypes == VK_TRUE) && (query.shaderSubgroupExtendedTypes == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSubgroupExtendedTypes, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSubgroupExtendedTypes = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSubgroupExtendedTypes %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSubgroupExtendedTypes =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->separateDepthStencilLayouts == VK_TRUE) && (query.separateDepthStencilLayouts == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature separateDepthStencilLayouts, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->separateDepthStencilLayouts = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature separateDepthStencilLayouts %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->separateDepthStencilLayouts =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->hostQueryReset == VK_TRUE) && (query.hostQueryReset == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature hostQueryReset, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->hostQueryReset = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature hostQueryReset %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->hostQueryReset =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->timelineSemaphore == VK_TRUE) && (query.timelineSemaphore == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature timelineSemaphore, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->timelineSemaphore = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature timelineSemaphore %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->timelineSemaphore =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bufferDeviceAddress == VK_TRUE) && (query.bufferDeviceAddress == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddress = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddress =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bufferDeviceAddressCaptureReplay == VK_TRUE) && (query.bufferDeviceAddressCaptureReplay == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddressCaptureReplay = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddressCaptureReplay =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bufferDeviceAddressMultiDevice == VK_TRUE) && (query.bufferDeviceAddressMultiDevice == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddressMultiDevice = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddressMultiDevice =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->vulkanMemoryModel == VK_TRUE) && (query.vulkanMemoryModel == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModel, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModel = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModel %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModel =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->vulkanMemoryModelDeviceScope == VK_TRUE) && (query.vulkanMemoryModelDeviceScope == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelDeviceScope, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModelDeviceScope = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelDeviceScope %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModelDeviceScope =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->vulkanMemoryModelAvailabilityVisibilityChains == VK_TRUE) && (query.vulkanMemoryModelAvailabilityVisibilityChains == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelAvailabilityVisibilityChains, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModelAvailabilityVisibilityChains = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelAvailabilityVisibilityChains %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModelAvailabilityVisibilityChains =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderOutputViewportIndex == VK_TRUE) && (query.shaderOutputViewportIndex == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderOutputViewportIndex, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderOutputViewportIndex = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderOutputViewportIndex %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderOutputViewportIndex =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderOutputLayer == VK_TRUE) && (query.shaderOutputLayer == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderOutputLayer, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderOutputLayer = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderOutputLayer %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderOutputLayer =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->subgroupBroadcastDynamicId == VK_TRUE) && (query.subgroupBroadcastDynamicId == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature subgroupBroadcastDynamicId, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->subgroupBroadcastDynamicId = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature subgroupBroadcastDynamicId %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->subgroupBroadcastDynamicId =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES:
             {
                 const VkPhysicalDevice8BitStorageFeatures* currentNext = reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(next);
@@ -482,21 +634,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->storageBuffer8BitAccess == VK_TRUE) && (query.storageBuffer8BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->storageBuffer8BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storageBuffer8BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->storageBuffer8BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->uniformAndStorageBuffer8BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer8BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->uniformAndStorageBuffer8BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer8BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->uniformAndStorageBuffer8BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->storagePushConstant8 == VK_TRUE) && (query.storagePushConstant8 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature storagePushConstant8, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->storagePushConstant8 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant8 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->storagePushConstant8 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES:
             {
                 const VkPhysicalDeviceShaderAtomicInt64Features* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(next);
@@ -505,16 +663,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderBufferInt64Atomics == VK_TRUE) && (query.shaderBufferInt64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferInt64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(currentNext)->shaderBufferInt64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferInt64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(currentNext)->shaderBufferInt64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedInt64Atomics == VK_TRUE) && (query.shaderSharedInt64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedInt64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(currentNext)->shaderSharedInt64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedInt64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(currentNext)->shaderSharedInt64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES:
             {
                 const VkPhysicalDeviceShaderFloat16Int8Features* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(next);
@@ -523,16 +685,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderFloat16 == VK_TRUE) && (query.shaderFloat16 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderFloat16, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(currentNext)->shaderFloat16 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderFloat16 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(currentNext)->shaderFloat16 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderInt8 == VK_TRUE) && (query.shaderInt8 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderInt8, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(currentNext)->shaderInt8 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderInt8 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(currentNext)->shaderInt8 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
             {
                 const VkPhysicalDeviceDescriptorIndexingFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(next);
@@ -541,106 +707,146 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderInputAttachmentArrayDynamicIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayDynamicIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderInputAttachmentArrayDynamicIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayDynamicIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderInputAttachmentArrayDynamicIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderUniformTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayDynamicIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformTexelBufferArrayDynamicIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayDynamicIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformTexelBufferArrayDynamicIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayDynamicIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageTexelBufferArrayDynamicIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayDynamicIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageTexelBufferArrayDynamicIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderUniformBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSampledImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderSampledImageArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderSampledImageArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderSampledImageArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageImageArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageImageArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageImageArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderInputAttachmentArrayNonUniformIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderInputAttachmentArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderInputAttachmentArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderUniformTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformTexelBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderStorageTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayNonUniformIndexing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayNonUniformIndexing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageTexelBufferArrayNonUniformIndexing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingUniformBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUniformBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUniformBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingSampledImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingSampledImageUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingSampledImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingSampledImageUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingSampledImageUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingSampledImageUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingStorageImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageImageUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageImageUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageImageUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageImageUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingStorageBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingUniformTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformTexelBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUniformTexelBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformTexelBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUniformTexelBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingStorageTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageTexelBufferUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageTexelBufferUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageTexelBufferUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageTexelBufferUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingUpdateUnusedWhilePending == VK_TRUE) && (query.descriptorBindingUpdateUnusedWhilePending == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingUpdateUnusedWhilePending, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUpdateUnusedWhilePending = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUpdateUnusedWhilePending %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUpdateUnusedWhilePending =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingPartiallyBound == VK_TRUE) && (query.descriptorBindingPartiallyBound == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingPartiallyBound, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingPartiallyBound = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingPartiallyBound %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingPartiallyBound =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingVariableDescriptorCount == VK_TRUE) && (query.descriptorBindingVariableDescriptorCount == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingVariableDescriptorCount, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingVariableDescriptorCount = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingVariableDescriptorCount %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingVariableDescriptorCount =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->runtimeDescriptorArray == VK_TRUE) && (query.runtimeDescriptorArray == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature runtimeDescriptorArray, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->runtimeDescriptorArray = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature runtimeDescriptorArray %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->runtimeDescriptorArray =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
             {
                 const VkPhysicalDeviceScalarBlockLayoutFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(next);
@@ -649,11 +855,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->scalarBlockLayout == VK_TRUE) && (query.scalarBlockLayout == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature scalarBlockLayout, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures*>(currentNext)->scalarBlockLayout = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature scalarBlockLayout %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures*>(currentNext)->scalarBlockLayout =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
             {
                 const VkPhysicalDeviceVulkanMemoryModelFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(next);
@@ -662,21 +870,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->vulkanMemoryModel == VK_TRUE) && (query.vulkanMemoryModel == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModel, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModel = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModel %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModel =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->vulkanMemoryModelDeviceScope == VK_TRUE) && (query.vulkanMemoryModelDeviceScope == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelDeviceScope, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModelDeviceScope = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelDeviceScope %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModelDeviceScope =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->vulkanMemoryModelAvailabilityVisibilityChains == VK_TRUE) && (query.vulkanMemoryModelAvailabilityVisibilityChains == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelAvailabilityVisibilityChains, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModelAvailabilityVisibilityChains = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelAvailabilityVisibilityChains %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModelAvailabilityVisibilityChains =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES:
             {
                 const VkPhysicalDeviceImagelessFramebufferFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(next);
@@ -685,11 +899,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->imagelessFramebuffer == VK_TRUE) && (query.imagelessFramebuffer == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imagelessFramebuffer, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImagelessFramebufferFeatures*>(currentNext)->imagelessFramebuffer = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imagelessFramebuffer %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImagelessFramebufferFeatures*>(currentNext)->imagelessFramebuffer =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES:
             {
                 const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(next);
@@ -698,11 +914,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->uniformBufferStandardLayout == VK_TRUE) && (query.uniformBufferStandardLayout == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature uniformBufferStandardLayout, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(currentNext)->uniformBufferStandardLayout = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature uniformBufferStandardLayout %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(currentNext)->uniformBufferStandardLayout =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES:
             {
                 const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(next);
@@ -711,11 +929,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderSubgroupExtendedTypes == VK_TRUE) && (query.shaderSubgroupExtendedTypes == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSubgroupExtendedTypes, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(currentNext)->shaderSubgroupExtendedTypes = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSubgroupExtendedTypes %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(currentNext)->shaderSubgroupExtendedTypes =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES:
             {
                 const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(next);
@@ -724,11 +944,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->separateDepthStencilLayouts == VK_TRUE) && (query.separateDepthStencilLayouts == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature separateDepthStencilLayouts, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(currentNext)->separateDepthStencilLayouts = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature separateDepthStencilLayouts %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(currentNext)->separateDepthStencilLayouts =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES:
             {
                 const VkPhysicalDeviceHostQueryResetFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(next);
@@ -737,11 +959,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->hostQueryReset == VK_TRUE) && (query.hostQueryReset == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature hostQueryReset, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceHostQueryResetFeatures*>(currentNext)->hostQueryReset = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature hostQueryReset %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceHostQueryResetFeatures*>(currentNext)->hostQueryReset =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
             {
                 const VkPhysicalDeviceTimelineSemaphoreFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(next);
@@ -750,11 +974,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->timelineSemaphore == VK_TRUE) && (query.timelineSemaphore == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature timelineSemaphore, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(currentNext)->timelineSemaphore = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature timelineSemaphore %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(currentNext)->timelineSemaphore =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
             {
                 const VkPhysicalDeviceBufferDeviceAddressFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(next);
@@ -763,21 +989,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->bufferDeviceAddress == VK_TRUE) && (query.bufferDeviceAddress == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddress = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddress =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bufferDeviceAddressCaptureReplay == VK_TRUE) && (query.bufferDeviceAddressCaptureReplay == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddressCaptureReplay = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddressCaptureReplay =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bufferDeviceAddressMultiDevice == VK_TRUE) && (query.bufferDeviceAddressMultiDevice == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddressMultiDevice = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddressMultiDevice =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES:
             {
                 const VkPhysicalDeviceVulkan13Features* currentNext = reinterpret_cast<const VkPhysicalDeviceVulkan13Features*>(next);
@@ -786,81 +1018,111 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->robustImageAccess == VK_TRUE) && (query.robustImageAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature robustImageAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->robustImageAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature robustImageAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->robustImageAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->inlineUniformBlock == VK_TRUE) && (query.inlineUniformBlock == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature inlineUniformBlock, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->inlineUniformBlock = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature inlineUniformBlock %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->inlineUniformBlock =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingInlineUniformBlockUpdateAfterBind == VK_TRUE) && (query.descriptorBindingInlineUniformBlockUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingInlineUniformBlockUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->descriptorBindingInlineUniformBlockUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingInlineUniformBlockUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->descriptorBindingInlineUniformBlockUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->pipelineCreationCacheControl == VK_TRUE) && (query.pipelineCreationCacheControl == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pipelineCreationCacheControl, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->pipelineCreationCacheControl = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pipelineCreationCacheControl %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->pipelineCreationCacheControl =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->privateData == VK_TRUE) && (query.privateData == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature privateData, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->privateData = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature privateData %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->privateData =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderDemoteToHelperInvocation == VK_TRUE) && (query.shaderDemoteToHelperInvocation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderDemoteToHelperInvocation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderDemoteToHelperInvocation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderDemoteToHelperInvocation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderDemoteToHelperInvocation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderTerminateInvocation == VK_TRUE) && (query.shaderTerminateInvocation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderTerminateInvocation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderTerminateInvocation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderTerminateInvocation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderTerminateInvocation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->subgroupSizeControl == VK_TRUE) && (query.subgroupSizeControl == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature subgroupSizeControl, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->subgroupSizeControl = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature subgroupSizeControl %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->subgroupSizeControl =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->computeFullSubgroups == VK_TRUE) && (query.computeFullSubgroups == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature computeFullSubgroups, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->computeFullSubgroups = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature computeFullSubgroups %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->computeFullSubgroups =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->synchronization2 == VK_TRUE) && (query.synchronization2 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature synchronization2, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->synchronization2 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature synchronization2 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->synchronization2 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->textureCompressionASTC_HDR == VK_TRUE) && (query.textureCompressionASTC_HDR == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature textureCompressionASTC_HDR, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->textureCompressionASTC_HDR = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature textureCompressionASTC_HDR %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->textureCompressionASTC_HDR =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderZeroInitializeWorkgroupMemory == VK_TRUE) && (query.shaderZeroInitializeWorkgroupMemory == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderZeroInitializeWorkgroupMemory, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderZeroInitializeWorkgroupMemory = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderZeroInitializeWorkgroupMemory %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderZeroInitializeWorkgroupMemory =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->dynamicRendering == VK_TRUE) && (query.dynamicRendering == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature dynamicRendering, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->dynamicRendering = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature dynamicRendering %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->dynamicRendering =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderIntegerDotProduct == VK_TRUE) && (query.shaderIntegerDotProduct == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderIntegerDotProduct, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderIntegerDotProduct = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderIntegerDotProduct %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->shaderIntegerDotProduct =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->maintenance4 == VK_TRUE) && (query.maintenance4 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature maintenance4, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->maintenance4 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature maintenance4 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVulkan13Features*>(currentNext)->maintenance4 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES:
             {
                 const VkPhysicalDeviceShaderTerminateInvocationFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures*>(next);
@@ -869,11 +1131,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderTerminateInvocation == VK_TRUE) && (query.shaderTerminateInvocation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderTerminateInvocation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderTerminateInvocationFeatures*>(currentNext)->shaderTerminateInvocation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderTerminateInvocation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderTerminateInvocationFeatures*>(currentNext)->shaderTerminateInvocation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES:
             {
                 const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(next);
@@ -882,11 +1146,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderDemoteToHelperInvocation == VK_TRUE) && (query.shaderDemoteToHelperInvocation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderDemoteToHelperInvocation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(currentNext)->shaderDemoteToHelperInvocation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderDemoteToHelperInvocation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(currentNext)->shaderDemoteToHelperInvocation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES:
             {
                 const VkPhysicalDevicePrivateDataFeatures* currentNext = reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures*>(next);
@@ -895,11 +1161,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->privateData == VK_TRUE) && (query.privateData == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature privateData, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePrivateDataFeatures*>(currentNext)->privateData = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature privateData %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePrivateDataFeatures*>(currentNext)->privateData =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES:
             {
                 const VkPhysicalDevicePipelineCreationCacheControlFeatures* currentNext = reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures*>(next);
@@ -908,11 +1176,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->pipelineCreationCacheControl == VK_TRUE) && (query.pipelineCreationCacheControl == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pipelineCreationCacheControl, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures*>(currentNext)->pipelineCreationCacheControl = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pipelineCreationCacheControl %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures*>(currentNext)->pipelineCreationCacheControl =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES:
             {
                 const VkPhysicalDeviceSynchronization2Features* currentNext = reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(next);
@@ -921,11 +1191,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->synchronization2 == VK_TRUE) && (query.synchronization2 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature synchronization2, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceSynchronization2Features*>(currentNext)->synchronization2 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature synchronization2 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceSynchronization2Features*>(currentNext)->synchronization2 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES:
             {
                 const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(next);
@@ -934,11 +1206,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderZeroInitializeWorkgroupMemory == VK_TRUE) && (query.shaderZeroInitializeWorkgroupMemory == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderZeroInitializeWorkgroupMemory, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(currentNext)->shaderZeroInitializeWorkgroupMemory = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderZeroInitializeWorkgroupMemory %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(currentNext)->shaderZeroInitializeWorkgroupMemory =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES:
             {
                 const VkPhysicalDeviceImageRobustnessFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(next);
@@ -947,11 +1221,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->robustImageAccess == VK_TRUE) && (query.robustImageAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature robustImageAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageRobustnessFeatures*>(currentNext)->robustImageAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature robustImageAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageRobustnessFeatures*>(currentNext)->robustImageAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES:
             {
                 const VkPhysicalDeviceSubgroupSizeControlFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(next);
@@ -960,16 +1236,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->subgroupSizeControl == VK_TRUE) && (query.subgroupSizeControl == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature subgroupSizeControl, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(currentNext)->subgroupSizeControl = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature subgroupSizeControl %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(currentNext)->subgroupSizeControl =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->computeFullSubgroups == VK_TRUE) && (query.computeFullSubgroups == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature computeFullSubgroups, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(currentNext)->computeFullSubgroups = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature computeFullSubgroups %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(currentNext)->computeFullSubgroups =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES:
             {
                 const VkPhysicalDeviceInlineUniformBlockFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures*>(next);
@@ -978,16 +1258,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->inlineUniformBlock == VK_TRUE) && (query.inlineUniformBlock == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature inlineUniformBlock, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(currentNext)->inlineUniformBlock = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature inlineUniformBlock %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(currentNext)->inlineUniformBlock =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingInlineUniformBlockUpdateAfterBind == VK_TRUE) && (query.descriptorBindingInlineUniformBlockUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingInlineUniformBlockUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(currentNext)->descriptorBindingInlineUniformBlockUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingInlineUniformBlockUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(currentNext)->descriptorBindingInlineUniformBlockUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES:
             {
                 const VkPhysicalDeviceTextureCompressionASTCHDRFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(next);
@@ -996,11 +1280,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->textureCompressionASTC_HDR == VK_TRUE) && (query.textureCompressionASTC_HDR == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature textureCompressionASTC_HDR, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(currentNext)->textureCompressionASTC_HDR = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature textureCompressionASTC_HDR %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(currentNext)->textureCompressionASTC_HDR =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES:
             {
                 const VkPhysicalDeviceDynamicRenderingFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures*>(next);
@@ -1009,11 +1295,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->dynamicRendering == VK_TRUE) && (query.dynamicRendering == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature dynamicRendering, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDynamicRenderingFeatures*>(currentNext)->dynamicRendering = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature dynamicRendering %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDynamicRenderingFeatures*>(currentNext)->dynamicRendering =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES:
             {
                 const VkPhysicalDeviceShaderIntegerDotProductFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures*>(next);
@@ -1022,11 +1310,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderIntegerDotProduct == VK_TRUE) && (query.shaderIntegerDotProduct == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderIntegerDotProduct, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderIntegerDotProductFeatures*>(currentNext)->shaderIntegerDotProduct = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderIntegerDotProduct %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderIntegerDotProductFeatures*>(currentNext)->shaderIntegerDotProduct =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES:
             {
                 const VkPhysicalDeviceMaintenance4Features* currentNext = reinterpret_cast<const VkPhysicalDeviceMaintenance4Features*>(next);
@@ -1035,11 +1325,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->maintenance4 == VK_TRUE) && (query.maintenance4 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature maintenance4, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMaintenance4Features*>(currentNext)->maintenance4 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature maintenance4 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMaintenance4Features*>(currentNext)->maintenance4 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR:
             {
                 const VkPhysicalDevicePerformanceQueryFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(next);
@@ -1048,16 +1340,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->performanceCounterQueryPools == VK_TRUE) && (query.performanceCounterQueryPools == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature performanceCounterQueryPools, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(currentNext)->performanceCounterQueryPools = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature performanceCounterQueryPools %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(currentNext)->performanceCounterQueryPools =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->performanceCounterMultipleQueryPools == VK_TRUE) && (query.performanceCounterMultipleQueryPools == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature performanceCounterMultipleQueryPools, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(currentNext)->performanceCounterMultipleQueryPools = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature performanceCounterMultipleQueryPools %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(currentNext)->performanceCounterMultipleQueryPools =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR:
             {
                 const VkPhysicalDevicePortabilitySubsetFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(next);
@@ -1066,81 +1362,111 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->constantAlphaColorBlendFactors == VK_TRUE) && (query.constantAlphaColorBlendFactors == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature constantAlphaColorBlendFactors, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->constantAlphaColorBlendFactors = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature constantAlphaColorBlendFactors %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->constantAlphaColorBlendFactors =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->events == VK_TRUE) && (query.events == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature events, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->events = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature events %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->events =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->imageViewFormatReinterpretation == VK_TRUE) && (query.imageViewFormatReinterpretation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imageViewFormatReinterpretation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageViewFormatReinterpretation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imageViewFormatReinterpretation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageViewFormatReinterpretation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->imageViewFormatSwizzle == VK_TRUE) && (query.imageViewFormatSwizzle == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imageViewFormatSwizzle, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageViewFormatSwizzle = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imageViewFormatSwizzle %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageViewFormatSwizzle =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->imageView2DOn3DImage == VK_TRUE) && (query.imageView2DOn3DImage == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imageView2DOn3DImage, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageView2DOn3DImage = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imageView2DOn3DImage %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageView2DOn3DImage =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multisampleArrayImage == VK_TRUE) && (query.multisampleArrayImage == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multisampleArrayImage, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->multisampleArrayImage = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multisampleArrayImage %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->multisampleArrayImage =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->mutableComparisonSamplers == VK_TRUE) && (query.mutableComparisonSamplers == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature mutableComparisonSamplers, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->mutableComparisonSamplers = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature mutableComparisonSamplers %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->mutableComparisonSamplers =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->pointPolygons == VK_TRUE) && (query.pointPolygons == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pointPolygons, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->pointPolygons = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pointPolygons %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->pointPolygons =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->samplerMipLodBias == VK_TRUE) && (query.samplerMipLodBias == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature samplerMipLodBias, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->samplerMipLodBias = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature samplerMipLodBias %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->samplerMipLodBias =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->separateStencilMaskRef == VK_TRUE) && (query.separateStencilMaskRef == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature separateStencilMaskRef, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->separateStencilMaskRef = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature separateStencilMaskRef %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->separateStencilMaskRef =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSampleRateInterpolationFunctions == VK_TRUE) && (query.shaderSampleRateInterpolationFunctions == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSampleRateInterpolationFunctions, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->shaderSampleRateInterpolationFunctions = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSampleRateInterpolationFunctions %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->shaderSampleRateInterpolationFunctions =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->tessellationIsolines == VK_TRUE) && (query.tessellationIsolines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature tessellationIsolines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->tessellationIsolines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature tessellationIsolines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->tessellationIsolines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->tessellationPointMode == VK_TRUE) && (query.tessellationPointMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature tessellationPointMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->tessellationPointMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature tessellationPointMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->tessellationPointMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->triangleFans == VK_TRUE) && (query.triangleFans == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature triangleFans, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->triangleFans = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature triangleFans %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->triangleFans =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->vertexAttributeAccessBeyondStride == VK_TRUE) && (query.vertexAttributeAccessBeyondStride == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vertexAttributeAccessBeyondStride, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->vertexAttributeAccessBeyondStride = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vertexAttributeAccessBeyondStride %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->vertexAttributeAccessBeyondStride =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR:
             {
                 const VkPhysicalDeviceShaderClockFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(next);
@@ -1149,16 +1475,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderSubgroupClock == VK_TRUE) && (query.shaderSubgroupClock == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSubgroupClock, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(currentNext)->shaderSubgroupClock = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSubgroupClock %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(currentNext)->shaderSubgroupClock =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderDeviceClock == VK_TRUE) && (query.shaderDeviceClock == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderDeviceClock, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(currentNext)->shaderDeviceClock = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderDeviceClock %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(currentNext)->shaderDeviceClock =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR:
             {
                 const VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR*>(next);
@@ -1167,11 +1497,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->globalPriorityQuery == VK_TRUE) && (query.globalPriorityQuery == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature globalPriorityQuery, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR*>(currentNext)->globalPriorityQuery = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature globalPriorityQuery %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR*>(currentNext)->globalPriorityQuery =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR:
             {
                 const VkPhysicalDeviceFragmentShadingRateFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(next);
@@ -1180,21 +1512,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->pipelineFragmentShadingRate == VK_TRUE) && (query.pipelineFragmentShadingRate == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pipelineFragmentShadingRate, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(currentNext)->pipelineFragmentShadingRate = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pipelineFragmentShadingRate %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(currentNext)->pipelineFragmentShadingRate =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->primitiveFragmentShadingRate == VK_TRUE) && (query.primitiveFragmentShadingRate == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature primitiveFragmentShadingRate, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(currentNext)->primitiveFragmentShadingRate = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature primitiveFragmentShadingRate %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(currentNext)->primitiveFragmentShadingRate =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->attachmentFragmentShadingRate == VK_TRUE) && (query.attachmentFragmentShadingRate == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature attachmentFragmentShadingRate, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(currentNext)->attachmentFragmentShadingRate = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature attachmentFragmentShadingRate %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(currentNext)->attachmentFragmentShadingRate =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR:
             {
                 const VkPhysicalDevicePresentWaitFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR*>(next);
@@ -1203,11 +1541,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->presentWait == VK_TRUE) && (query.presentWait == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature presentWait, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePresentWaitFeaturesKHR*>(currentNext)->presentWait = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature presentWait %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePresentWaitFeaturesKHR*>(currentNext)->presentWait =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR:
             {
                 const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(next);
@@ -1216,11 +1556,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->pipelineExecutableInfo == VK_TRUE) && (query.pipelineExecutableInfo == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pipelineExecutableInfo, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(currentNext)->pipelineExecutableInfo = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pipelineExecutableInfo %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(currentNext)->pipelineExecutableInfo =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR:
             {
                 const VkPhysicalDevicePresentIdFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR*>(next);
@@ -1229,11 +1571,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->presentId == VK_TRUE) && (query.presentId == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature presentId, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePresentIdFeaturesKHR*>(currentNext)->presentId = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature presentId %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePresentIdFeaturesKHR*>(currentNext)->presentId =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR:
             {
                 const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(next);
@@ -1242,11 +1586,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->fragmentShaderBarycentric == VK_TRUE) && (query.fragmentShaderBarycentric == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentShaderBarycentric, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(currentNext)->fragmentShaderBarycentric = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderBarycentric %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(currentNext)->fragmentShaderBarycentric =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR:
             {
                 const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(next);
@@ -1255,11 +1601,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderSubgroupUniformControlFlow == VK_TRUE) && (query.shaderSubgroupUniformControlFlow == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSubgroupUniformControlFlow, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(currentNext)->shaderSubgroupUniformControlFlow = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSubgroupUniformControlFlow %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(currentNext)->shaderSubgroupUniformControlFlow =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR:
             {
                 const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(next);
@@ -1268,26 +1616,34 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->workgroupMemoryExplicitLayout == VK_TRUE) && (query.workgroupMemoryExplicitLayout == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayout, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayout = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayout %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayout =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->workgroupMemoryExplicitLayoutScalarBlockLayout == VK_TRUE) && (query.workgroupMemoryExplicitLayoutScalarBlockLayout == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayoutScalarBlockLayout, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayoutScalarBlockLayout = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayoutScalarBlockLayout %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayoutScalarBlockLayout =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->workgroupMemoryExplicitLayout8BitAccess == VK_TRUE) && (query.workgroupMemoryExplicitLayout8BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayout8BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayout8BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayout8BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayout8BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->workgroupMemoryExplicitLayout16BitAccess == VK_TRUE) && (query.workgroupMemoryExplicitLayout16BitAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayout16BitAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayout16BitAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature workgroupMemoryExplicitLayout16BitAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(currentNext)->workgroupMemoryExplicitLayout16BitAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR:
             {
                 const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(next);
@@ -1296,16 +1652,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rayTracingMaintenance1 == VK_TRUE) && (query.rayTracingMaintenance1 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingMaintenance1, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(currentNext)->rayTracingMaintenance1 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingMaintenance1 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(currentNext)->rayTracingMaintenance1 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rayTracingPipelineTraceRaysIndirect2 == VK_TRUE) && (query.rayTracingPipelineTraceRaysIndirect2 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineTraceRaysIndirect2, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(currentNext)->rayTracingPipelineTraceRaysIndirect2 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineTraceRaysIndirect2 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(currentNext)->rayTracingPipelineTraceRaysIndirect2 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR:
             {
                 const VkPhysicalDeviceMaintenance5FeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceMaintenance5FeaturesKHR*>(next);
@@ -1314,11 +1674,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->maintenance5 == VK_TRUE) && (query.maintenance5 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature maintenance5, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMaintenance5FeaturesKHR*>(currentNext)->maintenance5 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature maintenance5 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMaintenance5FeaturesKHR*>(currentNext)->maintenance5 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR:
             {
                 const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(next);
@@ -1327,11 +1689,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rayTracingPositionFetch == VK_TRUE) && (query.rayTracingPositionFetch == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingPositionFetch, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(currentNext)->rayTracingPositionFetch = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingPositionFetch %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(currentNext)->rayTracingPositionFetch =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR:
             {
                 const VkPhysicalDeviceCooperativeMatrixFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(next);
@@ -1340,16 +1704,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->cooperativeMatrix == VK_TRUE) && (query.cooperativeMatrix == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature cooperativeMatrix, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(currentNext)->cooperativeMatrix = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature cooperativeMatrix %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(currentNext)->cooperativeMatrix =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->cooperativeMatrixRobustBufferAccess == VK_TRUE) && (query.cooperativeMatrixRobustBufferAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature cooperativeMatrixRobustBufferAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(currentNext)->cooperativeMatrixRobustBufferAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature cooperativeMatrixRobustBufferAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(currentNext)->cooperativeMatrixRobustBufferAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
             {
                 const VkPhysicalDeviceTransformFeedbackFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(next);
@@ -1358,16 +1726,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->transformFeedback == VK_TRUE) && (query.transformFeedback == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature transformFeedback, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(currentNext)->transformFeedback = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature transformFeedback %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(currentNext)->transformFeedback =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->geometryStreams == VK_TRUE) && (query.geometryStreams == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature geometryStreams, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(currentNext)->geometryStreams = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature geometryStreams %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(currentNext)->geometryStreams =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
             {
                 const VkPhysicalDeviceCornerSampledImageFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(next);
@@ -1376,11 +1748,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->cornerSampledImage == VK_TRUE) && (query.cornerSampledImage == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature cornerSampledImage, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV*>(currentNext)->cornerSampledImage = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature cornerSampledImage %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV*>(currentNext)->cornerSampledImage =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceASTCDecodeFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(next);
@@ -1389,11 +1763,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->decodeModeSharedExponent == VK_TRUE) && (query.decodeModeSharedExponent == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature decodeModeSharedExponent, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT*>(currentNext)->decodeModeSharedExponent = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature decodeModeSharedExponent %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT*>(currentNext)->decodeModeSharedExponent =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES_EXT:
             {
                 const VkPhysicalDevicePipelineRobustnessFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeaturesEXT*>(next);
@@ -1402,11 +1778,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->pipelineRobustness == VK_TRUE) && (query.pipelineRobustness == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pipelineRobustness, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePipelineRobustnessFeaturesEXT*>(currentNext)->pipelineRobustness = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pipelineRobustness %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePipelineRobustnessFeaturesEXT*>(currentNext)->pipelineRobustness =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
             {
                 const VkPhysicalDeviceConditionalRenderingFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(next);
@@ -1415,16 +1793,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->conditionalRendering == VK_TRUE) && (query.conditionalRendering == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature conditionalRendering, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(currentNext)->conditionalRendering = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature conditionalRendering %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(currentNext)->conditionalRendering =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->inheritedConditionalRendering == VK_TRUE) && (query.inheritedConditionalRendering == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature inheritedConditionalRendering, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(currentNext)->inheritedConditionalRendering = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature inheritedConditionalRendering %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(currentNext)->inheritedConditionalRendering =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceDepthClipEnableFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(next);
@@ -1433,11 +1815,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->depthClipEnable == VK_TRUE) && (query.depthClipEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature depthClipEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(currentNext)->depthClipEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature depthClipEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(currentNext)->depthClipEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
             {
                 const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(next);
@@ -1446,11 +1830,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->advancedBlendCoherentOperations == VK_TRUE) && (query.advancedBlendCoherentOperations == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature advancedBlendCoherentOperations, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(currentNext)->advancedBlendCoherentOperations = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature advancedBlendCoherentOperations %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(currentNext)->advancedBlendCoherentOperations =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV:
             {
                 const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(next);
@@ -1459,11 +1845,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderSMBuiltins == VK_TRUE) && (query.shaderSMBuiltins == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSMBuiltins, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(currentNext)->shaderSMBuiltins = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSMBuiltins %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(currentNext)->shaderSMBuiltins =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
             {
                 const VkPhysicalDeviceShadingRateImageFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(next);
@@ -1472,16 +1860,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shadingRateImage == VK_TRUE) && (query.shadingRateImage == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shadingRateImage, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(currentNext)->shadingRateImage = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shadingRateImage %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(currentNext)->shadingRateImage =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shadingRateCoarseSampleOrder == VK_TRUE) && (query.shadingRateCoarseSampleOrder == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shadingRateCoarseSampleOrder, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(currentNext)->shadingRateCoarseSampleOrder = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shadingRateCoarseSampleOrder %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(currentNext)->shadingRateCoarseSampleOrder =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
             {
                 const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(next);
@@ -1490,11 +1882,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->representativeFragmentTest == VK_TRUE) && (query.representativeFragmentTest == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature representativeFragmentTest, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(currentNext)->representativeFragmentTest = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature representativeFragmentTest %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(currentNext)->representativeFragmentTest =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT:
             {
                 const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(next);
@@ -1503,16 +1897,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->vertexAttributeInstanceRateDivisor == VK_TRUE) && (query.vertexAttributeInstanceRateDivisor == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vertexAttributeInstanceRateDivisor, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(currentNext)->vertexAttributeInstanceRateDivisor = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vertexAttributeInstanceRateDivisor %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(currentNext)->vertexAttributeInstanceRateDivisor =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->vertexAttributeInstanceRateZeroDivisor == VK_TRUE) && (query.vertexAttributeInstanceRateZeroDivisor == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vertexAttributeInstanceRateZeroDivisor, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(currentNext)->vertexAttributeInstanceRateZeroDivisor = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vertexAttributeInstanceRateZeroDivisor %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(currentNext)->vertexAttributeInstanceRateZeroDivisor =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:
             {
                 const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(next);
@@ -1521,16 +1919,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->computeDerivativeGroupQuads == VK_TRUE) && (query.computeDerivativeGroupQuads == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature computeDerivativeGroupQuads, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(currentNext)->computeDerivativeGroupQuads = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature computeDerivativeGroupQuads %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(currentNext)->computeDerivativeGroupQuads =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->computeDerivativeGroupLinear == VK_TRUE) && (query.computeDerivativeGroupLinear == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature computeDerivativeGroupLinear, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(currentNext)->computeDerivativeGroupLinear = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature computeDerivativeGroupLinear %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(currentNext)->computeDerivativeGroupLinear =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
             {
                 const VkPhysicalDeviceMeshShaderFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(next);
@@ -1539,16 +1941,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->taskShader == VK_TRUE) && (query.taskShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature taskShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMeshShaderFeaturesNV*>(currentNext)->taskShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature taskShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesNV*>(currentNext)->taskShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->meshShader == VK_TRUE) && (query.meshShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature meshShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMeshShaderFeaturesNV*>(currentNext)->meshShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature meshShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesNV*>(currentNext)->meshShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
             {
                 const VkPhysicalDeviceShaderImageFootprintFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(next);
@@ -1557,11 +1963,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->imageFootprint == VK_TRUE) && (query.imageFootprint == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imageFootprint, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(currentNext)->imageFootprint = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imageFootprint %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(currentNext)->imageFootprint =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
             {
                 const VkPhysicalDeviceExclusiveScissorFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(next);
@@ -1570,11 +1978,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->exclusiveScissor == VK_TRUE) && (query.exclusiveScissor == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature exclusiveScissor, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV*>(currentNext)->exclusiveScissor = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature exclusiveScissor %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV*>(currentNext)->exclusiveScissor =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL:
             {
                 const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(next);
@@ -1583,11 +1993,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderIntegerFunctions2 == VK_TRUE) && (query.shaderIntegerFunctions2 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderIntegerFunctions2, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(currentNext)->shaderIntegerFunctions2 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderIntegerFunctions2 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(currentNext)->shaderIntegerFunctions2 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
             {
                 const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(next);
@@ -1596,21 +2008,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->fragmentDensityMap == VK_TRUE) && (query.fragmentDensityMap == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentDensityMap, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMap = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMap %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMap =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->fragmentDensityMapDynamic == VK_TRUE) && (query.fragmentDensityMapDynamic == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapDynamic, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMapDynamic = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapDynamic %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMapDynamic =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->fragmentDensityMapNonSubsampledImages == VK_TRUE) && (query.fragmentDensityMapNonSubsampledImages == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapNonSubsampledImages, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMapNonSubsampledImages = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapNonSubsampledImages %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMapNonSubsampledImages =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD:
             {
                 const VkPhysicalDeviceCoherentMemoryFeaturesAMD* currentNext = reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(next);
@@ -1619,11 +2037,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->deviceCoherentMemory == VK_TRUE) && (query.deviceCoherentMemory == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceCoherentMemory, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(currentNext)->deviceCoherentMemory = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceCoherentMemory %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(currentNext)->deviceCoherentMemory =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT:
             {
                 const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(next);
@@ -1632,16 +2052,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderImageInt64Atomics == VK_TRUE) && (query.shaderImageInt64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderImageInt64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(currentNext)->shaderImageInt64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderImageInt64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(currentNext)->shaderImageInt64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->sparseImageInt64Atomics == VK_TRUE) && (query.sparseImageInt64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature sparseImageInt64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(currentNext)->sparseImageInt64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature sparseImageInt64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(currentNext)->sparseImageInt64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
             {
                 const VkPhysicalDeviceMemoryPriorityFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(next);
@@ -1650,11 +2074,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->memoryPriority == VK_TRUE) && (query.memoryPriority == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature memoryPriority, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(currentNext)->memoryPriority = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature memoryPriority %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(currentNext)->memoryPriority =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
             {
                 const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(next);
@@ -1663,11 +2089,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->dedicatedAllocationImageAliasing == VK_TRUE) && (query.dedicatedAllocationImageAliasing == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature dedicatedAllocationImageAliasing, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(currentNext)->dedicatedAllocationImageAliasing = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature dedicatedAllocationImageAliasing %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(currentNext)->dedicatedAllocationImageAliasing =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
             {
                 const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(next);
@@ -1676,21 +2104,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->bufferDeviceAddress == VK_TRUE) && (query.bufferDeviceAddress == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddress = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddress =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bufferDeviceAddressCaptureReplay == VK_TRUE) && (query.bufferDeviceAddressCaptureReplay == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddressCaptureReplay = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddressCaptureReplay =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bufferDeviceAddressMultiDevice == VK_TRUE) && (query.bufferDeviceAddressMultiDevice == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddressMultiDevice = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddressMultiDevice =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
             {
                 const VkPhysicalDeviceCooperativeMatrixFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(next);
@@ -1699,16 +2133,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->cooperativeMatrix == VK_TRUE) && (query.cooperativeMatrix == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature cooperativeMatrix, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(currentNext)->cooperativeMatrix = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature cooperativeMatrix %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(currentNext)->cooperativeMatrix =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->cooperativeMatrixRobustBufferAccess == VK_TRUE) && (query.cooperativeMatrixRobustBufferAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature cooperativeMatrixRobustBufferAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(currentNext)->cooperativeMatrixRobustBufferAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature cooperativeMatrixRobustBufferAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(currentNext)->cooperativeMatrixRobustBufferAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV:
             {
                 const VkPhysicalDeviceCoverageReductionModeFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(next);
@@ -1717,11 +2155,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->coverageReductionMode == VK_TRUE) && (query.coverageReductionMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature coverageReductionMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(currentNext)->coverageReductionMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature coverageReductionMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(currentNext)->coverageReductionMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT:
             {
                 const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(next);
@@ -1730,21 +2170,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->fragmentShaderSampleInterlock == VK_TRUE) && (query.fragmentShaderSampleInterlock == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentShaderSampleInterlock, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderSampleInterlock = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderSampleInterlock %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderSampleInterlock =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->fragmentShaderPixelInterlock == VK_TRUE) && (query.fragmentShaderPixelInterlock == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentShaderPixelInterlock, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderPixelInterlock = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderPixelInterlock %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderPixelInterlock =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->fragmentShaderShadingRateInterlock == VK_TRUE) && (query.fragmentShaderShadingRateInterlock == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentShaderShadingRateInterlock, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderShadingRateInterlock = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderShadingRateInterlock %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderShadingRateInterlock =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
             {
                 const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(next);
@@ -1753,11 +2199,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->ycbcrImageArrays == VK_TRUE) && (query.ycbcrImageArrays == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature ycbcrImageArrays, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(currentNext)->ycbcrImageArrays = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature ycbcrImageArrays %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(currentNext)->ycbcrImageArrays =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT:
             {
                 const VkPhysicalDeviceProvokingVertexFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT*>(next);
@@ -1766,16 +2214,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->provokingVertexLast == VK_TRUE) && (query.provokingVertexLast == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature provokingVertexLast, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(currentNext)->provokingVertexLast = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature provokingVertexLast %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(currentNext)->provokingVertexLast =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->transformFeedbackPreservesProvokingVertex == VK_TRUE) && (query.transformFeedbackPreservesProvokingVertex == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature transformFeedbackPreservesProvokingVertex, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(currentNext)->transformFeedbackPreservesProvokingVertex = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature transformFeedbackPreservesProvokingVertex %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(currentNext)->transformFeedbackPreservesProvokingVertex =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT:
             {
                 const VkPhysicalDeviceLineRasterizationFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeaturesEXT*>(next);
@@ -1784,36 +2236,48 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rectangularLines == VK_TRUE) && (query.rectangularLines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rectangularLines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->rectangularLines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rectangularLines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->rectangularLines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->bresenhamLines == VK_TRUE) && (query.bresenhamLines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature bresenhamLines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->bresenhamLines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature bresenhamLines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->bresenhamLines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->smoothLines == VK_TRUE) && (query.smoothLines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature smoothLines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->smoothLines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature smoothLines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->smoothLines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->stippledRectangularLines == VK_TRUE) && (query.stippledRectangularLines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature stippledRectangularLines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledRectangularLines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature stippledRectangularLines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledRectangularLines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->stippledBresenhamLines == VK_TRUE) && (query.stippledBresenhamLines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature stippledBresenhamLines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledBresenhamLines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature stippledBresenhamLines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledBresenhamLines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->stippledSmoothLines == VK_TRUE) && (query.stippledSmoothLines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature stippledSmoothLines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledSmoothLines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature stippledSmoothLines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledSmoothLines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT:
             {
                 const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(next);
@@ -1822,66 +2286,90 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderBufferFloat32Atomics == VK_TRUE) && (query.shaderBufferFloat32Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat32Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat32Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferFloat32AtomicAdd == VK_TRUE) && (query.shaderBufferFloat32AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat32AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat32AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferFloat64Atomics == VK_TRUE) && (query.shaderBufferFloat64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferFloat64AtomicAdd == VK_TRUE) && (query.shaderBufferFloat64AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat64AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat64AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat32Atomics == VK_TRUE) && (query.shaderSharedFloat32Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat32Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat32Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat32AtomicAdd == VK_TRUE) && (query.shaderSharedFloat32AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat32AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat32AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat64Atomics == VK_TRUE) && (query.shaderSharedFloat64Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat64Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat64Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat64AtomicAdd == VK_TRUE) && (query.shaderSharedFloat64AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat64AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat64AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderImageFloat32Atomics == VK_TRUE) && (query.shaderImageFloat32Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderImageFloat32Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderImageFloat32Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderImageFloat32AtomicAdd == VK_TRUE) && (query.shaderImageFloat32AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderImageFloat32AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderImageFloat32AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->sparseImageFloat32Atomics == VK_TRUE) && (query.sparseImageFloat32Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->sparseImageFloat32Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->sparseImageFloat32Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->sparseImageFloat32AtomicAdd == VK_TRUE) && (query.sparseImageFloat32AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->sparseImageFloat32AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->sparseImageFloat32AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT:
             {
                 const VkPhysicalDeviceIndexTypeUint8FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8FeaturesEXT*>(next);
@@ -1890,11 +2378,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->indexTypeUint8 == VK_TRUE) && (query.indexTypeUint8 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature indexTypeUint8, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceIndexTypeUint8FeaturesEXT*>(currentNext)->indexTypeUint8 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature indexTypeUint8 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceIndexTypeUint8FeaturesEXT*>(currentNext)->indexTypeUint8 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(next);
@@ -1903,11 +2393,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->extendedDynamicState == VK_TRUE) && (query.extendedDynamicState == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(currentNext)->extendedDynamicState = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(currentNext)->extendedDynamicState =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT:
             {
                 const VkPhysicalDeviceHostImageCopyFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeaturesEXT*>(next);
@@ -1916,11 +2408,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->hostImageCopy == VK_TRUE) && (query.hostImageCopy == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature hostImageCopy, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceHostImageCopyFeaturesEXT*>(currentNext)->hostImageCopy = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature hostImageCopy %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceHostImageCopyFeaturesEXT*>(currentNext)->hostImageCopy =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT:
             {
                 const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(next);
@@ -1929,66 +2423,90 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderBufferFloat16Atomics == VK_TRUE) && (query.shaderBufferFloat16Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat16Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat16Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat16Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat16Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferFloat16AtomicAdd == VK_TRUE) && (query.shaderBufferFloat16AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat16AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat16AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat16AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat16AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferFloat16AtomicMinMax == VK_TRUE) && (query.shaderBufferFloat16AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat16AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat16AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat16AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat16AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferFloat32AtomicMinMax == VK_TRUE) && (query.shaderBufferFloat32AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat32AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat32AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderBufferFloat64AtomicMinMax == VK_TRUE) && (query.shaderBufferFloat64AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat64AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderBufferFloat64AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat16Atomics == VK_TRUE) && (query.shaderSharedFloat16Atomics == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat16Atomics, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat16Atomics = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat16Atomics %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat16Atomics =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat16AtomicAdd == VK_TRUE) && (query.shaderSharedFloat16AtomicAdd == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat16AtomicAdd, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat16AtomicAdd = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat16AtomicAdd %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat16AtomicAdd =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat16AtomicMinMax == VK_TRUE) && (query.shaderSharedFloat16AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat16AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat16AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat16AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat16AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat32AtomicMinMax == VK_TRUE) && (query.shaderSharedFloat32AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat32AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat32AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderSharedFloat64AtomicMinMax == VK_TRUE) && (query.shaderSharedFloat64AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat64AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderSharedFloat64AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderImageFloat32AtomicMinMax == VK_TRUE) && (query.shaderImageFloat32AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderImageFloat32AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->shaderImageFloat32AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->sparseImageFloat32AtomicMinMax == VK_TRUE) && (query.sparseImageFloat32AtomicMinMax == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32AtomicMinMax, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->sparseImageFloat32AtomicMinMax = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32AtomicMinMax %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(currentNext)->sparseImageFloat32AtomicMinMax =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT:
             {
                 const VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*>(next);
@@ -1997,11 +2515,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->swapchainMaintenance1 == VK_TRUE) && (query.swapchainMaintenance1 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature swapchainMaintenance1, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*>(currentNext)->swapchainMaintenance1 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature swapchainMaintenance1 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*>(currentNext)->swapchainMaintenance1 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV:
             {
                 const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(next);
@@ -2010,11 +2530,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->deviceGeneratedCommands == VK_TRUE) && (query.deviceGeneratedCommands == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceGeneratedCommands, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(currentNext)->deviceGeneratedCommands = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceGeneratedCommands %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(currentNext)->deviceGeneratedCommands =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV:
             {
                 const VkPhysicalDeviceInheritedViewportScissorFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(next);
@@ -2023,11 +2545,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->inheritedViewportScissor2D == VK_TRUE) && (query.inheritedViewportScissor2D == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature inheritedViewportScissor2D, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(currentNext)->inheritedViewportScissor2D = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature inheritedViewportScissor2D %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(currentNext)->inheritedViewportScissor2D =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
             {
                 const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(next);
@@ -2036,11 +2560,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->texelBufferAlignment == VK_TRUE) && (query.texelBufferAlignment == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature texelBufferAlignment, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(currentNext)->texelBufferAlignment = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature texelBufferAlignment %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(currentNext)->texelBufferAlignment =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT:
             {
                 const VkPhysicalDeviceDepthBiasControlFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(next);
@@ -2049,26 +2575,34 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->depthBiasControl == VK_TRUE) && (query.depthBiasControl == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature depthBiasControl, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->depthBiasControl = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature depthBiasControl %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->depthBiasControl =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->leastRepresentableValueForceUnormRepresentation == VK_TRUE) && (query.leastRepresentableValueForceUnormRepresentation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature leastRepresentableValueForceUnormRepresentation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->leastRepresentableValueForceUnormRepresentation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature leastRepresentableValueForceUnormRepresentation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->leastRepresentableValueForceUnormRepresentation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->floatRepresentation == VK_TRUE) && (query.floatRepresentation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature floatRepresentation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->floatRepresentation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature floatRepresentation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->floatRepresentation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->depthBiasExact == VK_TRUE) && (query.depthBiasExact == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature depthBiasExact, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->depthBiasExact = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature depthBiasExact %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(currentNext)->depthBiasExact =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT:
             {
                 const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(next);
@@ -2077,11 +2611,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->deviceMemoryReport == VK_TRUE) && (query.deviceMemoryReport == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceMemoryReport, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(currentNext)->deviceMemoryReport = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceMemoryReport %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(currentNext)->deviceMemoryReport =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT:
             {
                 const VkPhysicalDeviceRobustness2FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesEXT*>(next);
@@ -2090,21 +2626,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->robustBufferAccess2 == VK_TRUE) && (query.robustBufferAccess2 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature robustBufferAccess2, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->robustBufferAccess2 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature robustBufferAccess2 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->robustBufferAccess2 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->robustImageAccess2 == VK_TRUE) && (query.robustImageAccess2 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature robustImageAccess2, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->robustImageAccess2 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature robustImageAccess2 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->robustImageAccess2 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->nullDescriptor == VK_TRUE) && (query.nullDescriptor == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature nullDescriptor, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->nullDescriptor = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature nullDescriptor %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->nullDescriptor =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT:
             {
                 const VkPhysicalDeviceCustomBorderColorFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(next);
@@ -2113,16 +2655,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->customBorderColors == VK_TRUE) && (query.customBorderColors == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature customBorderColors, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(currentNext)->customBorderColors = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature customBorderColors %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(currentNext)->customBorderColors =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->customBorderColorWithoutFormat == VK_TRUE) && (query.customBorderColorWithoutFormat == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature customBorderColorWithoutFormat, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(currentNext)->customBorderColorWithoutFormat = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature customBorderColorWithoutFormat %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(currentNext)->customBorderColorWithoutFormat =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV:
             {
                 const VkPhysicalDevicePresentBarrierFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV*>(next);
@@ -2131,11 +2677,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->presentBarrier == VK_TRUE) && (query.presentBarrier == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature presentBarrier, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePresentBarrierFeaturesNV*>(currentNext)->presentBarrier = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature presentBarrier %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePresentBarrierFeaturesNV*>(currentNext)->presentBarrier =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV:
             {
                 const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(next);
@@ -2144,11 +2692,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->diagnosticsConfig == VK_TRUE) && (query.diagnosticsConfig == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature diagnosticsConfig, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(currentNext)->diagnosticsConfig = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature diagnosticsConfig %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(currentNext)->diagnosticsConfig =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT:
             {
                 const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(next);
@@ -2157,11 +2707,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->graphicsPipelineLibrary == VK_TRUE) && (query.graphicsPipelineLibrary == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature graphicsPipelineLibrary, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(currentNext)->graphicsPipelineLibrary = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature graphicsPipelineLibrary %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(currentNext)->graphicsPipelineLibrary =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD:
             {
                 const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(next);
@@ -2170,11 +2722,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderEarlyAndLateFragmentTests == VK_TRUE) && (query.shaderEarlyAndLateFragmentTests == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderEarlyAndLateFragmentTests, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(currentNext)->shaderEarlyAndLateFragmentTests = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderEarlyAndLateFragmentTests %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(currentNext)->shaderEarlyAndLateFragmentTests =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV:
             {
                 const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(next);
@@ -2183,21 +2737,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->fragmentShadingRateEnums == VK_TRUE) && (query.fragmentShadingRateEnums == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentShadingRateEnums, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(currentNext)->fragmentShadingRateEnums = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentShadingRateEnums %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(currentNext)->fragmentShadingRateEnums =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->supersampleFragmentShadingRates == VK_TRUE) && (query.supersampleFragmentShadingRates == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature supersampleFragmentShadingRates, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(currentNext)->supersampleFragmentShadingRates = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature supersampleFragmentShadingRates %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(currentNext)->supersampleFragmentShadingRates =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->noInvocationFragmentShadingRates == VK_TRUE) && (query.noInvocationFragmentShadingRates == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature noInvocationFragmentShadingRates, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(currentNext)->noInvocationFragmentShadingRates = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature noInvocationFragmentShadingRates %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(currentNext)->noInvocationFragmentShadingRates =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV:
             {
                 const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(next);
@@ -2206,16 +2766,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rayTracingMotionBlur == VK_TRUE) && (query.rayTracingMotionBlur == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingMotionBlur, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(currentNext)->rayTracingMotionBlur = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingMotionBlur %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(currentNext)->rayTracingMotionBlur =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rayTracingMotionBlurPipelineTraceRaysIndirect == VK_TRUE) && (query.rayTracingMotionBlurPipelineTraceRaysIndirect == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingMotionBlurPipelineTraceRaysIndirect, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(currentNext)->rayTracingMotionBlurPipelineTraceRaysIndirect = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingMotionBlurPipelineTraceRaysIndirect %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(currentNext)->rayTracingMotionBlurPipelineTraceRaysIndirect =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT:
             {
                 const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(next);
@@ -2224,11 +2788,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->ycbcr2plane444Formats == VK_TRUE) && (query.ycbcr2plane444Formats == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature ycbcr2plane444Formats, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(currentNext)->ycbcr2plane444Formats = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature ycbcr2plane444Formats %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(currentNext)->ycbcr2plane444Formats =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT:
             {
                 const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(next);
@@ -2237,11 +2803,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->fragmentDensityMapDeferred == VK_TRUE) && (query.fragmentDensityMapDeferred == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapDeferred, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(currentNext)->fragmentDensityMapDeferred = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapDeferred %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(currentNext)->fragmentDensityMapDeferred =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT:
             {
                 const VkPhysicalDeviceImageCompressionControlFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(next);
@@ -2250,11 +2818,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->imageCompressionControl == VK_TRUE) && (query.imageCompressionControl == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imageCompressionControl, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(currentNext)->imageCompressionControl = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imageCompressionControl %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(currentNext)->imageCompressionControl =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT:
             {
                 const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(next);
@@ -2263,11 +2833,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->attachmentFeedbackLoopLayout == VK_TRUE) && (query.attachmentFeedbackLoopLayout == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature attachmentFeedbackLoopLayout, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(currentNext)->attachmentFeedbackLoopLayout = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature attachmentFeedbackLoopLayout %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(currentNext)->attachmentFeedbackLoopLayout =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT:
             {
                 const VkPhysicalDevice4444FormatsFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(next);
@@ -2276,16 +2848,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->formatA4R4G4B4 == VK_TRUE) && (query.formatA4R4G4B4 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature formatA4R4G4B4, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(currentNext)->formatA4R4G4B4 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature formatA4R4G4B4 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(currentNext)->formatA4R4G4B4 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->formatA4B4G4R4 == VK_TRUE) && (query.formatA4B4G4R4 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature formatA4B4G4R4, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(currentNext)->formatA4B4G4R4 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature formatA4B4G4R4 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(currentNext)->formatA4B4G4R4 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT:
             {
                 const VkPhysicalDeviceFaultFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT*>(next);
@@ -2294,16 +2870,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->deviceFault == VK_TRUE) && (query.deviceFault == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceFault, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(currentNext)->deviceFault = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceFault %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(currentNext)->deviceFault =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->deviceFaultVendorBinary == VK_TRUE) && (query.deviceFaultVendorBinary == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceFaultVendorBinary, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(currentNext)->deviceFaultVendorBinary = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceFaultVendorBinary %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(currentNext)->deviceFaultVendorBinary =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT:
             {
                 const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(next);
@@ -2312,21 +2892,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rasterizationOrderColorAttachmentAccess == VK_TRUE) && (query.rasterizationOrderColorAttachmentAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rasterizationOrderColorAttachmentAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(currentNext)->rasterizationOrderColorAttachmentAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rasterizationOrderColorAttachmentAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(currentNext)->rasterizationOrderColorAttachmentAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rasterizationOrderDepthAttachmentAccess == VK_TRUE) && (query.rasterizationOrderDepthAttachmentAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rasterizationOrderDepthAttachmentAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(currentNext)->rasterizationOrderDepthAttachmentAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rasterizationOrderDepthAttachmentAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(currentNext)->rasterizationOrderDepthAttachmentAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rasterizationOrderStencilAttachmentAccess == VK_TRUE) && (query.rasterizationOrderStencilAttachmentAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rasterizationOrderStencilAttachmentAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(currentNext)->rasterizationOrderStencilAttachmentAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rasterizationOrderStencilAttachmentAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(currentNext)->rasterizationOrderStencilAttachmentAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT:
             {
                 const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(next);
@@ -2335,11 +2921,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->formatRgba10x6WithoutYCbCrSampler == VK_TRUE) && (query.formatRgba10x6WithoutYCbCrSampler == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature formatRgba10x6WithoutYCbCrSampler, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(currentNext)->formatRgba10x6WithoutYCbCrSampler = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature formatRgba10x6WithoutYCbCrSampler %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(currentNext)->formatRgba10x6WithoutYCbCrSampler =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(next);
@@ -2348,11 +2936,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->mutableDescriptorType == VK_TRUE) && (query.mutableDescriptorType == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature mutableDescriptorType, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(currentNext)->mutableDescriptorType = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature mutableDescriptorType %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(currentNext)->mutableDescriptorType =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(next);
@@ -2361,11 +2951,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->vertexInputDynamicState == VK_TRUE) && (query.vertexInputDynamicState == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature vertexInputDynamicState, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(currentNext)->vertexInputDynamicState = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature vertexInputDynamicState %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(currentNext)->vertexInputDynamicState =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT:
             {
                 const VkPhysicalDeviceAddressBindingReportFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(next);
@@ -2374,11 +2966,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->reportAddressBinding == VK_TRUE) && (query.reportAddressBinding == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature reportAddressBinding, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(currentNext)->reportAddressBinding = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature reportAddressBinding %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(currentNext)->reportAddressBinding =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT:
             {
                 const VkPhysicalDeviceDepthClipControlFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT*>(next);
@@ -2387,11 +2981,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->depthClipControl == VK_TRUE) && (query.depthClipControl == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature depthClipControl, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDepthClipControlFeaturesEXT*>(currentNext)->depthClipControl = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature depthClipControl %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDepthClipControlFeaturesEXT*>(currentNext)->depthClipControl =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT:
             {
                 const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(next);
@@ -2400,16 +2996,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->primitiveTopologyListRestart == VK_TRUE) && (query.primitiveTopologyListRestart == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature primitiveTopologyListRestart, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(currentNext)->primitiveTopologyListRestart = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature primitiveTopologyListRestart %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(currentNext)->primitiveTopologyListRestart =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->primitiveTopologyPatchListRestart == VK_TRUE) && (query.primitiveTopologyPatchListRestart == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature primitiveTopologyPatchListRestart, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(currentNext)->primitiveTopologyPatchListRestart = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature primitiveTopologyPatchListRestart %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(currentNext)->primitiveTopologyPatchListRestart =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI:
             {
                 const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI* currentNext = reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(next);
@@ -2418,11 +3018,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->invocationMask == VK_TRUE) && (query.invocationMask == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature invocationMask, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(currentNext)->invocationMask = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature invocationMask %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(currentNext)->invocationMask =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV:
             {
                 const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(next);
@@ -2431,11 +3033,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->externalMemoryRDMA == VK_TRUE) && (query.externalMemoryRDMA == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature externalMemoryRDMA, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(currentNext)->externalMemoryRDMA = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature externalMemoryRDMA %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(currentNext)->externalMemoryRDMA =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT:
             {
                 const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(next);
@@ -2444,11 +3048,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->multisampledRenderToSingleSampled == VK_TRUE) && (query.multisampledRenderToSingleSampled == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multisampledRenderToSingleSampled, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(currentNext)->multisampledRenderToSingleSampled = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multisampledRenderToSingleSampled %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(currentNext)->multisampledRenderToSingleSampled =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT:
             {
                 const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(next);
@@ -2457,21 +3063,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->extendedDynamicState2 == VK_TRUE) && (query.extendedDynamicState2 == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState2, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(currentNext)->extendedDynamicState2 = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState2 %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(currentNext)->extendedDynamicState2 =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState2LogicOp == VK_TRUE) && (query.extendedDynamicState2LogicOp == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState2LogicOp, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(currentNext)->extendedDynamicState2LogicOp = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState2LogicOp %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(currentNext)->extendedDynamicState2LogicOp =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState2PatchControlPoints == VK_TRUE) && (query.extendedDynamicState2PatchControlPoints == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState2PatchControlPoints, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(currentNext)->extendedDynamicState2PatchControlPoints = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState2PatchControlPoints %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(currentNext)->extendedDynamicState2PatchControlPoints =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceColorWriteEnableFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(next);
@@ -2480,11 +3092,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->colorWriteEnable == VK_TRUE) && (query.colorWriteEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature colorWriteEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(currentNext)->colorWriteEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature colorWriteEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(currentNext)->colorWriteEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT:
             {
                 const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(next);
@@ -2493,21 +3107,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->primitivesGeneratedQuery == VK_TRUE) && (query.primitivesGeneratedQuery == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature primitivesGeneratedQuery, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(currentNext)->primitivesGeneratedQuery = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature primitivesGeneratedQuery %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(currentNext)->primitivesGeneratedQuery =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE) && (query.primitivesGeneratedQueryWithRasterizerDiscard == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature primitivesGeneratedQueryWithRasterizerDiscard, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(currentNext)->primitivesGeneratedQueryWithRasterizerDiscard = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature primitivesGeneratedQueryWithRasterizerDiscard %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(currentNext)->primitivesGeneratedQueryWithRasterizerDiscard =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->primitivesGeneratedQueryWithNonZeroStreams == VK_TRUE) && (query.primitivesGeneratedQueryWithNonZeroStreams == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature primitivesGeneratedQueryWithNonZeroStreams, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(currentNext)->primitivesGeneratedQueryWithNonZeroStreams = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature primitivesGeneratedQueryWithNonZeroStreams %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(currentNext)->primitivesGeneratedQueryWithNonZeroStreams =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT:
             {
                 const VkPhysicalDeviceImageViewMinLodFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(next);
@@ -2516,11 +3136,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->minLod == VK_TRUE) && (query.minLod == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature minLod, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(currentNext)->minLod = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature minLod %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(currentNext)->minLod =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT:
             {
                 const VkPhysicalDeviceMultiDrawFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(next);
@@ -2529,11 +3151,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->multiDraw == VK_TRUE) && (query.multiDraw == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiDraw, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMultiDrawFeaturesEXT*>(currentNext)->multiDraw = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiDraw %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMultiDrawFeaturesEXT*>(currentNext)->multiDraw =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT:
             {
                 const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(next);
@@ -2542,16 +3166,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->image2DViewOf3D == VK_TRUE) && (query.image2DViewOf3D == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature image2DViewOf3D, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(currentNext)->image2DViewOf3D = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature image2DViewOf3D %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(currentNext)->image2DViewOf3D =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->sampler2DViewOf3D == VK_TRUE) && (query.sampler2DViewOf3D == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature sampler2DViewOf3D, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(currentNext)->sampler2DViewOf3D = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature sampler2DViewOf3D %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(currentNext)->sampler2DViewOf3D =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceShaderTileImageFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT*>(next);
@@ -2560,21 +3188,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderTileImageColorReadAccess == VK_TRUE) && (query.shaderTileImageColorReadAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderTileImageColorReadAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(currentNext)->shaderTileImageColorReadAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderTileImageColorReadAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(currentNext)->shaderTileImageColorReadAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderTileImageDepthReadAccess == VK_TRUE) && (query.shaderTileImageDepthReadAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderTileImageDepthReadAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(currentNext)->shaderTileImageDepthReadAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderTileImageDepthReadAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(currentNext)->shaderTileImageDepthReadAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->shaderTileImageStencilReadAccess == VK_TRUE) && (query.shaderTileImageStencilReadAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderTileImageStencilReadAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(currentNext)->shaderTileImageStencilReadAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderTileImageStencilReadAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(currentNext)->shaderTileImageStencilReadAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT:
             {
                 const VkPhysicalDeviceOpacityMicromapFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(next);
@@ -2583,21 +3217,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->micromap == VK_TRUE) && (query.micromap == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature micromap, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(currentNext)->micromap = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature micromap %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(currentNext)->micromap =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->micromapCaptureReplay == VK_TRUE) && (query.micromapCaptureReplay == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature micromapCaptureReplay, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(currentNext)->micromapCaptureReplay = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature micromapCaptureReplay %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(currentNext)->micromapCaptureReplay =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->micromapHostCommands == VK_TRUE) && (query.micromapHostCommands == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature micromapHostCommands, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(currentNext)->micromapHostCommands = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature micromapHostCommands %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(currentNext)->micromapHostCommands =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV:
             {
                 const VkPhysicalDeviceDisplacementMicromapFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(next);
@@ -2606,11 +3246,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->displacementMicromap == VK_TRUE) && (query.displacementMicromap == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature displacementMicromap, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(currentNext)->displacementMicromap = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature displacementMicromap %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(currentNext)->displacementMicromap =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI:
             {
                 const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI* currentNext = reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(next);
@@ -2619,16 +3261,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->clustercullingShader == VK_TRUE) && (query.clustercullingShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature clustercullingShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(currentNext)->clustercullingShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature clustercullingShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(currentNext)->clustercullingShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multiviewClusterCullingShader == VK_TRUE) && (query.multiviewClusterCullingShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewClusterCullingShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(currentNext)->multiviewClusterCullingShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewClusterCullingShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(currentNext)->multiviewClusterCullingShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(next);
@@ -2637,16 +3283,20 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->borderColorSwizzle == VK_TRUE) && (query.borderColorSwizzle == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature borderColorSwizzle, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(currentNext)->borderColorSwizzle = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature borderColorSwizzle %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(currentNext)->borderColorSwizzle =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->borderColorSwizzleFromImage == VK_TRUE) && (query.borderColorSwizzleFromImage == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature borderColorSwizzleFromImage, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(currentNext)->borderColorSwizzleFromImage = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature borderColorSwizzleFromImage %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(currentNext)->borderColorSwizzleFromImage =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT:
             {
                 const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(next);
@@ -2655,11 +3305,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->pageableDeviceLocalMemory == VK_TRUE) && (query.pageableDeviceLocalMemory == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pageableDeviceLocalMemory, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(currentNext)->pageableDeviceLocalMemory = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pageableDeviceLocalMemory %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(currentNext)->pageableDeviceLocalMemory =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT:
             {
                 const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(next);
@@ -2668,11 +3320,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->imageSlicedViewOf3D == VK_TRUE) && (query.imageSlicedViewOf3D == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imageSlicedViewOf3D, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(currentNext)->imageSlicedViewOf3D = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imageSlicedViewOf3D %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(currentNext)->imageSlicedViewOf3D =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE:
             {
                 const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE* currentNext = reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(next);
@@ -2681,11 +3335,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->descriptorSetHostMapping == VK_TRUE) && (query.descriptorSetHostMapping == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorSetHostMapping, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(currentNext)->descriptorSetHostMapping = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorSetHostMapping %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(currentNext)->descriptorSetHostMapping =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceDepthClampZeroOneFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesEXT*>(next);
@@ -2694,11 +3350,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->depthClampZeroOne == VK_TRUE) && (query.depthClampZeroOne == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature depthClampZeroOne, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDepthClampZeroOneFeaturesEXT*>(currentNext)->depthClampZeroOne = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature depthClampZeroOne %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDepthClampZeroOneFeaturesEXT*>(currentNext)->depthClampZeroOne =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT:
             {
                 const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(next);
@@ -2707,11 +3365,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->nonSeamlessCubeMap == VK_TRUE) && (query.nonSeamlessCubeMap == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature nonSeamlessCubeMap, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(currentNext)->nonSeamlessCubeMap = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature nonSeamlessCubeMap %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(currentNext)->nonSeamlessCubeMap =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_QCOM:
             {
                 const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM*>(next);
@@ -2720,11 +3380,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->fragmentDensityMapOffset == VK_TRUE) && (query.fragmentDensityMapOffset == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapOffset, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM*>(currentNext)->fragmentDensityMapOffset = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapOffset %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM*>(currentNext)->fragmentDensityMapOffset =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV:
             {
                 const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(next);
@@ -2733,21 +3395,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->deviceGeneratedCompute == VK_TRUE) && (query.deviceGeneratedCompute == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceGeneratedCompute, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(currentNext)->deviceGeneratedCompute = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceGeneratedCompute %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(currentNext)->deviceGeneratedCompute =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->deviceGeneratedComputePipelines == VK_TRUE) && (query.deviceGeneratedComputePipelines == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceGeneratedComputePipelines, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(currentNext)->deviceGeneratedComputePipelines = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceGeneratedComputePipelines %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(currentNext)->deviceGeneratedComputePipelines =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->deviceGeneratedComputeCaptureReplay == VK_TRUE) && (query.deviceGeneratedComputeCaptureReplay == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature deviceGeneratedComputeCaptureReplay, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(currentNext)->deviceGeneratedComputeCaptureReplay = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature deviceGeneratedComputeCaptureReplay %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(currentNext)->deviceGeneratedComputeCaptureReplay =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV:
             {
                 const VkPhysicalDeviceLinearColorAttachmentFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(next);
@@ -2756,11 +3424,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->linearColorAttachment == VK_TRUE) && (query.linearColorAttachment == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature linearColorAttachment, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(currentNext)->linearColorAttachment = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature linearColorAttachment %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(currentNext)->linearColorAttachment =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT:
             {
                 const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(next);
@@ -2769,11 +3439,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->imageCompressionControlSwapchain == VK_TRUE) && (query.imageCompressionControlSwapchain == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature imageCompressionControlSwapchain, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(currentNext)->imageCompressionControlSwapchain = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature imageCompressionControlSwapchain %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(currentNext)->imageCompressionControlSwapchain =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM:
             {
                 const VkPhysicalDeviceImageProcessingFeaturesQCOM* currentNext = reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM*>(next);
@@ -2782,21 +3454,27 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->textureSampleWeighted == VK_TRUE) && (query.textureSampleWeighted == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature textureSampleWeighted, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(currentNext)->textureSampleWeighted = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature textureSampleWeighted %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(currentNext)->textureSampleWeighted =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->textureBoxFilter == VK_TRUE) && (query.textureBoxFilter == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature textureBoxFilter, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(currentNext)->textureBoxFilter = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature textureBoxFilter %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(currentNext)->textureBoxFilter =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->textureBlockMatch == VK_TRUE) && (query.textureBlockMatch == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature textureBlockMatch, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(currentNext)->textureBlockMatch = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature textureBlockMatch %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(currentNext)->textureBlockMatch =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT:
             {
                 const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(next);
@@ -2805,161 +3483,223 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->extendedDynamicState3TessellationDomainOrigin == VK_TRUE) && (query.extendedDynamicState3TessellationDomainOrigin == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3TessellationDomainOrigin, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3TessellationDomainOrigin = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3TessellationDomainOrigin %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3TessellationDomainOrigin =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3DepthClampEnable == VK_TRUE) && (query.extendedDynamicState3DepthClampEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3DepthClampEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3DepthClampEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3DepthClampEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3DepthClampEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3PolygonMode == VK_TRUE) && (query.extendedDynamicState3PolygonMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3PolygonMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3PolygonMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3PolygonMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3PolygonMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3RasterizationSamples == VK_TRUE) && (query.extendedDynamicState3RasterizationSamples == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3RasterizationSamples, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3RasterizationSamples = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3RasterizationSamples %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3RasterizationSamples =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3SampleMask == VK_TRUE) && (query.extendedDynamicState3SampleMask == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3SampleMask, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3SampleMask = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3SampleMask %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3SampleMask =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3AlphaToCoverageEnable == VK_TRUE) && (query.extendedDynamicState3AlphaToCoverageEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3AlphaToCoverageEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3AlphaToCoverageEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3AlphaToCoverageEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3AlphaToCoverageEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3AlphaToOneEnable == VK_TRUE) && (query.extendedDynamicState3AlphaToOneEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3AlphaToOneEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3AlphaToOneEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3AlphaToOneEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3AlphaToOneEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3LogicOpEnable == VK_TRUE) && (query.extendedDynamicState3LogicOpEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3LogicOpEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3LogicOpEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3LogicOpEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3LogicOpEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ColorBlendEnable == VK_TRUE) && (query.extendedDynamicState3ColorBlendEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorBlendEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorBlendEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorBlendEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorBlendEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ColorBlendEquation == VK_TRUE) && (query.extendedDynamicState3ColorBlendEquation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorBlendEquation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorBlendEquation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorBlendEquation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorBlendEquation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ColorWriteMask == VK_TRUE) && (query.extendedDynamicState3ColorWriteMask == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorWriteMask, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorWriteMask = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorWriteMask %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorWriteMask =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3RasterizationStream == VK_TRUE) && (query.extendedDynamicState3RasterizationStream == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3RasterizationStream, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3RasterizationStream = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3RasterizationStream %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3RasterizationStream =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ConservativeRasterizationMode == VK_TRUE) && (query.extendedDynamicState3ConservativeRasterizationMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ConservativeRasterizationMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ConservativeRasterizationMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ConservativeRasterizationMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ConservativeRasterizationMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ExtraPrimitiveOverestimationSize == VK_TRUE) && (query.extendedDynamicState3ExtraPrimitiveOverestimationSize == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ExtraPrimitiveOverestimationSize, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ExtraPrimitiveOverestimationSize = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ExtraPrimitiveOverestimationSize %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ExtraPrimitiveOverestimationSize =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3DepthClipEnable == VK_TRUE) && (query.extendedDynamicState3DepthClipEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3DepthClipEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3DepthClipEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3DepthClipEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3DepthClipEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3SampleLocationsEnable == VK_TRUE) && (query.extendedDynamicState3SampleLocationsEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3SampleLocationsEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3SampleLocationsEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3SampleLocationsEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3SampleLocationsEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ColorBlendAdvanced == VK_TRUE) && (query.extendedDynamicState3ColorBlendAdvanced == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorBlendAdvanced, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorBlendAdvanced = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ColorBlendAdvanced %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ColorBlendAdvanced =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ProvokingVertexMode == VK_TRUE) && (query.extendedDynamicState3ProvokingVertexMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ProvokingVertexMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ProvokingVertexMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ProvokingVertexMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ProvokingVertexMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3LineRasterizationMode == VK_TRUE) && (query.extendedDynamicState3LineRasterizationMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3LineRasterizationMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3LineRasterizationMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3LineRasterizationMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3LineRasterizationMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3LineStippleEnable == VK_TRUE) && (query.extendedDynamicState3LineStippleEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3LineStippleEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3LineStippleEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3LineStippleEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3LineStippleEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3DepthClipNegativeOneToOne == VK_TRUE) && (query.extendedDynamicState3DepthClipNegativeOneToOne == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3DepthClipNegativeOneToOne, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3DepthClipNegativeOneToOne = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3DepthClipNegativeOneToOne %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3DepthClipNegativeOneToOne =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ViewportWScalingEnable == VK_TRUE) && (query.extendedDynamicState3ViewportWScalingEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ViewportWScalingEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ViewportWScalingEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ViewportWScalingEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ViewportWScalingEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ViewportSwizzle == VK_TRUE) && (query.extendedDynamicState3ViewportSwizzle == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ViewportSwizzle, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ViewportSwizzle = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ViewportSwizzle %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ViewportSwizzle =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3CoverageToColorEnable == VK_TRUE) && (query.extendedDynamicState3CoverageToColorEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageToColorEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageToColorEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageToColorEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageToColorEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3CoverageToColorLocation == VK_TRUE) && (query.extendedDynamicState3CoverageToColorLocation == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageToColorLocation, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageToColorLocation = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageToColorLocation %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageToColorLocation =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3CoverageModulationMode == VK_TRUE) && (query.extendedDynamicState3CoverageModulationMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageModulationMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageModulationMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageModulationMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageModulationMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3CoverageModulationTableEnable == VK_TRUE) && (query.extendedDynamicState3CoverageModulationTableEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageModulationTableEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageModulationTableEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageModulationTableEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageModulationTableEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3CoverageModulationTable == VK_TRUE) && (query.extendedDynamicState3CoverageModulationTable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageModulationTable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageModulationTable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageModulationTable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageModulationTable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3CoverageReductionMode == VK_TRUE) && (query.extendedDynamicState3CoverageReductionMode == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageReductionMode, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageReductionMode = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3CoverageReductionMode %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3CoverageReductionMode =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3RepresentativeFragmentTestEnable == VK_TRUE) && (query.extendedDynamicState3RepresentativeFragmentTestEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3RepresentativeFragmentTestEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3RepresentativeFragmentTestEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3RepresentativeFragmentTestEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3RepresentativeFragmentTestEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->extendedDynamicState3ShadingRateImageEnable == VK_TRUE) && (query.extendedDynamicState3ShadingRateImageEnable == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ShadingRateImageEnable, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ShadingRateImageEnable = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState3ShadingRateImageEnable %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(currentNext)->extendedDynamicState3ShadingRateImageEnable =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT:
             {
                 const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(next);
@@ -2968,11 +3708,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->subpassMergeFeedback == VK_TRUE) && (query.subpassMergeFeedback == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature subpassMergeFeedback, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(currentNext)->subpassMergeFeedback = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature subpassMergeFeedback %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(currentNext)->subpassMergeFeedback =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT:
             {
                 const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(next);
@@ -2981,11 +3723,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderModuleIdentifier == VK_TRUE) && (query.shaderModuleIdentifier == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderModuleIdentifier, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(currentNext)->shaderModuleIdentifier = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderModuleIdentifier %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(currentNext)->shaderModuleIdentifier =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV:
             {
                 const VkPhysicalDeviceOpticalFlowFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV*>(next);
@@ -2994,11 +3738,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->opticalFlow == VK_TRUE) && (query.opticalFlow == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature opticalFlow, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceOpticalFlowFeaturesNV*>(currentNext)->opticalFlow = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature opticalFlow %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceOpticalFlowFeaturesNV*>(currentNext)->opticalFlow =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT:
             {
                 const VkPhysicalDeviceLegacyDitheringFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(next);
@@ -3007,11 +3753,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->legacyDithering == VK_TRUE) && (query.legacyDithering == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature legacyDithering, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(currentNext)->legacyDithering = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature legacyDithering %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(currentNext)->legacyDithering =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES_EXT:
             {
                 const VkPhysicalDevicePipelineProtectedAccessFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeaturesEXT*>(next);
@@ -3020,11 +3768,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->pipelineProtectedAccess == VK_TRUE) && (query.pipelineProtectedAccess == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pipelineProtectedAccess, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePipelineProtectedAccessFeaturesEXT*>(currentNext)->pipelineProtectedAccess = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pipelineProtectedAccess %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePipelineProtectedAccessFeaturesEXT*>(currentNext)->pipelineProtectedAccess =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT:
             {
                 const VkPhysicalDeviceShaderObjectFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT*>(next);
@@ -3033,11 +3783,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderObject == VK_TRUE) && (query.shaderObject == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderObject, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderObjectFeaturesEXT*>(currentNext)->shaderObject = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderObject %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderObjectFeaturesEXT*>(currentNext)->shaderObject =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM:
             {
                 const VkPhysicalDeviceTilePropertiesFeaturesQCOM* currentNext = reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(next);
@@ -3046,11 +3798,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->tileProperties == VK_TRUE) && (query.tileProperties == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature tileProperties, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(currentNext)->tileProperties = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature tileProperties %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(currentNext)->tileProperties =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC:
             {
                 const VkPhysicalDeviceAmigoProfilingFeaturesSEC* currentNext = reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(next);
@@ -3059,11 +3813,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->amigoProfiling == VK_TRUE) && (query.amigoProfiling == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature amigoProfiling, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(currentNext)->amigoProfiling = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature amigoProfiling %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(currentNext)->amigoProfiling =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM:
             {
                 const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM* currentNext = reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(next);
@@ -3072,11 +3828,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->multiviewPerViewViewports == VK_TRUE) && (query.multiviewPerViewViewports == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewPerViewViewports, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(currentNext)->multiviewPerViewViewports = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewPerViewViewports %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(currentNext)->multiviewPerViewViewports =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV:
             {
                 const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(next);
@@ -3085,11 +3843,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rayTracingInvocationReorder == VK_TRUE) && (query.rayTracingInvocationReorder == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingInvocationReorder, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(currentNext)->rayTracingInvocationReorder = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingInvocationReorder %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(currentNext)->rayTracingInvocationReorder =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM:
             {
                 const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(next);
@@ -3098,11 +3858,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->shaderCoreBuiltins == VK_TRUE) && (query.shaderCoreBuiltins == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature shaderCoreBuiltins, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(currentNext)->shaderCoreBuiltins = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature shaderCoreBuiltins %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(currentNext)->shaderCoreBuiltins =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT:
             {
                 const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(next);
@@ -3111,11 +3873,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->pipelineLibraryGroupHandles == VK_TRUE) && (query.pipelineLibraryGroupHandles == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature pipelineLibraryGroupHandles, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(currentNext)->pipelineLibraryGroupHandles = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature pipelineLibraryGroupHandles %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(currentNext)->pipelineLibraryGroupHandles =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT:
             {
                 const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(next);
@@ -3124,11 +3888,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->dynamicRenderingUnusedAttachments == VK_TRUE) && (query.dynamicRenderingUnusedAttachments == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature dynamicRenderingUnusedAttachments, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(currentNext)->dynamicRenderingUnusedAttachments = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature dynamicRenderingUnusedAttachments %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(currentNext)->dynamicRenderingUnusedAttachments =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM:
             {
                 const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM* currentNext = reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(next);
@@ -3137,11 +3903,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->multiviewPerViewRenderAreas == VK_TRUE) && (query.multiviewPerViewRenderAreas == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewPerViewRenderAreas, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(currentNext)->multiviewPerViewRenderAreas = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewPerViewRenderAreas %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(currentNext)->multiviewPerViewRenderAreas =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT:
             {
                 const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(next);
@@ -3150,11 +3918,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->attachmentFeedbackLoopDynamicState == VK_TRUE) && (query.attachmentFeedbackLoopDynamicState == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature attachmentFeedbackLoopDynamicState, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(currentNext)->attachmentFeedbackLoopDynamicState = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature attachmentFeedbackLoopDynamicState %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(currentNext)->attachmentFeedbackLoopDynamicState =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR:
             {
                 const VkPhysicalDeviceAccelerationStructureFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(next);
@@ -3163,31 +3933,41 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->accelerationStructure == VK_TRUE) && (query.accelerationStructure == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature accelerationStructure, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructure = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature accelerationStructure %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructure =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->accelerationStructureCaptureReplay == VK_TRUE) && (query.accelerationStructureCaptureReplay == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature accelerationStructureCaptureReplay, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructureCaptureReplay = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature accelerationStructureCaptureReplay %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructureCaptureReplay =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->accelerationStructureIndirectBuild == VK_TRUE) && (query.accelerationStructureIndirectBuild == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature accelerationStructureIndirectBuild, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructureIndirectBuild = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature accelerationStructureIndirectBuild %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructureIndirectBuild =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->accelerationStructureHostCommands == VK_TRUE) && (query.accelerationStructureHostCommands == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature accelerationStructureHostCommands, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructureHostCommands = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature accelerationStructureHostCommands %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->accelerationStructureHostCommands =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->descriptorBindingAccelerationStructureUpdateAfterBind == VK_TRUE) && (query.descriptorBindingAccelerationStructureUpdateAfterBind == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature descriptorBindingAccelerationStructureUpdateAfterBind, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->descriptorBindingAccelerationStructureUpdateAfterBind = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingAccelerationStructureUpdateAfterBind %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(currentNext)->descriptorBindingAccelerationStructureUpdateAfterBind =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR:
             {
                 const VkPhysicalDeviceRayTracingPipelineFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(next);
@@ -3196,31 +3976,41 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rayTracingPipeline == VK_TRUE) && (query.rayTracingPipeline == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingPipeline, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipeline = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingPipeline %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipeline =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rayTracingPipelineShaderGroupHandleCaptureReplay == VK_TRUE) && (query.rayTracingPipelineShaderGroupHandleCaptureReplay == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineShaderGroupHandleCaptureReplay, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipelineShaderGroupHandleCaptureReplay = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineShaderGroupHandleCaptureReplay %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipelineShaderGroupHandleCaptureReplay =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rayTracingPipelineShaderGroupHandleCaptureReplayMixed == VK_TRUE) && (query.rayTracingPipelineShaderGroupHandleCaptureReplayMixed == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineShaderGroupHandleCaptureReplayMixed, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipelineShaderGroupHandleCaptureReplayMixed = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineShaderGroupHandleCaptureReplayMixed %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipelineShaderGroupHandleCaptureReplayMixed =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rayTracingPipelineTraceRaysIndirect == VK_TRUE) && (query.rayTracingPipelineTraceRaysIndirect == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineTraceRaysIndirect, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipelineTraceRaysIndirect = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTracingPipelineTraceRaysIndirect %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTracingPipelineTraceRaysIndirect =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->rayTraversalPrimitiveCulling == VK_TRUE) && (query.rayTraversalPrimitiveCulling == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayTraversalPrimitiveCulling, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTraversalPrimitiveCulling = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayTraversalPrimitiveCulling %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(currentNext)->rayTraversalPrimitiveCulling =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR:
             {
                 const VkPhysicalDeviceRayQueryFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR*>(next);
@@ -3229,11 +4019,13 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->rayQuery == VK_TRUE) && (query.rayQuery == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature rayQuery, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceRayQueryFeaturesKHR*>(currentNext)->rayQuery = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature rayQuery %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceRayQueryFeaturesKHR*>(currentNext)->rayQuery =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT:
             {
                 const VkPhysicalDeviceMeshShaderFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT*>(next);
@@ -3242,31 +4034,41 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
                 GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
                 if ((currentNext->taskShader == VK_TRUE) && (query.taskShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature taskShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->taskShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature taskShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->taskShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->meshShader == VK_TRUE) && (query.meshShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature meshShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->meshShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature meshShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->meshShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->multiviewMeshShader == VK_TRUE) && (query.multiviewMeshShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature multiviewMeshShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->multiviewMeshShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature multiviewMeshShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->multiviewMeshShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->primitiveFragmentShadingRateMeshShader == VK_TRUE) && (query.primitiveFragmentShadingRateMeshShader == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature primitiveFragmentShadingRateMeshShader, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->primitiveFragmentShadingRateMeshShader = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature primitiveFragmentShadingRateMeshShader %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->primitiveFragmentShadingRateMeshShader =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 if ((currentNext->meshShaderQueries == VK_TRUE) && (query.meshShaderQueries == VK_FALSE))
                 {
-                    GFXRECON_LOG_WARNING("Feature meshShaderQueries, which is not supported by the replay device, will not be enabled");
-                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->meshShaderQueries = VK_FALSE;
+                    GFXRECON_LOG_WARNING("Feature meshShaderQueries %s", warn_message);
+                    found_unsupported = true;
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(currentNext)->meshShaderQueries =
+                        remove_unsupported ? VK_FALSE : VK_TRUE;
                 }
                 break;
-             }
+            }
              default:
                 break;
             }
@@ -3280,279 +4082,394 @@ void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysica
         GetPhysicalDeviceFeatures(physicalDevice, &query);
         if ((physicalDeviceFeatures->robustBufferAccess == VK_TRUE) && (query.robustBufferAccess == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature robustBufferAccess, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->robustBufferAccess = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature robustBufferAccess %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->robustBufferAccess =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->fullDrawIndexUint32 == VK_TRUE) && (query.fullDrawIndexUint32 == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature fullDrawIndexUint32, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fullDrawIndexUint32 = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature fullDrawIndexUint32 %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fullDrawIndexUint32 =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->imageCubeArray == VK_TRUE) && (query.imageCubeArray == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature imageCubeArray, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->imageCubeArray = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature imageCubeArray %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->imageCubeArray =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->independentBlend == VK_TRUE) && (query.independentBlend == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature independentBlend, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->independentBlend = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature independentBlend %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->independentBlend =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->geometryShader == VK_TRUE) && (query.geometryShader == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature geometryShader, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->geometryShader = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature geometryShader %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->geometryShader =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->tessellationShader == VK_TRUE) && (query.tessellationShader == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature tessellationShader, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->tessellationShader = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature tessellationShader %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->tessellationShader =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sampleRateShading == VK_TRUE) && (query.sampleRateShading == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sampleRateShading, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sampleRateShading = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sampleRateShading %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sampleRateShading =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->dualSrcBlend == VK_TRUE) && (query.dualSrcBlend == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature dualSrcBlend, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->dualSrcBlend = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature dualSrcBlend %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->dualSrcBlend =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->logicOp == VK_TRUE) && (query.logicOp == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature logicOp, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->logicOp = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature logicOp %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->logicOp =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->multiDrawIndirect == VK_TRUE) && (query.multiDrawIndirect == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature multiDrawIndirect, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->multiDrawIndirect = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature multiDrawIndirect %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->multiDrawIndirect =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->drawIndirectFirstInstance == VK_TRUE) && (query.drawIndirectFirstInstance == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature drawIndirectFirstInstance, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->drawIndirectFirstInstance = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature drawIndirectFirstInstance %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->drawIndirectFirstInstance =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->depthClamp == VK_TRUE) && (query.depthClamp == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature depthClamp, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthClamp = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature depthClamp %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthClamp =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->depthBiasClamp == VK_TRUE) && (query.depthBiasClamp == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature depthBiasClamp, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthBiasClamp = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature depthBiasClamp %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthBiasClamp =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->fillModeNonSolid == VK_TRUE) && (query.fillModeNonSolid == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature fillModeNonSolid, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fillModeNonSolid = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature fillModeNonSolid %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fillModeNonSolid =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->depthBounds == VK_TRUE) && (query.depthBounds == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature depthBounds, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthBounds = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature depthBounds %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthBounds =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->wideLines == VK_TRUE) && (query.wideLines == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature wideLines, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->wideLines = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature wideLines %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->wideLines =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->largePoints == VK_TRUE) && (query.largePoints == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature largePoints, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->largePoints = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature largePoints %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->largePoints =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->alphaToOne == VK_TRUE) && (query.alphaToOne == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature alphaToOne, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->alphaToOne = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature alphaToOne %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->alphaToOne =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->multiViewport == VK_TRUE) && (query.multiViewport == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature multiViewport, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->multiViewport = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature multiViewport %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->multiViewport =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->samplerAnisotropy == VK_TRUE) && (query.samplerAnisotropy == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature samplerAnisotropy, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->samplerAnisotropy = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature samplerAnisotropy %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->samplerAnisotropy =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->textureCompressionETC2 == VK_TRUE) && (query.textureCompressionETC2 == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature textureCompressionETC2, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionETC2 = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature textureCompressionETC2 %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionETC2 =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->textureCompressionASTC_LDR == VK_TRUE) && (query.textureCompressionASTC_LDR == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature textureCompressionASTC_LDR, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionASTC_LDR = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature textureCompressionASTC_LDR %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionASTC_LDR =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->textureCompressionBC == VK_TRUE) && (query.textureCompressionBC == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature textureCompressionBC, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionBC = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature textureCompressionBC %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionBC =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->occlusionQueryPrecise == VK_TRUE) && (query.occlusionQueryPrecise == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature occlusionQueryPrecise, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->occlusionQueryPrecise = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature occlusionQueryPrecise %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->occlusionQueryPrecise =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->pipelineStatisticsQuery == VK_TRUE) && (query.pipelineStatisticsQuery == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature pipelineStatisticsQuery, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->pipelineStatisticsQuery = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature pipelineStatisticsQuery %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->pipelineStatisticsQuery =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->vertexPipelineStoresAndAtomics == VK_TRUE) && (query.vertexPipelineStoresAndAtomics == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature vertexPipelineStoresAndAtomics, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->vertexPipelineStoresAndAtomics = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature vertexPipelineStoresAndAtomics %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->vertexPipelineStoresAndAtomics =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->fragmentStoresAndAtomics == VK_TRUE) && (query.fragmentStoresAndAtomics == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature fragmentStoresAndAtomics, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fragmentStoresAndAtomics = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature fragmentStoresAndAtomics %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fragmentStoresAndAtomics =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderTessellationAndGeometryPointSize == VK_TRUE) && (query.shaderTessellationAndGeometryPointSize == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderTessellationAndGeometryPointSize, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderTessellationAndGeometryPointSize = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderTessellationAndGeometryPointSize %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderTessellationAndGeometryPointSize =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderImageGatherExtended == VK_TRUE) && (query.shaderImageGatherExtended == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderImageGatherExtended, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderImageGatherExtended = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderImageGatherExtended %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderImageGatherExtended =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderStorageImageExtendedFormats == VK_TRUE) && (query.shaderStorageImageExtendedFormats == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderStorageImageExtendedFormats, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageExtendedFormats = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageExtendedFormats %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageExtendedFormats =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderStorageImageMultisample == VK_TRUE) && (query.shaderStorageImageMultisample == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderStorageImageMultisample, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageMultisample = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageMultisample %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageMultisample =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderStorageImageReadWithoutFormat == VK_TRUE) && (query.shaderStorageImageReadWithoutFormat == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderStorageImageReadWithoutFormat, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageReadWithoutFormat = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageReadWithoutFormat %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageReadWithoutFormat =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderStorageImageWriteWithoutFormat == VK_TRUE) && (query.shaderStorageImageWriteWithoutFormat == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderStorageImageWriteWithoutFormat, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageWriteWithoutFormat = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageWriteWithoutFormat %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageWriteWithoutFormat =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderUniformBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderUniformBufferArrayDynamicIndexing == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderUniformBufferArrayDynamicIndexing = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayDynamicIndexing %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderUniformBufferArrayDynamicIndexing =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderSampledImageArrayDynamicIndexing == VK_TRUE) && (query.shaderSampledImageArrayDynamicIndexing == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderSampledImageArrayDynamicIndexing = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayDynamicIndexing %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderSampledImageArrayDynamicIndexing =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderStorageBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageBufferArrayDynamicIndexing == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageBufferArrayDynamicIndexing = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayDynamicIndexing %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageBufferArrayDynamicIndexing =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderStorageImageArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageImageArrayDynamicIndexing == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageArrayDynamicIndexing = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayDynamicIndexing %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageArrayDynamicIndexing =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderClipDistance == VK_TRUE) && (query.shaderClipDistance == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderClipDistance, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderClipDistance = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderClipDistance %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderClipDistance =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderCullDistance == VK_TRUE) && (query.shaderCullDistance == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderCullDistance, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderCullDistance = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderCullDistance %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderCullDistance =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderFloat64 == VK_TRUE) && (query.shaderFloat64 == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderFloat64, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderFloat64 = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderFloat64 %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderFloat64 =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderInt64 == VK_TRUE) && (query.shaderInt64 == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderInt64, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderInt64 = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderInt64 %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderInt64 =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderInt16 == VK_TRUE) && (query.shaderInt16 == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderInt16, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderInt16 = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderInt16 %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderInt16 =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderResourceResidency == VK_TRUE) && (query.shaderResourceResidency == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderResourceResidency, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderResourceResidency = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderResourceResidency %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderResourceResidency =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->shaderResourceMinLod == VK_TRUE) && (query.shaderResourceMinLod == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature shaderResourceMinLod, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderResourceMinLod = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature shaderResourceMinLod %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderResourceMinLod =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseBinding == VK_TRUE) && (query.sparseBinding == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseBinding, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseBinding = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseBinding %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseBinding =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidencyBuffer == VK_TRUE) && (query.sparseResidencyBuffer == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidencyBuffer, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyBuffer = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidencyBuffer %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyBuffer =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidencyImage2D == VK_TRUE) && (query.sparseResidencyImage2D == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidencyImage2D, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyImage2D = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidencyImage2D %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyImage2D =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidencyImage3D == VK_TRUE) && (query.sparseResidencyImage3D == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidencyImage3D, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyImage3D = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidencyImage3D %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyImage3D =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidency2Samples == VK_TRUE) && (query.sparseResidency2Samples == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidency2Samples, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency2Samples = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidency2Samples %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency2Samples =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidency4Samples == VK_TRUE) && (query.sparseResidency4Samples == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidency4Samples, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency4Samples = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidency4Samples %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency4Samples =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidency8Samples == VK_TRUE) && (query.sparseResidency8Samples == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidency8Samples, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency8Samples = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidency8Samples %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency8Samples =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidency16Samples == VK_TRUE) && (query.sparseResidency16Samples == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidency16Samples, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency16Samples = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidency16Samples %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency16Samples =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->sparseResidencyAliased == VK_TRUE) && (query.sparseResidencyAliased == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature sparseResidencyAliased, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyAliased = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature sparseResidencyAliased %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyAliased =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->variableMultisampleRate == VK_TRUE) && (query.variableMultisampleRate == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature variableMultisampleRate, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->variableMultisampleRate = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature variableMultisampleRate %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->variableMultisampleRate =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
         if ((physicalDeviceFeatures->inheritedQueries == VK_TRUE) && (query.inheritedQueries == VK_FALSE))
         {
-            GFXRECON_LOG_WARNING("Feature inheritedQueries, which is not supported by the replay device, will not be enabled");
-            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->inheritedQueries = VK_FALSE;
+            GFXRECON_LOG_WARNING("Feature inheritedQueries %s", warn_message);
+            found_unsupported = true;
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->inheritedQueries =
+                remove_unsupported ? VK_FALSE : VK_TRUE;
         }
+    }
+
+    if (!remove_unsupported && found_unsupported)
+    {
+        GFXRECON_LOG_WARNING("Unsupported features were requested. This might cause the vkCreateDevice to fail. Try \"--remove-unsupported\" option to remove those features at replay.");
     }
 }
 

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -4469,7 +4469,7 @@ void CheckUnsupportedFeatures(VkPhysicalDevice physicalDevice,
 
     if (!remove_unsupported && found_unsupported)
     {
-        GFXRECON_LOG_WARNING("Unsupported features were requested. This might cause the vkCreateDevice to fail. Try \"--remove-unsupported\" option to remove those features at replay.");
+        GFXRECON_LOG_WARNING("Unsupported features were requested. This might cause vkCreateDevice to fail. Try \"--remove-unsupported\" option to remove those features at replay.");
     }
 }
 

--- a/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
@@ -127,7 +127,12 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
 
     def make_feature_helper(self):
         """Generate help function for features on replaying at device creation time."""
-        result = 'void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures, PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2, const void* pNext, const VkPhysicalDeviceFeatures* pEnabledFeatures)\n'
+        result = 'void CheckUnsupportedFeatures(VkPhysicalDevice physicalDevice,\n'
+        result += '                             PFN_vkGetPhysicalDeviceFeatures  GetPhysicalDeviceFeatures,\n'
+        result += '                             PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2,\n'
+        result += '                             const void*                      pNext,\n'
+        result += '                             const VkPhysicalDeviceFeatures*  pEnabledFeatures,\n'
+        result += '                             bool                             remove_unsupported)\n'
         result += '{\n'
         result += '    // If the pNext chain includes a VkPhysicalDeviceFeatures2 structure, then pEnabledFeatures must be NULL\n'
         result += '    const VkPhysicalDeviceFeatures* physicalDeviceFeatures = nullptr;\n'
@@ -135,6 +140,11 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
         result += '    {\n'
         result += '        physicalDeviceFeatures = pEnabledFeatures;\n'
         result += '    }\n\n'
+
+        result += '    bool found_unsupported = false;\n'
+        result += '    const char* warn_message =\n'
+        result += '        remove_unsupported ? "requested at capture is not supported by the replay device and it will not be enabled."\n'
+        result += '                           : "requested at capture is not supported by the replay device.";\n\n'
 
         result += '    if (GetPhysicalDeviceFeatures2 != nullptr)\n'
         result += '    {\n'
@@ -166,15 +176,17 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
                     member, member
                 )
                 result += '                {\n'
-                result += '                    GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(
+                result += '                    GFXRECON_LOG_WARNING("Feature {} %s", warn_message);\n'.format(
                     member
                 )
-                result += '                    const_cast<{}*>(currentNext)->{} = VK_FALSE;\n'.format(
+                result += '                    found_unsupported = true;\n'
+                result += '                    const_cast<{}*>(currentNext)->{} =\n'.format(
                     typename, member
                 )
+                result += '                        remove_unsupported ? VK_FALSE : VK_TRUE;\n'
                 result += '                }\n'
             result += '                break;\n'
-            result += '             }\n'
+            result += '            }\n'
 
         result += '             default:\n'
         result += '                break;\n'
@@ -192,13 +204,20 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
                 feature, feature
             )
             result += '        {\n'
-            result += '            GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(
+            result += '            GFXRECON_LOG_WARNING("Feature {} %s", warn_message);\n'.format(
                 feature
             )
-            result += '            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->{} = VK_FALSE;\n'.format(
+            result += '            found_unsupported = true;\n'
+            result += '            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->{} =\n'.format(
                 feature
             )
+            result += '                remove_unsupported ? VK_FALSE : VK_TRUE;\n'
             result += '        }\n'
+        result += '    }\n\n'
+
+        result += '    if (!remove_unsupported && found_unsupported)\n'
+        result += '    {\n'
+        result += '        GFXRECON_LOG_WARNING("Unsupported features were requested. This might cause the vkCreateDevice to fail. Try \\"--remove-unsupported\\" option to remove those features at replay.");\n'
         result += '    }\n'
         result += '}'
         return result

--- a/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
@@ -217,7 +217,7 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
 
         result += '    if (!remove_unsupported && found_unsupported)\n'
         result += '    {\n'
-        result += '        GFXRECON_LOG_WARNING("Unsupported features were requested. This might cause the vkCreateDevice to fail. Try \\"--remove-unsupported\\" option to remove those features at replay.");\n'
+        result += '        GFXRECON_LOG_WARNING("Unsupported features were requested. This might cause vkCreateDevice to fail. Try \\"--remove-unsupported\\" option to remove those features at replay.");\n'
         result += '    }\n'
         result += '}'
         return result


### PR DESCRIPTION
In case vkCreateInstance and vkCreateDevice fail at replay time because of an EXTENSION_NOT_PRESENT error, should now print which were the extensions that were not supported on the replay gpu and triggered the error.

Similarly features requested with vkCreateDevice during capture will be compared with what the replay device offers and print a warning for each feature not supported.