### PR TITLE
Added handling missing VK_EXT_swapchain_colorspace

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -751,7 +751,7 @@ usage: gfxrecon.py replay [-h] [--push-file LOCAL_FILE] [--version] [--pause-fra
                           [--measurement-file DEVICE_FILE] [--quit-after-measurement-range]
                           [--flush-measurement-range] [-m MODE]
                           [--swapchain MODE] [--use-captured-swapchain-indices]
-                          [--colorspace-fallback]
+                          [--use-colorspace-fallback]
                           [file]
 
 Launch the replay tool.
@@ -859,9 +859,9 @@ optional arguments:
                         If this is specified the replayer will flush and wait
                         for all current GPU work to finish at the start and end
                         of the measurement range. (forwarded to replay tool)
-  --colorspace-fallback
-                        Swap the swapchain color space if unsupported by replay device. 
-                        Check if color space is not supported by replay device and swap 
+  --use-colorspace-fallback
+                        Swap the swapchain color space if unsupported by replay device.
+                        Check if color space is not supported by replay device and swap
                         to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).
 ```
 
@@ -870,10 +870,10 @@ activity with the following:
 
 ```bash
 adb shell am force-stop com.lunarg.gfxreconstruct.replay
-adb shell am start -n "com.lunarg.gfxreconstruct.replay/android.app.NativeActivity" \ 
-                   -a android.intent.action.MAIN \ 
-                   -c android.intent.category.LAUNCHER \ 
-                   --es "args" \ 
+adb shell am start -n "com.lunarg.gfxreconstruct.replay/android.app.NativeActivity" \
+                   -a android.intent.action.MAIN \
+                   -c android.intent.category.LAUNCHER \
+                   --es "args" \
                    "<arg-list>"
 ```
 

--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -751,6 +751,7 @@ usage: gfxrecon.py replay [-h] [--push-file LOCAL_FILE] [--version] [--pause-fra
                           [--measurement-file DEVICE_FILE] [--quit-after-measurement-range]
                           [--flush-measurement-range] [-m MODE]
                           [--swapchain MODE] [--use-captured-swapchain-indices]
+                          [--colorspace-fallback]
                           [file]
 
 Launch the replay tool.
@@ -858,6 +859,10 @@ optional arguments:
                         If this is specified the replayer will flush and wait
                         for all current GPU work to finish at the start and end
                         of the measurement range. (forwarded to replay tool)
+  --colorspace-fallback
+                        Swap the swapchain color space if unsupported by replay device. 
+                        Check if color space is not supported by replay device and swap 
+                        to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -395,7 +395,7 @@ gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
                         [--flush-measurement-range]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
                         [--api <api>] [--no-debug-popup] <file>
-                        [--colorspace-fallback]
+                        [--use-colorspace-fallback]
 
 Required arguments:
   <file>                Path to the capture file to replay.
@@ -532,9 +532,9 @@ Optional arguments:
               If this is specified the replayer will flush
               and wait for all current GPU work to finish at the
               start and end of the measurement range.
-  --colorspace-fallback
+  --use-colorspace-fallback
               Swap the swapchain color space if unsupported by replay device.
-              Check if color space is not supported by replay device and 
+              Check if color space is not supported by replay device and
               fallback to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR.
 ```
 

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -395,6 +395,7 @@ gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
                         [--flush-measurement-range]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
                         [--api <api>] [--no-debug-popup] <file>
+                        [--colorspace-fallback]
 
 Required arguments:
   <file>                Path to the capture file to replay.
@@ -531,6 +532,10 @@ Optional arguments:
               If this is specified the replayer will flush
               and wait for all current GPU work to finish at the
               start and end of the measurement range.
