### PR TITLE
Removed Dead Copied Code

### DIFF
--- a/framework/generated/dx12_generators/dx12_struct_to_string_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_to_string_body_generator.py
@@ -27,11 +27,6 @@ from dx12_base_generator import Dx12BaseGenerator
 class Dx12StructToStringBodyGenerator(Dx12BaseGenerator):
     """TODO : Generates C++ functions responsible for Convert to texts."""
 
-    BITS_LIST = [
-        '_FLAGS', '_STATES', '_STATUS', 'D3D12_SHADER_MIN_PRECISION_SUPPORT',
-        'D3D12_FORMAT_SUPPORT1', 'D3D12_FORMAT_SUPPORT2'
-    ]
-
     def __init__(
         self,
         source_dict,

--- a/framework/generated/dx12_generators/dx12_struct_to_string_header_generator.py
+++ b/framework/generated/dx12_generators/dx12_struct_to_string_header_generator.py
@@ -27,11 +27,6 @@ from dx12_base_generator import Dx12BaseGenerator
 class Dx12StructToStringHeaderGenerator(Dx12BaseGenerator):
     """TODO : Generates C++ functions responsible for Convert to texts."""
 
-    BITS_LIST = [
-        '_FLAGS', '_STATES', '_STATUS', 'D3D12_SHADER_MIN_PRECISION_SUPPORT',
-        'D3D12_FORMAT_SUPPORT1', 'D3D12_FORMAT_SUPPORT2'
-    ]
-
     def __init__(
         self,
         source_dict,


### PR DESCRIPTION
Stray code obviously copied from the enum to string generator removed.

Struct generators don't use:
```
    BITS_LIST = [
        '_FLAGS', '_STATES', '_STATUS', 'D3D12_SHADER_MIN_PRECISION_SUPPORT',
        'D3D12_FORMAT_SUPPORT1', 'D3D12_FORMAT_SUPPORT2'
    ]
```

These are used to detects enums that are bit flags.