### PR TITLE
Added handling missing VK_EXT_swapchain_colorspace

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -252,6 +252,7 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     VkPhysicalDevice                         parent{ VK_NULL_HANDLE };
     std::unique_ptr<VulkanResourceAllocator> allocator;
     std::unordered_map<uint32_t, size_t>     array_counts;
+    std::vector<std::string>                 enabled_extensions;
 
     std::unordered_map<format::HandleId, uint64_t> opaque_addresses;
 


### PR DESCRIPTION
If the chosen color space is not supported on the replay platform, and swapchain uses one of it's color spaces, swap it for `VK_COLOR_SPACE_SRGB_NONLINEAR_KHR`, that should be available by default.