### PR TITLE
copy gfxrecon_interceptor.dll to bin

### DIFF
--- a/tools/launcher/CMakeLists.txt
+++ b/tools/launcher/CMakeLists.txt
@@ -42,4 +42,5 @@ if(BUILD_LAUNCHER_AND_INTERCEPTOR)
     common_build_directives(gfxrecon-launcher)
 
     install(TARGETS gfxrecon-launcher RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES ${CMAKE_BINARY_DIR}/layer/gfxrecon_interceptor/$<CONFIG>/gfxrecon_interceptor.dll DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()


### PR DESCRIPTION
**The problem**
`gfxrecon_interceptor.dll` is missing when using `build.py --build-launcher` option.

**The solution**
`cmakelists.txt` include install files command.

**Result**
`gfxrecon_interceptor.dll` is copied to bin folder.