### PR TITLE
Fix multi-threading issue with using real Vulkan handles

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_capture_manager.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_capture_manager.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrappers.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_scoped_destroy_lock.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_scoped_destroy_lock.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrapper_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrapper_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_info.h

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -90,6 +90,8 @@ target_sources(gfxrecon_encode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_capture_manager.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_capture_manager.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrappers.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_scoped_destroy_lock.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_scoped_destroy_lock.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrapper_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrapper_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_state_info.h

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -30,14 +30,9 @@ VulkanStateHandleTable state_handle_table_;
 
 std::shared_mutex mutex_for_create_destroy_handle_;
 
-void LockForDestroyHandle()
+std::unique_lock<std::shared_mutex> ScopedDestroyLock()
 {
-    mutex_for_create_destroy_handle_.lock();
-}
-
-void UnlockForDestroyHandle()
-{
-    mutex_for_create_destroy_handle_.unlock();
+    return std::move(std::unique_lock<std::shared_mutex>(mutex_for_create_destroy_handle_));
 }
 
 uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -1,6 +1,5 @@
 /*
 ** Copyright (c) 2020 LunarG, Inc.
-** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -27,8 +26,6 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
 VulkanStateHandleTable state_handle_table_;
-
-std::shared_mutex ScopedDestroyLock::mutex_for_create_destroy_handle_;
 
 uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
 {

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -28,12 +28,7 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 VulkanStateHandleTable state_handle_table_;
 
-std::shared_mutex mutex_for_create_destroy_handle_;
-
-std::unique_lock<std::shared_mutex> ScopedDestroyLock()
-{
-    return std::move(std::unique_lock<std::shared_mutex>(mutex_for_create_destroy_handle_));
-}
+std::shared_mutex ScopedDestroyLock::mutex_for_create_destroy_handle_;
 
 uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
 {

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -27,6 +27,18 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 VulkanStateHandleTable state_handle_table_;
 
+std::shared_mutex mutex_for_create_destroy_handle_;
+
+void LockForDestroyHandle()
+{
+    mutex_for_create_destroy_handle_.lock();
+}
+
+void UnlockForDestroyHandle()
+{
+    mutex_for_create_destroy_handle_.unlock();
+}
+
 uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
 {
     switch (object_type)

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -57,40 +57,36 @@ typedef format::HandleId (*PFN_GetHandleId)();
 extern VulkanStateHandleTable state_handle_table_;
 
 /*
-About mutex_for_create_destroy_handle_ and related lock/unlock functions
+Regarding mutex_for_create_destroy_handle_ and related lock/unlock functions. These are used to address the following
+race condition during capture:
 
-    1. mutex_for_create_destroy_handle_ is used for the following race condition issue, the issue caused some title
-crash during capturing :
+Sometimes an app will destroy some Vulkan handles in one thread (A) and create same type of Vulkan handle in another
+thread (B). There is a gap of time in between when the real handle is destroyed, and when its wrappers were deleted from
+map in thread A. If during this time period, thread B was able to run, and creates same type of handles, and if any of
+the newly-created handles had the same value of those destroyed by thread A, we crash.
 
-       On default GFXR setting, target title destroy some Vulkan handles in one thread (A) and create same type of
-Vulkan handle in another thread (B). At the time when is after real handles were destroyed and before their wrappers
-were deleted from map in thread A, if thread B got CPU and create same type of handles and if anyone of the new created
-handles was same value of previously destroyed handles. The crash happens.
+For example, lets say an app's thread A calls vkFreeCommandBuffers, and in thread B it calls vkAllocateCommandBuffers.
 
-       For example, In thread A target title call  vkFreeCommandBuffers , in thread B it calls vkAllocateCommandBuffers.
+GFXR's default API lock is AcquireSharedApiCallLock(), but if every API handling only request shared lock, that means
+there is actually no lock for them. Therefore execution could switch from one thread to another thread. If thread A
+calls vkFreeCommandBuffers to free command buffer group GC-X, those real Vulkan handles get destroyed by the driver, and
+GFXR will proceed to delete wrapper objects of GC-X from the corresponding map. During this time, thread B was able to
+run, and calls vkAllocateCommandBuffers to create a group of command buffers GC-Y. But because GC-X was already
+destroyed, the driver may return some of the same former handle values of GC-X, but their wrapper still exists, and
+GFXR's insertion of the new wrapper into its map will fail. And thread B will delete the wrapper later, so for any
+following process, there would be no wrapper for the real handle which will eventually provoke a crash.
 
-       Because with default GFXR setting, API lock is AcquireSharedApiCallLock(), and every API handling only request
-shared lock, that mean actually no lock for them. So, running can be switched from one thread to another thread during
-GFXR API handling. If thread A, after calling real API of vkFreeCommandBuffers to free command buffer group GC-X, those
-real Vulkan handles were destroyed by driver, the following post process of GFXR will be delete wrapper objects
-of GC-X from corresponding map. At this time, thread B got CPU and call vkAllocateCommandBuffers to create a group of
-command buffer GC-Y. Because GC-X were already destroyed, driver may return some handle values of GC-X that were
-previously destroyed, but wrapper still exist, at this time GFXR insert new wrapper into map will fail. And thread B
-will delete the wrapper later, so for any following process, no wrapper for the real handle. This will cause crash
-later.
+Note: destruction of other things could also potentially have this problem. For example, replace the above
+vkFreeCommandBuffers with vkDestroyCommandPool. This call will free all command buffers of the command pool.
 
-       Note, potentially destroying also has this issue, for example, replace above  vkFreeCommandBuffers  with
-       vkDestroyCommandPool, this call will free all command buffers of this command pool.
+Regarding mutex_for_create_destroy_handle_ :
 
-    2. The usage of mutex_for_create_destroy_handle_
+For any create wrapper operation, the operation which delete real Vulkan handle and its wrapper in map must be atomic.
+This means a real handle and its wrapper must both exist, or both not exist, for any create wrapper operation. In the
+following code, shared locks were already added to create wrapper functions.
 
-       For any create wrapper operation, the operation which delete real Vulkan handle and its wrapper in
-map must be atomic which mean a real handle and its wrapper must both exist or both not exist for any create wrapper
-operation.
-
-       In the following code, shared lock were alread added to create wrapper functions.
-LockForDestroyHandle/UnlockForDestroyHandle should be used in capturing process to add exclusive lock to the real API
-call of deteting handle and deleting its wrapper.
+The functions LockForDestroyHandle and UnlockForDestroyHandle should be used during capture. This will add exclusive
+lock to the deletion of handles and their wrapper.
 */
 
 extern std::shared_mutex mutex_for_create_destroy_handle_;

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -90,8 +90,8 @@ lock to the deletion of handles and their wrapper.
 */
 
 extern std::shared_mutex mutex_for_create_destroy_handle_;
-void                     LockForDestroyHandle();
-void                     UnlockForDestroyHandle();
+
+std::unique_lock<std::shared_mutex> ScopedDestroyLock();
 
 template <typename Wrapper>
 format::HandleId GetTempWrapperId(const typename Wrapper::HandleType& handle)

--- a/framework/encode/vulkan_scoped_destroy_lock.cpp
+++ b/framework/encode/vulkan_scoped_destroy_lock.cpp
@@ -1,0 +1,56 @@
+/*
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "vulkan_scoped_destroy_lock.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+std::shared_mutex ScopedDestroyLock::mutex_for_create_destroy_handle_;
+
+ScopedDestroyLock::ScopedDestroyLock(bool shared)
+{
+    lock_shared_ = shared;
+    if (shared)
+    {
+        mutex_for_create_destroy_handle_.lock_shared();
+    }
+    else
+    {
+        mutex_for_create_destroy_handle_.lock();
+    }
+};
+
+ScopedDestroyLock::~ScopedDestroyLock()
+{
+    if (lock_shared_)
+    {
+        mutex_for_create_destroy_handle_.unlock_shared();
+    }
+    else
+    {
+        mutex_for_create_destroy_handle_.unlock();
+    }
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_scoped_destroy_lock.h
+++ b/framework/encode/vulkan_scoped_destroy_lock.h
@@ -1,0 +1,85 @@
+/*
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_ENCODE_VULKAN_SCOPED_DESTROY_LOCK_H
+#define GFXRECON_ENCODE_VULKAN_SCOPED_DESTROY_LOCK_H
+
+#include "util/defines.h"
+
+#include <shared_mutex>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+/*
+Regarding ScopedDestroyLock class and its related methods. These are used to address the
+following race condition during capture:
+
+Sometimes an app will destroy some Vulkan handles in one thread (A) and create same type of Vulkan handle in another
+thread (B). There is a gap of time in between when the real handle is destroyed, and when its wrappers were deleted from
+map in thread A. If during this time period, thread B was able to run, and creates same type of handles, and if any of
+the newly-created handles had the same value of those destroyed by thread A, we crash.
+
+For example, lets say an app's thread A calls vkFreeCommandBuffers, and in thread B it calls vkAllocateCommandBuffers.
+
+GFXR's default API lock is AcquireSharedApiCallLock(), but if every API handling only request shared lock, that means
+there is actually no lock for them. Therefore execution could switch from one thread to another thread. If thread A
+calls vkFreeCommandBuffers to free command buffer group GC-X, those real Vulkan handles get destroyed by the driver, and
+GFXR will proceed to delete wrapper objects of GC-X from the corresponding map. During this time, thread B was able to
+run, and calls vkAllocateCommandBuffers to create a group of command buffers GC-Y. But because GC-X was already
+destroyed, the driver may return some of the same former handle values of GC-X, but their wrapper still exists, and
+GFXR's insertion of the new wrapper into its map will fail. And thread B will delete the wrapper later, so for any
+following process, there would be no wrapper for the real handle which will eventually provoke a crash.
+
+Note: destruction of other things could also potentially have this problem. For example, replace the above
+vkFreeCommandBuffers with vkDestroyCommandPool. This call will free all command buffers of the command pool.
+
+Regarding mutex_for_create_destroy_handle_ :
+
+For any create wrapper operation, the operation which delete real Vulkan handle and its wrapper in map must be atomic.
+This means a real handle and its wrapper must both exist, or both not exist, for any create wrapper operation.
+*/
+
+class ScopedDestroyLock
+{
+  public:
+    ScopedDestroyLock(bool shared = false);
+
+    ~ScopedDestroyLock();
+
+    ScopedDestroyLock(const ScopedDestroyLock&) = delete;
+
+    ScopedDestroyLock(ScopedDestroyLock&&) = delete;
+
+    ScopedDestroyLock& operator=(const ScopedDestroyLock&) = delete;
+
+    ScopedDestroyLock& operator=(ScopedDestroyLock&&) = delete;
+
+  private:
+    bool                     lock_shared_ = false;
+    static std::shared_mutex mutex_for_create_destroy_handle_;
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_VULKAN_SCOPED_DESTROY_LOCK_H

--- a/framework/generated/generated_decode_pnext_struct.cpp
+++ b/framework/generated/generated_decode_pnext_struct.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_encode_pnext_struct.cpp
+++ b/framework/generated/generated_encode_pnext_struct.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -112,11 +112,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
         manager->EndDestroyApiCallCapture<InstanceWrapper>(instance);
     }
 
+    LockForDestroyHandle();
     GetInstanceTable(instance)->DestroyInstance(instance, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(manager, instance, pAllocator);
 
     DestroyWrappedHandle<InstanceWrapper>(instance);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
@@ -463,11 +465,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
         manager->EndDestroyApiCallCapture<DeviceWrapper>(device);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyDevice(device, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(manager, device, pAllocator);
 
     DestroyWrappedHandle<DeviceWrapper>(device);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
@@ -696,11 +700,13 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
         manager->EndDestroyApiCallCapture<DeviceMemoryWrapper>(memory);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->FreeMemory(device, memory, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(manager, device, memory, pAllocator);
 
     DestroyWrappedHandle<DeviceMemoryWrapper>(memory);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
@@ -1259,11 +1265,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
         manager->EndDestroyApiCallCapture<FenceWrapper>(fence);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyFence(device, fence, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(manager, device, fence, pAllocator);
 
     DestroyWrappedHandle<FenceWrapper>(fence);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
@@ -1463,11 +1471,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
         manager->EndDestroyApiCallCapture<SemaphoreWrapper>(semaphore);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroySemaphore(device, semaphore, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(manager, device, semaphore, pAllocator);
 
     DestroyWrappedHandle<SemaphoreWrapper>(semaphore);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
@@ -1551,11 +1561,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
         manager->EndDestroyApiCallCapture<EventWrapper>(event);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyEvent(device, event, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(manager, device, event, pAllocator);
 
     DestroyWrappedHandle<EventWrapper>(event);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
@@ -1747,11 +1759,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
         manager->EndDestroyApiCallCapture<QueryPoolWrapper>(queryPool);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyQueryPool(device, queryPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(manager, device, queryPool, pAllocator);
 
     DestroyWrappedHandle<QueryPoolWrapper>(queryPool);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
@@ -1884,11 +1898,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
         manager->EndDestroyApiCallCapture<BufferWrapper>(buffer);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyBuffer(device, buffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(manager, device, buffer, pAllocator);
 
     DestroyWrappedHandle<BufferWrapper>(buffer);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
@@ -1975,11 +1991,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
         manager->EndDestroyApiCallCapture<BufferViewWrapper>(bufferView);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyBufferView(device, bufferView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(manager, device, bufferView, pAllocator);
 
     DestroyWrappedHandle<BufferViewWrapper>(bufferView);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
@@ -2058,11 +2076,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
         manager->EndDestroyApiCallCapture<ImageWrapper>(image);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyImage(device, image, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(manager, device, image, pAllocator);
 
     DestroyWrappedHandle<ImageWrapper>(image);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
@@ -2186,11 +2206,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
         manager->EndDestroyApiCallCapture<ImageViewWrapper>(imageView);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyImageView(device, imageView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(manager, device, imageView, pAllocator);
 
     DestroyWrappedHandle<ImageViewWrapper>(imageView);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
@@ -2277,11 +2299,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
         manager->EndDestroyApiCallCapture<ShaderModuleWrapper>(shaderModule);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyShaderModule(device, shaderModule, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(manager, device, shaderModule, pAllocator);
 
     DestroyWrappedHandle<ShaderModuleWrapper>(shaderModule);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
@@ -2365,11 +2389,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
         manager->EndDestroyApiCallCapture<PipelineCacheWrapper>(pipelineCache);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyPipelineCache(device, pipelineCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(manager, device, pipelineCache, pAllocator);
 
     DestroyWrappedHandle<PipelineCacheWrapper>(pipelineCache);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
@@ -2488,11 +2514,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
         manager->EndDestroyApiCallCapture<PipelineWrapper>(pipeline);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyPipeline(device, pipeline, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(manager, device, pipeline, pAllocator);
 
     DestroyWrappedHandle<PipelineWrapper>(pipeline);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
@@ -2579,11 +2607,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
         manager->EndDestroyApiCallCapture<PipelineLayoutWrapper>(pipelineLayout);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(manager, device, pipelineLayout, pAllocator);
 
     DestroyWrappedHandle<PipelineLayoutWrapper>(pipelineLayout);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
@@ -2670,11 +2700,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
         manager->EndDestroyApiCallCapture<SamplerWrapper>(sampler);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroySampler(device, sampler, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(manager, device, sampler, pAllocator);
 
     DestroyWrappedHandle<SamplerWrapper>(sampler);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
@@ -2761,11 +2793,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
         manager->EndDestroyApiCallCapture<DescriptorSetLayoutWrapper>(descriptorSetLayout);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(manager, device, descriptorSetLayout, pAllocator);
 
     DestroyWrappedHandle<DescriptorSetLayoutWrapper>(descriptorSetLayout);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
@@ -2849,11 +2883,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
         manager->EndDestroyApiCallCapture<DescriptorPoolWrapper>(descriptorPool);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyDescriptorPool(device, descriptorPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(manager, device, descriptorPool, pAllocator);
 
     DestroyWrappedHandle<DescriptorPoolWrapper>(descriptorPool);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
@@ -2877,6 +2913,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>::Dispatch(manager, device, descriptorPool, flags);
 
+    LockForDestroyHandle();
     VkResult result = GetDeviceTable(device)->ResetDescriptorPool(device, descriptorPool, flags);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetDescriptorPool);
@@ -2890,6 +2927,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>::Dispatch(manager, result, device, descriptorPool, flags);
+    UnlockForDestroyHandle();
 
     return result;
 }
@@ -2968,6 +3006,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
+    LockForDestroyHandle();
     VkResult result = GetDeviceTable(device)->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
@@ -2984,6 +3023,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, result, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
     DestroyWrappedHandles<DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
+    UnlockForDestroyHandle();
 
     return result;
 }
@@ -3115,11 +3155,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
         manager->EndDestroyApiCallCapture<FramebufferWrapper>(framebuffer);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyFramebuffer(device, framebuffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(manager, device, framebuffer, pAllocator);
 
     DestroyWrappedHandle<FramebufferWrapper>(framebuffer);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
@@ -3203,11 +3245,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
         manager->EndDestroyApiCallCapture<RenderPassWrapper>(renderPass);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyRenderPass(device, renderPass, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(manager, device, renderPass, pAllocator);
 
     DestroyWrappedHandle<RenderPassWrapper>(renderPass);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
@@ -3326,11 +3370,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
         manager->EndDestroyApiCallCapture<CommandPoolWrapper>(commandPool);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyCommandPool(device, commandPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(manager, device, commandPool, pAllocator);
 
     DestroyWrappedHandle<CommandPoolWrapper>(commandPool);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
@@ -3455,11 +3501,13 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
         manager->EndDestroyApiCallCapture<CommandBufferWrapper>(commandBufferCount, pCommandBuffers);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(manager, device, commandPool, commandBufferCount, pCommandBuffers);
 
     DestroyWrappedHandles<CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
@@ -6037,11 +6085,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
         manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
     DestroyWrappedHandle<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
@@ -6128,11 +6178,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
         manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
     DestroyWrappedHandle<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
@@ -6924,11 +6976,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
         manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyPrivateDataSlot(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
     DestroyWrappedHandle<PrivateDataSlotWrapper>(privateDataSlot);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
@@ -8184,11 +8238,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
         manager->EndDestroyApiCallCapture<SurfaceKHRWrapper>(surface);
     }
 
+    LockForDestroyHandle();
     GetInstanceTable(instance)->DestroySurfaceKHR(instance, surface, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(manager, instance, surface, pAllocator);
 
     DestroyWrappedHandle<SurfaceKHRWrapper>(surface);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
@@ -8457,11 +8513,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
         manager->EndDestroyApiCallCapture<SwapchainKHRWrapper>(swapchain);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroySwapchainKHR(device, swapchain, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(manager, device, swapchain, pAllocator);
 
     DestroyWrappedHandle<SwapchainKHRWrapper>(swapchain);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
@@ -9762,11 +9820,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
         manager->EndDestroyApiCallCapture<VideoSessionKHRWrapper>(videoSession);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyVideoSessionKHR(device, videoSession, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR>::Dispatch(manager, device, videoSession, pAllocator);
 
     DestroyWrappedHandle<VideoSessionKHRWrapper>(videoSession);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
@@ -9980,11 +10040,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
         manager->EndDestroyApiCallCapture<VideoSessionParametersKHRWrapper>(videoSessionParameters);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyVideoSessionParametersKHR(device, videoSessionParameters, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR>::Dispatch(manager, device, videoSessionParameters, pAllocator);
 
     DestroyWrappedHandle<VideoSessionParametersKHRWrapper>(videoSessionParameters);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
@@ -11197,11 +11259,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
         manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
     DestroyWrappedHandle<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
@@ -12243,11 +12307,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
         manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
     DestroyWrappedHandle<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
@@ -12895,11 +12961,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
         manager->EndDestroyApiCallCapture<DeferredOperationKHRWrapper>(operation);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyDeferredOperationKHR(device, operation, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR>::Dispatch(manager, device, operation, pAllocator);
 
     DestroyWrappedHandle<DeferredOperationKHRWrapper>(operation);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
@@ -14440,11 +14508,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
         manager->EndDestroyApiCallCapture<DebugReportCallbackEXTWrapper>(callback);
     }
 
+    LockForDestroyHandle();
     GetInstanceTable(instance)->DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(manager, instance, callback, pAllocator);
 
     DestroyWrappedHandle<DebugReportCallbackEXTWrapper>(callback);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
@@ -16476,11 +16546,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
         manager->EndDestroyApiCallCapture<DebugUtilsMessengerEXTWrapper>(messenger);
     }
 
+    LockForDestroyHandle();
     GetInstanceTable(instance)->DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(manager, instance, messenger, pAllocator);
 
     DestroyWrappedHandle<DebugUtilsMessengerEXTWrapper>(messenger);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
@@ -16804,11 +16876,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
         manager->EndDestroyApiCallCapture<ValidationCacheEXTWrapper>(validationCache);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyValidationCacheEXT(device, validationCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(manager, device, validationCache, pAllocator);
 
     DestroyWrappedHandle<ValidationCacheEXTWrapper>(validationCache);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
@@ -17090,11 +17164,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
         manager->EndDestroyApiCallCapture<AccelerationStructureNVWrapper>(accelerationStructure);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyAccelerationStructureNV(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
     DestroyWrappedHandle<AccelerationStructureNVWrapper>(accelerationStructure);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
@@ -18227,6 +18303,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, device, configuration);
 
+    LockForDestroyHandle();
     VkResult result = GetDeviceTable(device)->ReleasePerformanceConfigurationINTEL(device, configuration);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL);
@@ -18241,6 +18318,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, result, device, configuration);
 
     DestroyWrappedHandle<PerformanceConfigurationINTELWrapper>(configuration);
+    UnlockForDestroyHandle();
 
     return result;
 }
@@ -19809,11 +19887,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
         manager->EndDestroyApiCallCapture<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV>::Dispatch(manager, device, indirectCommandsLayout, pAllocator);
 
     DestroyWrappedHandle<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
@@ -20019,11 +20099,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
         manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
     DestroyWrappedHandle<PrivateDataSlotWrapper>(privateDataSlot);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
@@ -21117,11 +21199,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
         manager->EndDestroyApiCallCapture<MicromapEXTWrapper>(micromap);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyMicromapEXT(device, micromap, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyMicromapEXT>::Dispatch(manager, device, micromap, pAllocator);
 
     DestroyWrappedHandle<MicromapEXTWrapper>(micromap);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
@@ -23143,11 +23227,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
         manager->EndDestroyApiCallCapture<OpticalFlowSessionNVWrapper>(session);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyOpticalFlowSessionNV(device, session, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV>::Dispatch(manager, device, session, pAllocator);
 
     DestroyWrappedHandle<OpticalFlowSessionNVWrapper>(session);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
@@ -23313,11 +23399,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
         manager->EndDestroyApiCallCapture<ShaderEXTWrapper>(shader);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyShaderEXT(device, shader, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderEXT>::Dispatch(manager, device, shader, pAllocator);
 
     DestroyWrappedHandle<ShaderEXTWrapper>(shader);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
@@ -23605,11 +23693,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
         manager->EndDestroyApiCallCapture<AccelerationStructureKHRWrapper>(accelerationStructure);
     }
 
+    LockForDestroyHandle();
     GetDeviceTable(device)->DestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
     DestroyWrappedHandle<AccelerationStructureKHRWrapper>(accelerationStructure);
+    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -113,8 +113,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
         manager->EndDestroyApiCallCapture<InstanceWrapper>(instance);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetInstanceTable(instance)->DestroyInstance(instance, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(manager, instance, pAllocator);
@@ -466,8 +465,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
         manager->EndDestroyApiCallCapture<DeviceWrapper>(device);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyDevice(device, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(manager, device, pAllocator);
@@ -701,8 +699,7 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
         manager->EndDestroyApiCallCapture<DeviceMemoryWrapper>(memory);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->FreeMemory(device, memory, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(manager, device, memory, pAllocator);
@@ -1266,8 +1263,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
         manager->EndDestroyApiCallCapture<FenceWrapper>(fence);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyFence(device, fence, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(manager, device, fence, pAllocator);
@@ -1472,8 +1468,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
         manager->EndDestroyApiCallCapture<SemaphoreWrapper>(semaphore);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroySemaphore(device, semaphore, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(manager, device, semaphore, pAllocator);
@@ -1562,8 +1557,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
         manager->EndDestroyApiCallCapture<EventWrapper>(event);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyEvent(device, event, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(manager, device, event, pAllocator);
@@ -1760,8 +1754,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
         manager->EndDestroyApiCallCapture<QueryPoolWrapper>(queryPool);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyQueryPool(device, queryPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(manager, device, queryPool, pAllocator);
@@ -1899,8 +1892,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
         manager->EndDestroyApiCallCapture<BufferWrapper>(buffer);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyBuffer(device, buffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(manager, device, buffer, pAllocator);
@@ -1992,8 +1984,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
         manager->EndDestroyApiCallCapture<BufferViewWrapper>(bufferView);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyBufferView(device, bufferView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(manager, device, bufferView, pAllocator);
@@ -2077,8 +2068,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
         manager->EndDestroyApiCallCapture<ImageWrapper>(image);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyImage(device, image, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(manager, device, image, pAllocator);
@@ -2207,8 +2197,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
         manager->EndDestroyApiCallCapture<ImageViewWrapper>(imageView);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyImageView(device, imageView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(manager, device, imageView, pAllocator);
@@ -2300,8 +2289,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
         manager->EndDestroyApiCallCapture<ShaderModuleWrapper>(shaderModule);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyShaderModule(device, shaderModule, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(manager, device, shaderModule, pAllocator);
@@ -2390,8 +2378,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
         manager->EndDestroyApiCallCapture<PipelineCacheWrapper>(pipelineCache);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyPipelineCache(device, pipelineCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(manager, device, pipelineCache, pAllocator);
@@ -2515,8 +2502,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
         manager->EndDestroyApiCallCapture<PipelineWrapper>(pipeline);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyPipeline(device, pipeline, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(manager, device, pipeline, pAllocator);
@@ -2608,8 +2594,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
         manager->EndDestroyApiCallCapture<PipelineLayoutWrapper>(pipelineLayout);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(manager, device, pipelineLayout, pAllocator);
@@ -2701,8 +2686,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
         manager->EndDestroyApiCallCapture<SamplerWrapper>(sampler);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroySampler(device, sampler, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(manager, device, sampler, pAllocator);
@@ -2794,8 +2778,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
         manager->EndDestroyApiCallCapture<DescriptorSetLayoutWrapper>(descriptorSetLayout);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(manager, device, descriptorSetLayout, pAllocator);
@@ -2884,8 +2867,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
         manager->EndDestroyApiCallCapture<DescriptorPoolWrapper>(descriptorPool);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyDescriptorPool(device, descriptorPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(manager, device, descriptorPool, pAllocator);
@@ -2914,8 +2896,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>::Dispatch(manager, device, descriptorPool, flags);
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     VkResult result = GetDeviceTable(device)->ResetDescriptorPool(device, descriptorPool, flags);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetDescriptorPool);
@@ -3007,8 +2988,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     VkResult result = GetDeviceTable(device)->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
@@ -3156,8 +3136,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
         manager->EndDestroyApiCallCapture<FramebufferWrapper>(framebuffer);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyFramebuffer(device, framebuffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(manager, device, framebuffer, pAllocator);
@@ -3246,8 +3225,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
         manager->EndDestroyApiCallCapture<RenderPassWrapper>(renderPass);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyRenderPass(device, renderPass, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(manager, device, renderPass, pAllocator);
@@ -3371,8 +3349,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
         manager->EndDestroyApiCallCapture<CommandPoolWrapper>(commandPool);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyCommandPool(device, commandPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(manager, device, commandPool, pAllocator);
@@ -3502,8 +3479,7 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
         manager->EndDestroyApiCallCapture<CommandBufferWrapper>(commandBufferCount, pCommandBuffers);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(manager, device, commandPool, commandBufferCount, pCommandBuffers);
@@ -6086,8 +6062,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
         manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(manager, device, ycbcrConversion, pAllocator);
@@ -6179,8 +6154,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
         manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
@@ -6977,8 +6951,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
         manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyPrivateDataSlot(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot>::Dispatch(manager, device, privateDataSlot, pAllocator);
@@ -8239,8 +8212,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
         manager->EndDestroyApiCallCapture<SurfaceKHRWrapper>(surface);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetInstanceTable(instance)->DestroySurfaceKHR(instance, surface, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(manager, instance, surface, pAllocator);
@@ -8514,8 +8486,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
         manager->EndDestroyApiCallCapture<SwapchainKHRWrapper>(swapchain);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroySwapchainKHR(device, swapchain, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(manager, device, swapchain, pAllocator);
@@ -9821,8 +9792,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
         manager->EndDestroyApiCallCapture<VideoSessionKHRWrapper>(videoSession);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyVideoSessionKHR(device, videoSession, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR>::Dispatch(manager, device, videoSession, pAllocator);
@@ -10041,8 +10011,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
         manager->EndDestroyApiCallCapture<VideoSessionParametersKHRWrapper>(videoSessionParameters);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyVideoSessionParametersKHR(device, videoSessionParameters, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR>::Dispatch(manager, device, videoSessionParameters, pAllocator);
@@ -11260,8 +11229,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
         manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
@@ -12308,8 +12276,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
         manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(manager, device, ycbcrConversion, pAllocator);
@@ -12962,8 +12929,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
         manager->EndDestroyApiCallCapture<DeferredOperationKHRWrapper>(operation);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyDeferredOperationKHR(device, operation, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR>::Dispatch(manager, device, operation, pAllocator);
@@ -14509,8 +14475,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
         manager->EndDestroyApiCallCapture<DebugReportCallbackEXTWrapper>(callback);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetInstanceTable(instance)->DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(manager, instance, callback, pAllocator);
@@ -16547,8 +16512,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
         manager->EndDestroyApiCallCapture<DebugUtilsMessengerEXTWrapper>(messenger);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetInstanceTable(instance)->DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(manager, instance, messenger, pAllocator);
@@ -16877,8 +16841,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
         manager->EndDestroyApiCallCapture<ValidationCacheEXTWrapper>(validationCache);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyValidationCacheEXT(device, validationCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(manager, device, validationCache, pAllocator);
@@ -17165,8 +17128,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
         manager->EndDestroyApiCallCapture<AccelerationStructureNVWrapper>(accelerationStructure);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyAccelerationStructureNV(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV>::Dispatch(manager, device, accelerationStructure, pAllocator);
@@ -18304,8 +18266,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, device, configuration);
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     VkResult result = GetDeviceTable(device)->ReleasePerformanceConfigurationINTEL(device, configuration);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL);
@@ -19888,8 +19849,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
         manager->EndDestroyApiCallCapture<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV>::Dispatch(manager, device, indirectCommandsLayout, pAllocator);
@@ -20100,8 +20060,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
         manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT>::Dispatch(manager, device, privateDataSlot, pAllocator);
@@ -21200,8 +21159,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
         manager->EndDestroyApiCallCapture<MicromapEXTWrapper>(micromap);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyMicromapEXT(device, micromap, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyMicromapEXT>::Dispatch(manager, device, micromap, pAllocator);
@@ -23228,8 +23186,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
         manager->EndDestroyApiCallCapture<OpticalFlowSessionNVWrapper>(session);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyOpticalFlowSessionNV(device, session, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV>::Dispatch(manager, device, session, pAllocator);
@@ -23400,8 +23357,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
         manager->EndDestroyApiCallCapture<ShaderEXTWrapper>(shader);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyShaderEXT(device, shader, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderEXT>::Dispatch(manager, device, shader, pAllocator);
@@ -23694,8 +23650,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
         manager->EndDestroyApiCallCapture<AccelerationStructureKHRWrapper>(accelerationStructure);
     }
 
-    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
-    exclusive_scoped_lock = ScopedDestroyLock();
+    ScopedDestroyLock exclusive_scoped_lock;
     GetDeviceTable(device)->DestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR>::Dispatch(manager, device, accelerationStructure, pAllocator);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -113,13 +113,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
         manager->EndDestroyApiCallCapture<InstanceWrapper>(instance);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetInstanceTable(instance)->DestroyInstance(instance, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(manager, instance, pAllocator);
 
     DestroyWrappedHandle<InstanceWrapper>(instance);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
@@ -466,13 +466,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
         manager->EndDestroyApiCallCapture<DeviceWrapper>(device);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyDevice(device, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(manager, device, pAllocator);
 
     DestroyWrappedHandle<DeviceWrapper>(device);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
@@ -701,13 +701,13 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
         manager->EndDestroyApiCallCapture<DeviceMemoryWrapper>(memory);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->FreeMemory(device, memory, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(manager, device, memory, pAllocator);
 
     DestroyWrappedHandle<DeviceMemoryWrapper>(memory);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
@@ -1266,13 +1266,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
         manager->EndDestroyApiCallCapture<FenceWrapper>(fence);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyFence(device, fence, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(manager, device, fence, pAllocator);
 
     DestroyWrappedHandle<FenceWrapper>(fence);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
@@ -1472,13 +1472,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
         manager->EndDestroyApiCallCapture<SemaphoreWrapper>(semaphore);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroySemaphore(device, semaphore, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(manager, device, semaphore, pAllocator);
 
     DestroyWrappedHandle<SemaphoreWrapper>(semaphore);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
@@ -1562,13 +1562,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
         manager->EndDestroyApiCallCapture<EventWrapper>(event);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyEvent(device, event, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(manager, device, event, pAllocator);
 
     DestroyWrappedHandle<EventWrapper>(event);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
@@ -1760,13 +1760,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
         manager->EndDestroyApiCallCapture<QueryPoolWrapper>(queryPool);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyQueryPool(device, queryPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(manager, device, queryPool, pAllocator);
 
     DestroyWrappedHandle<QueryPoolWrapper>(queryPool);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
@@ -1899,13 +1899,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
         manager->EndDestroyApiCallCapture<BufferWrapper>(buffer);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyBuffer(device, buffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(manager, device, buffer, pAllocator);
 
     DestroyWrappedHandle<BufferWrapper>(buffer);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
@@ -1992,13 +1992,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
         manager->EndDestroyApiCallCapture<BufferViewWrapper>(bufferView);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyBufferView(device, bufferView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(manager, device, bufferView, pAllocator);
 
     DestroyWrappedHandle<BufferViewWrapper>(bufferView);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
@@ -2077,13 +2077,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
         manager->EndDestroyApiCallCapture<ImageWrapper>(image);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyImage(device, image, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(manager, device, image, pAllocator);
 
     DestroyWrappedHandle<ImageWrapper>(image);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
@@ -2207,13 +2207,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
         manager->EndDestroyApiCallCapture<ImageViewWrapper>(imageView);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyImageView(device, imageView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(manager, device, imageView, pAllocator);
 
     DestroyWrappedHandle<ImageViewWrapper>(imageView);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
@@ -2300,13 +2300,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
         manager->EndDestroyApiCallCapture<ShaderModuleWrapper>(shaderModule);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyShaderModule(device, shaderModule, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(manager, device, shaderModule, pAllocator);
 
     DestroyWrappedHandle<ShaderModuleWrapper>(shaderModule);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
@@ -2390,13 +2390,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
         manager->EndDestroyApiCallCapture<PipelineCacheWrapper>(pipelineCache);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyPipelineCache(device, pipelineCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(manager, device, pipelineCache, pAllocator);
 
     DestroyWrappedHandle<PipelineCacheWrapper>(pipelineCache);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
@@ -2515,13 +2515,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
         manager->EndDestroyApiCallCapture<PipelineWrapper>(pipeline);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyPipeline(device, pipeline, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(manager, device, pipeline, pAllocator);
 
     DestroyWrappedHandle<PipelineWrapper>(pipeline);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
@@ -2608,13 +2608,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
         manager->EndDestroyApiCallCapture<PipelineLayoutWrapper>(pipelineLayout);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(manager, device, pipelineLayout, pAllocator);
 
     DestroyWrappedHandle<PipelineLayoutWrapper>(pipelineLayout);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
@@ -2701,13 +2701,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
         manager->EndDestroyApiCallCapture<SamplerWrapper>(sampler);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroySampler(device, sampler, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(manager, device, sampler, pAllocator);
 
     DestroyWrappedHandle<SamplerWrapper>(sampler);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
@@ -2794,13 +2794,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
         manager->EndDestroyApiCallCapture<DescriptorSetLayoutWrapper>(descriptorSetLayout);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(manager, device, descriptorSetLayout, pAllocator);
 
     DestroyWrappedHandle<DescriptorSetLayoutWrapper>(descriptorSetLayout);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
@@ -2884,13 +2884,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
         manager->EndDestroyApiCallCapture<DescriptorPoolWrapper>(descriptorPool);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyDescriptorPool(device, descriptorPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(manager, device, descriptorPool, pAllocator);
 
     DestroyWrappedHandle<DescriptorPoolWrapper>(descriptorPool);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
@@ -2914,7 +2914,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>::Dispatch(manager, device, descriptorPool, flags);
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     VkResult result = GetDeviceTable(device)->ResetDescriptorPool(device, descriptorPool, flags);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetDescriptorPool);
@@ -2928,7 +2929,6 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>::Dispatch(manager, result, device, descriptorPool, flags);
-    UnlockForDestroyHandle();
 
     return result;
 }
@@ -3007,7 +3007,8 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     VkResult result = GetDeviceTable(device)->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
@@ -3024,7 +3025,6 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, result, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
     DestroyWrappedHandles<DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
-    UnlockForDestroyHandle();
 
     return result;
 }
@@ -3156,13 +3156,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
         manager->EndDestroyApiCallCapture<FramebufferWrapper>(framebuffer);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyFramebuffer(device, framebuffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(manager, device, framebuffer, pAllocator);
 
     DestroyWrappedHandle<FramebufferWrapper>(framebuffer);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
@@ -3246,13 +3246,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
         manager->EndDestroyApiCallCapture<RenderPassWrapper>(renderPass);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyRenderPass(device, renderPass, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(manager, device, renderPass, pAllocator);
 
     DestroyWrappedHandle<RenderPassWrapper>(renderPass);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
@@ -3371,13 +3371,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
         manager->EndDestroyApiCallCapture<CommandPoolWrapper>(commandPool);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyCommandPool(device, commandPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(manager, device, commandPool, pAllocator);
 
     DestroyWrappedHandle<CommandPoolWrapper>(commandPool);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
@@ -3502,13 +3502,13 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
         manager->EndDestroyApiCallCapture<CommandBufferWrapper>(commandBufferCount, pCommandBuffers);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(manager, device, commandPool, commandBufferCount, pCommandBuffers);
 
     DestroyWrappedHandles<CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
@@ -6086,13 +6086,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
         manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
     DestroyWrappedHandle<SamplerYcbcrConversionWrapper>(ycbcrConversion);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
@@ -6179,13 +6179,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
         manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
     DestroyWrappedHandle<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
@@ -6977,13 +6977,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
         manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyPrivateDataSlot(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
     DestroyWrappedHandle<PrivateDataSlotWrapper>(privateDataSlot);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
@@ -8239,13 +8239,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
         manager->EndDestroyApiCallCapture<SurfaceKHRWrapper>(surface);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetInstanceTable(instance)->DestroySurfaceKHR(instance, surface, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(manager, instance, surface, pAllocator);
 
     DestroyWrappedHandle<SurfaceKHRWrapper>(surface);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
@@ -8514,13 +8514,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
         manager->EndDestroyApiCallCapture<SwapchainKHRWrapper>(swapchain);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroySwapchainKHR(device, swapchain, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(manager, device, swapchain, pAllocator);
 
     DestroyWrappedHandle<SwapchainKHRWrapper>(swapchain);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
@@ -9821,13 +9821,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
         manager->EndDestroyApiCallCapture<VideoSessionKHRWrapper>(videoSession);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyVideoSessionKHR(device, videoSession, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR>::Dispatch(manager, device, videoSession, pAllocator);
 
     DestroyWrappedHandle<VideoSessionKHRWrapper>(videoSession);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
@@ -10041,13 +10041,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
         manager->EndDestroyApiCallCapture<VideoSessionParametersKHRWrapper>(videoSessionParameters);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyVideoSessionParametersKHR(device, videoSessionParameters, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR>::Dispatch(manager, device, videoSessionParameters, pAllocator);
 
     DestroyWrappedHandle<VideoSessionParametersKHRWrapper>(videoSessionParameters);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
@@ -11260,13 +11260,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
         manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
     DestroyWrappedHandle<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
@@ -12308,13 +12308,13 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
         manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
     DestroyWrappedHandle<SamplerYcbcrConversionWrapper>(ycbcrConversion);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
@@ -12962,13 +12962,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
         manager->EndDestroyApiCallCapture<DeferredOperationKHRWrapper>(operation);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyDeferredOperationKHR(device, operation, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR>::Dispatch(manager, device, operation, pAllocator);
 
     DestroyWrappedHandle<DeferredOperationKHRWrapper>(operation);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
@@ -14509,13 +14509,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
         manager->EndDestroyApiCallCapture<DebugReportCallbackEXTWrapper>(callback);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetInstanceTable(instance)->DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(manager, instance, callback, pAllocator);
 
     DestroyWrappedHandle<DebugReportCallbackEXTWrapper>(callback);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
@@ -16547,13 +16547,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
         manager->EndDestroyApiCallCapture<DebugUtilsMessengerEXTWrapper>(messenger);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetInstanceTable(instance)->DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(manager, instance, messenger, pAllocator);
 
     DestroyWrappedHandle<DebugUtilsMessengerEXTWrapper>(messenger);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
@@ -16877,13 +16877,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
         manager->EndDestroyApiCallCapture<ValidationCacheEXTWrapper>(validationCache);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyValidationCacheEXT(device, validationCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(manager, device, validationCache, pAllocator);
 
     DestroyWrappedHandle<ValidationCacheEXTWrapper>(validationCache);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
@@ -17165,13 +17165,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
         manager->EndDestroyApiCallCapture<AccelerationStructureNVWrapper>(accelerationStructure);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyAccelerationStructureNV(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
     DestroyWrappedHandle<AccelerationStructureNVWrapper>(accelerationStructure);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
@@ -18304,7 +18304,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, device, configuration);
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     VkResult result = GetDeviceTable(device)->ReleasePerformanceConfigurationINTEL(device, configuration);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL);
@@ -18319,7 +18320,6 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, result, device, configuration);
 
     DestroyWrappedHandle<PerformanceConfigurationINTELWrapper>(configuration);
-    UnlockForDestroyHandle();
 
     return result;
 }
@@ -19888,13 +19888,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
         manager->EndDestroyApiCallCapture<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV>::Dispatch(manager, device, indirectCommandsLayout, pAllocator);
 
     DestroyWrappedHandle<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
@@ -20100,13 +20100,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
         manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
     DestroyWrappedHandle<PrivateDataSlotWrapper>(privateDataSlot);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
@@ -21200,13 +21200,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
         manager->EndDestroyApiCallCapture<MicromapEXTWrapper>(micromap);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyMicromapEXT(device, micromap, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyMicromapEXT>::Dispatch(manager, device, micromap, pAllocator);
 
     DestroyWrappedHandle<MicromapEXTWrapper>(micromap);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
@@ -23228,13 +23228,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
         manager->EndDestroyApiCallCapture<OpticalFlowSessionNVWrapper>(session);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyOpticalFlowSessionNV(device, session, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV>::Dispatch(manager, device, session, pAllocator);
 
     DestroyWrappedHandle<OpticalFlowSessionNVWrapper>(session);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
@@ -23400,13 +23400,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
         manager->EndDestroyApiCallCapture<ShaderEXTWrapper>(shader);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyShaderEXT(device, shader, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderEXT>::Dispatch(manager, device, shader, pAllocator);
 
     DestroyWrappedHandle<ShaderEXTWrapper>(shader);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
@@ -23694,13 +23694,13 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
         manager->EndDestroyApiCallCapture<AccelerationStructureKHRWrapper>(accelerationStructure);
     }
 
-    LockForDestroyHandle();
+    std::unique_lock<std::shared_mutex> exclusive_scoped_lock;
+    exclusive_scoped_lock = ScopedDestroyLock();
     GetDeviceTable(device)->DestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
     DestroyWrappedHandle<AccelerationStructureKHRWrapper>(accelerationStructure);
-    UnlockForDestroyHandle();
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_command_buffer_util.cpp
+++ b/framework/generated/generated_vulkan_command_buffer_util.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_command_buffer_util.h
+++ b/framework/generated/generated_vulkan_command_buffer_util.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_constant_maps.h
+++ b/framework/generated/generated_vulkan_constant_maps.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_dispatch_table.h
+++ b/framework/generated/generated_vulkan_dispatch_table.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_enum_to_json.cpp
+++ b/framework/generated/generated_vulkan_enum_to_json.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_enum_to_json.h
+++ b/framework/generated/generated_vulkan_enum_to_json.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_enum_to_string.cpp
+++ b/framework/generated/generated_vulkan_enum_to_string.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_enum_to_string.h
+++ b/framework/generated/generated_vulkan_enum_to_string.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_json_consumer.cpp
+++ b/framework/generated/generated_vulkan_json_consumer.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_json_consumer.h
+++ b/framework/generated/generated_vulkan_json_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_object_info_table_base2.h
+++ b/framework/generated/generated_vulkan_object_info_table_base2.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_state_table.h
+++ b/framework/generated/generated_vulkan_state_table.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_decoders_forward.h
+++ b/framework/generated/generated_vulkan_struct_decoders_forward.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_to_json.cpp
+++ b/framework/generated/generated_vulkan_struct_to_json.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_to_json.h
+++ b/framework/generated/generated_vulkan_struct_to_json.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2018-2023 Valve Corporation
 # Copyright (c) 2018-2023 LunarG, Inc.
+# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -188,7 +189,8 @@ def make_gen_opts(args):
     # Copyright text prefixing all headers (list of strings).
     prefix_strings = [
         '/*', '** Copyright (c) 2018-2023 Valve Corporation',
-        '** Copyright (c) 2018-2023 LunarG, Inc.', '**',
+        '** Copyright (c) 2018-2023 LunarG, Inc.',
+        '** Copyright (c) 2023 Advanced Micro Devices, Inc.', '**',
         '** Permission is hereby granted, free of charge, to any person obtaining a',
         '** copy of this software and associated documentation files (the "Software"),',
         '** to deal in the Software without restriction, including without limitation',

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2018-2019 Valve Corporation
 # Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -302,7 +302,8 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                 body += '\n'
 
             if self.lock_for_destroy_handle_is_needed(name):
-                body += indent + 'LockForDestroyHandle();\n'
+                body += indent + 'std::unique_lock<std::shared_mutex> exclusive_scoped_lock;\n'
+                body += indent + 'exclusive_scoped_lock = ScopedDestroyLock();\n'
 
             # Construct the function call to dispatch to the next layer.
             (call_setup_expr, call_expr) = self.make_layer_dispatch_call(
@@ -359,9 +360,6 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
         if cleanup_expr:
             body += '\n'
             body += cleanup_expr
-
-        if self.lock_for_destroy_handle_is_needed(name):
-            body += indent + 'UnlockForDestroyHandle();\n'
 
         if return_type and return_type != 'void':
             body += '\n'

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -302,8 +302,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                 body += '\n'
 
             if self.lock_for_destroy_handle_is_needed(name):
-                body += indent + 'std::unique_lock<std::shared_mutex> exclusive_scoped_lock;\n'
-                body += indent + 'exclusive_scoped_lock = ScopedDestroyLock();\n'
+                body += indent + 'ScopedDestroyLock exclusive_scoped_lock;\n'
 
             # Construct the function call to dispatch to the next layer.
             (call_setup_expr, call_expr) = self.make_layer_dispatch_call(


### PR DESCRIPTION
**The problem**
   
With default GFXR setting, sometimes an app will destroy some Vulkan handles in one thread (A) and create same type of Vulkan handle in another thread (B). There is a gap of time in between when the real handle is destroyed, and when its wrappers were deleted from map in thread A. If during this time period, thread B was able to run, and creates same type of handles, and if any of the newly-created handles had the same value of those destroyed by thread A, capturing will crash because handle rapper handling error for the new created handle.
 
**The solution**

The fix fixed the issue by acquiring shared lock for all wrapped handle creation and acquiring exclusive lock for range from destroying real Vulkan handle to end of deleting related wrapper.

**Result**
Tested target title full trace and trim trace capture/playback with the build of the pull request, all tests passed, the commit fixed the issue.