### PR TITLE
Adding the capture options to annotation for display with info tool

### DIFF
--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -260,6 +260,7 @@ class CaptureManager
 
     std::string CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range);
     bool        CreateCaptureFile(const std::string& base_filename);
+    void        WriteCaptureOptions(std::string& operation_annotation);
     void        ActivateTrimming();
     void        DeactivateTrimming();
 
@@ -334,7 +335,11 @@ class CaptureManager
     bool                                    page_guard_track_ahb_memory_;
     bool                                    page_guard_unblock_sigsegv_;
     bool                                    page_guard_signal_handler_watcher_;
+    uint32_t                                page_guard_signal_handler_watcher_max_restores_;
     PageGuardMemoryMode                     page_guard_memory_mode_;
+    bool                                    page_guard_separate_read_;
+    bool                                    page_guard_copy_on_map_;
+    bool                                    page_guard_external_memory_;
     bool                                    trim_enabled_;
     CaptureSettings::TrimBoundary           trim_boundary_;
     std::vector<util::UintRange>            trim_ranges_;

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -65,7 +65,13 @@ const size_t   kAdapterDescriptionSize    = 128;
 
 /// Label for operation annotation, which captures parameters used by tools
 /// operating on a capture file.
-const char* const kAnnotationLabelOperation = "operation";
+const char* const kAnnotationLabelOperation     = "operation";
+const char* const kAnnotationLabelReplayOptions = "replayopts";
+
+const char* const kOperationAnnotationGfxreconstructVersion = "gfxrecon-version";
+const char* const kOperationAnnotationVulkanVersion         = "vulkan-version";
+const char* const kOperationAnnotationTimestamp             = "timestamp";
+const char* const kOperationAnnotationCaptureParameters     = "capture-parameters";
 
 constexpr uint32_t MakeCompressedBlockType(uint32_t block_type)
 {

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -220,19 +220,20 @@ void GatherApiAgnosticStats(ApiAgnosticStats&                api_agnostic_stats,
 
 std::string GetJsonValue(const nlohmann::json& json_obj, const std::string& key)
 {
-    std::string out = "";
-
-    if (json_obj.contains(key))
+    std::string out                    = "";
+    auto        search_result_iterator = json_obj.find(key);
+    if (search_result_iterator != json_obj.end())
     {
-        try
+        const nlohmann::json& value = *search_result_iterator;
+        if (value.is_object())
         {
-            out = json_obj.at(key).get<std::string>();
-        }
-        catch (const nlohmann::json::type_error& te)
-        {
-            out += "\n\t" + json_obj.at(key).dump(kDefaultIndent);
+            out += "\n\t" + value.dump(kDefaultIndent);
             out.pop_back();
             out += "\t}";
+        }
+        else
+        {
+            out = value;
         }
     }
 


### PR DESCRIPTION
Several options are recommended when dealing with visual corruption on traces. It would be good to know, which non-default options were used when capturing a trace. 

This change captures this information into the operation annotation, if non-default parameters were used, and can be viewed with `gfxrecon-info` tool.