### PR TITLE
Fix Codegen Side Effects of Modification of Shared Static Variables

### DIFF
--- a/framework/generated/dx12_generators/dx12_ascii_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_ascii_consumer_body_generator.py
@@ -55,6 +55,8 @@ class Dx12AsciiConsumerBodyGenerator(Dx12AsciiConsumerHeaderGenerator):
 
     def beginFile(self, genOpts):
         # The following functions/methods require custom handling
+        # @todo It would be cleaner to make a custom JSON listing for these as:
+        # framework\generated\dx12_generators\blacklists_ascii.json
         self.APICALL_BLACKLIST.append('D3D12CreateRootSignatureDeserializer')
         self.METHODCALL_BLACKLIST.append('ID3D12RootSignatureDeserializer_GetRootSignatureDesc')
         self.METHODCALL_BLACKLIST.append('ID3D12VersionedRootSignatureDeserializer_GetUnconvertedRootSignatureDesc')

--- a/framework/generated/dx12_generators/gencode.py
+++ b/framework/generated/dx12_generators/gencode.py
@@ -59,6 +59,9 @@ from dx12_struct_to_string_body_generator import Dx12StructToStringBodyGenerator
 from dx12_call_id_to_string_header_generator import Dx12CallIdToStringHeaderGenerator
 
 # JSON files for customizing code generation
+# @todo Review the file of blacklisted functions and determine if each generator
+# needs a custom set in its own file.
+
 default_blacklists = 'blacklists.json'
 default_platform_types = 'platform_types.json'
 default_replay_overrides = 'replay_overrides.json'
