### PR TITLE
Fix in ProcessInitImageCommand

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -874,8 +874,9 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
             if (data_size > 0)
             {
                 if ((image_info->tiling == VK_IMAGE_TILING_LINEAR) &&
-                    (image_info->memory_property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ==
-                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+                    (image_info->memory_property_flags &
+                     (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)) ==
+                        (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT))
                 {
                     result = initializer->LoadData(data_size, data, image_info->allocator_data);
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1755,7 +1755,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
             VkMemoryPropertyFlags memory_properties = 0;
             if (memory_wrapper != nullptr)
             {
-                GetMemoryProperties(device_wrapper, memory_wrapper, state_table);
+                memory_properties = GetMemoryProperties(device_wrapper, memory_wrapper, state_table);
             }
 
             bool is_transitioned = (wrapper->current_layout != VK_IMAGE_LAYOUT_UNDEFINED) &&


### PR DESCRIPTION
When capturing trimmed under certain conditions texture data were dumped to the capture file using a staging buffer and at during replay they were loaded back to the texture without a staging buffer. This occasionally led to corrupted textures. This patch should address this issue