### PR TITLE
Set CPU&GPU memory usage by command line option

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -329,7 +329,9 @@ D3D12-only:
                                assigns each object the generated name.
                                This is intended to assist replay debugging.
   --batching-memory-usage <pct>
-                               Max amount of memory consumption while loading a trimmed capture file.
+                               Max amount of system's physical memory use and the GPU memory budget
+                               consumption while loading a trimmed capture file.
+                               Not guarantee overall max memory usage while loading trimmed capture file.
                                Acceptable values range from 0 to 100 (default: 80)
                                0 means no batching at all
                                100 means use all available system and GPU memory

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -329,12 +329,14 @@ D3D12-only:
                                assigns each object the generated name.
                                This is intended to assist replay debugging.
   --batching-memory-usage <pct>
-                               Max amount of system's physical memory use and the GPU memory budget
-                               consumption while loading a trimmed capture file.
-                               Not guarantee overall max memory usage while loading trimmed capture file.
-                               Acceptable values range from 0 to 100 (default: 80)
-                               0 means no batching at all
-                               100 means use all available system and GPU memory
+                               Limits the max amount of additional memory that can be used to batch
+                               resource data uploads during trim state load. Batching resource data
+                               uploads may reduce the number of GPU submissions required to load the
+                               trim state. <pct> is applied to the total available physical system memory
+                               and to the application's GPU memory budget. This only limits memory use
+                               for batching and does not guarantee overall max memory usage.
+                               Acceptable values range from 0 to 100 (default: 80). 0 means no batching,
+                               100 means use all available system and GPU memory.
 ```
 
 

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -209,6 +209,7 @@ Usage:
                         [-m <mode> | --memory-translation <mode>]
                         [--fw <width,height> | --force-windowed <width,height>]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
+                        [--batching-memory-usage <pct>]
                         [--api <api>] <file>
 
 Required arguments:
@@ -327,6 +328,11 @@ D3D12-only:
   --dx12-override-object-names Generates unique names for all ID3D12Objects and
                                assigns each object the generated name.
                                This is intended to assist replay debugging.
+  --batching-memory-usage <pct>
+                               Max amount of memory consumption while loading a trimmed capture file.
+                               Acceptable values range from 0 to 100 (default: 80)
+                               0 means no batching at all
+                               100 means use all available system and GPU memory
 ```
 
 

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -418,9 +418,9 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
         // If no entry exists in resource_init_infos_, this is the first subresource of a new resource.
         GFXRECON_ASSERT(command_header.subresource == 0);
 
-        const double max_cpu_mem_usage = 15.0 / 16.0;
+        const double max_mem_usage = static_cast<double>(options_.memory_usage) / 100.0;
         if (!graphics::dx12::IsMemoryAvailable(
-                total_size_in_bytes, extra_device_info->adapter3, max_cpu_mem_usage, extra_device_info->is_uma))
+                total_size_in_bytes, extra_device_info->adapter3, max_mem_usage, extra_device_info->is_uma))
         {
             // If neither system memory or GPU memory are able to accommodate next resource,
             // execute the Copy() calls and release temp buffer to free memory

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -36,6 +36,8 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+static constexpr uint32_t kDefaultBatchingMemoryUsage = 80;
+
 struct DxReplayOptions : public ReplayOptions
 {
     bool                 enable_d3d12{ true };
@@ -50,6 +52,7 @@ struct DxReplayOptions : public ReplayOptions
     std::string                  screenshot_dir;
     std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
     std::string                  replace_dir;
+    int32_t                      memory_usage{ kDefaultBatchingMemoryUsage };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -779,11 +779,11 @@ void Dx12StateWriter::WriteResourceSnapshots(
                 uint64_t size_in_bytes = resource_info.get()->size_in_bytes;
                 auto     device_info   = device_wrapper->GetObjectInfo();
 
-                const double max_cpu_mem_usage = 7.0 / 8.0;
+                const double max_mem_usage = 7.0 / 8.0;
 
                 const bool is_uma = device_wrapper->GetObjectInfo()->is_uma;
                 if (!graphics::dx12::IsMemoryAvailable(
-                        size_in_bytes, device_info.get()->adapter3, max_cpu_mem_usage, is_uma))
+                        size_in_bytes, device_info.get()->adapter3, max_mem_usage, is_uma))
                 {
                     // If neither system memory or GPU memory are able to accommodate next resource,
                     // execute the existing Copy() calls and release temp buffer to free memory

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -223,14 +223,14 @@ bool IsUma(ID3D12Device* device);
 
 // This function is used to get available GPU virtual memory.
 // The input is current adapter which created current device.
-uint64_t GetAvailableGpuAdapterMemory(IDXGIAdapter3* adapter, bool is_uma);
+uint64_t GetAvailableGpuAdapterMemory(IDXGIAdapter3* adapter, double max_usage, bool is_uma);
 
 // This function is used to get available CPU memory.
 uint64_t GetAvailableCpuMemory(double max_usage);
 
 // Give require memory size to check if there are enough CPU&GPU memory to allocate the resource. If max_cpu_mem_usage
 // > 1.0, the result is not limited by available physical memory.
-bool IsMemoryAvailable(uint64_t requried_memory, IDXGIAdapter3* adapter, double max_cpu_mem_usage, bool is_uma);
+bool IsMemoryAvailable(uint64_t requried_memory, IDXGIAdapter3* adapter, double max_mem_usage, bool is_uma);
 
 // Get GPU memory usage by resource desc
 uint64_t GetResourceSizeInBytes(ID3D12Device* device, const D3D12_RESOURCE_DESC* desc);

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -36,7 +36,7 @@ const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
     "screenshot-dir,--screenshot-prefix,--screenshot-size,--screenshot-scale,--mfr|--measurement-frame-range,--fw|--"
-    "force-windowed";
+    "force-windowed,--batching-memory-usage";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -66,6 +66,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fw <width,height> | --force-windowed <width,height>]");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>] [--log-debugview]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--batching-memory-usage <pct>]");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--api <api>] [--no-debug-popup] <file>\n");
 #else