+  --colorspace-fallback
+              Swap the swapchain color space if unsupported by replay device.
+              Check if color space is not supported by replay device and 
+              fallback to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR.
 ```
 
 ### Key Controls

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -84,7 +84,7 @@ def CreateReplayParser():
     parser.add_argument('--remove-unsupported', action='store_true', default=False, help='Remove unsupported extensions and features from instance and device creation parameters (forwarded to replay tool)')
     parser.add_argument('--validate', action='store_true', default=False, help='Enables the Khronos Vulkan validation layer (forwarded to replay tool)')
     parser.add_argument('--onhb', '--omit-null-hardware-buffers', action='store_true', default=False, help='Omit Vulkan calls that would pass a NULL AHardwareBuffer* (forwarded to replay tool)')
-    parser.add_argument('--colorspace-fallback', action='store_true', default=False, help='Swap the swapchain color space if unsupported by replay device. Check if color space is not supported by replay device and swap to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).')
+    parser.add_argument('--use-colorspace-fallback', action='store_true', default=False, help='Swap the swapchain color space if unsupported by replay device. Check if color space is not supported by replay device and swap to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).')
     parser.add_argument('--mfr', '--measurement-frame-range', metavar='START-END', help='Custom framerange to measure FPS for. This range will include the start frame but not the end frame. The measurement frame range defaults to all frames except the loading frame but can be configured for any range. If the end frame is past the last frame in the trace it will be clamped to the frame after the last (so in that case the results would include the last frame). (forwarded to replay tool)')
     parser.add_argument('--measurement-file', metavar='DEVICE_FILE', help='Write measurements to a file at the specified path. Default is: \'/sdcard/gfxrecon-measurements.json\' on android and \'./gfxrecon-measurements.json\' on desktop. (forwarded to replay tool)')
     parser.add_argument('--quit-after-measurement-range', action='store_true', default=False, help='If this is specified the replayer will abort when it reaches the <end_frame> specified in the --measurement-frame-range argument. (forwarded to replay tool)')
@@ -166,9 +166,9 @@ def MakeExtrasString(args):
 
     if args.use_captured_swapchain_indices:
         arg_list.append('--use-captured-swapchain-indices')
-    
-    if args.colorspace_fallback:
-        arg_list.append('--colorspace-fallback')
+
+    if args.use_colorspace_fallback:
+        arg_list.append('--use-colorspace-fallback')
 
     if args.mfr:
         arg_list.append('--mfr')

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -84,6 +84,7 @@ def CreateReplayParser():
     parser.add_argument('--remove-unsupported', action='store_true', default=False, help='Remove unsupported extensions and features from instance and device creation parameters (forwarded to replay tool)')
     parser.add_argument('--validate', action='store_true', default=False, help='Enables the Khronos Vulkan validation layer (forwarded to replay tool)')
     parser.add_argument('--onhb', '--omit-null-hardware-buffers', action='store_true', default=False, help='Omit Vulkan calls that would pass a NULL AHardwareBuffer* (forwarded to replay tool)')
+    parser.add_argument('--colorspace-fallback', action='store_true', default=False, help='Swap the swapchain color space if unsupported by replay device. Check if color space is not supported by replay device and swap to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).')
     parser.add_argument('--mfr', '--measurement-frame-range', metavar='START-END', help='Custom framerange to measure FPS for. This range will include the start frame but not the end frame. The measurement frame range defaults to all frames except the loading frame but can be configured for any range. If the end frame is past the last frame in the trace it will be clamped to the frame after the last (so in that case the results would include the last frame). (forwarded to replay tool)')
     parser.add_argument('--measurement-file', metavar='DEVICE_FILE', help='Write measurements to a file at the specified path. Default is: \'/sdcard/gfxrecon-measurements.json\' on android and \'./gfxrecon-measurements.json\' on desktop. (forwarded to replay tool)')
     parser.add_argument('--quit-after-measurement-range', action='store_true', default=False, help='If this is specified the replayer will abort when it reaches the <end_frame> specified in the --measurement-frame-range argument. (forwarded to replay tool)')
@@ -165,6 +166,9 @@ def MakeExtrasString(args):
 
     if args.use_captured_swapchain_indices:
         arg_list.append('--use-captured-swapchain-indices')
+    
+    if args.scs:
+        arg_list.append('--colorspace-fallback')
 
     if args.mfr:
         arg_list.append('--mfr')

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -167,7 +167,7 @@ def MakeExtrasString(args):
     if args.use_captured_swapchain_indices:
         arg_list.append('--use-captured-swapchain-indices')
     
-    if args.scs:
+    if args.colorspace_fallback:
         arg_list.append('--colorspace-fallback')
 
     if args.mfr:

--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -29,6 +29,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -165,6 +166,25 @@ void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& prope
         else
         {
             ++extensionIter;
+        }
+    }
+}
+
+void RemoveExtensionIfUnsupported(const std::vector<VkExtensionProperties>& properties,
+                                  std::vector<const char*>*                 extensions,
+                                  const char*                               extension_to_remove)
+{
+    if (!feature_util::IsSupportedExtension(properties, extension_to_remove))
+    {
+        auto extension_iter =
+            std::find_if(extensions->begin(), extensions->end(), [&extension_to_remove](const char* extension) {
+                return util::platform::StringCompare(extension_to_remove, extension) == 0;
+            });
+        if (extension_iter != extensions->end())
+        {
+            GFXRECON_LOG_WARNING("Extension %s, which is not supported by the replay device, will not be enabled",
+                                 *extension_iter);
+            extensions->erase(extension_iter);
         }
     }
 }

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -50,7 +50,10 @@ bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, 
 void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
                                  std::vector<const char*>*                 extensions);
 
-bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, const char* extension);
+void RemoveExtensionIfUnsupported(const std::vector<VkExtensionProperties>& properties,
+                                  std::vector<const char*>*                 extensions,
+                                  const char*                               extension);
+
 void RemoveIgnorableExtensions(const std::vector<VkExtensionProperties>& properties,
                                std::vector<const char*>*                 extensions);
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2300,7 +2300,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
                     // Remove enabled extensions that are not available from the replay instance.
                     feature_util::RemoveUnsupportedExtensions(available_extensions, &filtered_extensions);
                 }
-                else if (options_.colorspace_fallback)
+                else if (options_.use_colorspace_fallback)
                 {
                     if (!feature_util::IsSupportedExtension(available_extensions,
                                                             VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME))
@@ -5075,7 +5075,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
 
         if (colorspace_extension_used_unsupported)
         {
-            if (options_.colorspace_fallback)
+            if (options_.use_colorspace_fallback)
             {
                 modified_create_info.imageColorSpace = VkColorSpaceKHR::VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
                 GFXRECON_LOG_INFO("Forcing supported color space for swapchain (ID = %" PRIu64 ")",

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -47,6 +47,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
     bool                         remove_unsupported_features{ false };
+    bool                         colorspace_fallback{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -47,7 +47,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
     bool                         remove_unsupported_features{ false };
-    bool                         colorspace_fallback{ false };
+    bool                         use_colorspace_fallback{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -78,6 +78,7 @@ generate_targets = [
     'generated_vulkan_struct_to_json.cpp',
     'generated_vulkan_enum_to_json.h',
     'generated_vulkan_enum_to_json.cpp',
+    'generated_vulkan_constant_maps.h'
 ]
 
 if __name__ == '__main__':

--- a/framework/generated/generated_vulkan_constant_maps.h
+++ b/framework/generated/generated_vulkan_constant_maps.h
@@ -1,0 +1,75 @@
+/*
+** Copyright (c) 2018-2023 Valve Corporation
+** Copyright (c) 2018-2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+/*
+** This file is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+#ifndef  GFXRECON_GENERATED_VULKAN_CONSTANT_MAPS_H
+#define  GFXRECON_GENERATED_VULKAN_CONSTANT_MAPS_H
+
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+#include "vk_video/vulkan_video_codec_h264std.h"
+#include "vk_video/vulkan_video_codec_h264std_decode.h"
+#include "vk_video/vulkan_video_codec_h264std_encode.h"
+#include "vk_video/vulkan_video_codec_h265std.h"
+#include "vk_video/vulkan_video_codec_h265std_decode.h"
+#include "vk_video/vulkan_video_codec_h265std_encode.h"
+#include "vk_video/vulkan_video_codecs_common.h"
+
+#include <unordered_map>
+#include <vector>
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+static const std::unordered_map<VkColorSpaceKHR, const char *> kColorSpaceExtensionMap = {
+{VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_BT709_LINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_BT709_NONLINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_BT2020_LINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_HDR10_ST2084_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_DOLBYVISION_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_HDR10_HLG_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_PASS_THROUGH_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_DCI_P3_LINEAR_EXT, "VK_EXT_swapchain_colorspace"},
+{VK_COLOR_SPACE_DISPLAY_NATIVE_AMD, "VK_AMD_display_native_hdr"},
+};
+
+static const std::vector<const char *> kColorSpaceExtensionNames = {
+"VK_AMD_display_native_hdr",
+"VK_EXT_swapchain_colorspace",
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -94,6 +94,9 @@ from vulkan_enum_to_json_header_generator import VulkanEnumToJsonHeaderGenerator
 from vulkan_struct_to_json_header_generator import VulkanStructToJsonHeaderGenerator, VulkanStructToJsonHeaderGeneratorOptions
 from vulkan_struct_to_json_body_generator import VulkanStructToJsonBodyGenerator, VulkanStructToJsonBodyGeneratorOptions
 
+# Constants
+from vulkan_constant_maps_generator import VulkanConstantMapsGenerator, VulkanConstantMapsGeneratorOptions
+
 # Simple timer functions
 start_time = None
 
@@ -695,6 +698,20 @@ def make_gen_opts(args):
             prefixText=prefix_strings + vk_prefix_strings,
             protectFile=False,
             protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders
+        )
+    ]
+
+    gen_opts['generated_vulkan_constant_maps.h'] = [
+        VulkanConstantMapsGenerator,
+        VulkanConstantMapsGeneratorOptions(
+            filename='generated_vulkan_constant_maps.h',
+            directory=directory,
+            blacklists=blacklists,
+            platform_types=platform_types,
+            prefix_text=prefix_strings + vk_prefix_strings,
+            protect_file=True,
+            protect_feature=False,
             extraVulkanHeaders=extraVulkanHeaders
         )
     ]

--- a/framework/generated/vulkan_generators/vulkan_constant_maps_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_constant_maps_generator.py
@@ -103,7 +103,7 @@ class VulkanConstantMapsGenerator(BaseGenerator):
             'static const std::vector<const char *> kColorSpaceExtensionNames = {',
             file=self.outFile
         )
-        for extension_name in colorspace_extensions_names:
+        for extension_name in sorted(colorspace_extensions_names):
             write(f'"{extension_name}",', file=self.outFile)
         write('};', file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_constant_maps_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_constant_maps_generator.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python3 -i
+
+import sys
+from base_generator import BaseGenerator, BaseGeneratorOptions, write
+
+
+class VulkanConstantMapsGeneratorOptions(BaseGeneratorOptions):
+    """Adds the following new option:
+    is_override - Specify whether the member function declarations are
+                  virtual function overrides or pure virtual functions.
+    Options for generating C++ class declarations for Vulkan parameter processing.
+    """
+
+    def __init__(
+        self,
+        blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+        platform_types=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+        filename=None,
+        directory='.',
+        prefix_text='',
+        protect_file=False,
+        protect_feature=True,
+        extraVulkanHeaders=[]
+    ):
+        BaseGeneratorOptions.__init__(
+            self,
+            blacklists,
+            platform_types,
+            filename,
+            directory,
+            prefix_text,
+            protect_file,
+            protect_feature,
+            extraVulkanHeaders=extraVulkanHeaders
+        )
+
+
+class VulkanConstantMapsGenerator(BaseGenerator):
+    """VulkanColorspaceMapGenerator - subclass of BaseGenerator.
+    """
+
+    def __init__(
+        self, err_file=sys.stderr, warn_file=sys.stderr, diag_file=sys.stdout
+    ):
+        BaseGenerator.__init__(
+            self,
+            process_cmds=True,
+            process_structs=False,
+            feature_break=True,
+            err_file=err_file,
+            warn_file=warn_file,
+            diag_file=diag_file
+        )
+
+    def beginFile(self, gen_opts):
+        """Method override."""
+        BaseGenerator.beginFile(self, gen_opts)
+
+        write('#include "util/defines.h"', file=self.outFile)
+        self.newline()
+        self.includeVulkanHeaders(gen_opts)
+        self.newline()
+        write('#include <unordered_map>', file=self.outFile)
+        write('#include <vector>', file=self.outFile)
+
+        write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
+        self.newline()
+
+        colorspace_extensions_names = set()
+        colorspace_extension_map = dict.fromkeys(
+            filter(
+                lambda enum_value: 'VK_COLOR_SPACE' in enum_value,
+                self.registry.enumdict
+            )
+        )
+        colorspace_extension_map.pop(
+            'VK_COLOR_SPACE_SRGB_NONLINEAR_KHR'
+        )  # Remove the core provided color space from extension map
+        for extension in self.registry.extensions:
+            colorspace_enum = filter(
+                lambda element: 'VK_COLOR_SPACE' in element.get('name'),
+                extension.findall('require/enum')
+            )
+            colorspace_enum = map(
+                lambda element: element.get('name'), colorspace_enum
+            )
+            for name in colorspace_enum:
+                value = extension.get("name")
+                colorspace_extensions_names.add(value)
+                colorspace_extension_map[name] = f'"{value}"'
+
+        write(
+            'static const std::unordered_map<VkColorSpaceKHR, const char *> kColorSpaceExtensionMap = {',
+            file=self.outFile
+        )
+        for key, value in colorspace_extension_map.items():
+            write(f'{{{key}, {value}}},', file=self.outFile)
+        write('};', file=self.outFile)
+        self.newline()
+
+        write(
+            'static const std::vector<const char *> kColorSpaceExtensionNames = {',
+            file=self.outFile
+        )
+        for extension_name in colorspace_extensions_names:
+            write(f'"{extension_name}",', file=self.outFile)
+        write('};', file=self.outFile)
+        self.newline()
+
+    def endFile(self):
+        """Method override."""
+        write('GFXRECON_END_NAMESPACE(decode)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
+
+        # Finish processing in superclass
+        BaseGenerator.endFile(self)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -31,7 +31,7 @@ const char kOptions[] =
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
     "range,--fmr|--flush-measurement-range,--use-captured-swapchain-indices,--dcp,--discard-cached-psos,"
-    "--colorspace-fallback,--use-cached-psos,--dx12-override-object-names";
+    "--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -64,7 +64,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--swapchain <mode>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-captured-swapchain-indices]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--colorspace-fallback]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--use-colorspace-fallback]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--mfr|--measurement-frame-range <start-frame>-<end-frame>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--measurement-file <file>] [--quit-after-measurement-range]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--flush-measurement-range]");
@@ -207,7 +207,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tframe but can be configured for any range. If the end frame is past the");
     GFXRECON_WRITE_CONSOLE("          \t\tlast frame in the trace it will be clamped to the frame after the last");
     GFXRECON_WRITE_CONSOLE("          \t\t(so in that case the results would include the last frame).");
-    GFXRECON_WRITE_CONSOLE("  --colorspace-fallback");
+    GFXRECON_WRITE_CONSOLE("  --use-colorspace-fallback");
     GFXRECON_WRITE_CONSOLE("          \t\tSwap the swapchain color space if unsupported by replay device.");
     GFXRECON_WRITE_CONSOLE("          \t\tCheck if color space is not supported by replay device and fallback to "
                            "VK_COLOR_SPACE_SRGB_NONLINEAR_KHR.");

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -31,7 +31,7 @@ const char kOptions[] =
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
     "range,--fmr|--flush-measurement-range,--use-captured-swapchain-indices,--dcp,--discard-cached-psos,"
-    "--use-cached-psos,--dx12-override-object-names";
+    "--colorspace-fallback,--use-cached-psos,--dx12-override-object-names";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -64,6 +64,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--swapchain <mode>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-captured-swapchain-indices]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--colorspace-fallback]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--mfr|--measurement-frame-range <start-frame>-<end-frame>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--measurement-file <file>] [--quit-after-measurement-range]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--flush-measurement-range]");
@@ -206,6 +207,10 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tframe but can be configured for any range. If the end frame is past the");
     GFXRECON_WRITE_CONSOLE("          \t\tlast frame in the trace it will be clamped to the frame after the last");
     GFXRECON_WRITE_CONSOLE("          \t\t(so in that case the results would include the last frame).");
+    GFXRECON_WRITE_CONSOLE("  --colorspace-fallback");
+    GFXRECON_WRITE_CONSOLE("          \t\tSwap the swapchain color space if unsupported by replay device.");
+    GFXRECON_WRITE_CONSOLE("          \t\tCheck if color space is not supported by replay device and fallback to "
+                           "VK_COLOR_SPACE_SRGB_NONLINEAR_KHR.");
     GFXRECON_WRITE_CONSOLE("  --measurement-file <file>");
     GFXRECON_WRITE_CONSOLE("          \t\tWrite measurements to a file at the specified path.");
     GFXRECON_WRITE_CONSOLE("          \t\tDefault is: '/sdcard/gfxrecon-measurements.json' on android and");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -106,7 +106,7 @@ const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
 const char kSwapchainOption[]                    = "--swapchain";
 const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
-const char kColorspaceFallback[]    = "--colorspace-fallback";
+const char kColorspaceFallback[]    = "--use-colorspace-fallback";
 const char kFormatArgument[]        = "--format";
 const char kIncludeBinariesOption[] = "--include-binaries";
 const char kExpandFlagsOption[]     = "--expand-flags";
@@ -870,7 +870,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
 
     if (arg_parser.IsOptionSet(kColorspaceFallback))
     {
-        replay_options.colorspace_fallback = true;
+        replay_options.use_colorspace_fallback = true;
     }
 
     replay_options.replace_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -106,6 +106,7 @@ const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
 const char kSwapchainOption[]                    = "--swapchain";
 const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
+const char kColorspaceFallback[]    = "--colorspace-fallback";
 const char kFormatArgument[]        = "--format";
 const char kIncludeBinariesOption[] = "--include-binaries";
 const char kExpandFlagsOption[]     = "--expand-flags";
@@ -865,6 +866,11 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         {
             GFXRECON_LOG_WARNING("Ignoring unrecognized \"--swapchain\" option: %s", swapchain_option.c_str());
         }
+    }
+
+    if (arg_parser.IsOptionSet(kColorspaceFallback))
+    {
+        replay_options.colorspace_fallback = true;
     }
 
     replay_options.replace_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);


### PR DESCRIPTION
- Check whether the color space used by swapchain is supported by the replay device. Inform the user through log if it is not.
- Introduce an option, that when enabled, will fallback to supported color space for swapchain.