### PR TITLE
Documented ApiCallInfo.index

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -37,6 +37,12 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 struct ApiCallInfo
 {
+    /// The block index of a function call. Stream processors like FileProcessor
+    /// must set this before dispatching function calls to decoders.
+    /// @note This is lightly used: only for a log output in replay and for JSON
+    /// Convert.
+    /// @see ApiDecoder::SetCurrentBlockIndex() which can pass the block index
+    /// to decoders so it is available for any block type, not just API calls.
     uint64_t         index{ 0 };
     format::ThreadId thread_id{ 0 };
 };


### PR DESCRIPTION
It is barely used and there is a second mechanism for sending the current block index around also in use. Clarifies that this is the block index rather than the i'th API call.

```
struct ApiCallInfo
{
    /// The block index of a function call. Stream processors like FileProcessor
    /// must set this before dispatching function calls to decoders.
    /// @note This is lightly used: only for a log output in replay and for JSON
    /// Convert.
    /// @see ApiDecoder::SetCurrentBlockIndex() which can pass the block index
    /// to decoders so it is available for any block type, not just API calls.
    uint64_t         index{ 0 };
    format::ThreadId thread_id{ 0 };
};
```