### PR TITLE
Remove oldswapchain images when swapchaincreate is captured

### DIFF
--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -8004,6 +8004,18 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>::Dispatch(VulkanCaptureManager::Get(), result, device, pCreateInfo, pAllocator, pSwapchain);
 
+    // Release all images associated with oldSwapchain
+    // This may not be right - maybe should not release images that were returned by vkAcquireNextImage??
+    if (pCreateInfo->oldSwapchain) {
+        auto wrapper = GetWrapper<SwapchainKHRWrapper>(pCreateInfo->oldSwapchain);
+        for (auto image_wrapper : wrapper->child_images)
+        {
+            RemoveWrapper<ImageWrapper>(image_wrapper);
+            delete image_wrapper;
+        }
+        wrapper->child_images.clear();
+    }
+
     return result;
 }
 


### PR DESCRIPTION
This is an experimental change. A generated file was directly modified so as to see how CI tests behave when images are removed from oldswapchain.