### PR TITLE
Screenshot size during replay is now configurable

### DIFF
--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -75,6 +75,8 @@ def CreateReplayParser():
     parser.add_argument('--screenshot-format', metavar='FORMAT', choices=['bmp', 'png'], help='Image file format to use for screenshot generation.  Available formats are: bmp, png (forwarded to replay tool)')
     parser.add_argument('--screenshot-dir', metavar='DIR', help='Directory to write screenshots. Default is "/sdcard" (forwarded to replay tool)')
     parser.add_argument('--screenshot-prefix', metavar='PREFIX', help='Prefix to apply to the screenshot file name.  Default is "screenshot" (forwarded to replay tool)')
+    parser.add_argument('--screenshot-size', metavar='SIZE', help='Screenshot dimensions. Ignored if --screenshot-scale is specified.  Expected format is <width>x<height>.')
+    parser.add_argument('--screenshot-scale', metavar='SCALE', help='Scale screenshot dimensions. Overrides --screenshot-size, if specified. Expects a number which can be decimal')
     parser.add_argument('--sfa', '--skip-failed-allocations', action='store_true', default=False, help='Skip vkAllocateMemory, vkAllocateCommandBuffers, and vkAllocateDescriptorSets calls that failed during capture (forwarded to replay tool)')
     parser.add_argument('--opcd', '--omit-pipeline-cache-data', action='store_true', default=False, help='Omit pipeline cache data from calls to vkCreatePipelineCache and skip calls to vkGetPipelineCacheData (forwarded to replay tool)')
     parser.add_argument('--surface-index', metavar='N', help='Restrict rendering to the Nth surface object created.  Used with captures that include multiple surfaces.  Default is -1 (render to all surfaces; forwarded to replay tool)')
@@ -126,6 +128,14 @@ def MakeExtrasString(args):
     if args.screenshot_prefix:
         arg_list.append('--screenshot-prefix')
         arg_list.append('{}'.format(args.screenshot_prefix))
+
+    if args.screenshot_size:
+        arg_list.append('--screenshot-size')
+        arg_list.append('{}'.format(args.screenshot_size))
+
+    if args.screenshot_scale:
+        arg_list.append('--screenshot-scale')
+        arg_list.append('{}'.format(args.screenshot_scale))
 
     if args.sfa:
         arg_list.append('--sfa')

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -60,6 +60,8 @@ class ScreenshotHandler : public ScreenshotHandlerBase
                     VkFormat                                format,
                     uint32_t                                width,
                     uint32_t                                height,
+                    uint32_t                                copy_width,
+                    uint32_t                                copy_height,
                     VkImageLayout                           image_layout);
 
     void DestroyDeviceResources(VkDevice device, const encode::DeviceTable* device_table);
@@ -109,6 +111,8 @@ class ScreenshotHandler : public ScreenshotHandlerBase
                                 VkFormat                                screenshot_format,
                                 uint32_t                                width,
                                 uint32_t                                height,
+                                uint32_t                                copy_width,
+                                uint32_t                                copy_height,
                                 CopyResource*                           copy_resource) const;
 
     void DestroyCopyResource(VkDevice device, CopyResource* copy_resource) const;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2142,6 +2142,17 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
                 filename_prefix += "_frame_";
                 filename_prefix += std::to_string(screenshot_handler_->GetCurrentFrame());
 
+                // If both copy_scale and copy_width are provided, use copy_scale.
+                const uint32_t screenshot_width =
+                    options_.screenshot_scale
+                        ? (options_.screenshot_scale * swapchain_info->width)
+                        : (options_.screenshot_width ? options_.screenshot_width : swapchain_info->width);
+
+                const uint32_t screenshot_height =
+                    options_.screenshot_scale
+                        ? (options_.screenshot_scale * swapchain_info->height)
+                        : (options_.screenshot_height ? options_.screenshot_height : swapchain_info->height);
+
                 screenshot_handler_->WriteImage(filename_prefix,
                                                 device_info->handle,
                                                 GetDeviceTable(device_info->handle),
@@ -2151,6 +2162,8 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
                                                 swapchain_info->format,
                                                 swapchain_info->width,
                                                 swapchain_info->height,
+                                                screenshot_width,
+                                                screenshot_height,
                                                 VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
             }
         }
@@ -2206,6 +2219,17 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(const Comm
                         filename_prefix += std::to_string(j);
                     }
 
+                    // If both copy_scale and copy_width are provided, use copy_scale.
+                    const uint32_t screenshot_width =
+                        options_.screenshot_scale
+                            ? (options_.screenshot_scale * image_info->extent.width)
+                            : (options_.screenshot_width ? options_.screenshot_width : image_info->extent.width);
+
+                    const uint32_t screenshot_height =
+                        options_.screenshot_scale
+                            ? (options_.screenshot_scale * image_info->extent.height)
+                            : (options_.screenshot_height ? options_.screenshot_height : image_info->extent.height);
+
                     screenshot_handler_->WriteImage(filename_prefix,
                                                     device_info->handle,
                                                     GetDeviceTable(device_info->handle),
@@ -2215,6 +2239,8 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(const Comm
                                                     image_info->format,
                                                     image_info->extent.width,
                                                     image_info->extent.height,
+                                                    screenshot_width,
+                                                    screenshot_height,
                                                     image_info->current_layout);
                 }
             }

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -55,6 +55,8 @@ struct VulkanReplayOptions : public ReplayOptions
     std::vector<ScreenshotRange> screenshot_ranges;
     std::string                  screenshot_dir;
     std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
+    uint32_t                     screenshot_width, screenshot_height;
+    float                        screenshot_scale;
     std::string                  replace_dir;
 };
 

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -35,7 +35,8 @@ const char kOptions[] =
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
-    "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range,--fw|--force-windowed";
+    "screenshot-dir,--screenshot-prefix,--screenshot-size,--screenshot-scale,--mfr|--measurement-frame-range,--fw|--"
+    "force-windowed";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -53,6 +54,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--pause-frame <N>] [--paused] [--sync] [--screenshot-all]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshots <N1(-N2),...>] [--screenshot-format <format>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-size <width>x<height>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-scale <scale>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-cached-psos] [--surface-index <N>]");


### PR DESCRIPTION
Adds two new replay options that controls the screenshot dimensions:

`--screenshot-size <width>x<height>` explicitly sets the dimensions of the
generated screenshot

`--screenshot-scale <number>` Scales the swapchain images by that number.
Number can be decimal