### PR TITLE
Permit annotations to be written when trimming is activated

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -976,8 +976,7 @@ void CaptureManager::WriteExeFileInfo(const gfxrecon::util::filepath::FileInfo& 
 
 void CaptureManager::WriteAnnotation(const format::AnnotationType type, const char* label, const char* data)
 {
-    if (((capture_mode_ & kModeWrite) == kModeWrite) ||
-        ((capture_mode_ & kModeWriteAndTrack) == kModeWriteAndTrack))
+    if (((capture_mode_ & kModeWrite) == kModeWrite) || ((capture_mode_ & kModeWriteAndTrack) == kModeWriteAndTrack))
     {
         auto       thread_data  = GetThreadData();
         const auto label_length = util::platform::StringLength(label);

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -141,6 +141,8 @@ class CaptureManager
 
     void WriteExeFileInfo(const gfxrecon::util::filepath::FileInfo& info);
 
+	void ForcedWriteAnnotation(const format::AnnotationType type, const char* label, const char* data);
+
     /// @brief Inject an Annotation block into the capture file.
     /// @param type Identifies the contents of data as plain, xml, or json text
     /// @param label The key or name of the annotation.
@@ -260,7 +262,6 @@ class CaptureManager
     bool        CreateCaptureFile(const std::string& base_filename);
     void        ActivateTrimming();
     void        DeactivateTrimming();
-    void        WriteNewCaptureAnnotation();
 
     void WriteFileHeader();
     void BuildOptionList(const format::EnabledOptions&        enabled_options,

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -141,7 +141,7 @@ class CaptureManager
 
     void WriteExeFileInfo(const gfxrecon::util::filepath::FileInfo& info);
 
-	void ForcedWriteAnnotation(const format::AnnotationType type, const char* label, const char* data);
+    void ForcedWriteAnnotation(const format::AnnotationType type, const char* label, const char* data);
 
     /// @brief Inject an Annotation block into the capture file.
     /// @param type Identifies the contents of data as plain, xml, or json text

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -260,6 +260,7 @@ class CaptureManager
     bool        CreateCaptureFile(const std::string& base_filename);
     void        ActivateTrimming();
     void        DeactivateTrimming();
+    void        WriteNewCaptureAnnotation();
 
     void WriteFileHeader();
     void BuildOptionList(const format::EnabledOptions&        enabled_options,


### PR DESCRIPTION
**Problem**
Full captures contain annotations, but trimmed ones do not. This is happening because:
- Annotation code only runs if `capture_mode_ == kModeWrite`
- Annotation code runs before trimming is activated, at which point `capture_mode_ == kModeTrack`

**Solution**
Permit annotation code to always run when creating a new capture file. This fixes https://github.com/LunarG/gfxreconstruct/issues/1076

**Testing**
Made sure a single annotation was written when testing 
- Full captures
- `GFXRECON_CAPTURE_TRIGGER`
- `GFXRECON_CAPTURE_FRAMES`