### PR TITLE
gfxrecon_replay: Define VMA_ASSERT to avoid assert crashes

### DIFF
--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -509,6 +509,10 @@ During replay, swapchain indices for present can be different from captured indi
 
 Virtual Swapchain insulates higher layers in the Vulkan stack from these problems by creating a set of images, exactly matching the swapchain configuration at capture time, which it exposes for them to render into.  Before a present, it copies the virtual image to a target swapchain image for display. Since this issue can happen in many situations, virtual swapchain is the default setup. If the user wants to bypass the feature and use the captured indices to present directly on the swapchain of the replay implementation, they should add the `--use-captured-swapchain-indices` option when invoking `gfxrecon-replay`.
 
+### Debug mode VMA errors
+
+gfxrec-replay with the -m rebind option uses the Vulkan Memory Allocator library for memory allocations. If gfxrecon-replay is compiled debuggable, VMA_ASSERT errors in VMA can be trapped for debugging by setting GFXRECON_LOG_BREAK_ON_ERROR to true.
+
 ## Other Capture File Processing Tools
 
 ### Capture File Info

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -29,19 +29,19 @@
 #ifdef NDEBUG
 #define VMA_ASSERT(expr_)
 #else
-#define VMA_ASSERT(expr_)                                                               \
-    if (!static_cast<bool>(expr_))                                                      \
-    {                                                                                   \
-        std::string msg = __FILE__ ":" + std::to_string(__LINE__) + " ASSERT failure "; \
-        if (strchr(#expr_, '"'))                                                        \
-        {                                                                               \
-            msg += strchr(#expr_, '"');                                                 \
-        }                                                                               \
-        else                                                                            \
-        {                                                                               \
-            msg += #expr_;                                                              \
-        }                                                                               \
-        GFXRECON_LOG_WARNING(msg.c_str());                                              \
+#define VMA_ASSERT(expr_)                                                \
+    if (!static_cast<bool>(expr_))                                       \
+    {                                                                    \
+        std::string msg = __FILE__ ":" + std::to_string(__LINE__) + " "; \
+        if (strchr(#expr_, '"'))                                         \
+        {                                                                \
+            msg += strchr(#expr_, '"');                                  \
+        }                                                                \
+        else                                                             \
+        {                                                                \
+            msg += #expr_;                                               \
+        }                                                                \
+        GFXRECON_LOG_ERROR(msg.c_str());                                 \
     }
 #endif
 

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -20,6 +20,31 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+// Define VMA_ASSERT for use in vk_mem_alloc.h
+// For debug compiles, VMA_ASSERT failure is treated as a warning.
+// For release compiles, VMA_ASSERT failure is a no-op.
+// The expr_ parameter can be in the form of 'condition && "error string"'.
+// The error string will be printed if condition is false.
+#include "util/logging.h"
+#ifdef NDEBUG
+#define VMA_ASSERT(expr_)
+#else
+#define VMA_ASSERT(expr_)                                                               \
+    if (!static_cast<bool>(expr_))                                                      \
+    {                                                                                   \
+        std::string msg = __FILE__ ":" + std::to_string(__LINE__) + " ASSERT failure "; \
+        if (strchr(#expr_, '"'))                                                        \
+        {                                                                               \
+            msg += strchr(#expr_, '"');                                                 \
+        }                                                                               \
+        else                                                                            \
+        {                                                                               \
+            msg += #expr_;                                                              \
+        }                                                                               \
+        GFXRECON_LOG_WARNING(msg.c_str());                                              \
+    }
+#endif
+
 // This file needs to be included first to ensure it is processed with the VMA_IMPLEMENTATION directive, in case it is
 // indirectly included by other include files.
 #define VMA_IMPLEMENTATION


### PR DESCRIPTION
The debug compiled version of gfxrecon_replay would crash with an assert failure in VMA because the captured app did not destroy all images or buffers that it created before calling vkDestroyDevice. This fix changes the assert failure to a warning.