@@ -351,6 +354,7 @@ def make_gen_opts(args):
         Dx12GeneratorOptions(
             filename='generated_dx12_wrapper_creators.h',
             directory=directory,
+            blacklists=blacklists,
             platform_types=platform_types,
             prefix_text=prefix_strings + py_prefix_strings,
             protect_file=True,
@@ -366,6 +370,7 @@ def make_gen_opts(args):
         Dx12GeneratorOptions(
             filename='generated_dx12_wrapper_creators.cpp',
             directory=directory,
+            blacklists=blacklists,
             platform_types=platform_types,
             prefix_text=prefix_strings + py_prefix_strings,
             protect_file=False,
@@ -381,6 +386,7 @@ def make_gen_opts(args):
         Dx12GeneratorOptions(
             filename='generated_dx12_struct_unwrappers.h',
             directory=directory,
+            blacklists=blacklists,
             platform_types=platform_types,
             prefix_text=prefix_strings + py_prefix_strings,
             protect_file=True,
@@ -396,6 +402,7 @@ def make_gen_opts(args):
         Dx12GeneratorOptions(
             filename='generated_dx12_struct_unwrappers.cpp',
             directory=directory,
+            blacklists=blacklists,
             platform_types=platform_types,
             prefix_text=prefix_strings + py_prefix_strings,
             protect_file=False,
@@ -563,6 +570,7 @@ def make_gen_opts(args):
         Dx12GeneratorOptions(
             filename='generated_dx12_struct_to_string.h',
             directory=directory,
+            blacklists=blacklists,
             platform_types=platform_types,
             prefix_text=prefix_strings + py_prefix_strings,
             protect_file=True,
@@ -578,6 +586,7 @@ def make_gen_opts(args):
         Dx12GeneratorOptions(
             filename='generated_dx12_struct_to_string.cpp',
             directory=directory,
+            blacklists=blacklists,
             platform_types=platform_types,
             prefix_text=prefix_strings + py_prefix_strings,
             protect_file=False,

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -271,94 +271,6 @@ class BaseGenerator(OutputGenerator):
     Base class for Vulkan API parameter encoding and decoding generators.
     """
 
-    # These API calls should not be processed by the code generator.  They require special implementations.
-    APICALL_BLACKLIST = []
-
-    APICALL_ENCODER_BLACKLIST = []
-
-    APICALL_DECODER_BLACKLIST = []
-
-    # These method calls should not be processed by the code generator.  They require special implementations.
-    METHODCALL_BLACKLIST = []
-
-    # These structures should not be processed by the code generator.  They require special implementations.
-    STRUCT_BLACKLIST = []
-
-    # Platform specific basic types that have been defined extarnally to the Vulkan header.
-    PLATFORM_TYPES = {}
-
-    # Platform specific structure types that have been defined extarnally to the Vulkan header.
-    PLATFORM_STRUCTS = []
-
-    GENERIC_HANDLE_APICALLS = {
-        'vkDebugReportMessageEXT': {
-            'object': 'objectType'
-        },
-        'vkSetPrivateDataEXT': {
-            'objectHandle': 'objectType'
-        },
-        'vkGetPrivateDataEXT': {
-            'objectHandle': 'objectType'
-        },
-        'vkSetPrivateData': {
-            'objectHandle': 'objectType'
-        },
-        'vkGetPrivateData': {
-            'objectHandle': 'objectType'
-        }
-    }
-
-    GENERIC_HANDLE_STRUCTS = {
-        'VkDebugMarkerObjectNameInfoEXT': {
-            'object': 'objectType'
-        },
-        'VkDebugMarkerObjectTagInfoEXT': {
-            'object': 'objectType'
-        },
-        'VkDebugUtilsObjectNameInfoEXT': {
-            'objectHandle': 'objectType'
-        },
-        'VkDebugUtilsObjectTagInfoEXT': {
-            'objectHandle': 'objectType'
-        }
-    }
-
-    VULKAN_REPLACE_TYPE = {
-        "VkRemoteAddressNV": {
-            "baseType": "void",
-            "replaceWith": "void*"
-        }
-    }
-
-    # These types represent pointers to non-Vulkan or non-Dx12 objects that were written as 64-bit address IDs.
-    EXTERNAL_OBJECT_TYPES = ['void', 'Void']
-
-    MAP_STRUCT_TYPE = {
-        'D3D12_GPU_DESCRIPTOR_HANDLE': [
-            'MapGpuDescriptorHandle', 'MapGpuDescriptorHandles',
-            'descriptor_map'
-        ],
-        'D3D12_GPU_VIRTUAL_ADDRESS':
-        ['MapGpuVirtualAddress', 'MapGpuVirtualAddresses', 'gpu_va_map']
-    }
-
-    # Dispatchable handle types.
-    DISPATCHABLE_HANDLE_TYPES = [
-        'VkInstance', 'VkPhysicalDevice', 'VkDevice', 'VkQueue',
-        'VkCommandBuffer'
-    ]
-
-    DUPLICATE_HANDLE_TYPES = [
-        'VkDescriptorUpdateTemplateKHR', 'VkSamplerYcbcrConversionKHR', 'VkPrivateDataSlotEXT'
-    ]
-
-    # Default C++ code indentation size.
-    INDENT_SIZE = 4
-
-    VIDEO_TREE = None
-
-    generate_video = False
-
     def __init__(
         self,
         process_cmds,
@@ -369,6 +281,94 @@ class BaseGenerator(OutputGenerator):
         diag_file=sys.stdout
     ):
         OutputGenerator.__init__(self, err_file, warn_file, diag_file)
+
+        # These API calls should not be processed by the code generator.  They require special implementations.
+        self.APICALL_BLACKLIST = []
+
+        self.APICALL_ENCODER_BLACKLIST = []
+
+        self.APICALL_DECODER_BLACKLIST = []
+
+        # These method calls should not be processed by the code generator.  They require special implementations.
+        self.METHODCALL_BLACKLIST = []
+
+        # These structures should not be processed by the code generator.  They require special implementations.
+        self.STRUCT_BLACKLIST = []
+
+        # Platform specific basic types that have been defined extarnally to the Vulkan header.
+        self.PLATFORM_TYPES = {}
+
+        # Platform specific structure types that have been defined extarnally to the Vulkan header.
+        self.PLATFORM_STRUCTS = []
+
+        self.GENERIC_HANDLE_APICALLS = {
+            'vkDebugReportMessageEXT': {
+                'object': 'objectType'
+            },
+            'vkSetPrivateDataEXT': {
+                'objectHandle': 'objectType'
+            },
+            'vkGetPrivateDataEXT': {
+                'objectHandle': 'objectType'
+            },
+            'vkSetPrivateData': {
+                'objectHandle': 'objectType'
+            },
+            'vkGetPrivateData': {
+                'objectHandle': 'objectType'
+            }
+        }
+
+        self.GENERIC_HANDLE_STRUCTS = {
+            'VkDebugMarkerObjectNameInfoEXT': {
+                'object': 'objectType'
+            },
+            'VkDebugMarkerObjectTagInfoEXT': {
+                'object': 'objectType'
+            },
+            'VkDebugUtilsObjectNameInfoEXT': {
+                'objectHandle': 'objectType'
+            },
+            'VkDebugUtilsObjectTagInfoEXT': {
+                'objectHandle': 'objectType'
+            }
+        }
+
+        self.VULKAN_REPLACE_TYPE = {
+            "VkRemoteAddressNV": {
+                "baseType": "void",
+                "replaceWith": "void*"
+            }
+        }
+
+        # These types represent pointers to non-Vulkan or non-Dx12 objects that were written as 64-bit address IDs.
+        self.EXTERNAL_OBJECT_TYPES = ['void', 'Void']
+
+        self.MAP_STRUCT_TYPE = {
+            'D3D12_GPU_DESCRIPTOR_HANDLE': [
+                'MapGpuDescriptorHandle', 'MapGpuDescriptorHandles',
+                'descriptor_map'
+            ],
+            'D3D12_GPU_VIRTUAL_ADDRESS':
+            ['MapGpuVirtualAddress', 'MapGpuVirtualAddresses', 'gpu_va_map']
+        }
+
+        # Dispatchable handle types.
+        self.DISPATCHABLE_HANDLE_TYPES = [
+            'VkInstance', 'VkPhysicalDevice', 'VkDevice', 'VkQueue',
+            'VkCommandBuffer'
+        ]
+
+        self.DUPLICATE_HANDLE_TYPES = [
+            'VkDescriptorUpdateTemplateKHR', 'VkSamplerYcbcrConversionKHR', 'VkPrivateDataSlotEXT'
+        ]
+
+        # Default C++ code indentation size.
+        self.INDENT_SIZE = 4
+
+        self.VIDEO_TREE = None
+
+        self.generate_video = False
 
         # Typenames
         self.struct_names = set()  # Set of Vulkan struct typenames


### PR DESCRIPTION
Several generator base class variables have always been shared static variables (effectively global variables which all the generator types can see) rather than ordinary member variables. This has made the order in which generators are run matter since later generators have been seeing the mutations of the variables made by previously run generators.

Prior to this PR, `Dx12AsciiConsumerBodyGenerator` in particular was blocking generation of lots of functions for any consumer added after it.

Rather than adding a workaround like saving/restoring state between generator runs, making the variables ordinary members seems to be the correct fix and that is what this PR does.