### PR TITLE
gfxrecon_replay: Add call to XInitThreads on startup

### DIFF
--- a/framework/application/xlib_context.cpp
+++ b/framework/application/xlib_context.cpp
@@ -46,8 +46,8 @@ XlibContext::XlibContext(Application* application) : WsiContext(application)
     }
 
     const auto xlib = xlib_loader_.GetFunctionTable();
+    xlib.InitThreads();
     xlib.SetErrorHandler(ErrorHandler);
-
     display_ = xlib.OpenDisplay(nullptr);
     if (!display_)
     {
@@ -78,6 +78,7 @@ Display* XlibContext::OpenDisplay()
     if (display_ == nullptr)
     {
         auto xlib = xlib_loader_.GetFunctionTable();
+        xlib.InitThreads();
         display_  = xlib.OpenDisplay(nullptr);
     }
     ++display_open_count_;

--- a/framework/util/xlib_loader.cpp
+++ b/framework/util/xlib_loader.cpp
@@ -70,6 +70,8 @@ bool XlibLoader::Initialize()
                 reinterpret_cast<decltype(XGetErrorText)*>(util::platform::GetProcAddress(libx11_, "XGetErrorText"));
             function_table_.GetWindowAttributes = reinterpret_cast<decltype(XGetWindowAttributes)*>(
                 util::platform::GetProcAddress(libx11_, "XGetWindowAttributes"));
+            function_table_.InitThreads =
+                reinterpret_cast<decltype(XInitThreads)*>(util::platform::GetProcAddress(libx11_, "XInitThreads"));
             function_table_.InternAtom =
                 reinterpret_cast<decltype(XInternAtom)*>(util::platform::GetProcAddress(libx11_, "XInternAtom"));
             function_table_.MapWindow =

--- a/framework/util/xlib_loader.h
+++ b/framework/util/xlib_loader.h
@@ -43,6 +43,7 @@ class XlibLoader
         decltype(XFlush)*               Flush;
         decltype(XGetErrorText)*        GetErrorText;
         decltype(XGetWindowAttributes)* GetWindowAttributes;
+        decltype(XInitThreads)*         InitThreads;
         decltype(XInternAtom)*          InternAtom;
         decltype(XMapWindow)*           MapWindow;
         decltype(XMoveWindow)*          MoveWindow;


### PR DESCRIPTION
During shutdown, gfxrecon-replay would sometimes get the following error msg:

   xcb_conn.c:215: write_vec: Assertion `!c->out.queue_len' failed.

This error can occur in multi-threaded apps that use xlib.  See man page for XInitThreads() for more info.

This commit adds a call to XInitThreads() before the first call to XOpenDisplay().