### PR TITLE
Fix Android incremental builds

### DIFF
--- a/android/layer/CMakeLists.txt
+++ b/android/layer/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.4.1)
 get_filename_component(GFXRECON_SOURCE_DIR ../.. ABSOLUTE)
 
 include(../framework/cmake-config/PlatformConfig.cmake)
-add_subdirectory(../framework/util ${CMAKE_SOURCE_DIR}/../framework/util/build)
-add_subdirectory(../framework/graphics ${CMAKE_SOURCE_DIR}/../framework/graphics/build)
-add_subdirectory(../framework/format ${CMAKE_SOURCE_DIR}/../framework/format/build)
-add_subdirectory(../framework/encode ${CMAKE_SOURCE_DIR}/../framework/encode/build)
+add_subdirectory(../framework/util ${CMAKE_SOURCE_DIR}/../framework/util/build/layer/${ANDROID_ABI})
+add_subdirectory(../framework/graphics ${CMAKE_SOURCE_DIR}/../framework/graphics/build/layer/${ANDROID_ABI})
+add_subdirectory(../framework/format ${CMAKE_SOURCE_DIR}/../framework/format/build/layer/${ANDROID_ABI})
+add_subdirectory(../framework/encode ${CMAKE_SOURCE_DIR}/../framework/encode/build/layer/${ANDROID_ABI})
 
 add_library(VkLayer_gfxreconstruct SHARED "")
 

--- a/android/tools/replay/CMakeLists.txt
+++ b/android/tools/replay/CMakeLists.txt
@@ -13,11 +13,11 @@ add_library(native_app_glue STATIC
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
 
 include(../../framework/cmake-config/PlatformConfig.cmake)
-add_subdirectory(../../framework/util ${CMAKE_SOURCE_DIR}/../../framework/util/build)
-add_subdirectory(../../framework/graphics ${CMAKE_SOURCE_DIR}/../../framework/graphics/build)
-add_subdirectory(../../framework/format ${CMAKE_SOURCE_DIR}/../../framework/format/build)
-add_subdirectory(../../framework/decode ${CMAKE_SOURCE_DIR}/../../framework/decode/build)
-add_subdirectory(../../framework/application ${CMAKE_SOURCE_DIR}/../../framework/application/build)
+add_subdirectory(../../framework/util ${CMAKE_SOURCE_DIR}/../../framework/util/build/tools/replay/${ANDROID_ABI})
+add_subdirectory(../../framework/graphics ${CMAKE_SOURCE_DIR}/../../framework/graphics/build/tools/replay/${ANDROID_ABI})
+add_subdirectory(../../framework/format ${CMAKE_SOURCE_DIR}/../../framework/format/build/tools/replay/${ANDROID_ABI})
+add_subdirectory(../../framework/decode ${CMAKE_SOURCE_DIR}/../../framework/decode/build/tools/replay/${ANDROID_ABI})
+add_subdirectory(../../framework/application ${CMAKE_SOURCE_DIR}/../../framework/application/build/tools/replay/${ANDROID_ABI})
 
 add_library(gfxrecon-replay
             SHARED


### PR DESCRIPTION
One issue is that the layer and the replay tool both rely on parts of the framework, and they both build the framework into the same output directory.  It also builds each ABI variant into the same output directory, so when doing a subsequent build, even if no inputs have changed, the outputs had been overwritten by other ABI builds, so it has to rebuild for each ABI.
