### PR TITLE
Display call index and thread on failing calls

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1124,7 +1124,10 @@ const VkAllocationCallbacks* VulkanReplayConsumerBase::GetAllocationCallbacks(
     return nullptr;
 }
 
-void VulkanReplayConsumerBase::CheckResult(const char* func_name, VkResult original, VkResult replay)
+void VulkanReplayConsumerBase::CheckResult(const char*                func_name,
+                                           VkResult                   original,
+                                           VkResult                   replay,
+                                           const decode::ApiCallInfo& call_info)
 {
     if (original != replay)
     {
@@ -1133,11 +1136,14 @@ void VulkanReplayConsumerBase::CheckResult(const char* func_name, VkResult origi
             // Raise a fatal error if replay produced an error that did not occur during capture.  Format not supported
             // errors are not treated as fatal, but will be reported as warnings below, allowing the replay to attempt
             // to continue for the case where an application may have queried for formats that it did not use.
-            GFXRECON_LOG_FATAL("API call %s returned error value %s that does not match the result from the "
-                               "capture file: %s.  Replay cannot continue.",
-                               func_name,
-                               util::ToString<VkResult>(replay).c_str(),
-                               util::ToString<VkResult>(original).c_str());
+            GFXRECON_LOG_FATAL(
+                "API call at index: %d thread: %d %s returned error value %s that does not match the result from the "
+                "capture file: %s.  Replay cannot continue.",
+                call_info.index,
+                call_info.thread_id,
+                func_name,
+                util::ToString<VkResult>(replay).c_str(),
+                util::ToString<VkResult>(original).c_str());
 
             RaiseFatalError(enumutil::GetResultDescription(replay));
         }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1138,7 +1138,7 @@ void VulkanReplayConsumerBase::CheckResult(const char*                func_name,
             // to continue for the case where an application may have queried for formats that it did not use.
             GFXRECON_LOG_FATAL(
                 "API call at index: %d thread: %d %s returned error value %s that does not match the result from the "
-                "capture file: %s.  Replay cannot continue.",
+                "capture file: %s. Replay cannot continue.",
                 call_info.index,
                 call_info.thread_id,
                 func_name,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -196,7 +196,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     const VkAllocationCallbacks*
     GetAllocationCallbacks(const StructPointerDecoder<Decoded_VkAllocationCallbacks>* original_callbacks);
 
-    void CheckResult(const char* func_name, VkResult original, VkResult replay);
+    void CheckResult(const char* func_name, VkResult original, VkResult replay, const decode::ApiCallInfo& call_info);
 
     template <typename T>
     typename T::HandleType MapHandle(format::HandleId id,

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -52,7 +52,7 @@ void VulkanReplayConsumer::Process_vkCreateInstance(
     pInstance->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateInstance(returnValue, pCreateInfo, pAllocator, pInstance);
-    CheckResult("vkCreateInstance", returnValue, replay_result);
+    CheckResult("vkCreateInstance", returnValue, replay_result, call_info);
 
     AddHandle<InstanceInfo>(format::kNullHandleId, pInstance->GetPointer(), pInstance->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddInstanceInfo);
 }
@@ -83,7 +83,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     for (size_t i = 0; i < *pPhysicalDeviceCount->GetOutputPointer(); ++i) { pPhysicalDevices->SetConsumerData(i, &handle_info[i]); }
 
     VkResult replay_result = OverrideEnumeratePhysicalDevices(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDevices, returnValue, in_instance, pPhysicalDeviceCount, pPhysicalDevices);
-    CheckResult("vkEnumeratePhysicalDevices", returnValue, replay_result);
+    CheckResult("vkEnumeratePhysicalDevices", returnValue, replay_result, call_info);
 
     if (pPhysicalDevices->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDevices, *pPhysicalDeviceCount->GetOutputPointer(), &VulkanObjectInfoTable::GetInstanceInfo); }
     AddHandles<PhysicalDeviceInfo>(instance, pPhysicalDevices->GetPointer(), pPhysicalDevices->GetLength(), pPhysicalDevices->GetHandlePointer(), *pPhysicalDeviceCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddPhysicalDeviceInfo);
@@ -127,7 +127,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
     VkImageFormatProperties* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceImageFormatProperties(in_physicalDevice, format, type, tiling, usage, flags, out_pImageFormatProperties);
-    CheckResult("vkGetPhysicalDeviceImageFormatProperties", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceImageFormatProperties", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties(
@@ -183,7 +183,7 @@ void VulkanReplayConsumer::Process_vkCreateDevice(
     pDevice->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateDevice(returnValue, in_physicalDevice, pCreateInfo, pAllocator, pDevice);
-    CheckResult("vkCreateDevice", returnValue, replay_result);
+    CheckResult("vkCreateDevice", returnValue, replay_result, call_info);
 
     AddHandle<DeviceInfo>(physicalDevice, pDevice->GetPointer(), pDevice->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDeviceInfo);
 }
@@ -230,7 +230,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit(
     auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
 
     VkResult replay_result = OverrideQueueSubmit(GetDeviceTable(in_queue->handle)->QueueSubmit, returnValue, in_queue, submitCount, pSubmits, in_fence);
-    CheckResult("vkQueueSubmit", returnValue, replay_result);
+    CheckResult("vkQueueSubmit", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkQueueWaitIdle(
@@ -241,7 +241,7 @@ void VulkanReplayConsumer::Process_vkQueueWaitIdle(
     VkQueue in_queue = MapHandle<QueueInfo>(queue, &VulkanObjectInfoTable::GetQueueInfo);
 
     VkResult replay_result = GetDeviceTable(in_queue)->QueueWaitIdle(in_queue);
-    CheckResult("vkQueueWaitIdle", returnValue, replay_result);
+    CheckResult("vkQueueWaitIdle", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkDeviceWaitIdle(
@@ -252,7 +252,7 @@ void VulkanReplayConsumer::Process_vkDeviceWaitIdle(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->DeviceWaitIdle(in_device);
-    CheckResult("vkDeviceWaitIdle", returnValue, replay_result);
+    CheckResult("vkDeviceWaitIdle", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkAllocateMemory(
@@ -271,7 +271,7 @@ void VulkanReplayConsumer::Process_vkAllocateMemory(
     pMemory->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideAllocateMemory(GetDeviceTable(in_device->handle)->AllocateMemory, returnValue, in_device, pAllocateInfo, pAllocator, pMemory);
-    CheckResult("vkAllocateMemory", returnValue, replay_result);
+    CheckResult("vkAllocateMemory", returnValue, replay_result, call_info);
 
     AddHandle<DeviceMemoryInfo>(device, pMemory->GetPointer(), pMemory->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDeviceMemoryInfo);
 }
@@ -304,7 +304,7 @@ void VulkanReplayConsumer::Process_vkMapMemory(
     void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
 
     VkResult replay_result = OverrideMapMemory(GetDeviceTable(in_device->handle)->MapMemory, returnValue, in_device, in_memory, offset, size, flags, out_ppData);
-    CheckResult("vkMapMemory", returnValue, replay_result);
+    CheckResult("vkMapMemory", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*ppData->GetPointer()), *ppData->GetOutputPointer(), format::ApiCallId::ApiCall_vkMapMemory, "vkMapMemory");
 }
@@ -332,7 +332,7 @@ void VulkanReplayConsumer::Process_vkFlushMappedMemoryRanges(
     MapStructArrayHandles(pMemoryRanges->GetMetaStructPointer(), pMemoryRanges->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideFlushMappedMemoryRanges(GetDeviceTable(in_device->handle)->FlushMappedMemoryRanges, returnValue, in_device, memoryRangeCount, pMemoryRanges);
-    CheckResult("vkFlushMappedMemoryRanges", returnValue, replay_result);
+    CheckResult("vkFlushMappedMemoryRanges", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkInvalidateMappedMemoryRanges(
@@ -347,7 +347,7 @@ void VulkanReplayConsumer::Process_vkInvalidateMappedMemoryRanges(
     MapStructArrayHandles(pMemoryRanges->GetMetaStructPointer(), pMemoryRanges->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideInvalidateMappedMemoryRanges(GetDeviceTable(in_device->handle)->InvalidateMappedMemoryRanges, returnValue, in_device, memoryRangeCount, pMemoryRanges);
-    CheckResult("vkInvalidateMappedMemoryRanges", returnValue, replay_result);
+    CheckResult("vkInvalidateMappedMemoryRanges", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceMemoryCommitment(
@@ -376,7 +376,7 @@ void VulkanReplayConsumer::Process_vkBindBufferMemory(
     auto in_memory = GetObjectInfoTable().GetDeviceMemoryInfo(memory);
 
     VkResult replay_result = OverrideBindBufferMemory(GetDeviceTable(in_device->handle)->BindBufferMemory, returnValue, in_device, in_buffer, in_memory, memoryOffset);
-    CheckResult("vkBindBufferMemory", returnValue, replay_result);
+    CheckResult("vkBindBufferMemory", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkBindImageMemory(
@@ -392,7 +392,7 @@ void VulkanReplayConsumer::Process_vkBindImageMemory(
     auto in_memory = GetObjectInfoTable().GetDeviceMemoryInfo(memory);
 
     VkResult replay_result = OverrideBindImageMemory(GetDeviceTable(in_device->handle)->BindImageMemory, returnValue, in_device, in_image, in_memory, memoryOffset);
-    CheckResult("vkBindImageMemory", returnValue, replay_result);
+    CheckResult("vkBindImageMemory", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements(
@@ -472,7 +472,7 @@ void VulkanReplayConsumer::Process_vkQueueBindSparse(
     auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
 
     VkResult replay_result = OverrideQueueBindSparse(GetDeviceTable(in_queue->handle)->QueueBindSparse, returnValue, in_queue, bindInfoCount, pBindInfo, in_fence);
-    CheckResult("vkQueueBindSparse", returnValue, replay_result);
+    CheckResult("vkQueueBindSparse", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateFence(
@@ -490,7 +490,7 @@ void VulkanReplayConsumer::Process_vkCreateFence(
     VkFence* out_pFence = pFence->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateFence(in_device, in_pCreateInfo, in_pAllocator, out_pFence);
-    CheckResult("vkCreateFence", returnValue, replay_result);
+    CheckResult("vkCreateFence", returnValue, replay_result, call_info);
 
     AddHandle<FenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
 }
@@ -520,7 +520,7 @@ void VulkanReplayConsumer::Process_vkResetFences(
     const VkFence* in_pFences = MapHandles<FenceInfo>(pFences, fenceCount, &VulkanObjectInfoTable::GetFenceInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->ResetFences(in_device, fenceCount, in_pFences);
-    CheckResult("vkResetFences", returnValue, replay_result);
+    CheckResult("vkResetFences", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetFenceStatus(
@@ -533,7 +533,7 @@ void VulkanReplayConsumer::Process_vkGetFenceStatus(
     auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
 
     VkResult replay_result = OverrideGetFenceStatus(GetDeviceTable(in_device->handle)->GetFenceStatus, returnValue, in_device, in_fence);
-    CheckResult("vkGetFenceStatus", returnValue, replay_result);
+    CheckResult("vkGetFenceStatus", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkWaitForFences(
@@ -549,7 +549,7 @@ void VulkanReplayConsumer::Process_vkWaitForFences(
     MapHandles<FenceInfo>(pFences, fenceCount, &VulkanObjectInfoTable::GetFenceInfo);
 
     VkResult replay_result = OverrideWaitForFences(GetDeviceTable(in_device->handle)->WaitForFences, returnValue, in_device, fenceCount, pFences, waitAll, timeout);
-    CheckResult("vkWaitForFences", returnValue, replay_result);
+    CheckResult("vkWaitForFences", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateSemaphore(
@@ -567,7 +567,7 @@ void VulkanReplayConsumer::Process_vkCreateSemaphore(
     VkSemaphore* out_pSemaphore = pSemaphore->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateSemaphore(in_device, in_pCreateInfo, in_pAllocator, out_pSemaphore);
-    CheckResult("vkCreateSemaphore", returnValue, replay_result);
+    CheckResult("vkCreateSemaphore", returnValue, replay_result, call_info);
 
     AddHandle<SemaphoreInfo>(device, pSemaphore->GetPointer(), out_pSemaphore, &VulkanObjectInfoTable::AddSemaphoreInfo);
 }
@@ -601,7 +601,7 @@ void VulkanReplayConsumer::Process_vkCreateEvent(
     VkEvent* out_pEvent = pEvent->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateEvent(in_device, in_pCreateInfo, in_pAllocator, out_pEvent);
-    CheckResult("vkCreateEvent", returnValue, replay_result);
+    CheckResult("vkCreateEvent", returnValue, replay_result, call_info);
 
     AddHandle<EventInfo>(device, pEvent->GetPointer(), out_pEvent, &VulkanObjectInfoTable::AddEventInfo);
 }
@@ -630,7 +630,7 @@ void VulkanReplayConsumer::Process_vkGetEventStatus(
     auto in_event = GetObjectInfoTable().GetEventInfo(event);
 
     VkResult replay_result = OverrideGetEventStatus(GetDeviceTable(in_device->handle)->GetEventStatus, returnValue, in_device, in_event);
-    CheckResult("vkGetEventStatus", returnValue, replay_result);
+    CheckResult("vkGetEventStatus", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkSetEvent(
@@ -643,7 +643,7 @@ void VulkanReplayConsumer::Process_vkSetEvent(
     VkEvent in_event = MapHandle<EventInfo>(event, &VulkanObjectInfoTable::GetEventInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->SetEvent(in_device, in_event);
-    CheckResult("vkSetEvent", returnValue, replay_result);
+    CheckResult("vkSetEvent", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkResetEvent(
@@ -656,7 +656,7 @@ void VulkanReplayConsumer::Process_vkResetEvent(
     VkEvent in_event = MapHandle<EventInfo>(event, &VulkanObjectInfoTable::GetEventInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->ResetEvent(in_device, in_event);
-    CheckResult("vkResetEvent", returnValue, replay_result);
+    CheckResult("vkResetEvent", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateQueryPool(
@@ -674,7 +674,7 @@ void VulkanReplayConsumer::Process_vkCreateQueryPool(
     VkQueryPool* out_pQueryPool = pQueryPool->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateQueryPool(in_device, in_pCreateInfo, in_pAllocator, out_pQueryPool);
-    CheckResult("vkCreateQueryPool", returnValue, replay_result);
+    CheckResult("vkCreateQueryPool", returnValue, replay_result, call_info);
 
     AddHandle<QueryPoolInfo>(device, pQueryPool->GetPointer(), out_pQueryPool, &VulkanObjectInfoTable::AddQueryPoolInfo);
 }
@@ -710,7 +710,7 @@ void VulkanReplayConsumer::Process_vkGetQueryPoolResults(
     if (!pData->IsNull()) { pData->AllocateOutputData(dataSize); }
 
     VkResult replay_result = OverrideGetQueryPoolResults(GetDeviceTable(in_device->handle)->GetQueryPoolResults, returnValue, in_device, in_queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
-    CheckResult("vkGetQueryPoolResults", returnValue, replay_result);
+    CheckResult("vkGetQueryPoolResults", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateBuffer(
@@ -727,7 +727,7 @@ void VulkanReplayConsumer::Process_vkCreateBuffer(
     pBuffer->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateBuffer(GetDeviceTable(in_device->handle)->CreateBuffer, returnValue, in_device, pCreateInfo, pAllocator, pBuffer);
-    CheckResult("vkCreateBuffer", returnValue, replay_result);
+    CheckResult("vkCreateBuffer", returnValue, replay_result, call_info);
 
     AddHandle<BufferInfo>(device, pBuffer->GetPointer(), pBuffer->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddBufferInfo);
 }
@@ -761,7 +761,7 @@ void VulkanReplayConsumer::Process_vkCreateBufferView(
     VkBufferView* out_pView = pView->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateBufferView(in_device, in_pCreateInfo, in_pAllocator, out_pView);
-    CheckResult("vkCreateBufferView", returnValue, replay_result);
+    CheckResult("vkCreateBufferView", returnValue, replay_result, call_info);
 
     AddHandle<BufferViewInfo>(device, pView->GetPointer(), out_pView, &VulkanObjectInfoTable::AddBufferViewInfo);
 }
@@ -796,7 +796,7 @@ void VulkanReplayConsumer::Process_vkCreateImage(
     pImage->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateImage(GetDeviceTable(in_device->handle)->CreateImage, returnValue, in_device, pCreateInfo, pAllocator, pImage);
-    CheckResult("vkCreateImage", returnValue, replay_result);
+    CheckResult("vkCreateImage", returnValue, replay_result, call_info);
 
     AddHandle<ImageInfo>(device, pImage->GetPointer(), pImage->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageInfo);
 }
@@ -844,7 +844,7 @@ void VulkanReplayConsumer::Process_vkCreateImageView(
     pView->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateImageView(GetDeviceTable(in_device->handle)->CreateImageView, returnValue, in_device, pCreateInfo, pAllocator, pView);
-    CheckResult("vkCreateImageView", returnValue, replay_result);
+    CheckResult("vkCreateImageView", returnValue, replay_result, call_info);
 
     AddHandle<ImageViewInfo>(device, pView->GetPointer(), pView->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageViewInfo);
 }
@@ -879,7 +879,7 @@ void VulkanReplayConsumer::Process_vkCreateShaderModule(
     pShaderModule->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateShaderModule(GetDeviceTable(in_device->handle)->CreateShaderModule, returnValue, in_device, pCreateInfo, pAllocator, pShaderModule);
-    CheckResult("vkCreateShaderModule", returnValue, replay_result);
+    CheckResult("vkCreateShaderModule", returnValue, replay_result, call_info);
 
     AddHandle<ShaderModuleInfo>(device, pShaderModule->GetPointer(), pShaderModule->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddShaderModuleInfo);
 }
@@ -912,7 +912,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineCache(
     pPipelineCache->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreatePipelineCache(GetDeviceTable(in_device->handle)->CreatePipelineCache, returnValue, in_device, pCreateInfo, pAllocator, pPipelineCache);
-    CheckResult("vkCreatePipelineCache", returnValue, replay_result);
+    CheckResult("vkCreatePipelineCache", returnValue, replay_result, call_info);
 
     AddHandle<PipelineCacheInfo>(device, pPipelineCache->GetPointer(), pPipelineCache->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddPipelineCacheInfo);
 }
@@ -945,7 +945,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
     if (!pData->IsNull()) { pData->AllocateOutputData(*pDataSize->GetOutputPointer()); }
 
     VkResult replay_result = OverrideGetPipelineCacheData(GetDeviceTable(in_device->handle)->GetPipelineCacheData, returnValue, in_device, in_pipelineCache, pDataSize, pData);
-    CheckResult("vkGetPipelineCacheData", returnValue, replay_result);
+    CheckResult("vkGetPipelineCacheData", returnValue, replay_result, call_info);
 
     if (pData->IsNull()) { SetOutputArrayCount<PipelineCacheInfo>(pipelineCache, kPipelineCacheArrayGetPipelineCacheData, *pDataSize->GetOutputPointer(), &VulkanObjectInfoTable::GetPipelineCacheInfo); }
 }
@@ -963,7 +963,7 @@ void VulkanReplayConsumer::Process_vkMergePipelineCaches(
     const VkPipelineCache* in_pSrcCaches = MapHandles<PipelineCacheInfo>(pSrcCaches, srcCacheCount, &VulkanObjectInfoTable::GetPipelineCacheInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->MergePipelineCaches(in_device, in_dstCache, srcCacheCount, in_pSrcCaches);
-    CheckResult("vkMergePipelineCaches", returnValue, replay_result);
+    CheckResult("vkMergePipelineCaches", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
@@ -985,7 +985,7 @@ void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
     VkPipeline* out_pPipelines = pPipelines->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateGraphicsPipelines(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
-    CheckResult("vkCreateGraphicsPipelines", returnValue, replay_result);
+    CheckResult("vkCreateGraphicsPipelines", returnValue, replay_result, call_info);
 
     AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
 }
@@ -1009,7 +1009,7 @@ void VulkanReplayConsumer::Process_vkCreateComputePipelines(
     VkPipeline* out_pPipelines = pPipelines->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateComputePipelines(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
-    CheckResult("vkCreateComputePipelines", returnValue, replay_result);
+    CheckResult("vkCreateComputePipelines", returnValue, replay_result, call_info);
 
     AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
 }
@@ -1044,7 +1044,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
     VkPipelineLayout* out_pPipelineLayout = pPipelineLayout->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreatePipelineLayout(in_device, in_pCreateInfo, in_pAllocator, out_pPipelineLayout);
-    CheckResult("vkCreatePipelineLayout", returnValue, replay_result);
+    CheckResult("vkCreatePipelineLayout", returnValue, replay_result, call_info);
 
     AddHandle<PipelineLayoutInfo>(device, pPipelineLayout->GetPointer(), out_pPipelineLayout, &VulkanObjectInfoTable::AddPipelineLayoutInfo);
 }
@@ -1079,7 +1079,7 @@ void VulkanReplayConsumer::Process_vkCreateSampler(
     VkSampler* out_pSampler = pSampler->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateSampler(in_device, in_pCreateInfo, in_pAllocator, out_pSampler);
-    CheckResult("vkCreateSampler", returnValue, replay_result);
+    CheckResult("vkCreateSampler", returnValue, replay_result, call_info);
 
     AddHandle<SamplerInfo>(device, pSampler->GetPointer(), out_pSampler, &VulkanObjectInfoTable::AddSamplerInfo);
 }
@@ -1114,7 +1114,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorSetLayout(
     VkDescriptorSetLayout* out_pSetLayout = pSetLayout->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateDescriptorSetLayout(in_device, in_pCreateInfo, in_pAllocator, out_pSetLayout);
-    CheckResult("vkCreateDescriptorSetLayout", returnValue, replay_result);
+    CheckResult("vkCreateDescriptorSetLayout", returnValue, replay_result, call_info);
 
     AddHandle<DescriptorSetLayoutInfo>(device, pSetLayout->GetPointer(), out_pSetLayout, &VulkanObjectInfoTable::AddDescriptorSetLayoutInfo);
 }
@@ -1147,7 +1147,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
     pDescriptorPool->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateDescriptorPool(GetDeviceTable(in_device->handle)->CreateDescriptorPool, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorPool);
-    CheckResult("vkCreateDescriptorPool", returnValue, replay_result);
+    CheckResult("vkCreateDescriptorPool", returnValue, replay_result, call_info);
 
     AddHandle<DescriptorPoolInfo>(device, pDescriptorPool->GetPointer(), pDescriptorPool->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorPoolInfo);
 }
@@ -1176,7 +1176,7 @@ void VulkanReplayConsumer::Process_vkResetDescriptorPool(
     auto in_descriptorPool = GetObjectInfoTable().GetDescriptorPoolInfo(descriptorPool);
 
     VkResult replay_result = OverrideResetDescriptorPool(GetDeviceTable(in_device->handle)->ResetDescriptorPool, returnValue, in_device, in_descriptorPool, flags);
-    CheckResult("vkResetDescriptorPool", returnValue, replay_result);
+    CheckResult("vkResetDescriptorPool", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
@@ -1194,7 +1194,7 @@ void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
     for (size_t i = 0; i < pAllocateInfo->GetPointer()->descriptorSetCount; ++i) { pDescriptorSets->SetConsumerData(i, &handle_info[i]); }
 
     VkResult replay_result = OverrideAllocateDescriptorSets(GetDeviceTable(in_device->handle)->AllocateDescriptorSets, returnValue, in_device, pAllocateInfo, pDescriptorSets);
-    CheckResult("vkAllocateDescriptorSets", returnValue, replay_result);
+    CheckResult("vkAllocateDescriptorSets", returnValue, replay_result, call_info);
 
     AddPoolHandles<DescriptorPoolInfo, DescriptorSetInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pDescriptorSets->GetPointer(), pDescriptorSets->GetLength(), pDescriptorSets->GetHandlePointer(), pAllocateInfo->GetPointer()->descriptorSetCount, std::move(handle_info), &VulkanObjectInfoTable::GetDescriptorPoolInfo, &VulkanObjectInfoTable::AddDescriptorSetInfo);
 }
@@ -1212,7 +1212,7 @@ void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
     const VkDescriptorSet* in_pDescriptorSets = MapHandles<DescriptorSetInfo>(pDescriptorSets, descriptorSetCount, &VulkanObjectInfoTable::GetDescriptorSetInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->FreeDescriptorSets(in_device, in_descriptorPool, descriptorSetCount, in_pDescriptorSets);
-    CheckResult("vkFreeDescriptorSets", returnValue, replay_result);
+    CheckResult("vkFreeDescriptorSets", returnValue, replay_result, call_info);
     RemovePoolHandles<DescriptorPoolInfo, DescriptorSetInfo>(descriptorPool, pDescriptorSets, descriptorSetCount, &VulkanObjectInfoTable::GetDescriptorPoolInfo, &VulkanObjectInfoTable::RemoveDescriptorSetInfo);
 }
 
@@ -1249,7 +1249,7 @@ void VulkanReplayConsumer::Process_vkCreateFramebuffer(
     pFramebuffer->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateFramebuffer(GetDeviceTable(in_device->handle)->CreateFramebuffer, returnValue, in_device, pCreateInfo, pAllocator, pFramebuffer);
-    CheckResult("vkCreateFramebuffer", returnValue, replay_result);
+    CheckResult("vkCreateFramebuffer", returnValue, replay_result, call_info);
 
     AddHandle<FramebufferInfo>(device, pFramebuffer->GetPointer(), pFramebuffer->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddFramebufferInfo);
 }
@@ -1282,7 +1282,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass(
     pRenderPass->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateRenderPass(GetDeviceTable(in_device->handle)->CreateRenderPass, returnValue, in_device, pCreateInfo, pAllocator, pRenderPass);
-    CheckResult("vkCreateRenderPass", returnValue, replay_result);
+    CheckResult("vkCreateRenderPass", returnValue, replay_result, call_info);
 
     AddHandle<RenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddRenderPassInfo);
 }
@@ -1329,7 +1329,7 @@ void VulkanReplayConsumer::Process_vkCreateCommandPool(
     VkCommandPool* out_pCommandPool = pCommandPool->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateCommandPool(in_device, in_pCreateInfo, in_pAllocator, out_pCommandPool);
-    CheckResult("vkCreateCommandPool", returnValue, replay_result);
+    CheckResult("vkCreateCommandPool", returnValue, replay_result, call_info);
 
     AddHandle<CommandPoolInfo>(device, pCommandPool->GetPointer(), out_pCommandPool, &VulkanObjectInfoTable::AddCommandPoolInfo);
 }
@@ -1359,7 +1359,7 @@ void VulkanReplayConsumer::Process_vkResetCommandPool(
     VkCommandPool in_commandPool = MapHandle<CommandPoolInfo>(commandPool, &VulkanObjectInfoTable::GetCommandPoolInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->ResetCommandPool(in_device, in_commandPool, flags);
-    CheckResult("vkResetCommandPool", returnValue, replay_result);
+    CheckResult("vkResetCommandPool", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
@@ -1377,7 +1377,7 @@ void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
     for (size_t i = 0; i < pAllocateInfo->GetPointer()->commandBufferCount; ++i) { pCommandBuffers->SetConsumerData(i, &handle_info[i]); }
 
     VkResult replay_result = OverrideAllocateCommandBuffers(GetDeviceTable(in_device->handle)->AllocateCommandBuffers, returnValue, in_device, pAllocateInfo, pCommandBuffers);
-    CheckResult("vkAllocateCommandBuffers", returnValue, replay_result);
+    CheckResult("vkAllocateCommandBuffers", returnValue, replay_result, call_info);
 
     AddPoolHandles<CommandPoolInfo, CommandBufferInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pCommandBuffers->GetPointer(), pCommandBuffers->GetLength(), pCommandBuffers->GetHandlePointer(), pAllocateInfo->GetPointer()->commandBufferCount, std::move(handle_info), &VulkanObjectInfoTable::GetCommandPoolInfo, &VulkanObjectInfoTable::AddCommandBufferInfo);
 }
@@ -1408,7 +1408,7 @@ void VulkanReplayConsumer::Process_vkBeginCommandBuffer(
     MapStructHandles(pBeginInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideBeginCommandBuffer(GetDeviceTable(in_commandBuffer->handle)->BeginCommandBuffer, returnValue, in_commandBuffer, pBeginInfo);
-    CheckResult("vkBeginCommandBuffer", returnValue, replay_result);
+    CheckResult("vkBeginCommandBuffer", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkEndCommandBuffer(
@@ -1419,7 +1419,7 @@ void VulkanReplayConsumer::Process_vkEndCommandBuffer(
     VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->EndCommandBuffer(in_commandBuffer);
-    CheckResult("vkEndCommandBuffer", returnValue, replay_result);
+    CheckResult("vkEndCommandBuffer", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkResetCommandBuffer(
@@ -1431,7 +1431,7 @@ void VulkanReplayConsumer::Process_vkResetCommandBuffer(
     auto in_commandBuffer = GetObjectInfoTable().GetCommandBufferInfo(commandBuffer);
 
     VkResult replay_result = OverrideResetCommandBuffer(GetDeviceTable(in_commandBuffer->handle)->ResetCommandBuffer, returnValue, in_commandBuffer, flags);
-    CheckResult("vkResetCommandBuffer", returnValue, replay_result);
+    CheckResult("vkResetCommandBuffer", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindPipeline(
@@ -2070,7 +2070,7 @@ void VulkanReplayConsumer::Process_vkBindBufferMemory2(
     MapStructArrayHandles(pBindInfos->GetMetaStructPointer(), pBindInfos->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideBindBufferMemory2(GetDeviceTable(in_device->handle)->BindBufferMemory2, returnValue, in_device, bindInfoCount, pBindInfos);
-    CheckResult("vkBindBufferMemory2", returnValue, replay_result);
+    CheckResult("vkBindBufferMemory2", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkBindImageMemory2(
@@ -2085,7 +2085,7 @@ void VulkanReplayConsumer::Process_vkBindImageMemory2(
     MapStructArrayHandles(pBindInfos->GetMetaStructPointer(), pBindInfos->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideBindImageMemory2(GetDeviceTable(in_device->handle)->BindImageMemory2, returnValue, in_device, bindInfoCount, pBindInfos);
-    CheckResult("vkBindImageMemory2", returnValue, replay_result);
+    CheckResult("vkBindImageMemory2", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
@@ -2140,7 +2140,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     if (!pPhysicalDeviceGroupProperties->IsNull()) { pPhysicalDeviceGroupProperties->AllocateOutputData(*pPhysicalDeviceGroupCount->GetOutputPointer(), VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideEnumeratePhysicalDeviceGroups(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDeviceGroups, returnValue, in_instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    CheckResult("vkEnumeratePhysicalDeviceGroups", returnValue, replay_result);
+    CheckResult("vkEnumeratePhysicalDeviceGroups", returnValue, replay_result, call_info);
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroups, *pPhysicalDeviceGroupCount->GetOutputPointer(), &VulkanObjectInfoTable::GetInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), pPhysicalDeviceGroupProperties->GetOutputPointer(), *pPhysicalDeviceGroupCount->GetOutputPointer(), &GetObjectInfoTable());
@@ -2244,7 +2244,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
     InitializeOutputStructPNext(pImageFormatProperties);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceImageFormatProperties2(in_physicalDevice, in_pImageFormatInfo, out_pImageFormatProperties);
-    CheckResult("vkGetPhysicalDeviceImageFormatProperties2", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceImageFormatProperties2", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
@@ -2334,7 +2334,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
     VkSamplerYcbcrConversion* out_pYcbcrConversion = pYcbcrConversion->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversion(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
-    CheckResult("vkCreateSamplerYcbcrConversion", returnValue, replay_result);
+    CheckResult("vkCreateSamplerYcbcrConversion", returnValue, replay_result, call_info);
 
     AddHandle<SamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddSamplerYcbcrConversionInfo);
 }
@@ -2369,7 +2369,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
     pDescriptorUpdateTemplate->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->CreateDescriptorUpdateTemplate, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
-    CheckResult("vkCreateDescriptorUpdateTemplate", returnValue, replay_result);
+    CheckResult("vkCreateDescriptorUpdateTemplate", returnValue, replay_result, call_info);
 
     AddHandle<DescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorUpdateTemplateInfo);
 }
@@ -2492,7 +2492,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2(
     pRenderPass->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateRenderPass2(GetDeviceTable(in_device->handle)->CreateRenderPass2, returnValue, in_device, pCreateInfo, pAllocator, pRenderPass);
-    CheckResult("vkCreateRenderPass2", returnValue, replay_result);
+    CheckResult("vkCreateRenderPass2", returnValue, replay_result, call_info);
 
     AddHandle<RenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddRenderPassInfo);
 }
@@ -2560,7 +2560,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValue(
     uint64_t* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreCounterValue(in_device, in_semaphore, out_pValue);
-    CheckResult("vkGetSemaphoreCounterValue", returnValue, replay_result);
+    CheckResult("vkGetSemaphoreCounterValue", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkWaitSemaphores(
@@ -2575,7 +2575,7 @@ void VulkanReplayConsumer::Process_vkWaitSemaphores(
     MapStructHandles(pWaitInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideWaitSemaphores(GetDeviceTable(in_device->handle)->WaitSemaphores, returnValue, in_device, pWaitInfo, timeout);
-    CheckResult("vkWaitSemaphores", returnValue, replay_result);
+    CheckResult("vkWaitSemaphores", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkSignalSemaphore(
@@ -2589,7 +2589,7 @@ void VulkanReplayConsumer::Process_vkSignalSemaphore(
     MapStructHandles(pSignalInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->SignalSemaphore(in_device, in_pSignalInfo);
-    CheckResult("vkSignalSemaphore", returnValue, replay_result);
+    CheckResult("vkSignalSemaphore", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddress(
@@ -2643,7 +2643,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolProperties(
     if (!pToolProperties->IsNull()) { pToolProperties->AllocateOutputData(*pToolCount->GetOutputPointer(), VkPhysicalDeviceToolProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideGetPhysicalDeviceToolProperties(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceToolProperties, returnValue, in_physicalDevice, pToolCount, pToolProperties);
-    CheckResult("vkGetPhysicalDeviceToolProperties", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceToolProperties", returnValue, replay_result, call_info);
 
     if (pToolProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolProperties, *pToolCount->GetOutputPointer(), &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -2663,7 +2663,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlot(
     VkPrivateDataSlot* out_pPrivateDataSlot = pPrivateDataSlot->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreatePrivateDataSlot(in_device, in_pCreateInfo, in_pAllocator, out_pPrivateDataSlot);
-    CheckResult("vkCreatePrivateDataSlot", returnValue, replay_result);
+    CheckResult("vkCreatePrivateDataSlot", returnValue, replay_result, call_info);
 
     AddHandle<PrivateDataSlotInfo>(device, pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &VulkanObjectInfoTable::AddPrivateDataSlotInfo);
 }
@@ -2696,7 +2696,7 @@ void VulkanReplayConsumer::Process_vkSetPrivateData(
     VkPrivateDataSlot in_privateDataSlot = MapHandle<PrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetPrivateDataSlotInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->SetPrivateData(in_device, objectType, in_objectHandle, in_privateDataSlot, data);
-    CheckResult("vkSetPrivateData", returnValue, replay_result);
+    CheckResult("vkSetPrivateData", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPrivateData(
@@ -2795,7 +2795,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2(
     auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
 
     VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2, returnValue, in_queue, submitCount, pSubmits, in_fence);
-    CheckResult("vkQueueSubmit2", returnValue, replay_result);
+    CheckResult("vkQueueSubmit2", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBuffer2(
@@ -3133,7 +3133,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
     VkBool32* out_pSupported = pSupported->IsNull() ? nullptr : pSupported->AllocateOutputData(1, static_cast<VkBool32>(0));
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceSupportKHR(in_physicalDevice, queueFamilyIndex, in_surface, out_pSupported);
-    CheckResult("vkGetPhysicalDeviceSurfaceSupportKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfaceSupportKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
@@ -3149,7 +3149,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1);
 
     VkResult replay_result = OverrideGetPhysicalDeviceSurfaceCapabilitiesKHR(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceSurfaceCapabilitiesKHR, returnValue, in_physicalDevice, in_surface, pSurfaceCapabilities);
-    CheckResult("vkGetPhysicalDeviceSurfaceCapabilitiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfaceCapabilitiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
@@ -3167,7 +3167,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
     VkSurfaceFormatKHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormatsKHR(in_physicalDevice, in_surface, out_pSurfaceFormatCount, out_pSurfaceFormats);
-    CheckResult("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, replay_result, call_info);
 
     if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<SurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, *out_pSurfaceFormatCount, &VulkanObjectInfoTable::GetSurfaceKHRInfo); }
 }
@@ -3187,7 +3187,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModesKHR(in_physicalDevice, in_surface, out_pPresentModeCount, out_pPresentModes);
-    CheckResult("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, replay_result, call_info);
 
     if (pPresentModes->IsNull()) { SetOutputArrayCount<SurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, *out_pPresentModeCount, &VulkanObjectInfoTable::GetSurfaceKHRInfo); }
 }
@@ -3208,7 +3208,7 @@ void VulkanReplayConsumer::Process_vkCreateSwapchainKHR(
     pSwapchain->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateSwapchainKHR(GetDeviceTable(in_device->handle)->CreateSwapchainKHR, returnValue, in_device, pCreateInfo, pAllocator, pSwapchain);
-    CheckResult("vkCreateSwapchainKHR", returnValue, replay_result);
+    CheckResult("vkCreateSwapchainKHR", returnValue, replay_result, call_info);
 
     AddHandle<SwapchainKHRInfo>(device, pSwapchain->GetPointer(), pSwapchain->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSwapchainKHRInfo);
 }
@@ -3242,7 +3242,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
     for (size_t i = 0; i < *pSwapchainImageCount->GetOutputPointer(); ++i) { pSwapchainImages->SetConsumerData(i, &handle_info[i]); }
 
     VkResult replay_result = OverrideGetSwapchainImagesKHR(GetDeviceTable(in_device->handle)->GetSwapchainImagesKHR, returnValue, in_device, in_swapchain, pSwapchainImageCount, pSwapchainImages);
-    CheckResult("vkGetSwapchainImagesKHR", returnValue, replay_result);
+    CheckResult("vkGetSwapchainImagesKHR", returnValue, replay_result, call_info);
 
     if (pSwapchainImages->IsNull()) { SetOutputArrayCount<SwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, *pSwapchainImageCount->GetOutputPointer(), &VulkanObjectInfoTable::GetSwapchainKHRInfo); }
     AddHandles<ImageInfo>(device, pSwapchainImages->GetPointer(), pSwapchainImages->GetLength(), pSwapchainImages->GetHandlePointer(), *pSwapchainImageCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageInfo);
@@ -3265,7 +3265,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
     pImageIndex->IsNull() ? nullptr : pImageIndex->AllocateOutputData(1, static_cast<uint32_t>(0));
 
     VkResult replay_result = OverrideAcquireNextImageKHR(GetDeviceTable(in_device->handle)->AcquireNextImageKHR, returnValue, in_device, in_swapchain, timeout, in_semaphore, in_fence, pImageIndex);
-    CheckResult("vkAcquireNextImageKHR", returnValue, replay_result);
+    CheckResult("vkAcquireNextImageKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkQueuePresentKHR(
@@ -3279,7 +3279,7 @@ void VulkanReplayConsumer::Process_vkQueuePresentKHR(
     MapStructHandles(pPresentInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideQueuePresentKHR(GetDeviceTable(in_queue->handle)->QueuePresentKHR, returnValue, in_queue, pPresentInfo);
-    CheckResult("vkQueuePresentKHR", returnValue, replay_result);
+    CheckResult("vkQueuePresentKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
@@ -3293,7 +3293,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
     InitializeOutputStructPNext(pDeviceGroupPresentCapabilities);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeviceGroupPresentCapabilitiesKHR(in_device, out_pDeviceGroupPresentCapabilities);
-    CheckResult("vkGetDeviceGroupPresentCapabilitiesKHR", returnValue, replay_result);
+    CheckResult("vkGetDeviceGroupPresentCapabilitiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
@@ -3309,7 +3309,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
     VkDeviceGroupPresentModeFlagsKHR* out_pModes = pModes->IsNull() ? nullptr : pModes->AllocateOutputData(1, static_cast<VkDeviceGroupPresentModeFlagsKHR>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeviceGroupSurfacePresentModesKHR(in_device, in_surface, out_pModes);
-    CheckResult("vkGetDeviceGroupSurfacePresentModesKHR", returnValue, replay_result);
+    CheckResult("vkGetDeviceGroupSurfacePresentModesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
@@ -3327,7 +3327,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
     VkRect2D* out_pRects = pRects->IsNull() ? nullptr : pRects->AllocateOutputData(*out_pRectCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDevicePresentRectanglesKHR(in_physicalDevice, in_surface, out_pRectCount, out_pRects);
-    CheckResult("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, replay_result, call_info);
 
     if (pRects->IsNull()) { SetOutputArrayCount<SurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, *out_pRectCount, &VulkanObjectInfoTable::GetSurfaceKHRInfo); }
 }
@@ -3345,7 +3345,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImage2KHR(
     pImageIndex->IsNull() ? nullptr : pImageIndex->AllocateOutputData(1, static_cast<uint32_t>(0));
 
     VkResult replay_result = OverrideAcquireNextImage2KHR(GetDeviceTable(in_device->handle)->AcquireNextImage2KHR, returnValue, in_device, pAcquireInfo, pImageIndex);
-    CheckResult("vkAcquireNextImage2KHR", returnValue, replay_result);
+    CheckResult("vkAcquireNextImage2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
@@ -3360,7 +3360,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     VkDisplayPropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -3378,7 +3378,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     VkDisplayPlanePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -3398,7 +3398,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     VkDisplayKHR* out_pDisplays = pDisplays->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneSupportedDisplaysKHR(in_physicalDevice, planeIndex, out_pDisplayCount, out_pDisplays);
-    CheckResult("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, replay_result);
+    CheckResult("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, replay_result, call_info);
 
     if (pDisplays->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, *out_pDisplayCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddHandles<DisplayKHRInfo>(physicalDevice, pDisplays->GetPointer(), pDisplays->GetLength(), out_pDisplays, *out_pDisplayCount, &VulkanObjectInfoTable::AddDisplayKHRInfo);
@@ -3418,7 +3418,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
     VkDisplayModePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModePropertiesKHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetDisplayModePropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetDisplayModePropertiesKHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -3441,7 +3441,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
     VkDisplayModeKHR* out_pMode = pMode->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->CreateDisplayModeKHR(in_physicalDevice, in_display, in_pCreateInfo, in_pAllocator, out_pMode);
-    CheckResult("vkCreateDisplayModeKHR", returnValue, replay_result);
+    CheckResult("vkCreateDisplayModeKHR", returnValue, replay_result, call_info);
 
     AddHandle<DisplayModeKHRInfo>(physicalDevice, pMode->GetPointer(), out_pMode, &VulkanObjectInfoTable::AddDisplayModeKHRInfo);
 }
@@ -3459,7 +3459,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
     VkDisplayPlaneCapabilitiesKHR* out_pCapabilities = pCapabilities->IsNull() ? nullptr : pCapabilities->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneCapabilitiesKHR(in_physicalDevice, in_mode, planeIndex, out_pCapabilities);
-    CheckResult("vkGetDisplayPlaneCapabilitiesKHR", returnValue, replay_result);
+    CheckResult("vkGetDisplayPlaneCapabilitiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
@@ -3478,7 +3478,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateDisplayPlaneSurfaceKHR(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateDisplayPlaneSurfaceKHR", returnValue, replay_result);
+    CheckResult("vkCreateDisplayPlaneSurfaceKHR", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -3500,7 +3500,7 @@ void VulkanReplayConsumer::Process_vkCreateSharedSwapchainsKHR(
     VkSwapchainKHR* out_pSwapchains = pSwapchains->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateSharedSwapchainsKHR(in_device, swapchainCount, in_pCreateInfos, in_pAllocator, out_pSwapchains);
-    CheckResult("vkCreateSharedSwapchainsKHR", returnValue, replay_result);
+    CheckResult("vkCreateSharedSwapchainsKHR", returnValue, replay_result, call_info);
 
     AddHandles<SwapchainKHRInfo>(device, pSwapchains->GetPointer(), pSwapchains->GetLength(), out_pSwapchains, swapchainCount, &VulkanObjectInfoTable::AddSwapchainKHRInfo);
 }
@@ -3519,7 +3519,7 @@ void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
     pSurface->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateXlibSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateXlibSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
-    CheckResult("vkCreateXlibSurfaceKHR", returnValue, replay_result);
+    CheckResult("vkCreateXlibSurfaceKHR", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -3552,7 +3552,7 @@ void VulkanReplayConsumer::Process_vkCreateXcbSurfaceKHR(
     pSurface->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateXcbSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateXcbSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
-    CheckResult("vkCreateXcbSurfaceKHR", returnValue, replay_result);
+    CheckResult("vkCreateXcbSurfaceKHR", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -3585,7 +3585,7 @@ void VulkanReplayConsumer::Process_vkCreateWaylandSurfaceKHR(
     pSurface->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateWaylandSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateWaylandSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
-    CheckResult("vkCreateWaylandSurfaceKHR", returnValue, replay_result);
+    CheckResult("vkCreateWaylandSurfaceKHR", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -3617,7 +3617,7 @@ void VulkanReplayConsumer::Process_vkCreateAndroidSurfaceKHR(
     pSurface->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateAndroidSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateAndroidSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
-    CheckResult("vkCreateAndroidSurfaceKHR", returnValue, replay_result);
+    CheckResult("vkCreateAndroidSurfaceKHR", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -3636,7 +3636,7 @@ void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
     pSurface->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateWin32SurfaceKHR(GetInstanceTable(in_instance->handle)->CreateWin32SurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
-    CheckResult("vkCreateWin32SurfaceKHR", returnValue, replay_result);
+    CheckResult("vkCreateWin32SurfaceKHR", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -3665,7 +3665,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoCapabilitiesKHR(
     InitializeOutputStructPNext(pCapabilities);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceVideoCapabilitiesKHR(in_physicalDevice, in_pVideoProfile, out_pCapabilities);
-    CheckResult("vkGetPhysicalDeviceVideoCapabilitiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceVideoCapabilitiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoFormatPropertiesKHR(
@@ -3682,7 +3682,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoFormatPropertiesKHR(
     VkVideoFormatPropertiesKHR* out_pVideoFormatProperties = pVideoFormatProperties->IsNull() ? nullptr : pVideoFormatProperties->AllocateOutputData(*out_pVideoFormatPropertyCount, VkVideoFormatPropertiesKHR{ VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceVideoFormatPropertiesKHR(in_physicalDevice, in_pVideoFormatInfo, out_pVideoFormatPropertyCount, out_pVideoFormatProperties);
-    CheckResult("vkGetPhysicalDeviceVideoFormatPropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceVideoFormatPropertiesKHR", returnValue, replay_result, call_info);
 
     if (pVideoFormatProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceVideoFormatPropertiesKHR, *out_pVideoFormatPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -3702,7 +3702,7 @@ void VulkanReplayConsumer::Process_vkCreateVideoSessionKHR(
     VkVideoSessionKHR* out_pVideoSession = pVideoSession->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateVideoSessionKHR(in_device, in_pCreateInfo, in_pAllocator, out_pVideoSession);
-    CheckResult("vkCreateVideoSessionKHR", returnValue, replay_result);
+    CheckResult("vkCreateVideoSessionKHR", returnValue, replay_result, call_info);
 
     AddHandle<VideoSessionKHRInfo>(device, pVideoSession->GetPointer(), out_pVideoSession, &VulkanObjectInfoTable::AddVideoSessionKHRInfo);
 }
@@ -3735,7 +3735,7 @@ void VulkanReplayConsumer::Process_vkGetVideoSessionMemoryRequirementsKHR(
     VkVideoSessionMemoryRequirementsKHR* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(*out_pMemoryRequirementsCount, VkVideoSessionMemoryRequirementsKHR{ VK_STRUCTURE_TYPE_VIDEO_SESSION_MEMORY_REQUIREMENTS_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetVideoSessionMemoryRequirementsKHR(in_device, in_videoSession, out_pMemoryRequirementsCount, out_pMemoryRequirements);
-    CheckResult("vkGetVideoSessionMemoryRequirementsKHR", returnValue, replay_result);
+    CheckResult("vkGetVideoSessionMemoryRequirementsKHR", returnValue, replay_result, call_info);
 
     if (pMemoryRequirements->IsNull()) { SetOutputArrayCount<VideoSessionKHRInfo>(videoSession, kVideoSessionKHRArrayGetVideoSessionMemoryRequirementsKHR, *out_pMemoryRequirementsCount, &VulkanObjectInfoTable::GetVideoSessionKHRInfo); }
 }
@@ -3754,7 +3754,7 @@ void VulkanReplayConsumer::Process_vkBindVideoSessionMemoryKHR(
     MapStructArrayHandles(pBindSessionMemoryInfos->GetMetaStructPointer(), pBindSessionMemoryInfos->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->BindVideoSessionMemoryKHR(in_device, in_videoSession, bindSessionMemoryInfoCount, in_pBindSessionMemoryInfos);
-    CheckResult("vkBindVideoSessionMemoryKHR", returnValue, replay_result);
+    CheckResult("vkBindVideoSessionMemoryKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateVideoSessionParametersKHR(
@@ -3773,7 +3773,7 @@ void VulkanReplayConsumer::Process_vkCreateVideoSessionParametersKHR(
     VkVideoSessionParametersKHR* out_pVideoSessionParameters = pVideoSessionParameters->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateVideoSessionParametersKHR(in_device, in_pCreateInfo, in_pAllocator, out_pVideoSessionParameters);
-    CheckResult("vkCreateVideoSessionParametersKHR", returnValue, replay_result);
+    CheckResult("vkCreateVideoSessionParametersKHR", returnValue, replay_result, call_info);
 
     AddHandle<VideoSessionParametersKHRInfo>(device, pVideoSessionParameters->GetPointer(), out_pVideoSessionParameters, &VulkanObjectInfoTable::AddVideoSessionParametersKHRInfo);
 }
@@ -3790,7 +3790,7 @@ void VulkanReplayConsumer::Process_vkUpdateVideoSessionParametersKHR(
     const VkVideoSessionParametersUpdateInfoKHR* in_pUpdateInfo = pUpdateInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->UpdateVideoSessionParametersKHR(in_device, in_videoSessionParameters, in_pUpdateInfo);
-    CheckResult("vkUpdateVideoSessionParametersKHR", returnValue, replay_result);
+    CheckResult("vkUpdateVideoSessionParametersKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyVideoSessionParametersKHR(
@@ -3924,7 +3924,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
     InitializeOutputStructPNext(pImageFormatProperties);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceImageFormatProperties2KHR(in_physicalDevice, in_pImageFormatInfo, out_pImageFormatProperties);
-    CheckResult("vkGetPhysicalDeviceImageFormatProperties2KHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceImageFormatProperties2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
@@ -4035,7 +4035,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     if (!pPhysicalDeviceGroupProperties->IsNull()) { pPhysicalDeviceGroupProperties->AllocateOutputData(*pPhysicalDeviceGroupCount->GetOutputPointer(), VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideEnumeratePhysicalDeviceGroups(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDeviceGroupsKHR, returnValue, in_instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
-    CheckResult("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, replay_result);
+    CheckResult("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, replay_result, call_info);
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, *pPhysicalDeviceGroupCount->GetOutputPointer(), &VulkanObjectInfoTable::GetInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), pPhysicalDeviceGroupProperties->GetOutputPointer(), *pPhysicalDeviceGroupCount->GetOutputPointer(), &GetObjectInfoTable());
@@ -4068,7 +4068,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleKHR(
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryWin32HandleKHR(in_device, in_pGetWin32HandleInfo, out_pHandle);
-    CheckResult("vkGetMemoryWin32HandleKHR", returnValue, replay_result);
+    CheckResult("vkGetMemoryWin32HandleKHR", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*pHandle->GetPointer()), static_cast<void*>(*out_pHandle), format::ApiCallId::ApiCall_vkGetMemoryWin32HandleKHR, "vkGetMemoryWin32HandleKHR");
 }
@@ -4087,7 +4087,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
     InitializeOutputStructPNext(pMemoryWin32HandleProperties);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryWin32HandlePropertiesKHR(in_device, handleType, in_handle, out_pMemoryWin32HandleProperties);
-    CheckResult("vkGetMemoryWin32HandlePropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetMemoryWin32HandlePropertiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryFdKHR(
@@ -4103,7 +4103,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdKHR(
     int* out_pFd = pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryFdKHR(in_device, in_pGetFdInfo, out_pFd);
-    CheckResult("vkGetMemoryFdKHR", returnValue, replay_result);
+    CheckResult("vkGetMemoryFdKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryFdPropertiesKHR(
@@ -4119,7 +4119,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdPropertiesKHR(
     InitializeOutputStructPNext(pMemoryFdProperties);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryFdPropertiesKHR(in_device, handleType, fd, out_pMemoryFdProperties);
-    CheckResult("vkGetMemoryFdPropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetMemoryFdPropertiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
@@ -4147,7 +4147,7 @@ void VulkanReplayConsumer::Process_vkImportSemaphoreWin32HandleKHR(
     MapStructHandles(pImportSemaphoreWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideImportSemaphoreWin32HandleKHR(GetDeviceTable(in_device->handle)->ImportSemaphoreWin32HandleKHR, returnValue, in_device, pImportSemaphoreWin32HandleInfo);
-    CheckResult("vkImportSemaphoreWin32HandleKHR", returnValue, replay_result);
+    CheckResult("vkImportSemaphoreWin32HandleKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreWin32HandleKHR(
@@ -4163,7 +4163,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreWin32HandleKHR(
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreWin32HandleKHR(in_device, in_pGetWin32HandleInfo, out_pHandle);
-    CheckResult("vkGetSemaphoreWin32HandleKHR", returnValue, replay_result);
+    CheckResult("vkGetSemaphoreWin32HandleKHR", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*pHandle->GetPointer()), static_cast<void*>(*out_pHandle), format::ApiCallId::ApiCall_vkGetSemaphoreWin32HandleKHR, "vkGetSemaphoreWin32HandleKHR");
 }
@@ -4179,7 +4179,7 @@ void VulkanReplayConsumer::Process_vkImportSemaphoreFdKHR(
     MapStructHandles(pImportSemaphoreFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideImportSemaphoreFdKHR(GetDeviceTable(in_device->handle)->ImportSemaphoreFdKHR, returnValue, in_device, pImportSemaphoreFdInfo);
-    CheckResult("vkImportSemaphoreFdKHR", returnValue, replay_result);
+    CheckResult("vkImportSemaphoreFdKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreFdKHR(
@@ -4195,7 +4195,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreFdKHR(
     pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
 
     VkResult replay_result = OverrideGetSemaphoreFdKHR(GetDeviceTable(in_device->handle)->GetSemaphoreFdKHR, returnValue, in_device, pGetFdInfo, pFd);
-    CheckResult("vkGetSemaphoreFdKHR", returnValue, replay_result);
+    CheckResult("vkGetSemaphoreFdKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdPushDescriptorSetKHR(
@@ -4231,7 +4231,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     pDescriptorUpdateTemplate->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->CreateDescriptorUpdateTemplateKHR, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
-    CheckResult("vkCreateDescriptorUpdateTemplateKHR", returnValue, replay_result);
+    CheckResult("vkCreateDescriptorUpdateTemplateKHR", returnValue, replay_result, call_info);
 
     AddHandle<DescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorUpdateTemplateInfo);
 }
@@ -4263,7 +4263,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
     pRenderPass->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateRenderPass2(GetDeviceTable(in_device->handle)->CreateRenderPass2KHR, returnValue, in_device, pCreateInfo, pAllocator, pRenderPass);
-    CheckResult("vkCreateRenderPass2KHR", returnValue, replay_result);
+    CheckResult("vkCreateRenderPass2KHR", returnValue, replay_result, call_info);
 
     AddHandle<RenderPassInfo>(device, pRenderPass->GetPointer(), pRenderPass->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddRenderPassInfo);
 }
@@ -4317,7 +4317,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainStatusKHR(
     if (GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().GetSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().GetSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSwapchainStatusKHR(in_device, in_swapchain);
-    CheckResult("vkGetSwapchainStatusKHR", returnValue, replay_result);
+    CheckResult("vkGetSwapchainStatusKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
@@ -4345,7 +4345,7 @@ void VulkanReplayConsumer::Process_vkImportFenceWin32HandleKHR(
     MapStructHandles(pImportFenceWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->ImportFenceWin32HandleKHR(in_device, in_pImportFenceWin32HandleInfo);
-    CheckResult("vkImportFenceWin32HandleKHR", returnValue, replay_result);
+    CheckResult("vkImportFenceWin32HandleKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetFenceWin32HandleKHR(
@@ -4361,7 +4361,7 @@ void VulkanReplayConsumer::Process_vkGetFenceWin32HandleKHR(
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetFenceWin32HandleKHR(in_device, in_pGetWin32HandleInfo, out_pHandle);
-    CheckResult("vkGetFenceWin32HandleKHR", returnValue, replay_result);
+    CheckResult("vkGetFenceWin32HandleKHR", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*pHandle->GetPointer()), static_cast<void*>(*out_pHandle), format::ApiCallId::ApiCall_vkGetFenceWin32HandleKHR, "vkGetFenceWin32HandleKHR");
 }
@@ -4377,7 +4377,7 @@ void VulkanReplayConsumer::Process_vkImportFenceFdKHR(
     MapStructHandles(pImportFenceFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->ImportFenceFdKHR(in_device, in_pImportFenceFdInfo);
-    CheckResult("vkImportFenceFdKHR", returnValue, replay_result);
+    CheckResult("vkImportFenceFdKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetFenceFdKHR(
@@ -4393,7 +4393,7 @@ void VulkanReplayConsumer::Process_vkGetFenceFdKHR(
     int* out_pFd = pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetFenceFdKHR(in_device, in_pGetFdInfo, out_pFd);
-    CheckResult("vkGetFenceFdKHR", returnValue, replay_result);
+    CheckResult("vkGetFenceFdKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
@@ -4411,7 +4411,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerforman
     VkPerformanceCounterDescriptionKHR* out_pCounterDescriptions = pCounterDescriptions->IsNull() ? nullptr : pCounterDescriptions->AllocateOutputData(*out_pCounterCount, VkPerformanceCounterDescriptionKHR{ VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_DESCRIPTION_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(in_physicalDevice, queueFamilyIndex, out_pCounterCount, out_pCounters, out_pCounterDescriptions);
-    CheckResult("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", returnValue, replay_result);
+    CheckResult("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", returnValue, replay_result, call_info);
 
     if (pCounters->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, *out_pCounterCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     if (pCounterDescriptions->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR, *out_pCounterCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
@@ -4439,7 +4439,7 @@ void VulkanReplayConsumer::Process_vkAcquireProfilingLockKHR(
     auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
 
     VkResult replay_result = OverrideAcquireProfilingLockKHR(GetDeviceTable(in_device->handle)->AcquireProfilingLockKHR, returnValue, in_device, pInfo);
-    CheckResult("vkAcquireProfilingLockKHR", returnValue, replay_result);
+    CheckResult("vkAcquireProfilingLockKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkReleaseProfilingLockKHR(
@@ -4468,7 +4468,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     InitializeOutputStructPNext(pSurfaceCapabilities);
 
     VkResult replay_result = OverrideGetPhysicalDeviceSurfaceCapabilities2KHR(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceSurfaceCapabilities2KHR, returnValue, in_physicalDevice, pSurfaceInfo, pSurfaceCapabilities);
-    CheckResult("vkGetPhysicalDeviceSurfaceCapabilities2KHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfaceCapabilities2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
@@ -4489,7 +4489,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
     VkSurfaceFormat2KHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount, VkSurfaceFormat2KHR{ VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormats2KHR(in_physicalDevice, in_pSurfaceInfo, out_pSurfaceFormatCount, out_pSurfaceFormats);
-    CheckResult("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, replay_result, call_info);
 
     if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, *out_pSurfaceFormatCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -4506,7 +4506,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     VkDisplayProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -4524,7 +4524,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     VkDisplayPlaneProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayPlaneProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -4544,7 +4544,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
     VkDisplayModeProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayModeProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModeProperties2KHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetDisplayModeProperties2KHR", returnValue, replay_result);
+    CheckResult("vkGetDisplayModeProperties2KHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModeProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
@@ -4564,7 +4564,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
     InitializeOutputStructPNext(pCapabilities);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneCapabilities2KHR(in_physicalDevice, in_pDisplayPlaneInfo, out_pCapabilities);
-    CheckResult("vkGetDisplayPlaneCapabilities2KHR", returnValue, replay_result);
+    CheckResult("vkGetDisplayPlaneCapabilities2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2KHR(
@@ -4630,7 +4630,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     VkSamplerYcbcrConversion* out_pYcbcrConversion = pYcbcrConversion->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversionKHR(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
-    CheckResult("vkCreateSamplerYcbcrConversionKHR", returnValue, replay_result);
+    CheckResult("vkCreateSamplerYcbcrConversionKHR", returnValue, replay_result, call_info);
 
     AddHandle<SamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddSamplerYcbcrConversionInfo);
 }
@@ -4661,7 +4661,7 @@ void VulkanReplayConsumer::Process_vkBindBufferMemory2KHR(
     MapStructArrayHandles(pBindInfos->GetMetaStructPointer(), pBindInfos->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideBindBufferMemory2(GetDeviceTable(in_device->handle)->BindBufferMemory2KHR, returnValue, in_device, bindInfoCount, pBindInfos);
-    CheckResult("vkBindBufferMemory2KHR", returnValue, replay_result);
+    CheckResult("vkBindBufferMemory2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkBindImageMemory2KHR(
@@ -4676,7 +4676,7 @@ void VulkanReplayConsumer::Process_vkBindImageMemory2KHR(
     MapStructArrayHandles(pBindInfos->GetMetaStructPointer(), pBindInfos->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = OverrideBindImageMemory2(GetDeviceTable(in_device->handle)->BindImageMemory2KHR, returnValue, in_device, bindInfoCount, pBindInfos);
-    CheckResult("vkBindImageMemory2KHR", returnValue, replay_result);
+    CheckResult("vkBindImageMemory2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
@@ -4740,7 +4740,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValueKHR(
     uint64_t* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreCounterValueKHR(in_device, in_semaphore, out_pValue);
-    CheckResult("vkGetSemaphoreCounterValueKHR", returnValue, replay_result);
+    CheckResult("vkGetSemaphoreCounterValueKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkWaitSemaphoresKHR(
@@ -4755,7 +4755,7 @@ void VulkanReplayConsumer::Process_vkWaitSemaphoresKHR(
     MapStructHandles(pWaitInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->WaitSemaphoresKHR(in_device, in_pWaitInfo, timeout);
-    CheckResult("vkWaitSemaphoresKHR", returnValue, replay_result);
+    CheckResult("vkWaitSemaphoresKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkSignalSemaphoreKHR(
@@ -4769,7 +4769,7 @@ void VulkanReplayConsumer::Process_vkSignalSemaphoreKHR(
     MapStructHandles(pSignalInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->SignalSemaphoreKHR(in_device, in_pSignalInfo);
-    CheckResult("vkSignalSemaphoreKHR", returnValue, replay_result);
+    CheckResult("vkSignalSemaphoreKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
@@ -4784,7 +4784,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
     VkPhysicalDeviceFragmentShadingRateKHR* out_pFragmentShadingRates = pFragmentShadingRates->IsNull() ? nullptr : pFragmentShadingRates->AllocateOutputData(*out_pFragmentShadingRateCount, VkPhysicalDeviceFragmentShadingRateKHR{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFragmentShadingRatesKHR(in_physicalDevice, out_pFragmentShadingRateCount, out_pFragmentShadingRates);
-    CheckResult("vkGetPhysicalDeviceFragmentShadingRatesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceFragmentShadingRatesKHR", returnValue, replay_result, call_info);
 
     if (pFragmentShadingRates->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceFragmentShadingRatesKHR, *out_pFragmentShadingRateCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -4814,7 +4814,7 @@ void VulkanReplayConsumer::Process_vkWaitForPresentKHR(
     auto in_swapchain = GetObjectInfoTable().GetSwapchainKHRInfo(swapchain);
 
     VkResult replay_result = OverrideWaitForPresentKHR(GetDeviceTable(in_device->handle)->WaitForPresentKHR, returnValue, in_device, in_swapchain, presentId, timeout);
-    CheckResult("vkWaitForPresentKHR", returnValue, replay_result);
+    CheckResult("vkWaitForPresentKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressKHR(
@@ -4869,7 +4869,7 @@ void VulkanReplayConsumer::Process_vkCreateDeferredOperationKHR(
     VkDeferredOperationKHR* out_pDeferredOperation = pDeferredOperation->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateDeferredOperationKHR(in_device, in_pAllocator, out_pDeferredOperation);
-    CheckResult("vkCreateDeferredOperationKHR", returnValue, replay_result);
+    CheckResult("vkCreateDeferredOperationKHR", returnValue, replay_result, call_info);
 
     AddHandle<DeferredOperationKHRInfo>(device, pDeferredOperation->GetPointer(), out_pDeferredOperation, &VulkanObjectInfoTable::AddDeferredOperationKHRInfo);
 }
@@ -4910,7 +4910,7 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationResultKHR(
     VkDeferredOperationKHR in_operation = MapHandle<DeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeferredOperationResultKHR(in_device, in_operation);
-    CheckResult("vkGetDeferredOperationResultKHR", returnValue, replay_result);
+    CheckResult("vkGetDeferredOperationResultKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
@@ -4923,7 +4923,7 @@ void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
     auto in_operation = GetObjectInfoTable().GetDeferredOperationKHRInfo(operation);
 
     VkResult replay_result = OverrideDeferredOperationJoinKHR(GetDeviceTable(in_device->handle)->DeferredOperationJoinKHR, returnValue, in_device, in_operation);
-    CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result);
+    CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
@@ -4941,7 +4941,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     VkPipelineExecutablePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pExecutableCount, VkPipelineExecutablePropertiesKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutablePropertiesKHR(in_device, in_pPipelineInfo, out_pExecutableCount, out_pProperties);
-    CheckResult("vkGetPipelineExecutablePropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPipelineExecutablePropertiesKHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetPipelineExecutablePropertiesKHR, *out_pExecutableCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
@@ -4961,7 +4961,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     VkPipelineExecutableStatisticKHR* out_pStatistics = pStatistics->IsNull() ? nullptr : pStatistics->AllocateOutputData(*out_pStatisticCount, VkPipelineExecutableStatisticKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableStatisticsKHR(in_device, in_pExecutableInfo, out_pStatisticCount, out_pStatistics);
-    CheckResult("vkGetPipelineExecutableStatisticsKHR", returnValue, replay_result);
+    CheckResult("vkGetPipelineExecutableStatisticsKHR", returnValue, replay_result, call_info);
 
     if (pStatistics->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetPipelineExecutableStatisticsKHR, *out_pStatisticCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
@@ -4981,7 +4981,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentation
     VkPipelineExecutableInternalRepresentationKHR* out_pInternalRepresentations = pInternalRepresentations->IsNull() ? nullptr : pInternalRepresentations->AllocateOutputData(*out_pInternalRepresentationCount, VkPipelineExecutableInternalRepresentationKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableInternalRepresentationsKHR(in_device, in_pExecutableInfo, out_pInternalRepresentationCount, out_pInternalRepresentations);
-    CheckResult("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, replay_result);
+    CheckResult("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, replay_result, call_info);
 
     if (pInternalRepresentations->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, *out_pInternalRepresentationCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
@@ -4999,7 +4999,7 @@ void VulkanReplayConsumer::Process_vkMapMemory2KHR(
     void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
 
     VkResult replay_result = GetDeviceTable(in_device)->MapMemory2KHR(in_device, in_pMemoryMapInfo, out_ppData);
-    CheckResult("vkMapMemory2KHR", returnValue, replay_result);
+    CheckResult("vkMapMemory2KHR", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*ppData->GetPointer()), *ppData->GetOutputPointer(), format::ApiCallId::ApiCall_vkMapMemory2KHR, "vkMapMemory2KHR");
 }
@@ -5015,7 +5015,7 @@ void VulkanReplayConsumer::Process_vkUnmapMemory2KHR(
     MapStructHandles(pMemoryUnmapInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->UnmapMemory2KHR(in_device, in_pMemoryUnmapInfo);
-    CheckResult("vkUnmapMemory2KHR", returnValue, replay_result);
+    CheckResult("vkUnmapMemory2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(
@@ -5031,7 +5031,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceVideoEncodeQualityLevelPro
     InitializeOutputStructPNext(pQualityLevelProperties);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(in_physicalDevice, in_pQualityLevelInfo, out_pQualityLevelProperties);
-    CheckResult("vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetEncodedVideoSessionParametersKHR(
@@ -5052,7 +5052,7 @@ void VulkanReplayConsumer::Process_vkGetEncodedVideoSessionParametersKHR(
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetEncodedVideoSessionParametersKHR(in_device, in_pVideoSessionParametersInfo, out_pFeedbackInfo, out_pDataSize, out_pData);
-    CheckResult("vkGetEncodedVideoSessionParametersKHR", returnValue, replay_result);
+    CheckResult("vkGetEncodedVideoSessionParametersKHR", returnValue, replay_result, call_info);
 
     if (pData->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetEncodedVideoSessionParametersKHR, *out_pDataSize, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
@@ -5149,7 +5149,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2KHR(
     auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
 
     VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2KHR, returnValue, in_queue, submitCount, pSubmits, in_fence);
-    CheckResult("vkQueueSubmit2KHR", returnValue, replay_result);
+    CheckResult("vkQueueSubmit2KHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteBufferMarker2AMD(
@@ -5380,7 +5380,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
     VkCooperativeMatrixPropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkCooperativeMatrixPropertiesKHR{ VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -5399,7 +5399,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
     pCallback->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateDebugReportCallbackEXT(GetInstanceTable(in_instance->handle)->CreateDebugReportCallbackEXT, returnValue, in_instance, pCreateInfo, pAllocator, pCallback);
-    CheckResult("vkCreateDebugReportCallbackEXT", returnValue, replay_result);
+    CheckResult("vkCreateDebugReportCallbackEXT", returnValue, replay_result, call_info);
 
     AddHandle<DebugReportCallbackEXTInfo>(instance, pCallback->GetPointer(), pCallback->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDebugReportCallbackEXTInfo);
 }
@@ -5448,7 +5448,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectTagEXT(
     MapStructHandles(pTagInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->DebugMarkerSetObjectTagEXT(in_device, in_pTagInfo);
-    CheckResult("vkDebugMarkerSetObjectTagEXT", returnValue, replay_result);
+    CheckResult("vkDebugMarkerSetObjectTagEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectNameEXT(
@@ -5462,7 +5462,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectNameEXT(
     MapStructHandles(pNameInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->DebugMarkerSetObjectNameEXT(in_device, in_pNameInfo);
-    CheckResult("vkDebugMarkerSetObjectNameEXT", returnValue, replay_result);
+    CheckResult("vkDebugMarkerSetObjectNameEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdDebugMarkerBeginEXT(
@@ -5611,7 +5611,7 @@ void VulkanReplayConsumer::Process_vkGetImageViewAddressNVX(
     InitializeOutputStructPNext(pProperties);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetImageViewAddressNVX(in_device, in_imageView, out_pProperties);
-    CheckResult("vkGetImageViewAddressNVX", returnValue, replay_result);
+    CheckResult("vkGetImageViewAddressNVX", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountAMD(
@@ -5664,7 +5664,7 @@ void VulkanReplayConsumer::Process_vkGetShaderInfoAMD(
     void* out_pInfo = pInfo->IsNull() ? nullptr : pInfo->AllocateOutputData(*out_pInfoSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetShaderInfoAMD(in_device, in_pipeline, shaderStage, infoType, out_pInfoSize, out_pInfo);
-    CheckResult("vkGetShaderInfoAMD", returnValue, replay_result);
+    CheckResult("vkGetShaderInfoAMD", returnValue, replay_result, call_info);
 
     if (pInfo->IsNull()) { SetOutputArrayCount<PipelineInfo>(pipeline, kPipelineArrayGetShaderInfoAMD, *out_pInfoSize, &VulkanObjectInfoTable::GetPipelineInfo); }
 }
@@ -5684,7 +5684,7 @@ void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateStreamDescriptorSurfaceGGP(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateStreamDescriptorSurfaceGGP", returnValue, replay_result);
+    CheckResult("vkCreateStreamDescriptorSurfaceGGP", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -5705,7 +5705,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropert
     VkExternalImageFormatPropertiesNV* out_pExternalImageFormatProperties = pExternalImageFormatProperties->IsNull() ? nullptr : pExternalImageFormatProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalImageFormatPropertiesNV(in_physicalDevice, format, type, tiling, usage, flags, externalHandleType, out_pExternalImageFormatProperties);
-    CheckResult("vkGetPhysicalDeviceExternalImageFormatPropertiesNV", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceExternalImageFormatPropertiesNV", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleNV(
@@ -5721,7 +5721,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleNV(
     HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryWin32HandleNV(in_device, in_memory, handleType, out_pHandle);
-    CheckResult("vkGetMemoryWin32HandleNV", returnValue, replay_result);
+    CheckResult("vkGetMemoryWin32HandleNV", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*pHandle->GetPointer()), static_cast<void*>(*out_pHandle), format::ApiCallId::ApiCall_vkGetMemoryWin32HandleNV, "vkGetMemoryWin32HandleNV");
 }
@@ -5741,7 +5741,7 @@ void VulkanReplayConsumer::Process_vkCreateViSurfaceNN(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateViSurfaceNN(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateViSurfaceNN", returnValue, replay_result);
+    CheckResult("vkCreateViSurfaceNN", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -5790,7 +5790,7 @@ void VulkanReplayConsumer::Process_vkReleaseDisplayEXT(
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->ReleaseDisplayEXT(in_physicalDevice, in_display);
-    CheckResult("vkReleaseDisplayEXT", returnValue, replay_result);
+    CheckResult("vkReleaseDisplayEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkAcquireXlibDisplayEXT(
@@ -5805,7 +5805,7 @@ void VulkanReplayConsumer::Process_vkAcquireXlibDisplayEXT(
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->AcquireXlibDisplayEXT(in_physicalDevice, in_dpy, in_display);
-    CheckResult("vkAcquireXlibDisplayEXT", returnValue, replay_result);
+    CheckResult("vkAcquireXlibDisplayEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetRandROutputDisplayEXT(
@@ -5823,7 +5823,7 @@ void VulkanReplayConsumer::Process_vkGetRandROutputDisplayEXT(
     pDisplay->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideGetRandROutputDisplayEXT(GetInstanceTable(in_physicalDevice->handle)->GetRandROutputDisplayEXT, returnValue, in_physicalDevice, in_dpy, rrOutput, pDisplay);
-    CheckResult("vkGetRandROutputDisplayEXT", returnValue, replay_result);
+    CheckResult("vkGetRandROutputDisplayEXT", returnValue, replay_result, call_info);
 
     AddHandle<DisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), pDisplay->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDisplayKHRInfo);
 }
@@ -5842,7 +5842,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
     InitializeOutputStructPNext(pSurfaceCapabilities);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2EXT(in_physicalDevice, in_surface, out_pSurfaceCapabilities);
-    CheckResult("vkGetPhysicalDeviceSurfaceCapabilities2EXT", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfaceCapabilities2EXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkDisplayPowerControlEXT(
@@ -5857,7 +5857,7 @@ void VulkanReplayConsumer::Process_vkDisplayPowerControlEXT(
     const VkDisplayPowerInfoEXT* in_pDisplayPowerInfo = pDisplayPowerInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->DisplayPowerControlEXT(in_device, in_display, in_pDisplayPowerInfo);
-    CheckResult("vkDisplayPowerControlEXT", returnValue, replay_result);
+    CheckResult("vkDisplayPowerControlEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
@@ -5875,7 +5875,7 @@ void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
     VkFence* out_pFence = pFence->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->RegisterDeviceEventEXT(in_device, in_pDeviceEventInfo, in_pAllocator, out_pFence);
-    CheckResult("vkRegisterDeviceEventEXT", returnValue, replay_result);
+    CheckResult("vkRegisterDeviceEventEXT", returnValue, replay_result, call_info);
 
     AddHandle<FenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
 }
@@ -5897,7 +5897,7 @@ void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
     VkFence* out_pFence = pFence->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->RegisterDisplayEventEXT(in_device, in_display, in_pDisplayEventInfo, in_pAllocator, out_pFence);
-    CheckResult("vkRegisterDisplayEventEXT", returnValue, replay_result);
+    CheckResult("vkRegisterDisplayEventEXT", returnValue, replay_result, call_info);
 
     AddHandle<FenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
 }
@@ -5916,7 +5916,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainCounterEXT(
     uint64_t* out_pCounterValue = pCounterValue->IsNull() ? nullptr : pCounterValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSwapchainCounterEXT(in_device, in_swapchain, counter, out_pCounterValue);
-    CheckResult("vkGetSwapchainCounterEXT", returnValue, replay_result);
+    CheckResult("vkGetSwapchainCounterEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
@@ -5932,7 +5932,7 @@ void VulkanReplayConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
     VkRefreshCycleDurationGOOGLE* out_pDisplayTimingProperties = pDisplayTimingProperties->IsNull() ? nullptr : pDisplayTimingProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetRefreshCycleDurationGOOGLE(in_device, in_swapchain, out_pDisplayTimingProperties);
-    CheckResult("vkGetRefreshCycleDurationGOOGLE", returnValue, replay_result);
+    CheckResult("vkGetRefreshCycleDurationGOOGLE", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
@@ -5950,7 +5950,7 @@ void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
     VkPastPresentationTimingGOOGLE* out_pPresentationTimings = pPresentationTimings->IsNull() ? nullptr : pPresentationTimings->AllocateOutputData(*out_pPresentationTimingCount);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPastPresentationTimingGOOGLE(in_device, in_swapchain, out_pPresentationTimingCount, out_pPresentationTimings);
-    CheckResult("vkGetPastPresentationTimingGOOGLE", returnValue, replay_result);
+    CheckResult("vkGetPastPresentationTimingGOOGLE", returnValue, replay_result, call_info);
 
     if (pPresentationTimings->IsNull()) { SetOutputArrayCount<SwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, *out_pPresentationTimingCount, &VulkanObjectInfoTable::GetSwapchainKHRInfo); }
 }
@@ -6017,7 +6017,7 @@ void VulkanReplayConsumer::Process_vkCreateIOSSurfaceMVK(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateIOSSurfaceMVK(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateIOSSurfaceMVK", returnValue, replay_result);
+    CheckResult("vkCreateIOSSurfaceMVK", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -6037,7 +6037,7 @@ void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateMacOSSurfaceMVK(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateMacOSSurfaceMVK", returnValue, replay_result);
+    CheckResult("vkCreateMacOSSurfaceMVK", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -6055,7 +6055,7 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
     VkPhysicalDevice             physical_device = device_info->parent;
 
     VkResult replay_result = GetInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT(in_device, in_pNameInfo);
-    CheckResult("vkSetDebugUtilsObjectNameEXT", returnValue, replay_result);
+    CheckResult("vkSetDebugUtilsObjectNameEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
@@ -6071,7 +6071,7 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
     VkPhysicalDevice             physical_device = device_info->parent;
 
     VkResult replay_result = GetInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT(in_device, in_pTagInfo);
-    CheckResult("vkSetDebugUtilsObjectTagEXT", returnValue, replay_result);
+    CheckResult("vkSetDebugUtilsObjectTagEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
@@ -6150,7 +6150,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugUtilsMessengerEXT(
     pMessenger->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateDebugUtilsMessengerEXT(GetInstanceTable(in_instance->handle)->CreateDebugUtilsMessengerEXT, returnValue, in_instance, pCreateInfo, pAllocator, pMessenger);
-    CheckResult("vkCreateDebugUtilsMessengerEXT", returnValue, replay_result);
+    CheckResult("vkCreateDebugUtilsMessengerEXT", returnValue, replay_result, call_info);
 
     AddHandle<DebugUtilsMessengerEXTInfo>(instance, pMessenger->GetPointer(), pMessenger->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDebugUtilsMessengerEXTInfo);
 }
@@ -6195,7 +6195,7 @@ void VulkanReplayConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
     InitializeOutputStructPNext(pProperties);
 
     VkResult replay_result = OverrideGetAndroidHardwareBufferPropertiesANDROID(GetDeviceTable(in_device->handle)->GetAndroidHardwareBufferPropertiesANDROID, returnValue, in_device, in_buffer, pProperties);
-    CheckResult("vkGetAndroidHardwareBufferPropertiesANDROID", returnValue, replay_result);
+    CheckResult("vkGetAndroidHardwareBufferPropertiesANDROID", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
@@ -6211,7 +6211,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
     struct AHardwareBuffer** out_pBuffer = pBuffer->IsNull() ? nullptr : reinterpret_cast<struct AHardwareBuffer**>(pBuffer->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryAndroidHardwareBufferANDROID(in_device, in_pInfo, out_pBuffer);
-    CheckResult("vkGetMemoryAndroidHardwareBufferANDROID", returnValue, replay_result);
+    CheckResult("vkGetMemoryAndroidHardwareBufferANDROID", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*pBuffer->GetPointer()), static_cast<void*>(*out_pBuffer), format::ApiCallId::ApiCall_vkGetMemoryAndroidHardwareBufferANDROID, "vkGetMemoryAndroidHardwareBufferANDROID");
 }
@@ -6253,7 +6253,7 @@ void VulkanReplayConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
     InitializeOutputStructPNext(pProperties);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetImageDrmFormatModifierPropertiesEXT(in_device, in_image, out_pProperties);
-    CheckResult("vkGetImageDrmFormatModifierPropertiesEXT", returnValue, replay_result);
+    CheckResult("vkGetImageDrmFormatModifierPropertiesEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
@@ -6271,7 +6271,7 @@ void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
     VkValidationCacheEXT* out_pValidationCache = pValidationCache->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateValidationCacheEXT(in_device, in_pCreateInfo, in_pAllocator, out_pValidationCache);
-    CheckResult("vkCreateValidationCacheEXT", returnValue, replay_result);
+    CheckResult("vkCreateValidationCacheEXT", returnValue, replay_result, call_info);
 
     AddHandle<ValidationCacheEXTInfo>(device, pValidationCache->GetPointer(), out_pValidationCache, &VulkanObjectInfoTable::AddValidationCacheEXTInfo);
 }
@@ -6303,7 +6303,7 @@ void VulkanReplayConsumer::Process_vkMergeValidationCachesEXT(
     const VkValidationCacheEXT* in_pSrcCaches = MapHandles<ValidationCacheEXTInfo>(pSrcCaches, srcCacheCount, &VulkanObjectInfoTable::GetValidationCacheEXTInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->MergeValidationCachesEXT(in_device, in_dstCache, srcCacheCount, in_pSrcCaches);
-    CheckResult("vkMergeValidationCachesEXT", returnValue, replay_result);
+    CheckResult("vkMergeValidationCachesEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
@@ -6320,7 +6320,7 @@ void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetValidationCacheDataEXT(in_device, in_validationCache, out_pDataSize, out_pData);
-    CheckResult("vkGetValidationCacheDataEXT", returnValue, replay_result);
+    CheckResult("vkGetValidationCacheDataEXT", returnValue, replay_result, call_info);
 
     if (pData->IsNull()) { SetOutputArrayCount<ValidationCacheEXTInfo>(validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, *out_pDataSize, &VulkanObjectInfoTable::GetValidationCacheEXTInfo); }
 }
@@ -6379,7 +6379,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureNV(
     VkAccelerationStructureNV* out_pAccelerationStructure = pAccelerationStructure->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateAccelerationStructureNV(in_device, in_pCreateInfo, in_pAllocator, out_pAccelerationStructure);
-    CheckResult("vkCreateAccelerationStructureNV", returnValue, replay_result);
+    CheckResult("vkCreateAccelerationStructureNV", returnValue, replay_result, call_info);
 
     AddHandle<AccelerationStructureNVInfo>(device, pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &VulkanObjectInfoTable::AddAccelerationStructureNVInfo);
 }
@@ -6424,7 +6424,7 @@ void VulkanReplayConsumer::Process_vkBindAccelerationStructureMemoryNV(
     MapStructArrayHandles(pBindInfos->GetMetaStructPointer(), pBindInfos->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->BindAccelerationStructureMemoryNV(in_device, bindInfoCount, in_pBindInfos);
-    CheckResult("vkBindAccelerationStructureMemoryNV", returnValue, replay_result);
+    CheckResult("vkBindAccelerationStructureMemoryNV", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructureNV(
@@ -6510,7 +6510,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesNV(
     VkPipeline* out_pPipelines = pPipelines->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateRayTracingPipelinesNV(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
-    CheckResult("vkCreateRayTracingPipelinesNV", returnValue, replay_result);
+    CheckResult("vkCreateRayTracingPipelinesNV", returnValue, replay_result, call_info);
 
     AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
 }
@@ -6530,7 +6530,7 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
     if (!pData->IsNull()) { pData->AllocateOutputData(dataSize); }
 
     VkResult replay_result = OverrideGetRayTracingShaderGroupHandlesKHR(GetDeviceTable(in_device->handle)->GetRayTracingShaderGroupHandlesKHR, returnValue, in_device, in_pipeline, firstGroup, groupCount, dataSize, pData);
-    CheckResult("vkGetRayTracingShaderGroupHandlesKHR", returnValue, replay_result);
+    CheckResult("vkGetRayTracingShaderGroupHandlesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
@@ -6548,7 +6548,7 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetRayTracingShaderGroupHandlesNV(in_device, in_pipeline, firstGroup, groupCount, dataSize, out_pData);
-    CheckResult("vkGetRayTracingShaderGroupHandlesNV", returnValue, replay_result);
+    CheckResult("vkGetRayTracingShaderGroupHandlesNV", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureHandleNV(
@@ -6564,7 +6564,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureHandleNV(
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetAccelerationStructureHandleNV(in_device, in_accelerationStructure, dataSize, out_pData);
-    CheckResult("vkGetAccelerationStructureHandleNV", returnValue, replay_result);
+    CheckResult("vkGetAccelerationStructureHandleNV", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
@@ -6594,7 +6594,7 @@ void VulkanReplayConsumer::Process_vkCompileDeferredNV(
     VkPipeline in_pipeline = MapHandle<PipelineInfo>(pipeline, &VulkanObjectInfoTable::GetPipelineInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->CompileDeferredNV(in_device, in_pipeline, shader);
-    CheckResult("vkCompileDeferredNV", returnValue, replay_result);
+    CheckResult("vkCompileDeferredNV", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
@@ -6611,7 +6611,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
     InitializeOutputStructPNext(pMemoryHostPointerProperties);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryHostPointerPropertiesEXT(in_device, handleType, in_pHostPointer, out_pMemoryHostPointerProperties);
-    CheckResult("vkGetMemoryHostPointerPropertiesEXT", returnValue, replay_result);
+    CheckResult("vkGetMemoryHostPointerPropertiesEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteBufferMarkerAMD(
@@ -6640,7 +6640,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEX
     VkTimeDomainEXT* out_pTimeDomains = pTimeDomains->IsNull() ? nullptr : pTimeDomains->AllocateOutputData(*out_pTimeDomainCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsEXT(in_physicalDevice, out_pTimeDomainCount, out_pTimeDomains);
-    CheckResult("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, replay_result, call_info);
 
     if (pTimeDomains->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, *out_pTimeDomainCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -6660,7 +6660,7 @@ void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
     uint64_t* out_pMaxDeviation = pMaxDeviation->IsNull() ? nullptr : pMaxDeviation->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetCalibratedTimestampsEXT(in_device, timestampCount, in_pTimestampInfos, out_pTimestamps, out_pMaxDeviation);
-    CheckResult("vkGetCalibratedTimestampsEXT", returnValue, replay_result);
+    CheckResult("vkGetCalibratedTimestampsEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksNV(
@@ -6767,7 +6767,7 @@ void VulkanReplayConsumer::Process_vkInitializePerformanceApiINTEL(
     const VkInitializePerformanceApiInfoINTEL* in_pInitializeInfo = pInitializeInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->InitializePerformanceApiINTEL(in_device, in_pInitializeInfo);
-    CheckResult("vkInitializePerformanceApiINTEL", returnValue, replay_result);
+    CheckResult("vkInitializePerformanceApiINTEL", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkUninitializePerformanceApiINTEL(
@@ -6789,7 +6789,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
     const VkPerformanceMarkerInfoINTEL* in_pMarkerInfo = pMarkerInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->CmdSetPerformanceMarkerINTEL(in_commandBuffer, in_pMarkerInfo);
-    CheckResult("vkCmdSetPerformanceMarkerINTEL", returnValue, replay_result);
+    CheckResult("vkCmdSetPerformanceMarkerINTEL", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
@@ -6802,7 +6802,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
     const VkPerformanceStreamMarkerInfoINTEL* in_pMarkerInfo = pMarkerInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->CmdSetPerformanceStreamMarkerINTEL(in_commandBuffer, in_pMarkerInfo);
-    CheckResult("vkCmdSetPerformanceStreamMarkerINTEL", returnValue, replay_result);
+    CheckResult("vkCmdSetPerformanceStreamMarkerINTEL", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
@@ -6815,7 +6815,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
     const VkPerformanceOverrideInfoINTEL* in_pOverrideInfo = pOverrideInfo->GetPointer();
 
     VkResult replay_result = GetDeviceTable(in_commandBuffer)->CmdSetPerformanceOverrideINTEL(in_commandBuffer, in_pOverrideInfo);
-    CheckResult("vkCmdSetPerformanceOverrideINTEL", returnValue, replay_result);
+    CheckResult("vkCmdSetPerformanceOverrideINTEL", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
@@ -6831,7 +6831,7 @@ void VulkanReplayConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     VkPerformanceConfigurationINTEL* out_pConfiguration = pConfiguration->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->AcquirePerformanceConfigurationINTEL(in_device, in_pAcquireInfo, out_pConfiguration);
-    CheckResult("vkAcquirePerformanceConfigurationINTEL", returnValue, replay_result);
+    CheckResult("vkAcquirePerformanceConfigurationINTEL", returnValue, replay_result, call_info);
 
     AddHandle<PerformanceConfigurationINTELInfo>(device, pConfiguration->GetPointer(), out_pConfiguration, &VulkanObjectInfoTable::AddPerformanceConfigurationINTELInfo);
 }
@@ -6846,7 +6846,7 @@ void VulkanReplayConsumer::Process_vkReleasePerformanceConfigurationINTEL(
     VkPerformanceConfigurationINTEL in_configuration = MapHandle<PerformanceConfigurationINTELInfo>(configuration, &VulkanObjectInfoTable::GetPerformanceConfigurationINTELInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->ReleasePerformanceConfigurationINTEL(in_device, in_configuration);
-    CheckResult("vkReleasePerformanceConfigurationINTEL", returnValue, replay_result);
+    CheckResult("vkReleasePerformanceConfigurationINTEL", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
@@ -6859,7 +6859,7 @@ void VulkanReplayConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
     VkPerformanceConfigurationINTEL in_configuration = MapHandle<PerformanceConfigurationINTELInfo>(configuration, &VulkanObjectInfoTable::GetPerformanceConfigurationINTELInfo);
 
     VkResult replay_result = GetDeviceTable(in_queue)->QueueSetPerformanceConfigurationINTEL(in_queue, in_configuration);
-    CheckResult("vkQueueSetPerformanceConfigurationINTEL", returnValue, replay_result);
+    CheckResult("vkQueueSetPerformanceConfigurationINTEL", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPerformanceParameterINTEL(
@@ -6873,7 +6873,7 @@ void VulkanReplayConsumer::Process_vkGetPerformanceParameterINTEL(
     VkPerformanceValueINTEL* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPerformanceParameterINTEL(in_device, parameter, out_pValue);
-    CheckResult("vkGetPerformanceParameterINTEL", returnValue, replay_result);
+    CheckResult("vkGetPerformanceParameterINTEL", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkSetLocalDimmingAMD(
@@ -6903,7 +6903,7 @@ void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateImagePipeSurfaceFUCHSIA(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateImagePipeSurfaceFUCHSIA", returnValue, replay_result);
+    CheckResult("vkCreateImagePipeSurfaceFUCHSIA", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -6923,7 +6923,7 @@ void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateMetalSurfaceEXT(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateMetalSurfaceEXT", returnValue, replay_result);
+    CheckResult("vkCreateMetalSurfaceEXT", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -6953,7 +6953,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
     if (!pToolProperties->IsNull()) { pToolProperties->AllocateOutputData(*pToolCount->GetOutputPointer(), VkPhysicalDeviceToolProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES, nullptr }); }
 
     VkResult replay_result = OverrideGetPhysicalDeviceToolProperties(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceToolPropertiesEXT, returnValue, in_physicalDevice, pToolCount, pToolProperties);
-    CheckResult("vkGetPhysicalDeviceToolPropertiesEXT", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceToolPropertiesEXT", returnValue, replay_result, call_info);
 
     if (pToolProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceToolPropertiesEXT, *pToolCount->GetOutputPointer(), &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -6970,7 +6970,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
     VkCooperativeMatrixPropertiesNV* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkCooperativeMatrixPropertiesNV{ VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(in_physicalDevice, out_pPropertyCount, out_pProperties);
-    CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -6987,7 +6987,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedS
     VkFramebufferMixedSamplesCombinationNV* out_pCombinations = pCombinations->IsNull() ? nullptr : pCombinations->AllocateOutputData(*out_pCombinationCount, VkFramebufferMixedSamplesCombinationNV{ VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(in_physicalDevice, out_pCombinationCount, out_pCombinations);
-    CheckResult("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, replay_result, call_info);
 
     if (pCombinations->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, *out_pCombinationCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -7010,7 +7010,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModes2EXT(in_physicalDevice, in_pSurfaceInfo, out_pPresentModeCount, out_pPresentModes);
-    CheckResult("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, replay_result, call_info);
 
     if (pPresentModes->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, *out_pPresentModeCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -7026,7 +7026,7 @@ void VulkanReplayConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
     if (GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().GetSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().GetSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
 
     VkResult replay_result = GetDeviceTable(in_device)->AcquireFullScreenExclusiveModeEXT(in_device, in_swapchain);
-    CheckResult("vkAcquireFullScreenExclusiveModeEXT", returnValue, replay_result);
+    CheckResult("vkAcquireFullScreenExclusiveModeEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
@@ -7040,7 +7040,7 @@ void VulkanReplayConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
     if (GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().GetSwapchainKHRInfo(swapchain)->surface_id) == nullptr || GetObjectInfoTable().GetSurfaceKHRInfo(GetObjectInfoTable().GetSwapchainKHRInfo(swapchain)->surface_id)->surface_creation_skipped) { return; }
 
     VkResult replay_result = GetDeviceTable(in_device)->ReleaseFullScreenExclusiveModeEXT(in_device, in_swapchain);
-    CheckResult("vkReleaseFullScreenExclusiveModeEXT", returnValue, replay_result);
+    CheckResult("vkReleaseFullScreenExclusiveModeEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
@@ -7059,7 +7059,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
     VkDeviceGroupPresentModeFlagsKHR* out_pModes = pModes->IsNull() ? nullptr : pModes->AllocateOutputData(1, static_cast<VkDeviceGroupPresentModeFlagsKHR>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeviceGroupSurfacePresentModes2EXT(in_device, in_pSurfaceInfo, out_pModes);
-    CheckResult("vkGetDeviceGroupSurfacePresentModes2EXT", returnValue, replay_result);
+    CheckResult("vkGetDeviceGroupSurfacePresentModes2EXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCreateHeadlessSurfaceEXT(
@@ -7077,7 +7077,7 @@ void VulkanReplayConsumer::Process_vkCreateHeadlessSurfaceEXT(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateHeadlessSurfaceEXT(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateHeadlessSurfaceEXT", returnValue, replay_result);
+    CheckResult("vkCreateHeadlessSurfaceEXT", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -7254,7 +7254,7 @@ void VulkanReplayConsumer::Process_vkCopyMemoryToImageEXT(
     MapStructHandles(pCopyMemoryToImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyMemoryToImageEXT(in_device, in_pCopyMemoryToImageInfo);
-    CheckResult("vkCopyMemoryToImageEXT", returnValue, replay_result);
+    CheckResult("vkCopyMemoryToImageEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCopyImageToMemoryEXT(
@@ -7268,7 +7268,7 @@ void VulkanReplayConsumer::Process_vkCopyImageToMemoryEXT(
     MapStructHandles(pCopyImageToMemoryInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyImageToMemoryEXT(in_device, in_pCopyImageToMemoryInfo);
-    CheckResult("vkCopyImageToMemoryEXT", returnValue, replay_result);
+    CheckResult("vkCopyImageToMemoryEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCopyImageToImageEXT(
@@ -7282,7 +7282,7 @@ void VulkanReplayConsumer::Process_vkCopyImageToImageEXT(
     MapStructHandles(pCopyImageToImageInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyImageToImageEXT(in_device, in_pCopyImageToImageInfo);
-    CheckResult("vkCopyImageToImageEXT", returnValue, replay_result);
+    CheckResult("vkCopyImageToImageEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkTransitionImageLayoutEXT(
@@ -7297,7 +7297,7 @@ void VulkanReplayConsumer::Process_vkTransitionImageLayoutEXT(
     MapStructArrayHandles(pTransitions->GetMetaStructPointer(), pTransitions->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->TransitionImageLayoutEXT(in_device, transitionCount, in_pTransitions);
-    CheckResult("vkTransitionImageLayoutEXT", returnValue, replay_result);
+    CheckResult("vkTransitionImageLayoutEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout2EXT(
@@ -7327,7 +7327,7 @@ void VulkanReplayConsumer::Process_vkReleaseSwapchainImagesEXT(
     MapStructHandles(pReleaseInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->ReleaseSwapchainImagesEXT(in_device, in_pReleaseInfo);
-    CheckResult("vkReleaseSwapchainImagesEXT", returnValue, replay_result);
+    CheckResult("vkReleaseSwapchainImagesEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
@@ -7399,7 +7399,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutNV(
     VkIndirectCommandsLayoutNV* out_pIndirectCommandsLayout = pIndirectCommandsLayout->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateIndirectCommandsLayoutNV(in_device, in_pCreateInfo, in_pAllocator, out_pIndirectCommandsLayout);
-    CheckResult("vkCreateIndirectCommandsLayoutNV", returnValue, replay_result);
+    CheckResult("vkCreateIndirectCommandsLayoutNV", returnValue, replay_result, call_info);
 
     AddHandle<IndirectCommandsLayoutNVInfo>(device, pIndirectCommandsLayout->GetPointer(), out_pIndirectCommandsLayout, &VulkanObjectInfoTable::AddIndirectCommandsLayoutNVInfo);
 }
@@ -7440,7 +7440,7 @@ void VulkanReplayConsumer::Process_vkAcquireDrmDisplayEXT(
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->AcquireDrmDisplayEXT(in_physicalDevice, drmFd, in_display);
-    CheckResult("vkAcquireDrmDisplayEXT", returnValue, replay_result);
+    CheckResult("vkAcquireDrmDisplayEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetDrmDisplayEXT(
@@ -7456,7 +7456,7 @@ void VulkanReplayConsumer::Process_vkGetDrmDisplayEXT(
     VkDisplayKHR* out_display = display->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDrmDisplayEXT(in_physicalDevice, drmFd, connectorId, out_display);
-    CheckResult("vkGetDrmDisplayEXT", returnValue, replay_result);
+    CheckResult("vkGetDrmDisplayEXT", returnValue, replay_result, call_info);
 
     AddHandle<DisplayKHRInfo>(physicalDevice, display->GetPointer(), out_display, &VulkanObjectInfoTable::AddDisplayKHRInfo);
 }
@@ -7476,7 +7476,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
     VkPrivateDataSlot* out_pPrivateDataSlot = pPrivateDataSlot->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreatePrivateDataSlotEXT(in_device, in_pCreateInfo, in_pAllocator, out_pPrivateDataSlot);
-    CheckResult("vkCreatePrivateDataSlotEXT", returnValue, replay_result);
+    CheckResult("vkCreatePrivateDataSlotEXT", returnValue, replay_result, call_info);
 
     AddHandle<PrivateDataSlotInfo>(device, pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &VulkanObjectInfoTable::AddPrivateDataSlotInfo);
 }
@@ -7509,7 +7509,7 @@ void VulkanReplayConsumer::Process_vkSetPrivateDataEXT(
     VkPrivateDataSlot in_privateDataSlot = MapHandle<PrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetPrivateDataSlotInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->SetPrivateDataEXT(in_device, objectType, in_objectHandle, in_privateDataSlot, data);
-    CheckResult("vkSetPrivateDataEXT", returnValue, replay_result);
+    CheckResult("vkSetPrivateDataEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetPrivateDataEXT(
@@ -7554,7 +7554,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceFaultInfoEXT(
     InitializeOutputStructPNext(pFaultInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeviceFaultInfoEXT(in_device, out_pFaultCounts, out_pFaultInfo);
-    CheckResult("vkGetDeviceFaultInfoEXT", returnValue, replay_result);
+    CheckResult("vkGetDeviceFaultInfoEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkAcquireWinrtDisplayNV(
@@ -7567,7 +7567,7 @@ void VulkanReplayConsumer::Process_vkAcquireWinrtDisplayNV(
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->AcquireWinrtDisplayNV(in_physicalDevice, in_display);
-    CheckResult("vkAcquireWinrtDisplayNV", returnValue, replay_result);
+    CheckResult("vkAcquireWinrtDisplayNV", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetWinrtDisplayNV(
@@ -7582,7 +7582,7 @@ void VulkanReplayConsumer::Process_vkGetWinrtDisplayNV(
     VkDisplayKHR* out_pDisplay = pDisplay->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetWinrtDisplayNV(in_physicalDevice, deviceRelativeId, out_pDisplay);
-    CheckResult("vkGetWinrtDisplayNV", returnValue, replay_result);
+    CheckResult("vkGetWinrtDisplayNV", returnValue, replay_result, call_info);
 
     AddHandle<DisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), out_pDisplay, &VulkanObjectInfoTable::AddDisplayKHRInfo);
 }
@@ -7602,7 +7602,7 @@ void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateDirectFBSurfaceEXT(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateDirectFBSurfaceEXT", returnValue, replay_result);
+    CheckResult("vkCreateDirectFBSurfaceEXT", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -7648,7 +7648,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
     zx_handle_t* out_pZirconHandle = pZirconHandle->IsNull() ? nullptr : pZirconHandle->AllocateOutputData(1, static_cast<uint32_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryZirconHandleFUCHSIA(in_device, in_pGetZirconHandleInfo, out_pZirconHandle);
-    CheckResult("vkGetMemoryZirconHandleFUCHSIA", returnValue, replay_result);
+    CheckResult("vkGetMemoryZirconHandleFUCHSIA", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
@@ -7664,7 +7664,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
     InitializeOutputStructPNext(pMemoryZirconHandleProperties);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryZirconHandlePropertiesFUCHSIA(in_device, handleType, zirconHandle, out_pMemoryZirconHandleProperties);
-    CheckResult("vkGetMemoryZirconHandlePropertiesFUCHSIA", returnValue, replay_result);
+    CheckResult("vkGetMemoryZirconHandlePropertiesFUCHSIA", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
@@ -7678,7 +7678,7 @@ void VulkanReplayConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
     MapStructHandles(pImportSemaphoreZirconHandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->ImportSemaphoreZirconHandleFUCHSIA(in_device, in_pImportSemaphoreZirconHandleInfo);
-    CheckResult("vkImportSemaphoreZirconHandleFUCHSIA", returnValue, replay_result);
+    CheckResult("vkImportSemaphoreZirconHandleFUCHSIA", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
@@ -7694,7 +7694,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
     zx_handle_t* out_pZirconHandle = pZirconHandle->IsNull() ? nullptr : pZirconHandle->AllocateOutputData(1, static_cast<uint32_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreZirconHandleFUCHSIA(in_device, in_pGetZirconHandleInfo, out_pZirconHandle);
-    CheckResult("vkGetSemaphoreZirconHandleFUCHSIA", returnValue, replay_result);
+    CheckResult("vkGetSemaphoreZirconHandleFUCHSIA", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
@@ -7722,7 +7722,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryRemoteAddressNV(
     VkRemoteAddressNV* out_pAddress = pAddress->IsNull() ? nullptr : reinterpret_cast<VkRemoteAddressNV*>(pAddress->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryRemoteAddressNV(in_device, in_pMemoryGetRemoteAddressInfo, out_pAddress);
-    CheckResult("vkGetMemoryRemoteAddressNV", returnValue, replay_result);
+    CheckResult("vkGetMemoryRemoteAddressNV", returnValue, replay_result, call_info);
 
     PostProcessExternalObject(replay_result, (*pAddress->GetPointer()), static_cast<void*>(*out_pAddress), format::ApiCallId::ApiCall_vkGetMemoryRemoteAddressNV, "vkGetMemoryRemoteAddressNV");
 }
@@ -7792,7 +7792,7 @@ void VulkanReplayConsumer::Process_vkCreateScreenSurfaceQNX(
     VkSurfaceKHR* out_pSurface = pSurface->GetHandlePointer();
 
     VkResult replay_result = GetInstanceTable(in_instance)->CreateScreenSurfaceQNX(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
-    CheckResult("vkCreateScreenSurfaceQNX", returnValue, replay_result);
+    CheckResult("vkCreateScreenSurfaceQNX", returnValue, replay_result, call_info);
 
     AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
@@ -7870,7 +7870,7 @@ void VulkanReplayConsumer::Process_vkCreateMicromapEXT(
     VkMicromapEXT* out_pMicromap = pMicromap->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateMicromapEXT(in_device, in_pCreateInfo, in_pAllocator, out_pMicromap);
-    CheckResult("vkCreateMicromapEXT", returnValue, replay_result);
+    CheckResult("vkCreateMicromapEXT", returnValue, replay_result, call_info);
 
     AddHandle<MicromapEXTInfo>(device, pMicromap->GetPointer(), out_pMicromap, &VulkanObjectInfoTable::AddMicromapEXTInfo);
 }
@@ -7916,7 +7916,7 @@ void VulkanReplayConsumer::Process_vkBuildMicromapsEXT(
     MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->BuildMicromapsEXT(in_device, in_deferredOperation, infoCount, in_pInfos);
-    CheckResult("vkBuildMicromapsEXT", returnValue, replay_result);
+    CheckResult("vkBuildMicromapsEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCopyMicromapEXT(
@@ -7932,7 +7932,7 @@ void VulkanReplayConsumer::Process_vkCopyMicromapEXT(
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyMicromapEXT(in_device, in_deferredOperation, in_pInfo);
-    CheckResult("vkCopyMicromapEXT", returnValue, replay_result);
+    CheckResult("vkCopyMicromapEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCopyMicromapToMemoryEXT(
@@ -7948,7 +7948,7 @@ void VulkanReplayConsumer::Process_vkCopyMicromapToMemoryEXT(
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyMicromapToMemoryEXT(in_device, in_deferredOperation, in_pInfo);
-    CheckResult("vkCopyMicromapToMemoryEXT", returnValue, replay_result);
+    CheckResult("vkCopyMicromapToMemoryEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCopyMemoryToMicromapEXT(
@@ -7964,7 +7964,7 @@ void VulkanReplayConsumer::Process_vkCopyMemoryToMicromapEXT(
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyMemoryToMicromapEXT(in_device, in_deferredOperation, in_pInfo);
-    CheckResult("vkCopyMemoryToMicromapEXT", returnValue, replay_result);
+    CheckResult("vkCopyMemoryToMicromapEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkWriteMicromapsPropertiesEXT(
@@ -7983,7 +7983,7 @@ void VulkanReplayConsumer::Process_vkWriteMicromapsPropertiesEXT(
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->WriteMicromapsPropertiesEXT(in_device, micromapCount, in_pMicromaps, queryType, dataSize, out_pData, stride);
-    CheckResult("vkWriteMicromapsPropertiesEXT", returnValue, replay_result);
+    CheckResult("vkWriteMicromapsPropertiesEXT", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyMicromapEXT(
@@ -8545,7 +8545,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceOpticalFlowImageFormatsNV(
     VkOpticalFlowImageFormatPropertiesNV* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(*out_pFormatCount, VkOpticalFlowImageFormatPropertiesNV{ VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceOpticalFlowImageFormatsNV(in_physicalDevice, in_pOpticalFlowImageFormatInfo, out_pFormatCount, out_pImageFormatProperties);
-    CheckResult("vkGetPhysicalDeviceOpticalFlowImageFormatsNV", returnValue, replay_result);
+    CheckResult("vkGetPhysicalDeviceOpticalFlowImageFormatsNV", returnValue, replay_result, call_info);
 
     if (pImageFormatProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceOpticalFlowImageFormatsNV, *out_pFormatCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
@@ -8565,7 +8565,7 @@ void VulkanReplayConsumer::Process_vkCreateOpticalFlowSessionNV(
     VkOpticalFlowSessionNV* out_pSession = pSession->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateOpticalFlowSessionNV(in_device, in_pCreateInfo, in_pAllocator, out_pSession);
-    CheckResult("vkCreateOpticalFlowSessionNV", returnValue, replay_result);
+    CheckResult("vkCreateOpticalFlowSessionNV", returnValue, replay_result, call_info);
 
     AddHandle<OpticalFlowSessionNVInfo>(device, pSession->GetPointer(), out_pSession, &VulkanObjectInfoTable::AddOpticalFlowSessionNVInfo);
 }
@@ -8598,7 +8598,7 @@ void VulkanReplayConsumer::Process_vkBindOpticalFlowSessionImageNV(
     VkImageView in_view = MapHandle<ImageViewInfo>(view, &VulkanObjectInfoTable::GetImageViewInfo);
 
     VkResult replay_result = GetDeviceTable(in_device)->BindOpticalFlowSessionImageNV(in_device, in_session, bindingPoint, in_view, layout);
-    CheckResult("vkBindOpticalFlowSessionImageNV", returnValue, replay_result);
+    CheckResult("vkBindOpticalFlowSessionImageNV", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdOpticalFlowExecuteNV(
@@ -8631,7 +8631,7 @@ void VulkanReplayConsumer::Process_vkCreateShadersEXT(
     VkShaderEXT* out_pShaders = pShaders->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateShadersEXT(in_device, createInfoCount, in_pCreateInfos, in_pAllocator, out_pShaders);
-    CheckResult("vkCreateShadersEXT", returnValue, replay_result);
+    CheckResult("vkCreateShadersEXT", returnValue, replay_result, call_info);
 
     AddHandles<ShaderEXTInfo>(device, pShaders->GetPointer(), pShaders->GetLength(), out_pShaders, createInfoCount, &VulkanObjectInfoTable::AddShaderEXTInfo);
 }
@@ -8664,7 +8664,7 @@ void VulkanReplayConsumer::Process_vkGetShaderBinaryDataEXT(
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetShaderBinaryDataEXT(in_device, in_shader, out_pDataSize, out_pData);
-    CheckResult("vkGetShaderBinaryDataEXT", returnValue, replay_result);
+    CheckResult("vkGetShaderBinaryDataEXT", returnValue, replay_result, call_info);
 
     if (pData->IsNull()) { SetOutputArrayCount<ShaderEXTInfo>(shader, kShaderEXTArrayGetShaderBinaryDataEXT, *out_pDataSize, &VulkanObjectInfoTable::GetShaderEXTInfo); }
 }
@@ -8697,7 +8697,7 @@ void VulkanReplayConsumer::Process_vkGetFramebufferTilePropertiesQCOM(
     VkTilePropertiesQCOM* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertiesCount, VkTilePropertiesQCOM{ VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetFramebufferTilePropertiesQCOM(in_device, in_framebuffer, out_pPropertiesCount, out_pProperties);
-    CheckResult("vkGetFramebufferTilePropertiesQCOM", returnValue, replay_result);
+    CheckResult("vkGetFramebufferTilePropertiesQCOM", returnValue, replay_result, call_info);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<FramebufferInfo>(framebuffer, kFramebufferArrayGetFramebufferTilePropertiesQCOM, *out_pPropertiesCount, &VulkanObjectInfoTable::GetFramebufferInfo); }
 }
@@ -8716,7 +8716,7 @@ void VulkanReplayConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
     InitializeOutputStructPNext(pProperties);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDynamicRenderingTilePropertiesQCOM(in_device, in_pRenderingInfo, out_pProperties);
-    CheckResult("vkGetDynamicRenderingTilePropertiesQCOM", returnValue, replay_result);
+    CheckResult("vkGetDynamicRenderingTilePropertiesQCOM", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetAttachmentFeedbackLoopEnableEXT(
@@ -8745,7 +8745,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureKHR(
     pAccelerationStructure->SetConsumerData(0, &handle_info);
 
     VkResult replay_result = OverrideCreateAccelerationStructureKHR(GetDeviceTable(in_device->handle)->CreateAccelerationStructureKHR, returnValue, in_device, pCreateInfo, pAllocator, pAccelerationStructure);
-    CheckResult("vkCreateAccelerationStructureKHR", returnValue, replay_result);
+    CheckResult("vkCreateAccelerationStructureKHR", returnValue, replay_result, call_info);
 
     AddHandle<AccelerationStructureKHRInfo>(device, pAccelerationStructure->GetPointer(), pAccelerationStructure->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddAccelerationStructureKHRInfo);
 }
@@ -8811,7 +8811,7 @@ void VulkanReplayConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyAccelerationStructureToMemoryKHR(in_device, in_deferredOperation, in_pInfo);
-    CheckResult("vkCopyAccelerationStructureToMemoryKHR", returnValue, replay_result);
+    CheckResult("vkCopyAccelerationStructureToMemoryKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
@@ -8827,7 +8827,7 @@ void VulkanReplayConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->CopyMemoryToAccelerationStructureKHR(in_device, in_deferredOperation, in_pInfo);
-    CheckResult("vkCopyMemoryToAccelerationStructureKHR", returnValue, replay_result);
+    CheckResult("vkCopyMemoryToAccelerationStructureKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
@@ -8846,7 +8846,7 @@ void VulkanReplayConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->WriteAccelerationStructuresPropertiesKHR(in_device, accelerationStructureCount, in_pAccelerationStructures, queryType, dataSize, out_pData, stride);
-    CheckResult("vkWriteAccelerationStructuresPropertiesKHR", returnValue, replay_result);
+    CheckResult("vkWriteAccelerationStructuresPropertiesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureKHR(
@@ -8986,7 +8986,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesKHR(
     for (size_t i = 0; i < createInfoCount; ++i) { pPipelines->SetConsumerData(i, &handle_info[i]); }
 
     VkResult replay_result = OverrideCreateRayTracingPipelinesKHR(GetDeviceTable(in_device->handle)->CreateRayTracingPipelinesKHR, returnValue, in_device, in_deferredOperation, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
-    CheckResult("vkCreateRayTracingPipelinesKHR", returnValue, replay_result);
+    CheckResult("vkCreateRayTracingPipelinesKHR", returnValue, replay_result, call_info);
 
     AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(handle_info), &VulkanObjectInfoTable::AddPipelineInfo);
 }
@@ -9006,7 +9006,7 @@ void VulkanReplayConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandle
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetRayTracingCaptureReplayShaderGroupHandlesKHR(in_device, in_pipeline, firstGroup, groupCount, dataSize, out_pData);
-    CheckResult("vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", returnValue, replay_result);
+    CheckResult("vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", returnValue, replay_result, call_info);
 }
 
 void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirectKHR(

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -287,7 +287,7 @@ class VulkanReplayConsumerBodyGenerator(
             body += '\n'
         if return_type == 'VkResult':
             body += '    VkResult replay_result = {};\n'.format(call_expr)
-            body += '    CheckResult("{}", returnValue, replay_result);\n'.format(
+            body += '    CheckResult("{}", returnValue, replay_result, call_info);\n'.format(
                 name
             )
         else:


### PR DESCRIPTION
Adds call index and thread id to the error message displayed when the returned value does not match the original one