### PR TITLE
Check whether ANDROID_SERIAL was set when working with multiple devices

### DIFF
--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -68,7 +68,7 @@ def CheckDeviceSelection():
     devices = QueryAvailableDevices()
     if len(devices) <= 1:
         return
-    
+
     selection = os.getenv(android_serial)
     if selection is None or selection == '':
         raise DeviceSelectionException('Multiple devices detected - you must specify which one to use by setting ANDROID_SERIAL environment variable.')
@@ -365,8 +365,6 @@ def Replay(replay_args):
     if extras:
         if args.push_file:
             cmd = ' '.join([adb_push, args.push_file, args.file])
-            if selection is not None:
-                cmd = InsertDeviceSelectionArgument(cmd, selection)
             print('Executing:', cmd)
             subprocess.check_call(shlex.split(cmd, posix='win' not in sys.platform))
 
@@ -374,8 +372,6 @@ def Replay(replay_args):
         subprocess.check_call(shlex.split(adb_stop, posix='win' not in sys.platform))
 
         cmd = ' '.join([adb_start, '--es', '"args"', '"{}"'.format(extras)])
-        if selection is not None:
-            cmd = InsertDeviceSelectionArgument(cmd, selection)
         print('Executing:', cmd)
 
         # Specify posix=False to prevent removal of quotes from adb extras.

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -371,7 +371,7 @@ def Replay(replay_args):
 
         print('Executing:', adb_stop)
         subprocess.check_call(shlex.split(adb_stop, posix='win' not in sys.platform))
-        
+
         cmd = ' '.join([adb_start, '--es', '"args"', '"{}"'.format(extras)])
         if selection is not None:
             cmd = InsertDeviceSelectionArgument(cmd, selection)

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -60,7 +60,8 @@ class DeviceSelectionException(Exception):
     pass
 
 def QueryAvailableDevices():
-    devices = subprocess.getoutput(adb_devices).splitlines()[1:]
+    result = subprocess.run(shlex.split(adb_devices, posix='win' not in sys.platform), capture_output=True, check=True)
+    devices = result.stdout.decode().strip().splitlines()[1:]
     return [device.split('\t')[0] for device in devices]
 
 def CheckDeviceSelection():

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -51,6 +51,24 @@ adb_sdk_version = 'adb shell getprop ro.build.version.sdk'
 adb_start = 'adb shell am start -n {} -a {} -c {}'.format(app_activity, app_action, app_category)
 adb_stop = 'adb shell am force-stop {}'.format(app_name)
 adb_push = 'adb push'
+adb_devices = 'adb devices'
+
+# List of available devices
+devices = []
+device_selection_insertion_index = len('adb') + 1
+selection_flag = '-s'
+
+class DeviceSelectionException(Exception):
+    pass
+
+def QueryAvailableDevices():
+    devices = subprocess.getoutput(adb_devices).splitlines()[1:]
+    for i in range(len(devices)):
+        devices[i] = devices[i].split('\t')[0]
+    return devices
+
+def InsertDeviceSelectionArgument(cmd, device):
+        return cmd[:device_selection_insertion_index] + f'{selection_flag} {device} ' + cmd[device_selection_insertion_index:]
 
 def CreateCommandParser():
     parser = argparse.ArgumentParser(description='GFXReconstruct utility launcher for Android.')
@@ -61,6 +79,7 @@ def CreateCommandParser():
 def CreateInstallApkParser():
     parser = argparse.ArgumentParser(prog=os.path.basename(sys.argv[0]) + ' install-apk', description='Install the replay tool.')
     parser.add_argument('file', help='APK file to install')
+    parser.add_argument('-s', '--select', metavar='DEVICE_ID', help='Specify the destination device id. Needed if multiple devices are attached.')
     return parser
 
 def CreateReplayParser():
@@ -120,6 +139,8 @@ def CreateReplayParser():
     parser.add_argument('--load-pipeline-cache', metavar='DEVICE_FILE', help='If set, loads data created by the `--save-pipeline-cache` option in DEVICE_FILE and uses it to create the pipelines instead of the pipeline caches saved at capture time. (forwarded to replay tool)')
     parser.add_argument('--add-new-pipeline-caches', action='store_true', default=False, help='If set, allows gfxreconstruct to create new vkPipelineCache objects when it encounters a pipeline created without cache. This option can be used in coordination with `--save-pipeline-cache` and `--load-pipeline-cache`. (forwarded to replay tool)')
     parser.add_argument('--quit-after-frame', metavar='FRAME', help='Specify a frame after which replay will terminate.')
+    parser.add_argument('-s', '--select', metavar='DEVICE_ID', help='Specify the destination device id. Needed if multiple devices are attached.')
+
     return parser
 
 def MakeExtrasString(args):
@@ -323,6 +344,17 @@ def InstallApk(install_args):
     sdk = int(subprocess.check_output(shlex.split(adb_sdk_version)).decode())
     force_queryable = ' --force-queryable' if sdk >= 30 else ''
     cmd = adb_install + force_queryable + ' ' + args.file
+    
+    if len(devices) > 1:
+        selection = None
+        if args.select:
+            selection = args.select
+            if selection not in devices:
+                raise DeviceSelectionException('Selected device not present.')
+            cmd = InsertDeviceSelectionArgument(cmd, selection)
+        else:
+            raise DeviceSelectionException('Multiple devices detected - you must specify which one to use.')
+            
     print('Executing:', cmd)
     subprocess.check_call(shlex.split(cmd, posix='win' not in sys.platform))
 
@@ -332,22 +364,41 @@ def Replay(replay_args):
 
     extras = MakeExtrasString(args)
 
+    selection = None
+    if len(devices) > 1:
+        if args.select:
+            selection = args.select
+            if selection not in devices:
+                raise DeviceSelectionException('Selected device not present.')
+        else:
+            raise DeviceSelectionException('Multiple devices detected - you must specify which one to use.')
+
+
     if extras:
         if args.push_file:
             cmd = ' '.join([adb_push, args.push_file, args.file])
+            if selection is not None:
+                cmd = InsertDeviceSelectionArgument(cmd, selection)
             print('Executing:', cmd)
             subprocess.check_call(shlex.split(cmd, posix='win' not in sys.platform))
 
-        print('Executing:', adb_stop)
-        subprocess.check_call(shlex.split(adb_stop, posix='win' not in sys.platform))
-
+        cmd = adb_stop
+        if selection is not None:
+            cmd = InsertDeviceSelectionArgument(cmd, selection)
+        print('Executing:', cmd)
+        subprocess.check_call(shlex.split(cmd, posix='win' not in sys.platform))
+        
         cmd = ' '.join([adb_start, '--es', '"args"', '"{}"'.format(extras)])
+        if selection is not None:
+            cmd = InsertDeviceSelectionArgument(cmd, selection)
         print('Executing:', cmd)
 
         # Specify posix=False to prevent removal of quotes from adb extras.
         subprocess.check_call(shlex.split(cmd, posix=False))
 
 if __name__ == '__main__':
+    devices = QueryAvailableDevices()
+
     command_parser = CreateCommandParser()
     command = command_parser.parse_args()
 


### PR DESCRIPTION
Added a check whether the ANDROID_SERIAL was set.

This change is needed as when more than one device is connected, the script crashes if the selection is not explicitly specified. This change makes the error message more transparent and suggests the way to fix it.