@@ -225,6 +226,11 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --dx12-override-object-names Generates unique names for all ID3D12Objects and");
     GFXRECON_WRITE_CONSOLE("                               assigns each object the generated name.");
     GFXRECON_WRITE_CONSOLE("                               This is intended to assist replay debugging.");
+    GFXRECON_WRITE_CONSOLE("  --batching-memory-usage <pct>");
+    GFXRECON_WRITE_CONSOLE("          \t\tMax amount of memory consumption while loading a trimmed capture file.");
+    GFXRECON_WRITE_CONSOLE("          \t\tAcceptable values range from 0 to 100 (default: 80)");
+    GFXRECON_WRITE_CONSOLE("          \t\t0 means no batching at all");
+    GFXRECON_WRITE_CONSOLE("          \t\t100 means use all available system and GPU memory");
 
 #endif
 

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -111,6 +111,7 @@ const char kFilePerFrameOption[]                 = "--file-per-frame";
 const char kApiFamilyOption[]       = "--api";
 const char kDxTwoPassReplay[]       = "--dx12-two-pass-replay";
 const char kDxOverrideObjectNames[] = "--dx12-override-object-names";
+const char kBatchingMemoryUsageArgument[] = "--batching-memory-usage";
 #endif
 
 enum class WsiPlatform
@@ -878,6 +879,12 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     if (arg_parser.IsOptionSet(kDxOverrideObjectNames))
     {
         replay_options.override_object_names = true;
+    }
+
+    const std::string& memory_usage = arg_parser.GetArgumentValue(kBatchingMemoryUsageArgument);
+    if (!memory_usage.empty())
+    {
+        replay_options.memory_usage = std::stoi(memory_usage);
     }
 
     replay_options.screenshot_ranges      = GetScreenshotRanges(arg_parser);

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -108,9 +108,9 @@ const char kIncludeBinariesOption[]              = "--include-binaries";
 const char kExpandFlagsOption[]                  = "--expand-flags";
 const char kFilePerFrameOption[]                 = "--file-per-frame";
 #if defined(WIN32)
-const char kApiFamilyOption[]       = "--api";
-const char kDxTwoPassReplay[]       = "--dx12-two-pass-replay";
-const char kDxOverrideObjectNames[] = "--dx12-override-object-names";
+const char kApiFamilyOption[]             = "--api";
+const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
+const char kDxOverrideObjectNames[]       = "--dx12-override-object-names";
 const char kBatchingMemoryUsageArgument[] = "--batching-memory-usage";
 #endif
 
@@ -884,7 +884,14 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     const std::string& memory_usage = arg_parser.GetArgumentValue(kBatchingMemoryUsageArgument);
     if (!memory_usage.empty())
     {
-        replay_options.memory_usage = std::stoi(memory_usage);
+        if (replay_options.memory_usage >= 0 && replay_options.memory_usage <= 100)
+        {
+            replay_options.memory_usage = std::stoi(memory_usage);
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("The parameters --batching-memory-usage out of range, will use 80 as default value");
+        }
     }
 
     replay_options.screenshot_ranges      = GetScreenshotRanges(arg_parser);

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -884,13 +884,15 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     const std::string& memory_usage = arg_parser.GetArgumentValue(kBatchingMemoryUsageArgument);
     if (!memory_usage.empty())
     {
-        if (replay_options.memory_usage >= 0 && replay_options.memory_usage <= 100)
+        int memory_usage_int = std::stoi(memory_usage);
+        if (memory_usage_int >= 0 && memory_usage_int <= 100)
         {
-            replay_options.memory_usage = std::stoi(memory_usage);
+            replay_options.memory_usage = static_cast<uint32_t>(memory_usage_int);
         }
         else
         {
-            GFXRECON_LOG_WARNING("The parameters --batching-memory-usage out of range, will use 80 as default value");
+            GFXRECON_LOG_WARNING(
+                "The parameter to --batching-memory-usage is out of range [0, 100], will use 80 as default value.");
         }
     }
 


### PR DESCRIPTION
**Problem:**
The GFXR trapped system error "bad allocations" on a VM system. But the system reported it had enough memory room for GFXR to replay.

**Solution:**
Add a replay option to set memory usage to avoid system memory issue.