### PR TITLE
gfxrecon-replay - handle wrap around of xcb events sequence numbers

### DIFF
--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -473,9 +473,12 @@ void XcbWindow::InitializeAtoms()
     bypass_compositor_atom_ = GetAtomReply(connection, kBypassCompositorName, bypass_compositor_atom_cookie);
 }
 
-void XcbWindow::CheckEventStatus(uint32_t sequence, uint32_t type)
+void XcbWindow::CheckEventStatus(uint16_t sequence, uint32_t type)
 {
-    if ((sequence >= pending_event_.sequence) && (type == pending_event_.type))
+    // Note that sequence is 16 bits and pending_event_.sequence is 32 bits, so we only compare the lower 16 bits.
+    // We're checking for equality, so checking for the arrival of certain events needs to be done in the same order
+    // as the xcb calls that cause those events to be generated.
+    if ((sequence == static_cast<uint16_t>(pending_event_.sequence & 0xffff)) && (type == pending_event_.type))
     {
         pending_event_.complete = true;
     }

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -44,20 +44,20 @@ class XcbWindow : public decode::Window
 
     xcb_atom_t GetDeleteWindowAtom() const { return delete_window_atom_; }
 
-    void MapNotifyReceived(uint32_t sequence, bool visible)
+    void MapNotifyReceived(uint16_t seq16, bool visible)
     {
-        CheckEventStatus(sequence, XCB_MAP_NOTIFY);
+        CheckEventStatus(seq16, XCB_MAP_NOTIFY);
         visible_ = visible;
     }
 
-    void ResizeNotifyReceived(uint32_t sequence, uint32_t width, uint32_t height)
+    void ResizeNotifyReceived(uint16_t seq16, uint32_t width, uint32_t height)
     {
-        CheckEventStatus(sequence, XCB_CONFIGURE_NOTIFY);
+        CheckEventStatus(seq16, XCB_CONFIGURE_NOTIFY);
         width_  = width;
         height_ = height;
     }
 
-    void DestroyNotifyReceived(uint32_t sequence) { CheckEventStatus(sequence, XCB_DESTROY_NOTIFY); }
+    void DestroyNotifyReceived(uint16_t seq16) { CheckEventStatus(seq16, XCB_DESTROY_NOTIFY); }
 
     virtual bool Create(const std::string& title,
                         const int32_t      xpos,
@@ -101,7 +101,7 @@ class XcbWindow : public decode::Window
 
     void InitializeAtoms();
 
-    void CheckEventStatus(uint32_t sequence, uint32_t type);
+    void CheckEventStatus(uint16_t seq16, uint32_t type);
 
     bool WaitForEvent(uint32_t sequence, uint32_t type);
 


### PR DESCRIPTION
The sequence number in the cookie returned by many xcb calls (i.e. xcb_map_window) is 32 bits. The sequence number in the event returned by xcb_wait_for_event is 16 bits. When comparing the two sequence numbers to see if the xcb call has completed, need to mask off the top 16 bits from the cookie sequence number.