### PR TITLE
C++ Indenter for Python Codegen

### DIFF
--- a/framework/generated/base_generators/reformat_code.py
+++ b/framework/generated/base_generators/reformat_code.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2023 Valve Corporation
+# Copyright (c) 2023 LunarG, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+## @file Helpers used to clean up generated C++ code, allowing generators to be
+## a little rougher in their indentation and then fix the result in post.
+## For example they could use triple quote multiline string literals to
+## encompass snippets of C++ and keep the C++ indented appropriately for the
+## surrounding Python code for human readability rather than indented to the
+## level appropriate for the final C++ output.
+
+CPP_DEFAULT_INDENT = '    '
+
+## Sort out the indentation of a generated chunk of C++ code that puts braces on
+## their own lines. Strips wholy-whitespace lines and trailing white.
+## @note It relies on the C++ code having braces on their own lines or else it
+## might all go wrong.
+def indent_cpp_code(code, left_level=0, indent=CPP_DEFAULT_INDENT):
+    formatted_code = ""
+    level = 0
+    for line in code.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith('}'):
+            level -= 1
+
+        modified_line = (left_level + level) * indent + stripped
+        modified_line = modified_line.rstrip()
+
+        if modified_line.endswith('{'):
+            level += 1
+
+        modified_line += '\n'
+
+        formatted_code += modified_line
+
+    return formatted_code
+
+def format_cpp_code(code, left_level=0, indent=CPP_DEFAULT_INDENT):
+    formatted_code = indent_cpp_code(code, left_level, indent)
+    formatted_code = remove_trailing_empty_lines(formatted_code)
+    formatted_code = remove_leading_empty_lines(formatted_code)
+    return formatted_code
+
+def remove_leading_empty_lines(code):
+    return code.lstrip('\n')
+
+def remove_trailing_empty_lines(code):
+    return code.rstrip('\n')

--- a/framework/generated/generated_vulkan_enum_to_json.h
+++ b/framework/generated/generated_vulkan_enum_to_json.h
@@ -39,9 +39,9 @@
 #include "vk_video/vulkan_video_codec_h265std_decode.h"
 #include "vk_video/vulkan_video_codec_h265std_encode.h"
 #include "vk_video/vulkan_video_codecs_common.h"
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
-
 
 struct VkAccelerationStructureCreateFlagsKHR_t { };
 struct VkAccelerationStructureMotionInfoFlagsNV_t { };
@@ -230,7 +230,6 @@ struct VkBufferUsageFlagBits2KHR_t { };
 struct VkFormatFeatureFlagBits2_t { };
 struct VkPipelineCreateFlagBits2KHR_t { };
 struct VkPipelineStageFlagBits2_t { };
-
 
 void FieldToJson(nlohmann::ordered_json& jdata, const StdVideoDecodeH264FieldOrderCount& value, const JsonOptions& options = JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const StdVideoH264AspectRatioIdc& value, const JsonOptions& options = JsonOptions());
@@ -683,6 +682,7 @@ void FieldToJson(VkWaylandSurfaceCreateFlagsKHR_t, nlohmann::ordered_json& jdata
 void FieldToJson(VkWin32SurfaceCreateFlagsKHR_t, nlohmann::ordered_json& jdata, const VkFlags flags, const JsonOptions& options = JsonOptions());
 void FieldToJson(VkXcbSurfaceCreateFlagsKHR_t, nlohmann::ordered_json& jdata, const VkFlags flags, const JsonOptions& options = JsonOptions());
 void FieldToJson(VkXlibSurfaceCreateFlagsKHR_t, nlohmann::ordered_json& jdata, const VkFlags flags, const JsonOptions& options = JsonOptions());
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/generated/generated_vulkan_export_json_consumer.cpp
+++ b/framework/generated/generated_vulkan_export_json_consumer.cpp
@@ -37,6 +37,7 @@
 #include "vk_video/vulkan_video_codec_h265std_decode.h"
 #include "vk_video/vulkan_video_codec_h265std_encode.h"
 #include "vk_video/vulkan_video_codecs_common.h"
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 

--- a/framework/generated/generated_vulkan_struct_to_json.cpp
+++ b/framework/generated/generated_vulkan_struct_to_json.cpp
@@ -31,12 +31,15 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+
+
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264SpsVuiFlags* data, const JsonOptions& options)
 {
     if (data && data->decoded_value)
     {
         const StdVideoH264SpsVuiFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264SpsVuiFlags& meta_struct = *data;
+
         FieldToJson(jdata["aspect_ratio_info_present_flag"], decoded_value.aspect_ratio_info_present_flag, options);
         FieldToJson(jdata["overscan_info_present_flag"], decoded_value.overscan_info_present_flag, options);
         FieldToJson(jdata["overscan_appropriate_flag"], decoded_value.overscan_appropriate_flag, options);
@@ -58,6 +61,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264HrdPar
     {
         const StdVideoH264HrdParameters& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264HrdParameters& meta_struct = *data;
+
         FieldToJson(jdata["cpb_cnt_minus1"], decoded_value.cpb_cnt_minus1, options);
         FieldToJson(jdata["bit_rate_scale"], decoded_value.bit_rate_scale, options);
         FieldToJson(jdata["cpb_size_scale"], decoded_value.cpb_size_scale, options);
@@ -78,6 +82,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264Sequen
     {
         const StdVideoH264SequenceParameterSetVui& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264SequenceParameterSetVui& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["aspect_ratio_idc"], decoded_value.aspect_ratio_idc, options);
         FieldToJson(jdata["sar_width"], decoded_value.sar_width, options);
@@ -103,6 +108,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264SpsFla
     {
         const StdVideoH264SpsFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264SpsFlags& meta_struct = *data;
+
         FieldToJson(jdata["constraint_set0_flag"], decoded_value.constraint_set0_flag, options);
         FieldToJson(jdata["constraint_set1_flag"], decoded_value.constraint_set1_flag, options);
         FieldToJson(jdata["constraint_set2_flag"], decoded_value.constraint_set2_flag, options);
@@ -128,6 +134,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264Scalin
     {
         const StdVideoH264ScalingLists& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264ScalingLists& meta_struct = *data;
+
         FieldToJson(jdata["scaling_list_present_mask"], decoded_value.scaling_list_present_mask, options);
         FieldToJson(jdata["use_default_scaling_matrix_mask"], decoded_value.use_default_scaling_matrix_mask, options);
         FieldToJson(jdata["ScalingList4x4"], &meta_struct.ScalingList4x4, options);
@@ -141,6 +148,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264Sequen
     {
         const StdVideoH264SequenceParameterSet& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264SequenceParameterSet& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["profile_idc"], decoded_value.profile_idc, options);
         FieldToJson(jdata["level_idc"], decoded_value.level_idc, options);
@@ -175,6 +183,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264PpsFla
     {
         const StdVideoH264PpsFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264PpsFlags& meta_struct = *data;
+
         FieldToJson(jdata["transform_8x8_mode_flag"], decoded_value.transform_8x8_mode_flag, options);
         FieldToJson(jdata["redundant_pic_cnt_present_flag"], decoded_value.redundant_pic_cnt_present_flag, options);
         FieldToJson(jdata["constrained_intra_pred_flag"], decoded_value.constrained_intra_pred_flag, options);
@@ -192,6 +201,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264Pictur
     {
         const StdVideoH264PictureParameterSet& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH264PictureParameterSet& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["seq_parameter_set_id"], decoded_value.seq_parameter_set_id, options);
         FieldToJson(jdata["pic_parameter_set_id"], decoded_value.pic_parameter_set_id, options);
@@ -212,6 +222,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH264
     {
         const StdVideoDecodeH264PictureInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH264PictureInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["field_pic_flag"], decoded_value.field_pic_flag, options);
         FieldToJson(jdata["is_intra"], decoded_value.is_intra, options);
         FieldToJson(jdata["IdrPicFlag"], decoded_value.IdrPicFlag, options);
@@ -227,6 +238,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH264
     {
         const StdVideoDecodeH264PictureInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH264PictureInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["seq_parameter_set_id"], decoded_value.seq_parameter_set_id, options);
         FieldToJson(jdata["pic_parameter_set_id"], decoded_value.pic_parameter_set_id, options);
@@ -244,6 +256,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH264
     {
         const StdVideoDecodeH264ReferenceInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH264ReferenceInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["top_field_flag"], decoded_value.top_field_flag, options);
         FieldToJson(jdata["bottom_field_flag"], decoded_value.bottom_field_flag, options);
         FieldToJson(jdata["used_for_long_term_reference"], decoded_value.used_for_long_term_reference, options);
@@ -257,6 +270,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH264
     {
         const StdVideoDecodeH264ReferenceInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH264ReferenceInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["FrameNum"], decoded_value.FrameNum, options);
         FieldToJson(jdata["reserved"], decoded_value.reserved, options);
@@ -270,6 +284,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264WeightTableFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264WeightTableFlags& meta_struct = *data;
+
         FieldToJson(jdata["luma_weight_l0_flag"], decoded_value.luma_weight_l0_flag, options);
         FieldToJson(jdata["chroma_weight_l0_flag"], decoded_value.chroma_weight_l0_flag, options);
         FieldToJson(jdata["luma_weight_l1_flag"], decoded_value.luma_weight_l1_flag, options);
@@ -283,6 +298,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264WeightTable& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264WeightTable& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["luma_log2_weight_denom"], decoded_value.luma_log2_weight_denom, options);
         FieldToJson(jdata["chroma_log2_weight_denom"], decoded_value.chroma_log2_weight_denom, options);
@@ -303,6 +319,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264SliceHeaderFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264SliceHeaderFlags& meta_struct = *data;
+
         FieldToJson(jdata["direct_spatial_mv_pred_flag"], decoded_value.direct_spatial_mv_pred_flag, options);
         FieldToJson(jdata["num_ref_idx_active_override_flag"], decoded_value.num_ref_idx_active_override_flag, options);
         FieldToJson(jdata["reserved"], decoded_value.reserved, options);
@@ -315,6 +332,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264PictureInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264PictureInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["IdrPicFlag"], decoded_value.IdrPicFlag, options);
         FieldToJson(jdata["is_reference"], decoded_value.is_reference, options);
         FieldToJson(jdata["no_output_of_prior_pics_flag"], decoded_value.no_output_of_prior_pics_flag, options);
@@ -330,6 +348,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264ReferenceInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264ReferenceInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["used_for_long_term_reference"], decoded_value.used_for_long_term_reference, options);
         FieldToJson(jdata["reserved"], decoded_value.reserved, options);
     }
@@ -341,6 +360,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264ReferenceListsInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264ReferenceListsInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["ref_pic_list_modification_flag_l0"], decoded_value.ref_pic_list_modification_flag_l0, options);
         FieldToJson(jdata["ref_pic_list_modification_flag_l1"], decoded_value.ref_pic_list_modification_flag_l1, options);
         FieldToJson(jdata["reserved"], decoded_value.reserved, options);
@@ -353,6 +373,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264RefListModEntry& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264RefListModEntry& meta_struct = *data;
+
         FieldToJson(jdata["modification_of_pic_nums_idc"], decoded_value.modification_of_pic_nums_idc, options);
         FieldToJson(jdata["abs_diff_pic_num_minus1"], decoded_value.abs_diff_pic_num_minus1, options);
         FieldToJson(jdata["long_term_pic_num"], decoded_value.long_term_pic_num, options);
@@ -365,6 +386,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264RefPicMarkingEntry& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264RefPicMarkingEntry& meta_struct = *data;
+
         FieldToJson(jdata["memory_management_control_operation"], decoded_value.memory_management_control_operation, options);
         FieldToJson(jdata["difference_of_pic_nums_minus1"], decoded_value.difference_of_pic_nums_minus1, options);
         FieldToJson(jdata["long_term_pic_num"], decoded_value.long_term_pic_num, options);
@@ -379,6 +401,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264ReferenceListsInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264ReferenceListsInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["num_ref_idx_l0_active_minus1"], decoded_value.num_ref_idx_l0_active_minus1, options);
         FieldToJson(jdata["num_ref_idx_l1_active_minus1"], decoded_value.num_ref_idx_l1_active_minus1, options);
@@ -400,6 +423,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264PictureInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264PictureInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["seq_parameter_set_id"], decoded_value.seq_parameter_set_id, options);
         FieldToJson(jdata["pic_parameter_set_id"], decoded_value.pic_parameter_set_id, options);
@@ -419,6 +443,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264ReferenceInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264ReferenceInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["primary_pic_type"], decoded_value.primary_pic_type, options);
         FieldToJson(jdata["FrameNum"], decoded_value.FrameNum, options);
@@ -435,6 +460,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH264
     {
         const StdVideoEncodeH264SliceHeader& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH264SliceHeader& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["first_mb_in_slice"], decoded_value.first_mb_in_slice, options);
         FieldToJson(jdata["slice_type"], decoded_value.slice_type, options);
@@ -454,6 +480,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265Profil
     {
         const StdVideoH265ProfileTierLevelFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265ProfileTierLevelFlags& meta_struct = *data;
+
         FieldToJson(jdata["general_tier_flag"], decoded_value.general_tier_flag, options);
         FieldToJson(jdata["general_progressive_source_flag"], decoded_value.general_progressive_source_flag, options);
         FieldToJson(jdata["general_interlaced_source_flag"], decoded_value.general_interlaced_source_flag, options);
@@ -468,6 +495,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265Profil
     {
         const StdVideoH265ProfileTierLevel& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265ProfileTierLevel& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["general_profile_idc"], decoded_value.general_profile_idc, options);
         FieldToJson(jdata["general_level_idc"], decoded_value.general_level_idc, options);
@@ -480,6 +508,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265DecPic
     {
         const StdVideoH265DecPicBufMgr& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265DecPicBufMgr& meta_struct = *data;
+
         FieldToJson(jdata["max_latency_increase_plus1"], &meta_struct.max_latency_increase_plus1, options);
         FieldToJson(jdata["max_dec_pic_buffering_minus1"], &meta_struct.max_dec_pic_buffering_minus1, options);
         FieldToJson(jdata["max_num_reorder_pics"], &meta_struct.max_num_reorder_pics, options);
@@ -492,6 +521,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265SubLay
     {
         const StdVideoH265SubLayerHrdParameters& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265SubLayerHrdParameters& meta_struct = *data;
+
         FieldToJson(jdata["bit_rate_value_minus1"], &meta_struct.bit_rate_value_minus1, options);
         FieldToJson(jdata["cpb_size_value_minus1"], &meta_struct.cpb_size_value_minus1, options);
         FieldToJson(jdata["cpb_size_du_value_minus1"], &meta_struct.cpb_size_du_value_minus1, options);
@@ -506,6 +536,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265HrdFla
     {
         const StdVideoH265HrdFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265HrdFlags& meta_struct = *data;
+
         FieldToJson(jdata["nal_hrd_parameters_present_flag"], decoded_value.nal_hrd_parameters_present_flag, options);
         FieldToJson(jdata["vcl_hrd_parameters_present_flag"], decoded_value.vcl_hrd_parameters_present_flag, options);
         FieldToJson(jdata["sub_pic_hrd_params_present_flag"], decoded_value.sub_pic_hrd_params_present_flag, options);
@@ -522,6 +553,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265HrdPar
     {
         const StdVideoH265HrdParameters& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265HrdParameters& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["tick_divisor_minus2"], decoded_value.tick_divisor_minus2, options);
         FieldToJson(jdata["du_cpb_removal_delay_increment_length_minus1"], decoded_value.du_cpb_removal_delay_increment_length_minus1, options);
@@ -546,6 +578,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265VpsFla
     {
         const StdVideoH265VpsFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265VpsFlags& meta_struct = *data;
+
         FieldToJson(jdata["vps_temporal_id_nesting_flag"], decoded_value.vps_temporal_id_nesting_flag, options);
         FieldToJson(jdata["vps_sub_layer_ordering_info_present_flag"], decoded_value.vps_sub_layer_ordering_info_present_flag, options);
         FieldToJson(jdata["vps_timing_info_present_flag"], decoded_value.vps_timing_info_present_flag, options);
@@ -559,6 +592,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265VideoP
     {
         const StdVideoH265VideoParameterSet& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265VideoParameterSet& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["vps_video_parameter_set_id"], decoded_value.vps_video_parameter_set_id, options);
         FieldToJson(jdata["vps_max_sub_layers_minus1"], decoded_value.vps_max_sub_layers_minus1, options);
@@ -580,6 +614,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265Scalin
     {
         const StdVideoH265ScalingLists& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265ScalingLists& meta_struct = *data;
+
         FieldToJson(jdata["ScalingList4x4"], &meta_struct.ScalingList4x4, options);
         FieldToJson(jdata["ScalingList8x8"], &meta_struct.ScalingList8x8, options);
         FieldToJson(jdata["ScalingList16x16"], &meta_struct.ScalingList16x16, options);
@@ -595,6 +630,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265ShortT
     {
         const StdVideoH265ShortTermRefPicSetFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265ShortTermRefPicSetFlags& meta_struct = *data;
+
         FieldToJson(jdata["inter_ref_pic_set_prediction_flag"], decoded_value.inter_ref_pic_set_prediction_flag, options);
         FieldToJson(jdata["delta_rps_sign"], decoded_value.delta_rps_sign, options);
     }
@@ -606,6 +642,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265ShortT
     {
         const StdVideoH265ShortTermRefPicSet& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265ShortTermRefPicSet& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["delta_idx_minus1"], decoded_value.delta_idx_minus1, options);
         FieldToJson(jdata["use_delta_flag"], decoded_value.use_delta_flag, options);
@@ -629,6 +666,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265LongTe
     {
         const StdVideoH265LongTermRefPicsSps& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265LongTermRefPicsSps& meta_struct = *data;
+
         FieldToJson(jdata["used_by_curr_pic_lt_sps_flag"], decoded_value.used_by_curr_pic_lt_sps_flag, options);
         FieldToJson(jdata["lt_ref_pic_poc_lsb_sps"], &meta_struct.lt_ref_pic_poc_lsb_sps, options);
     }
@@ -640,6 +678,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265SpsVui
     {
         const StdVideoH265SpsVuiFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265SpsVuiFlags& meta_struct = *data;
+
         FieldToJson(jdata["aspect_ratio_info_present_flag"], decoded_value.aspect_ratio_info_present_flag, options);
         FieldToJson(jdata["overscan_info_present_flag"], decoded_value.overscan_info_present_flag, options);
         FieldToJson(jdata["overscan_appropriate_flag"], decoded_value.overscan_appropriate_flag, options);
@@ -667,6 +706,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265Sequen
     {
         const StdVideoH265SequenceParameterSetVui& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265SequenceParameterSetVui& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["aspect_ratio_idc"], decoded_value.aspect_ratio_idc, options);
         FieldToJson(jdata["sar_width"], decoded_value.sar_width, options);
@@ -702,6 +742,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265Predic
     {
         const StdVideoH265PredictorPaletteEntries& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265PredictorPaletteEntries& meta_struct = *data;
+
         FieldToJson(jdata["PredictorPaletteEntries"], &meta_struct.PredictorPaletteEntries, options);
     }
 }
@@ -712,6 +753,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265SpsFla
     {
         const StdVideoH265SpsFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265SpsFlags& meta_struct = *data;
+
         FieldToJson(jdata["sps_temporal_id_nesting_flag"], decoded_value.sps_temporal_id_nesting_flag, options);
         FieldToJson(jdata["separate_colour_plane_flag"], decoded_value.separate_colour_plane_flag, options);
         FieldToJson(jdata["conformance_window_flag"], decoded_value.conformance_window_flag, options);
@@ -751,6 +793,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265Sequen
     {
         const StdVideoH265SequenceParameterSet& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265SequenceParameterSet& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["chroma_format_idc"], decoded_value.chroma_format_idc, options);
         FieldToJson(jdata["pic_width_in_luma_samples"], decoded_value.pic_width_in_luma_samples, options);
@@ -799,6 +842,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265PpsFla
     {
         const StdVideoH265PpsFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265PpsFlags& meta_struct = *data;
+
         FieldToJson(jdata["dependent_slice_segments_enabled_flag"], decoded_value.dependent_slice_segments_enabled_flag, options);
         FieldToJson(jdata["output_flag_present_flag"], decoded_value.output_flag_present_flag, options);
         FieldToJson(jdata["sign_data_hiding_enabled_flag"], decoded_value.sign_data_hiding_enabled_flag, options);
@@ -839,6 +883,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH265Pictur
     {
         const StdVideoH265PictureParameterSet& decoded_value = *data->decoded_value;
         const Decoded_StdVideoH265PictureParameterSet& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["pps_pic_parameter_set_id"], decoded_value.pps_pic_parameter_set_id, options);
         FieldToJson(jdata["pps_seq_parameter_set_id"], decoded_value.pps_seq_parameter_set_id, options);
@@ -884,6 +929,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH265
     {
         const StdVideoDecodeH265PictureInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH265PictureInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["IrapPicFlag"], decoded_value.IrapPicFlag, options);
         FieldToJson(jdata["IdrPicFlag"], decoded_value.IdrPicFlag, options);
         FieldToJson(jdata["IsReference"], decoded_value.IsReference, options);
@@ -897,6 +943,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH265
     {
         const StdVideoDecodeH265PictureInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH265PictureInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["sps_video_parameter_set_id"], decoded_value.sps_video_parameter_set_id, options);
         FieldToJson(jdata["pps_seq_parameter_set_id"], decoded_value.pps_seq_parameter_set_id, options);
@@ -917,6 +964,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH265
     {
         const StdVideoDecodeH265ReferenceInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH265ReferenceInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["used_for_long_term_reference"], decoded_value.used_for_long_term_reference, options);
         FieldToJson(jdata["unused_for_reference"], decoded_value.unused_for_reference, options);
     }
@@ -928,6 +976,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoDecodeH265
     {
         const StdVideoDecodeH265ReferenceInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoDecodeH265ReferenceInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["PicOrderCntVal"], decoded_value.PicOrderCntVal, options);
     }
@@ -939,6 +988,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265WeightTableFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265WeightTableFlags& meta_struct = *data;
+
         FieldToJson(jdata["luma_weight_l0_flag"], decoded_value.luma_weight_l0_flag, options);
         FieldToJson(jdata["chroma_weight_l0_flag"], decoded_value.chroma_weight_l0_flag, options);
         FieldToJson(jdata["luma_weight_l1_flag"], decoded_value.luma_weight_l1_flag, options);
@@ -952,6 +1002,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265WeightTable& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265WeightTable& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["luma_log2_weight_denom"], decoded_value.luma_log2_weight_denom, options);
         FieldToJson(jdata["delta_chroma_log2_weight_denom"], decoded_value.delta_chroma_log2_weight_denom, options);
@@ -972,6 +1023,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265LongTermRefPics& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265LongTermRefPics& meta_struct = *data;
+
         FieldToJson(jdata["num_long_term_sps"], decoded_value.num_long_term_sps, options);
         FieldToJson(jdata["num_long_term_pics"], decoded_value.num_long_term_pics, options);
         FieldToJson(jdata["lt_idx_sps"], &meta_struct.lt_idx_sps, options);
@@ -988,6 +1040,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265SliceSegmentHeaderFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265SliceSegmentHeaderFlags& meta_struct = *data;
+
         FieldToJson(jdata["first_slice_segment_in_pic_flag"], decoded_value.first_slice_segment_in_pic_flag, options);
         FieldToJson(jdata["dependent_slice_segment_flag"], decoded_value.dependent_slice_segment_flag, options);
         FieldToJson(jdata["slice_sao_luma_flag"], decoded_value.slice_sao_luma_flag, options);
@@ -1010,6 +1063,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265SliceSegmentHeader& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265SliceSegmentHeader& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["slice_type"], decoded_value.slice_type, options);
         FieldToJson(jdata["slice_segment_address"], decoded_value.slice_segment_address, options);
@@ -1034,6 +1088,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265ReferenceListsInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265ReferenceListsInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["ref_pic_list_modification_flag_l0"], decoded_value.ref_pic_list_modification_flag_l0, options);
         FieldToJson(jdata["ref_pic_list_modification_flag_l1"], decoded_value.ref_pic_list_modification_flag_l1, options);
         FieldToJson(jdata["reserved"], decoded_value.reserved, options);
@@ -1046,6 +1101,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265ReferenceListsInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265ReferenceListsInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["num_ref_idx_l0_active_minus1"], decoded_value.num_ref_idx_l0_active_minus1, options);
         FieldToJson(jdata["num_ref_idx_l1_active_minus1"], decoded_value.num_ref_idx_l1_active_minus1, options);
@@ -1062,6 +1118,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265PictureInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265PictureInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["is_reference"], decoded_value.is_reference, options);
         FieldToJson(jdata["IrapPicFlag"], decoded_value.IrapPicFlag, options);
         FieldToJson(jdata["used_for_long_term_reference"], decoded_value.used_for_long_term_reference, options);
@@ -1081,6 +1138,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265PictureInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265PictureInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["pic_type"], decoded_value.pic_type, options);
         FieldToJson(jdata["sps_video_parameter_set_id"], decoded_value.sps_video_parameter_set_id, options);
@@ -1102,6 +1160,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265ReferenceInfoFlags& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265ReferenceInfoFlags& meta_struct = *data;
+
         FieldToJson(jdata["used_for_long_term_reference"], decoded_value.used_for_long_term_reference, options);
         FieldToJson(jdata["unused_for_reference"], decoded_value.unused_for_reference, options);
         FieldToJson(jdata["reserved"], decoded_value.reserved, options);
@@ -1114,6 +1173,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoEncodeH265
     {
         const StdVideoEncodeH265ReferenceInfo& decoded_value = *data->decoded_value;
         const Decoded_StdVideoEncodeH265ReferenceInfo& meta_struct = *data;
+
         FieldToJson(jdata["flags"], meta_struct.flags, options);
         FieldToJson(jdata["pic_type"], decoded_value.pic_type, options);
         FieldToJson(jdata["PicOrderCntVal"], decoded_value.PicOrderCntVal, options);
@@ -1127,6 +1187,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExtent2D* data, 
     {
         const VkExtent2D& decoded_value = *data->decoded_value;
         const Decoded_VkExtent2D& meta_struct = *data;
+
         FieldToJson(jdata["width"], decoded_value.width, options);
         FieldToJson(jdata["height"], decoded_value.height, options);
     }
@@ -1138,6 +1199,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExtent3D* data, 
     {
         const VkExtent3D& decoded_value = *data->decoded_value;
         const Decoded_VkExtent3D& meta_struct = *data;
+
         FieldToJson(jdata["width"], decoded_value.width, options);
         FieldToJson(jdata["height"], decoded_value.height, options);
         FieldToJson(jdata["depth"], decoded_value.depth, options);
@@ -1150,6 +1212,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkOffset2D* data, 
     {
         const VkOffset2D& decoded_value = *data->decoded_value;
         const Decoded_VkOffset2D& meta_struct = *data;
+
         FieldToJson(jdata["x"], decoded_value.x, options);
         FieldToJson(jdata["y"], decoded_value.y, options);
     }
@@ -1161,6 +1224,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkOffset3D* data, 
     {
         const VkOffset3D& decoded_value = *data->decoded_value;
         const Decoded_VkOffset3D& meta_struct = *data;
+
         FieldToJson(jdata["x"], decoded_value.x, options);
         FieldToJson(jdata["y"], decoded_value.y, options);
         FieldToJson(jdata["z"], decoded_value.z, options);
@@ -1173,6 +1237,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRect2D* data, co
     {
         const VkRect2D& decoded_value = *data->decoded_value;
         const Decoded_VkRect2D& meta_struct = *data;
+
         FieldToJson(jdata["offset"], meta_struct.offset, options);
         FieldToJson(jdata["extent"], meta_struct.extent, options);
     }
@@ -1184,6 +1249,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferMemoryBarr
     {
         const VkBufferMemoryBarrier& decoded_value = *data->decoded_value;
         const Decoded_VkBufferMemoryBarrier& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkAccessFlags_t(),jdata["srcAccessMask"], decoded_value.srcAccessMask, options);
         FieldToJson(VkAccessFlags_t(),jdata["dstAccessMask"], decoded_value.dstAccessMask, options);
@@ -1202,6 +1268,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDispatchIndirect
     {
         const VkDispatchIndirectCommand& decoded_value = *data->decoded_value;
         const Decoded_VkDispatchIndirectCommand& meta_struct = *data;
+
         FieldToJson(jdata["x"], decoded_value.x, options);
         FieldToJson(jdata["y"], decoded_value.y, options);
         FieldToJson(jdata["z"], decoded_value.z, options);
@@ -1214,6 +1281,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrawIndexedIndir
     {
         const VkDrawIndexedIndirectCommand& decoded_value = *data->decoded_value;
         const Decoded_VkDrawIndexedIndirectCommand& meta_struct = *data;
+
         FieldToJson(jdata["indexCount"], decoded_value.indexCount, options);
         FieldToJson(jdata["instanceCount"], decoded_value.instanceCount, options);
         FieldToJson(jdata["firstIndex"], decoded_value.firstIndex, options);
@@ -1228,6 +1296,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrawIndirectComm
     {
         const VkDrawIndirectCommand& decoded_value = *data->decoded_value;
         const Decoded_VkDrawIndirectCommand& meta_struct = *data;
+
         FieldToJson(jdata["vertexCount"], decoded_value.vertexCount, options);
         FieldToJson(jdata["instanceCount"], decoded_value.instanceCount, options);
         FieldToJson(jdata["firstVertex"], decoded_value.firstVertex, options);
@@ -1241,6 +1310,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageSubresource
     {
         const VkImageSubresourceRange& decoded_value = *data->decoded_value;
         const Decoded_VkImageSubresourceRange& meta_struct = *data;
+
         FieldToJson(VkImageAspectFlags_t(),jdata["aspectMask"], decoded_value.aspectMask, options);
         FieldToJson(jdata["baseMipLevel"], decoded_value.baseMipLevel, options);
         FieldToJson(jdata["levelCount"], decoded_value.levelCount, options);
@@ -1255,6 +1325,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageMemoryBarri
     {
         const VkImageMemoryBarrier& decoded_value = *data->decoded_value;
         const Decoded_VkImageMemoryBarrier& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkAccessFlags_t(),jdata["srcAccessMask"], decoded_value.srcAccessMask, options);
         FieldToJson(VkAccessFlags_t(),jdata["dstAccessMask"], decoded_value.dstAccessMask, options);
@@ -1274,6 +1345,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryBarrier* d
     {
         const VkMemoryBarrier& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryBarrier& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkAccessFlags_t(),jdata["srcAccessMask"], decoded_value.srcAccessMask, options);
         FieldToJson(VkAccessFlags_t(),jdata["dstAccessMask"], decoded_value.dstAccessMask, options);
@@ -1287,6 +1359,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCacheHea
     {
         const VkPipelineCacheHeaderVersionOne& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCacheHeaderVersionOne& meta_struct = *data;
+
         FieldToJson(jdata["headerSize"], decoded_value.headerSize, options);
         FieldToJson(jdata["headerVersion"], decoded_value.headerVersion, options);
         FieldToJson(jdata["vendorID"], decoded_value.vendorID, options);
@@ -1301,6 +1374,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAllocationCallba
     {
         const VkAllocationCallbacks& decoded_value = *data->decoded_value;
         const Decoded_VkAllocationCallbacks& meta_struct = *data;
+
         FieldToJson(jdata["pUserData"], to_hex_variable_width(meta_struct.pUserData), options);
         FieldToJson(jdata["pfnAllocation"], to_hex_variable_width(meta_struct.pfnAllocation), options);
         FieldToJson(jdata["pfnReallocation"], to_hex_variable_width(meta_struct.pfnReallocation), options);
@@ -1316,6 +1390,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkApplicationInfo*
     {
         const VkApplicationInfo& decoded_value = *data->decoded_value;
         const Decoded_VkApplicationInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pApplicationName"], &meta_struct.pApplicationName, options);
         FieldToJson(jdata["applicationVersion"], decoded_value.applicationVersion, options);
@@ -1332,6 +1407,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFormatProperties
     {
         const VkFormatProperties& decoded_value = *data->decoded_value;
         const Decoded_VkFormatProperties& meta_struct = *data;
+
         FieldToJson(VkFormatFeatureFlags_t(),jdata["linearTilingFeatures"], decoded_value.linearTilingFeatures, options);
         FieldToJson(VkFormatFeatureFlags_t(),jdata["optimalTilingFeatures"], decoded_value.optimalTilingFeatures, options);
         FieldToJson(VkFormatFeatureFlags_t(),jdata["bufferFeatures"], decoded_value.bufferFeatures, options);
@@ -1344,6 +1420,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageFormatPrope
     {
         const VkImageFormatProperties& decoded_value = *data->decoded_value;
         const Decoded_VkImageFormatProperties& meta_struct = *data;
+
         FieldToJson(jdata["maxExtent"], meta_struct.maxExtent, options);
         FieldToJson(jdata["maxMipLevels"], decoded_value.maxMipLevels, options);
         FieldToJson(jdata["maxArrayLayers"], decoded_value.maxArrayLayers, options);
@@ -1358,6 +1435,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkInstanceCreateIn
     {
         const VkInstanceCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkInstanceCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkInstanceCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pApplicationInfo"], meta_struct.pApplicationInfo, options);
@@ -1375,6 +1453,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryHeap* data
     {
         const VkMemoryHeap& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryHeap& meta_struct = *data;
+
         FieldToJson(jdata["size"], decoded_value.size, options);
         FieldToJson(VkMemoryHeapFlags_t(),jdata["flags"], decoded_value.flags, options);
     }
@@ -1386,6 +1465,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryType* data
     {
         const VkMemoryType& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryType& meta_struct = *data;
+
         FieldToJson(VkMemoryPropertyFlags_t(),jdata["propertyFlags"], decoded_value.propertyFlags, options);
         FieldToJson(jdata["heapIndex"], decoded_value.heapIndex, options);
     }
@@ -1397,6 +1477,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFe
     {
         const VkPhysicalDeviceFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFeatures& meta_struct = *data;
+
         jdata["robustBufferAccess"] = static_cast<bool>(decoded_value.robustBufferAccess);
         jdata["fullDrawIndexUint32"] = static_cast<bool>(decoded_value.fullDrawIndexUint32);
         jdata["imageCubeArray"] = static_cast<bool>(decoded_value.imageCubeArray);
@@ -1461,6 +1542,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceLi
     {
         const VkPhysicalDeviceLimits& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceLimits& meta_struct = *data;
+
         FieldToJson(jdata["maxImageDimension1D"], decoded_value.maxImageDimension1D, options);
         FieldToJson(jdata["maxImageDimension2D"], decoded_value.maxImageDimension2D, options);
         FieldToJson(jdata["maxImageDimension3D"], decoded_value.maxImageDimension3D, options);
@@ -1576,6 +1658,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMemoryProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMemoryProperties& meta_struct = *data;
+
         FieldToJson(jdata["memoryTypeCount"], decoded_value.memoryTypeCount, options);
         FieldToJson(jdata["memoryTypes"], meta_struct.memoryTypes, options);
         FieldToJson(jdata["memoryHeapCount"], decoded_value.memoryHeapCount, options);
@@ -1589,6 +1672,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSp
     {
         const VkPhysicalDeviceSparseProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSparseProperties& meta_struct = *data;
+
         jdata["residencyStandard2DBlockShape"] = static_cast<bool>(decoded_value.residencyStandard2DBlockShape);
         jdata["residencyStandard2DMultisampleBlockShape"] = static_cast<bool>(decoded_value.residencyStandard2DMultisampleBlockShape);
         jdata["residencyStandard3DBlockShape"] = static_cast<bool>(decoded_value.residencyStandard3DBlockShape);
@@ -1603,6 +1687,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDeviceProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceProperties& meta_struct = *data;
+
         FieldToJson(jdata["apiVersion"], decoded_value.apiVersion, options);
         FieldToJson(jdata["driverVersion"], decoded_value.driverVersion, options);
         FieldToJson(jdata["vendorID"], decoded_value.vendorID, options);
@@ -1621,6 +1706,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueueFamilyPrope
     {
         const VkQueueFamilyProperties& decoded_value = *data->decoded_value;
         const Decoded_VkQueueFamilyProperties& meta_struct = *data;
+
         FieldToJson(VkQueueFlags_t(),jdata["queueFlags"], decoded_value.queueFlags, options);
         FieldToJson(jdata["queueCount"], decoded_value.queueCount, options);
         FieldToJson(jdata["timestampValidBits"], decoded_value.timestampValidBits, options);
@@ -1634,6 +1720,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceQueueCreat
     {
         const VkDeviceQueueCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceQueueCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceQueueCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["queueFamilyIndex"], decoded_value.queueFamilyIndex, options);
@@ -1649,6 +1736,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceCreateInfo
     {
         const VkDeviceCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["queueCreateInfoCount"], decoded_value.queueCreateInfoCount, options);
@@ -1668,6 +1756,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExtensionPropert
     {
         const VkExtensionProperties& decoded_value = *data->decoded_value;
         const Decoded_VkExtensionProperties& meta_struct = *data;
+
         FieldToJson(jdata["extensionName"], &meta_struct.extensionName, options);
         FieldToJson(jdata["specVersion"], decoded_value.specVersion, options);
     }
@@ -1679,6 +1768,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkLayerProperties*
     {
         const VkLayerProperties& decoded_value = *data->decoded_value;
         const Decoded_VkLayerProperties& meta_struct = *data;
+
         FieldToJson(jdata["layerName"], &meta_struct.layerName, options);
         FieldToJson(jdata["specVersion"], decoded_value.specVersion, options);
         FieldToJson(jdata["implementationVersion"], decoded_value.implementationVersion, options);
@@ -1692,6 +1782,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubmitInfo* data
     {
         const VkSubmitInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSubmitInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["waitSemaphoreCount"], decoded_value.waitSemaphoreCount, options);
         HandleToJson(jdata["pWaitSemaphores"], &meta_struct.pWaitSemaphores, options);
@@ -1710,6 +1801,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMappedMemoryRang
     {
         const VkMappedMemoryRange& decoded_value = *data->decoded_value;
         const Decoded_VkMappedMemoryRange& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
         FieldToJson(jdata["offset"], decoded_value.offset, options);
@@ -1724,6 +1816,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryAllocateIn
     {
         const VkMemoryAllocateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryAllocateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["allocationSize"], decoded_value.allocationSize, options);
         FieldToJson(jdata["memoryTypeIndex"], decoded_value.memoryTypeIndex, options);
@@ -1737,6 +1830,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryRequiremen
     {
         const VkMemoryRequirements& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryRequirements& meta_struct = *data;
+
         FieldToJson(jdata["size"], decoded_value.size, options);
         FieldToJson(jdata["alignment"], decoded_value.alignment, options);
         FieldToJson(jdata["memoryTypeBits"], decoded_value.memoryTypeBits, options);
@@ -1749,6 +1843,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseMemoryBind
     {
         const VkSparseMemoryBind& decoded_value = *data->decoded_value;
         const Decoded_VkSparseMemoryBind& meta_struct = *data;
+
         FieldToJson(jdata["resourceOffset"], decoded_value.resourceOffset, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
@@ -1763,6 +1858,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseBufferMemo
     {
         const VkSparseBufferMemoryBindInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSparseBufferMemoryBindInfo& meta_struct = *data;
+
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
         FieldToJson(jdata["bindCount"], decoded_value.bindCount, options);
         FieldToJson(jdata["pBinds"], meta_struct.pBinds, options);
@@ -1775,6 +1871,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseImageOpaqu
     {
         const VkSparseImageOpaqueMemoryBindInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSparseImageOpaqueMemoryBindInfo& meta_struct = *data;
+
         HandleToJson(jdata["image"], meta_struct.image, options);
         FieldToJson(jdata["bindCount"], decoded_value.bindCount, options);
         FieldToJson(jdata["pBinds"], meta_struct.pBinds, options);
@@ -1787,6 +1884,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageSubresource
     {
         const VkImageSubresource& decoded_value = *data->decoded_value;
         const Decoded_VkImageSubresource& meta_struct = *data;
+
         FieldToJson(VkImageAspectFlags_t(),jdata["aspectMask"], decoded_value.aspectMask, options);
         FieldToJson(jdata["mipLevel"], decoded_value.mipLevel, options);
         FieldToJson(jdata["arrayLayer"], decoded_value.arrayLayer, options);
@@ -1799,6 +1897,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseImageMemor
     {
         const VkSparseImageMemoryBind& decoded_value = *data->decoded_value;
         const Decoded_VkSparseImageMemoryBind& meta_struct = *data;
+
         FieldToJson(jdata["subresource"], meta_struct.subresource, options);
         FieldToJson(jdata["offset"], meta_struct.offset, options);
         FieldToJson(jdata["extent"], meta_struct.extent, options);
@@ -1814,6 +1913,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseImageMemor
     {
         const VkSparseImageMemoryBindInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSparseImageMemoryBindInfo& meta_struct = *data;
+
         HandleToJson(jdata["image"], meta_struct.image, options);
         FieldToJson(jdata["bindCount"], decoded_value.bindCount, options);
         FieldToJson(jdata["pBinds"], meta_struct.pBinds, options);
@@ -1826,6 +1926,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindSparseInfo* 
     {
         const VkBindSparseInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBindSparseInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["waitSemaphoreCount"], decoded_value.waitSemaphoreCount, options);
         HandleToJson(jdata["pWaitSemaphores"], &meta_struct.pWaitSemaphores, options);
@@ -1847,6 +1948,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseImageForma
     {
         const VkSparseImageFormatProperties& decoded_value = *data->decoded_value;
         const Decoded_VkSparseImageFormatProperties& meta_struct = *data;
+
         FieldToJson(VkImageAspectFlags_t(),jdata["aspectMask"], decoded_value.aspectMask, options);
         FieldToJson(jdata["imageGranularity"], meta_struct.imageGranularity, options);
         FieldToJson(VkSparseImageFormatFlags_t(),jdata["flags"], decoded_value.flags, options);
@@ -1859,6 +1961,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseImageMemor
     {
         const VkSparseImageMemoryRequirements& decoded_value = *data->decoded_value;
         const Decoded_VkSparseImageMemoryRequirements& meta_struct = *data;
+
         FieldToJson(jdata["formatProperties"], meta_struct.formatProperties, options);
         FieldToJson(jdata["imageMipTailFirstLod"], decoded_value.imageMipTailFirstLod, options);
         FieldToJson(jdata["imageMipTailSize"], decoded_value.imageMipTailSize, options);
@@ -1873,6 +1976,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFenceCreateInfo*
     {
         const VkFenceCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkFenceCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkFenceCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -1885,6 +1989,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreCreateI
     {
         const VkSemaphoreCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSemaphoreCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -1897,6 +2002,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkEventCreateInfo*
     {
         const VkEventCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkEventCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkEventCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -1909,6 +2015,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueryPoolCreateI
     {
         const VkQueryPoolCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkQueryPoolCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkQueryPoolCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["queryType"], decoded_value.queryType, options);
@@ -1924,6 +2031,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferCreateInfo
     {
         const VkBufferCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBufferCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkBufferCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -1941,6 +2049,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferViewCreate
     {
         const VkBufferViewCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBufferViewCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkBufferViewCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
@@ -1957,6 +2066,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageCreateInfo*
     {
         const VkImageCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkImageCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["imageType"], decoded_value.imageType, options);
@@ -1981,6 +2091,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubresourceLayou
     {
         const VkSubresourceLayout& decoded_value = *data->decoded_value;
         const Decoded_VkSubresourceLayout& meta_struct = *data;
+
         FieldToJson(jdata["offset"], decoded_value.offset, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
         FieldToJson(jdata["rowPitch"], decoded_value.rowPitch, options);
@@ -1995,6 +2106,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkComponentMapping
     {
         const VkComponentMapping& decoded_value = *data->decoded_value;
         const Decoded_VkComponentMapping& meta_struct = *data;
+
         FieldToJson(jdata["r"], decoded_value.r, options);
         FieldToJson(jdata["g"], decoded_value.g, options);
         FieldToJson(jdata["b"], decoded_value.b, options);
@@ -2008,6 +2120,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewCreateI
     {
         const VkImageViewCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageViewCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["image"], meta_struct.image, options);
@@ -2025,6 +2138,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSpecializationMa
     {
         const VkSpecializationMapEntry& decoded_value = *data->decoded_value;
         const Decoded_VkSpecializationMapEntry& meta_struct = *data;
+
         FieldToJson(jdata["constantID"], decoded_value.constantID, options);
         FieldToJson(jdata["offset"], decoded_value.offset, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -2037,6 +2151,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSpecializationIn
     {
         const VkSpecializationInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSpecializationInfo& meta_struct = *data;
+
         FieldToJson(jdata["mapEntryCount"], decoded_value.mapEntryCount, options);
         FieldToJson(jdata["pMapEntries"], meta_struct.pMapEntries, options);
         FieldToJson(jdata["dataSize"], decoded_value.dataSize, options);
@@ -2050,6 +2165,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineShaderSt
     {
         const VkPipelineShaderStageCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineShaderStageCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineShaderStageCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["stage"], decoded_value.stage, options);
@@ -2066,6 +2182,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkComputePipelineC
     {
         const VkComputePipelineCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkComputePipelineCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["stage"], meta_struct.stage, options);
@@ -2082,6 +2199,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVertexInputBindi
     {
         const VkVertexInputBindingDescription& decoded_value = *data->decoded_value;
         const Decoded_VkVertexInputBindingDescription& meta_struct = *data;
+
         FieldToJson(jdata["binding"], decoded_value.binding, options);
         FieldToJson(jdata["stride"], decoded_value.stride, options);
         FieldToJson(jdata["inputRate"], decoded_value.inputRate, options);
@@ -2094,6 +2212,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVertexInputAttri
     {
         const VkVertexInputAttributeDescription& decoded_value = *data->decoded_value;
         const Decoded_VkVertexInputAttributeDescription& meta_struct = *data;
+
         FieldToJson(jdata["location"], decoded_value.location, options);
         FieldToJson(jdata["binding"], decoded_value.binding, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
@@ -2107,6 +2226,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineVertexIn
     {
         const VkPipelineVertexInputStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineVertexInputStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineVertexInputStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["vertexBindingDescriptionCount"], decoded_value.vertexBindingDescriptionCount, options);
@@ -2123,6 +2243,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineInputAss
     {
         const VkPipelineInputAssemblyStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineInputAssemblyStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineInputAssemblyStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["topology"], decoded_value.topology, options);
@@ -2137,6 +2258,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineTessella
     {
         const VkPipelineTessellationStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineTessellationStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineTessellationStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["patchControlPoints"], decoded_value.patchControlPoints, options);
@@ -2150,6 +2272,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkViewport* data, 
     {
         const VkViewport& decoded_value = *data->decoded_value;
         const Decoded_VkViewport& meta_struct = *data;
+
         FieldToJson(jdata["x"], decoded_value.x, options);
         FieldToJson(jdata["y"], decoded_value.y, options);
         FieldToJson(jdata["width"], decoded_value.width, options);
@@ -2165,6 +2288,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineViewport
     {
         const VkPipelineViewportStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineViewportStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineViewportStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["viewportCount"], decoded_value.viewportCount, options);
@@ -2181,6 +2305,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRasteriz
     {
         const VkPipelineRasterizationStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRasterizationStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineRasterizationStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         jdata["depthClampEnable"] = static_cast<bool>(decoded_value.depthClampEnable);
@@ -2203,6 +2328,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineMultisam
     {
         const VkPipelineMultisampleStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineMultisampleStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineMultisampleStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["rasterizationSamples"], decoded_value.rasterizationSamples, options);
@@ -2221,6 +2347,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkStencilOpState* 
     {
         const VkStencilOpState& decoded_value = *data->decoded_value;
         const Decoded_VkStencilOpState& meta_struct = *data;
+
         FieldToJson(jdata["failOp"], decoded_value.failOp, options);
         FieldToJson(jdata["passOp"], decoded_value.passOp, options);
         FieldToJson(jdata["depthFailOp"], decoded_value.depthFailOp, options);
@@ -2237,6 +2364,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineDepthSte
     {
         const VkPipelineDepthStencilStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineDepthStencilStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineDepthStencilStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         jdata["depthTestEnable"] = static_cast<bool>(decoded_value.depthTestEnable);
@@ -2258,6 +2386,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineColorBle
     {
         const VkPipelineColorBlendAttachmentState& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineColorBlendAttachmentState& meta_struct = *data;
+
         jdata["blendEnable"] = static_cast<bool>(decoded_value.blendEnable);
         FieldToJson(jdata["srcColorBlendFactor"], decoded_value.srcColorBlendFactor, options);
         FieldToJson(jdata["dstColorBlendFactor"], decoded_value.dstColorBlendFactor, options);
@@ -2275,6 +2404,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineColorBle
     {
         const VkPipelineColorBlendStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineColorBlendStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineColorBlendStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         jdata["logicOpEnable"] = static_cast<bool>(decoded_value.logicOpEnable);
@@ -2292,6 +2422,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineDynamicS
     {
         const VkPipelineDynamicStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineDynamicStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineDynamicStateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["dynamicStateCount"], decoded_value.dynamicStateCount, options);
@@ -2306,6 +2437,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGraphicsPipeline
     {
         const VkGraphicsPipelineCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkGraphicsPipelineCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["stageCount"], decoded_value.stageCount, options);
@@ -2334,6 +2466,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPushConstantRang
     {
         const VkPushConstantRange& decoded_value = *data->decoded_value;
         const Decoded_VkPushConstantRange& meta_struct = *data;
+
         FieldToJson(VkShaderStageFlags_t(),jdata["stageFlags"], decoded_value.stageFlags, options);
         FieldToJson(jdata["offset"], decoded_value.offset, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -2346,6 +2479,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineLayoutCr
     {
         const VkPipelineLayoutCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineLayoutCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineLayoutCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["setLayoutCount"], decoded_value.setLayoutCount, options);
@@ -2362,6 +2496,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerCreateInf
     {
         const VkSamplerCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSamplerCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["magFilter"], decoded_value.magFilter, options);
@@ -2389,6 +2524,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyDescriptorSe
     {
         const VkCopyDescriptorSet& decoded_value = *data->decoded_value;
         const Decoded_VkCopyDescriptorSet& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["srcSet"], meta_struct.srcSet, options);
         FieldToJson(jdata["srcBinding"], decoded_value.srcBinding, options);
@@ -2407,6 +2543,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorBuffer
     {
         const VkDescriptorBufferInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorBufferInfo& meta_struct = *data;
+
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
         FieldToJson(jdata["offset"], decoded_value.offset, options);
         FieldToJson(jdata["range"], decoded_value.range, options);
@@ -2419,6 +2556,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorPoolSi
     {
         const VkDescriptorPoolSize& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorPoolSize& meta_struct = *data;
+
         FieldToJson(jdata["type"], decoded_value.type, options);
         FieldToJson(jdata["descriptorCount"], decoded_value.descriptorCount, options);
     }
@@ -2430,6 +2568,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorPoolCr
     {
         const VkDescriptorPoolCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorPoolCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDescriptorPoolCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["maxSets"], decoded_value.maxSets, options);
@@ -2445,6 +2584,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetAll
     {
         const VkDescriptorSetAllocateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetAllocateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["descriptorPool"], meta_struct.descriptorPool, options);
         FieldToJson(jdata["descriptorSetCount"], decoded_value.descriptorSetCount, options);
@@ -2459,6 +2599,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetLay
     {
         const VkDescriptorSetLayoutBinding& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetLayoutBinding& meta_struct = *data;
+
         FieldToJson(jdata["binding"], decoded_value.binding, options);
         FieldToJson(jdata["descriptorType"], decoded_value.descriptorType, options);
         FieldToJson(jdata["descriptorCount"], decoded_value.descriptorCount, options);
@@ -2473,6 +2614,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetLay
     {
         const VkDescriptorSetLayoutCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetLayoutCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDescriptorSetLayoutCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["bindingCount"], decoded_value.bindingCount, options);
@@ -2487,6 +2629,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentDescri
     {
         const VkAttachmentDescription& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentDescription& meta_struct = *data;
+
         FieldToJson(VkAttachmentDescriptionFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["samples"], decoded_value.samples, options);
@@ -2505,6 +2648,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentRefere
     {
         const VkAttachmentReference& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentReference& meta_struct = *data;
+
         FieldToJson(jdata["attachment"], decoded_value.attachment, options);
         FieldToJson(jdata["layout"], decoded_value.layout, options);
     }
@@ -2516,6 +2660,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFramebufferCreat
     {
         const VkFramebufferCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkFramebufferCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkFramebufferCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["renderPass"], meta_struct.renderPass, options);
@@ -2534,6 +2679,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassDescripti
     {
         const VkSubpassDescription& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassDescription& meta_struct = *data;
+
         FieldToJson(VkSubpassDescriptionFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pipelineBindPoint"], decoded_value.pipelineBindPoint, options);
         FieldToJson(jdata["inputAttachmentCount"], decoded_value.inputAttachmentCount, options);
@@ -2553,6 +2699,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassDependenc
     {
         const VkSubpassDependency& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassDependency& meta_struct = *data;
+
         FieldToJson(jdata["srcSubpass"], decoded_value.srcSubpass, options);
         FieldToJson(jdata["dstSubpass"], decoded_value.dstSubpass, options);
         FieldToJson(VkPipelineStageFlags_t(),jdata["srcStageMask"], decoded_value.srcStageMask, options);
@@ -2569,6 +2716,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassCreate
     {
         const VkRenderPassCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkRenderPassCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["attachmentCount"], decoded_value.attachmentCount, options);
@@ -2587,6 +2735,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandPoolCreat
     {
         const VkCommandPoolCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkCommandPoolCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkCommandPoolCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["queueFamilyIndex"], decoded_value.queueFamilyIndex, options);
@@ -2600,6 +2749,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferAll
     {
         const VkCommandBufferAllocateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferAllocateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["commandPool"], meta_struct.commandPool, options);
         FieldToJson(jdata["level"], decoded_value.level, options);
@@ -2614,6 +2764,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferInh
     {
         const VkCommandBufferInheritanceInfo& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferInheritanceInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["renderPass"], meta_struct.renderPass, options);
         FieldToJson(jdata["subpass"], decoded_value.subpass, options);
@@ -2631,6 +2782,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferBeg
     {
         const VkCommandBufferBeginInfo& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferBeginInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkCommandBufferUsageFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pInheritanceInfo"], meta_struct.pInheritanceInfo, options);
@@ -2644,6 +2796,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferCopy* data
     {
         const VkBufferCopy& decoded_value = *data->decoded_value;
         const Decoded_VkBufferCopy& meta_struct = *data;
+
         FieldToJson(jdata["srcOffset"], decoded_value.srcOffset, options);
         FieldToJson(jdata["dstOffset"], decoded_value.dstOffset, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -2656,6 +2809,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageSubresource
     {
         const VkImageSubresourceLayers& decoded_value = *data->decoded_value;
         const Decoded_VkImageSubresourceLayers& meta_struct = *data;
+
         FieldToJson(VkImageAspectFlags_t(),jdata["aspectMask"], decoded_value.aspectMask, options);
         FieldToJson(jdata["mipLevel"], decoded_value.mipLevel, options);
         FieldToJson(jdata["baseArrayLayer"], decoded_value.baseArrayLayer, options);
@@ -2669,6 +2823,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferImageCopy*
     {
         const VkBufferImageCopy& decoded_value = *data->decoded_value;
         const Decoded_VkBufferImageCopy& meta_struct = *data;
+
         FieldToJson(jdata["bufferOffset"], decoded_value.bufferOffset, options);
         FieldToJson(jdata["bufferRowLength"], decoded_value.bufferRowLength, options);
         FieldToJson(jdata["bufferImageHeight"], decoded_value.bufferImageHeight, options);
@@ -2684,6 +2839,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkClearDepthStenci
     {
         const VkClearDepthStencilValue& decoded_value = *data->decoded_value;
         const Decoded_VkClearDepthStencilValue& meta_struct = *data;
+
         FieldToJson(jdata["depth"], decoded_value.depth, options);
         FieldToJson(jdata["stencil"], decoded_value.stencil, options);
     }
@@ -2695,6 +2851,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkClearAttachment*
     {
         const VkClearAttachment& decoded_value = *data->decoded_value;
         const Decoded_VkClearAttachment& meta_struct = *data;
+
         FieldToJson(VkImageAspectFlags_t(),jdata["aspectMask"], decoded_value.aspectMask, options);
         FieldToJson(jdata["colorAttachment"], decoded_value.colorAttachment, options);
         FieldToJson(jdata["clearValue"], meta_struct.clearValue, options);
@@ -2707,6 +2864,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkClearRect* data,
     {
         const VkClearRect& decoded_value = *data->decoded_value;
         const Decoded_VkClearRect& meta_struct = *data;
+
         FieldToJson(jdata["rect"], meta_struct.rect, options);
         FieldToJson(jdata["baseArrayLayer"], decoded_value.baseArrayLayer, options);
         FieldToJson(jdata["layerCount"], decoded_value.layerCount, options);
@@ -2719,6 +2877,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageBlit* data,
     {
         const VkImageBlit& decoded_value = *data->decoded_value;
         const Decoded_VkImageBlit& meta_struct = *data;
+
         FieldToJson(jdata["srcSubresource"], meta_struct.srcSubresource, options);
         FieldToJson(jdata["srcOffsets"], meta_struct.srcOffsets, options);
         FieldToJson(jdata["dstSubresource"], meta_struct.dstSubresource, options);
@@ -2732,6 +2891,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageCopy* data,
     {
         const VkImageCopy& decoded_value = *data->decoded_value;
         const Decoded_VkImageCopy& meta_struct = *data;
+
         FieldToJson(jdata["srcSubresource"], meta_struct.srcSubresource, options);
         FieldToJson(jdata["srcOffset"], meta_struct.srcOffset, options);
         FieldToJson(jdata["dstSubresource"], meta_struct.dstSubresource, options);
@@ -2746,6 +2906,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageResolve* da
     {
         const VkImageResolve& decoded_value = *data->decoded_value;
         const Decoded_VkImageResolve& meta_struct = *data;
+
         FieldToJson(jdata["srcSubresource"], meta_struct.srcSubresource, options);
         FieldToJson(jdata["srcOffset"], meta_struct.srcOffset, options);
         FieldToJson(jdata["dstSubresource"], meta_struct.dstSubresource, options);
@@ -2760,6 +2921,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassBeginI
     {
         const VkRenderPassBeginInfo& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassBeginInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["renderPass"], meta_struct.renderPass, options);
         HandleToJson(jdata["framebuffer"], meta_struct.framebuffer, options);
@@ -2776,6 +2938,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSu
     {
         const VkPhysicalDeviceSubgroupProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSubgroupProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["subgroupSize"], decoded_value.subgroupSize, options);
         FieldToJson(VkShaderStageFlags_t(),jdata["supportedStages"], decoded_value.supportedStages, options);
@@ -2791,6 +2954,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindBufferMemory
     {
         const VkBindBufferMemoryInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBindBufferMemoryInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
@@ -2805,6 +2969,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindImageMemoryI
     {
         const VkBindImageMemoryInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBindImageMemoryInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["image"], meta_struct.image, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
@@ -2819,6 +2984,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevice16
     {
         const VkPhysicalDevice16BitStorageFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevice16BitStorageFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["storageBuffer16BitAccess"] = static_cast<bool>(decoded_value.storageBuffer16BitAccess);
         jdata["uniformAndStorageBuffer16BitAccess"] = static_cast<bool>(decoded_value.uniformAndStorageBuffer16BitAccess);
@@ -2834,6 +3000,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryDedicatedR
     {
         const VkMemoryDedicatedRequirements& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryDedicatedRequirements& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["prefersDedicatedAllocation"] = static_cast<bool>(decoded_value.prefersDedicatedAllocation);
         jdata["requiresDedicatedAllocation"] = static_cast<bool>(decoded_value.requiresDedicatedAllocation);
@@ -2847,6 +3014,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryDedicatedA
     {
         const VkMemoryDedicatedAllocateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryDedicatedAllocateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["image"], meta_struct.image, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
@@ -2860,6 +3028,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryAllocateFl
     {
         const VkMemoryAllocateFlagsInfo& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryAllocateFlagsInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkMemoryAllocateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["deviceMask"], decoded_value.deviceMask, options);
@@ -2873,6 +3042,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupRende
     {
         const VkDeviceGroupRenderPassBeginInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupRenderPassBeginInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceMask"], decoded_value.deviceMask, options);
         FieldToJson(jdata["deviceRenderAreaCount"], decoded_value.deviceRenderAreaCount, options);
@@ -2887,6 +3057,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupComma
     {
         const VkDeviceGroupCommandBufferBeginInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupCommandBufferBeginInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceMask"], decoded_value.deviceMask, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -2899,6 +3070,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupSubmi
     {
         const VkDeviceGroupSubmitInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupSubmitInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["waitSemaphoreCount"], decoded_value.waitSemaphoreCount, options);
         FieldToJson(jdata["pWaitSemaphoreDeviceIndices"], meta_struct.pWaitSemaphoreDeviceIndices, options);
@@ -2916,6 +3088,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupBindS
     {
         const VkDeviceGroupBindSparseInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupBindSparseInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["resourceDeviceIndex"], decoded_value.resourceDeviceIndex, options);
         FieldToJson(jdata["memoryDeviceIndex"], decoded_value.memoryDeviceIndex, options);
@@ -2929,6 +3102,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindBufferMemory
     {
         const VkBindBufferMemoryDeviceGroupInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBindBufferMemoryDeviceGroupInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceIndexCount"], decoded_value.deviceIndexCount, options);
         FieldToJson(jdata["pDeviceIndices"], meta_struct.pDeviceIndices, options);
@@ -2942,6 +3116,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindImageMemoryD
     {
         const VkBindImageMemoryDeviceGroupInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBindImageMemoryDeviceGroupInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceIndexCount"], decoded_value.deviceIndexCount, options);
         FieldToJson(jdata["pDeviceIndices"], meta_struct.pDeviceIndices, options);
@@ -2957,6 +3132,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceGr
     {
         const VkPhysicalDeviceGroupProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceGroupProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["physicalDeviceCount"], decoded_value.physicalDeviceCount, options);
         HandleToJson(jdata["physicalDevices"], &meta_struct.physicalDevices, options);
@@ -2971,6 +3147,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupDevic
     {
         const VkDeviceGroupDeviceCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupDeviceCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["physicalDeviceCount"], decoded_value.physicalDeviceCount, options);
         HandleToJson(jdata["pPhysicalDevices"], &meta_struct.pPhysicalDevices, options);
@@ -2984,6 +3161,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferMemoryRequ
     {
         const VkBufferMemoryRequirementsInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkBufferMemoryRequirementsInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -2996,6 +3174,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageMemoryRequi
     {
         const VkImageMemoryRequirementsInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkImageMemoryRequirementsInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["image"], meta_struct.image, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3008,6 +3187,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageSparseMemor
     {
         const VkImageSparseMemoryRequirementsInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkImageSparseMemoryRequirementsInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["image"], meta_struct.image, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3020,6 +3200,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryRequiremen
     {
         const VkMemoryRequirements2& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryRequirements2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryRequirements"], meta_struct.memoryRequirements, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3032,6 +3213,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseImageMemor
     {
         const VkSparseImageMemoryRequirements2& decoded_value = *data->decoded_value;
         const Decoded_VkSparseImageMemoryRequirements2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryRequirements"], meta_struct.memoryRequirements, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3044,6 +3226,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFe
     {
         const VkPhysicalDeviceFeatures2& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFeatures2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["features"], meta_struct.features, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3056,6 +3239,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDeviceProperties2& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceProperties2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["properties"], meta_struct.properties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3068,6 +3252,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFormatProperties
     {
         const VkFormatProperties2& decoded_value = *data->decoded_value;
         const Decoded_VkFormatProperties2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["formatProperties"], meta_struct.formatProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3080,6 +3265,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageFormatPrope
     {
         const VkImageFormatProperties2& decoded_value = *data->decoded_value;
         const Decoded_VkImageFormatProperties2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["imageFormatProperties"], meta_struct.imageFormatProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3092,6 +3278,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageFormatInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageFormatInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
@@ -3108,6 +3295,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueueFamilyPrope
     {
         const VkQueueFamilyProperties2& decoded_value = *data->decoded_value;
         const Decoded_VkQueueFamilyProperties2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["queueFamilyProperties"], meta_struct.queueFamilyProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3120,6 +3308,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMemoryProperties2& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMemoryProperties2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryProperties"], meta_struct.memoryProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3132,6 +3321,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSparseImageForma
     {
         const VkSparseImageFormatProperties2& decoded_value = *data->decoded_value;
         const Decoded_VkSparseImageFormatProperties2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["properties"], meta_struct.properties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3144,6 +3334,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSp
     {
         const VkPhysicalDeviceSparseImageFormatInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSparseImageFormatInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
@@ -3160,6 +3351,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePo
     {
         const VkPhysicalDevicePointClippingProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePointClippingProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pointClippingBehavior"], decoded_value.pointClippingBehavior, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3172,6 +3364,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkInputAttachmentA
     {
         const VkInputAttachmentAspectReference& decoded_value = *data->decoded_value;
         const Decoded_VkInputAttachmentAspectReference& meta_struct = *data;
+
         FieldToJson(jdata["subpass"], decoded_value.subpass, options);
         FieldToJson(jdata["inputAttachmentIndex"], decoded_value.inputAttachmentIndex, options);
         FieldToJson(VkImageAspectFlags_t(),jdata["aspectMask"], decoded_value.aspectMask, options);
@@ -3184,6 +3377,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassInputA
     {
         const VkRenderPassInputAttachmentAspectCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassInputAttachmentAspectCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["aspectReferenceCount"], decoded_value.aspectReferenceCount, options);
         FieldToJson(jdata["pAspectReferences"], meta_struct.pAspectReferences, options);
@@ -3197,6 +3391,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewUsageCr
     {
         const VkImageViewUsageCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewUsageCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageUsageFlags_t(),jdata["usage"], decoded_value.usage, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3209,6 +3404,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineTessella
     {
         const VkPipelineTessellationDomainOriginStateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineTessellationDomainOriginStateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["domainOrigin"], decoded_value.domainOrigin, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3221,6 +3417,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassMultiv
     {
         const VkRenderPassMultiviewCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassMultiviewCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["subpassCount"], decoded_value.subpassCount, options);
         FieldToJson(jdata["pViewMasks"], meta_struct.pViewMasks, options);
@@ -3238,6 +3435,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultiviewFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultiviewFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["multiview"] = static_cast<bool>(decoded_value.multiview);
         jdata["multiviewGeometryShader"] = static_cast<bool>(decoded_value.multiviewGeometryShader);
@@ -3252,6 +3450,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultiviewProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultiviewProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxMultiviewViewCount"], decoded_value.maxMultiviewViewCount, options);
         FieldToJson(jdata["maxMultiviewInstanceIndex"], decoded_value.maxMultiviewInstanceIndex, options);
@@ -3265,6 +3464,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVa
     {
         const VkPhysicalDeviceVariablePointersFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVariablePointersFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["variablePointersStorageBuffer"] = static_cast<bool>(decoded_value.variablePointersStorageBuffer);
         jdata["variablePointers"] = static_cast<bool>(decoded_value.variablePointers);
@@ -3278,6 +3478,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDeviceProtectedMemoryFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceProtectedMemoryFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["protectedMemory"] = static_cast<bool>(decoded_value.protectedMemory);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3290,6 +3491,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDeviceProtectedMemoryProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceProtectedMemoryProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["protectedNoFault"] = static_cast<bool>(decoded_value.protectedNoFault);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3302,6 +3504,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceQueueInfo2
     {
         const VkDeviceQueueInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceQueueInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceQueueCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["queueFamilyIndex"], decoded_value.queueFamilyIndex, options);
@@ -3316,6 +3519,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkProtectedSubmitI
     {
         const VkProtectedSubmitInfo& decoded_value = *data->decoded_value;
         const Decoded_VkProtectedSubmitInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["protectedSubmit"] = static_cast<bool>(decoded_value.protectedSubmit);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3328,6 +3532,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerYcbcrConv
     {
         const VkSamplerYcbcrConversionCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerYcbcrConversionCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["ycbcrModel"], decoded_value.ycbcrModel, options);
@@ -3347,6 +3552,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerYcbcrConv
     {
         const VkSamplerYcbcrConversionInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerYcbcrConversionInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["conversion"], meta_struct.conversion, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3359,6 +3565,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindImagePlaneMe
     {
         const VkBindImagePlaneMemoryInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBindImagePlaneMemoryInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["planeAspect"], decoded_value.planeAspect, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3371,6 +3578,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImagePlaneMemory
     {
         const VkImagePlaneMemoryRequirementsInfo& decoded_value = *data->decoded_value;
         const Decoded_VkImagePlaneMemoryRequirementsInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["planeAspect"], decoded_value.planeAspect, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3383,6 +3591,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSa
     {
         const VkPhysicalDeviceSamplerYcbcrConversionFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["samplerYcbcrConversion"] = static_cast<bool>(decoded_value.samplerYcbcrConversion);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3395,6 +3604,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerYcbcrConv
     {
         const VkSamplerYcbcrConversionImageFormatProperties& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerYcbcrConversionImageFormatProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["combinedImageSamplerDescriptorCount"], decoded_value.combinedImageSamplerDescriptorCount, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3407,6 +3617,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorUpdate
     {
         const VkDescriptorUpdateTemplateEntry& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorUpdateTemplateEntry& meta_struct = *data;
+
         FieldToJson(jdata["dstBinding"], decoded_value.dstBinding, options);
         FieldToJson(jdata["dstArrayElement"], decoded_value.dstArrayElement, options);
         FieldToJson(jdata["descriptorCount"], decoded_value.descriptorCount, options);
@@ -3422,6 +3633,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorUpdate
     {
         const VkDescriptorUpdateTemplateCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorUpdateTemplateCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDescriptorUpdateTemplateCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["descriptorUpdateEntryCount"], decoded_value.descriptorUpdateEntryCount, options);
@@ -3441,6 +3653,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalMemoryPr
     {
         const VkExternalMemoryProperties& decoded_value = *data->decoded_value;
         const Decoded_VkExternalMemoryProperties& meta_struct = *data;
+
         FieldToJson(VkExternalMemoryFeatureFlags_t(),jdata["externalMemoryFeatures"], decoded_value.externalMemoryFeatures, options);
         FieldToJson(VkExternalMemoryHandleTypeFlags_t(),jdata["exportFromImportedHandleTypes"], decoded_value.exportFromImportedHandleTypes, options);
         FieldToJson(VkExternalMemoryHandleTypeFlags_t(),jdata["compatibleHandleTypes"], decoded_value.compatibleHandleTypes, options);
@@ -3453,6 +3666,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalImageFormatInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalImageFormatInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3465,6 +3679,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalImageFor
     {
         const VkExternalImageFormatProperties& decoded_value = *data->decoded_value;
         const Decoded_VkExternalImageFormatProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["externalMemoryProperties"], meta_struct.externalMemoryProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3477,6 +3692,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalBufferInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalBufferInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkBufferCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(VkBufferUsageFlags_t(),jdata["usage"], decoded_value.usage, options);
@@ -3491,6 +3707,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalBufferPr
     {
         const VkExternalBufferProperties& decoded_value = *data->decoded_value;
         const Decoded_VkExternalBufferProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["externalMemoryProperties"], meta_struct.externalMemoryProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3503,6 +3720,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceID
     {
         const VkPhysicalDeviceIDProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceIDProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceUUID"], uuid_to_string(sizeof(decoded_value.deviceUUID), decoded_value.deviceUUID), options);
         FieldToJson(jdata["driverUUID"], uuid_to_string(sizeof(decoded_value.driverUUID), decoded_value.driverUUID), options);
@@ -3519,6 +3737,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalMemoryIm
     {
         const VkExternalMemoryImageCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkExternalMemoryImageCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalMemoryHandleTypeFlags_t(),jdata["handleTypes"], decoded_value.handleTypes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3531,6 +3750,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalMemoryBu
     {
         const VkExternalMemoryBufferCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkExternalMemoryBufferCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalMemoryHandleTypeFlags_t(),jdata["handleTypes"], decoded_value.handleTypes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3543,6 +3763,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportMemoryAllo
     {
         const VkExportMemoryAllocateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkExportMemoryAllocateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalMemoryHandleTypeFlags_t(),jdata["handleTypes"], decoded_value.handleTypes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3555,6 +3776,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalFenceInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalFenceInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3567,6 +3789,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalFencePro
     {
         const VkExternalFenceProperties& decoded_value = *data->decoded_value;
         const Decoded_VkExternalFenceProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalFenceHandleTypeFlags_t(),jdata["exportFromImportedHandleTypes"], decoded_value.exportFromImportedHandleTypes, options);
         FieldToJson(VkExternalFenceHandleTypeFlags_t(),jdata["compatibleHandleTypes"], decoded_value.compatibleHandleTypes, options);
@@ -3581,6 +3804,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportFenceCreat
     {
         const VkExportFenceCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkExportFenceCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalFenceHandleTypeFlags_t(),jdata["handleTypes"], decoded_value.handleTypes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3593,6 +3817,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportSemaphoreC
     {
         const VkExportSemaphoreCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkExportSemaphoreCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalSemaphoreHandleTypeFlags_t(),jdata["handleTypes"], decoded_value.handleTypes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3605,6 +3830,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalSemaphoreInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalSemaphoreInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3617,6 +3843,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalSemaphor
     {
         const VkExternalSemaphoreProperties& decoded_value = *data->decoded_value;
         const Decoded_VkExternalSemaphoreProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalSemaphoreHandleTypeFlags_t(),jdata["exportFromImportedHandleTypes"], decoded_value.exportFromImportedHandleTypes, options);
         FieldToJson(VkExternalSemaphoreHandleTypeFlags_t(),jdata["compatibleHandleTypes"], decoded_value.compatibleHandleTypes, options);
@@ -3631,6 +3858,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMa
     {
         const VkPhysicalDeviceMaintenance3Properties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMaintenance3Properties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxPerSetDescriptors"], decoded_value.maxPerSetDescriptors, options);
         FieldToJson(jdata["maxMemoryAllocationSize"], decoded_value.maxMemoryAllocationSize, options);
@@ -3644,6 +3872,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetLay
     {
         const VkDescriptorSetLayoutSupport& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetLayoutSupport& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["supported"] = static_cast<bool>(decoded_value.supported);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3656,6 +3885,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderDrawParametersFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderDrawParametersFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderDrawParameters"] = static_cast<bool>(decoded_value.shaderDrawParameters);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3668,6 +3898,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVu
     {
         const VkPhysicalDeviceVulkan11Features& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVulkan11Features& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["storageBuffer16BitAccess"] = static_cast<bool>(decoded_value.storageBuffer16BitAccess);
         jdata["uniformAndStorageBuffer16BitAccess"] = static_cast<bool>(decoded_value.uniformAndStorageBuffer16BitAccess);
@@ -3691,6 +3922,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVu
     {
         const VkPhysicalDeviceVulkan11Properties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVulkan11Properties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceUUID"], uuid_to_string(sizeof(decoded_value.deviceUUID), decoded_value.deviceUUID), options);
         FieldToJson(jdata["driverUUID"], uuid_to_string(sizeof(decoded_value.driverUUID), decoded_value.driverUUID), options);
@@ -3717,6 +3949,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVu
     {
         const VkPhysicalDeviceVulkan12Features& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVulkan12Features& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["samplerMirrorClampToEdge"] = static_cast<bool>(decoded_value.samplerMirrorClampToEdge);
         jdata["drawIndirectCount"] = static_cast<bool>(decoded_value.drawIndirectCount);
@@ -3775,6 +4008,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkConformanceVersi
     {
         const VkConformanceVersion& decoded_value = *data->decoded_value;
         const Decoded_VkConformanceVersion& meta_struct = *data;
+
         FieldToJson(jdata["major"], decoded_value.major, options);
         FieldToJson(jdata["minor"], decoded_value.minor, options);
         FieldToJson(jdata["subminor"], decoded_value.subminor, options);
@@ -3788,6 +4022,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVu
     {
         const VkPhysicalDeviceVulkan12Properties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVulkan12Properties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["driverID"], decoded_value.driverID, options);
         FieldToJson(jdata["driverName"], &meta_struct.driverName, options);
@@ -3851,6 +4086,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageFormatListC
     {
         const VkImageFormatListCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkImageFormatListCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["viewFormatCount"], decoded_value.viewFormatCount, options);
         FieldToJson(jdata["pViewFormats"], meta_struct.pViewFormats, options);
@@ -3864,6 +4100,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentDescri
     {
         const VkAttachmentDescription2& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentDescription2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkAttachmentDescriptionFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
@@ -3884,6 +4121,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentRefere
     {
         const VkAttachmentReference2& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentReference2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["attachment"], decoded_value.attachment, options);
         FieldToJson(jdata["layout"], decoded_value.layout, options);
@@ -3898,6 +4136,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassDescripti
     {
         const VkSubpassDescription2& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassDescription2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSubpassDescriptionFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pipelineBindPoint"], decoded_value.pipelineBindPoint, options);
@@ -3920,6 +4159,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassDependenc
     {
         const VkSubpassDependency2& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassDependency2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["srcSubpass"], decoded_value.srcSubpass, options);
         FieldToJson(jdata["dstSubpass"], decoded_value.dstSubpass, options);
@@ -3939,6 +4179,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassCreate
     {
         const VkRenderPassCreateInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassCreateInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkRenderPassCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["attachmentCount"], decoded_value.attachmentCount, options);
@@ -3959,6 +4200,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassBeginInfo
     {
         const VkSubpassBeginInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassBeginInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["contents"], decoded_value.contents, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -3971,6 +4213,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassEndInfo* 
     {
         const VkSubpassEndInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassEndInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
     }
@@ -3982,6 +4225,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevice8B
     {
         const VkPhysicalDevice8BitStorageFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevice8BitStorageFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["storageBuffer8BitAccess"] = static_cast<bool>(decoded_value.storageBuffer8BitAccess);
         jdata["uniformAndStorageBuffer8BitAccess"] = static_cast<bool>(decoded_value.uniformAndStorageBuffer8BitAccess);
@@ -3996,6 +4240,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDr
     {
         const VkPhysicalDeviceDriverProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDriverProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["driverID"], decoded_value.driverID, options);
         FieldToJson(jdata["driverName"], &meta_struct.driverName, options);
@@ -4011,6 +4256,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderAtomicInt64Features& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderAtomicInt64Features& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderBufferInt64Atomics"] = static_cast<bool>(decoded_value.shaderBufferInt64Atomics);
         jdata["shaderSharedInt64Atomics"] = static_cast<bool>(decoded_value.shaderSharedInt64Atomics);
@@ -4024,6 +4270,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderFloat16Int8Features& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderFloat16Int8Features& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderFloat16"] = static_cast<bool>(decoded_value.shaderFloat16);
         jdata["shaderInt8"] = static_cast<bool>(decoded_value.shaderInt8);
@@ -4037,6 +4284,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFl
     {
         const VkPhysicalDeviceFloatControlsProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFloatControlsProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["denormBehaviorIndependence"], decoded_value.denormBehaviorIndependence, options);
         FieldToJson(jdata["roundingModeIndependence"], decoded_value.roundingModeIndependence, options);
@@ -4065,6 +4313,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetLay
     {
         const VkDescriptorSetLayoutBindingFlagsCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["bindingCount"], decoded_value.bindingCount, options);
         FieldToJson(jdata["pBindingFlags"], meta_struct.pBindingFlags, options);
@@ -4078,6 +4327,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDescriptorIndexingFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDescriptorIndexingFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderInputAttachmentArrayDynamicIndexing"] = static_cast<bool>(decoded_value.shaderInputAttachmentArrayDynamicIndexing);
         jdata["shaderUniformTexelBufferArrayDynamicIndexing"] = static_cast<bool>(decoded_value.shaderUniformTexelBufferArrayDynamicIndexing);
@@ -4109,6 +4359,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDescriptorIndexingProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDescriptorIndexingProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxUpdateAfterBindDescriptorsInAllPools"], decoded_value.maxUpdateAfterBindDescriptorsInAllPools, options);
         jdata["shaderUniformBufferArrayNonUniformIndexingNative"] = static_cast<bool>(decoded_value.shaderUniformBufferArrayNonUniformIndexingNative);
@@ -4143,6 +4394,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetVar
     {
         const VkDescriptorSetVariableDescriptorCountAllocateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["descriptorSetCount"], decoded_value.descriptorSetCount, options);
         FieldToJson(jdata["pDescriptorCounts"], meta_struct.pDescriptorCounts, options);
@@ -4156,6 +4408,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetVar
     {
         const VkDescriptorSetVariableDescriptorCountLayoutSupport& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupport& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxVariableDescriptorCount"], decoded_value.maxVariableDescriptorCount, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4168,6 +4421,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassDescripti
     {
         const VkSubpassDescriptionDepthStencilResolve& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassDescriptionDepthStencilResolve& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["depthResolveMode"], decoded_value.depthResolveMode, options);
         FieldToJson(jdata["stencilResolveMode"], decoded_value.stencilResolveMode, options);
@@ -4182,6 +4436,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDepthStencilResolveProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDepthStencilResolveProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkResolveModeFlags_t(),jdata["supportedDepthResolveModes"], decoded_value.supportedDepthResolveModes, options);
         FieldToJson(VkResolveModeFlags_t(),jdata["supportedStencilResolveModes"], decoded_value.supportedStencilResolveModes, options);
@@ -4197,6 +4452,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSc
     {
         const VkPhysicalDeviceScalarBlockLayoutFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["scalarBlockLayout"] = static_cast<bool>(decoded_value.scalarBlockLayout);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4209,6 +4465,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageStencilUsag
     {
         const VkImageStencilUsageCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkImageStencilUsageCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageUsageFlags_t(),jdata["stencilUsage"], decoded_value.stencilUsage, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4221,6 +4478,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerReduction
     {
         const VkSamplerReductionModeCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerReductionModeCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["reductionMode"], decoded_value.reductionMode, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4233,6 +4491,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSa
     {
         const VkPhysicalDeviceSamplerFilterMinmaxProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSamplerFilterMinmaxProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["filterMinmaxSingleComponentFormats"] = static_cast<bool>(decoded_value.filterMinmaxSingleComponentFormats);
         jdata["filterMinmaxImageComponentMapping"] = static_cast<bool>(decoded_value.filterMinmaxImageComponentMapping);
@@ -4246,6 +4505,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVu
     {
         const VkPhysicalDeviceVulkanMemoryModelFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVulkanMemoryModelFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["vulkanMemoryModel"] = static_cast<bool>(decoded_value.vulkanMemoryModel);
         jdata["vulkanMemoryModelDeviceScope"] = static_cast<bool>(decoded_value.vulkanMemoryModelDeviceScope);
@@ -4260,6 +4520,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImagelessFramebufferFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImagelessFramebufferFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["imagelessFramebuffer"] = static_cast<bool>(decoded_value.imagelessFramebuffer);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4272,6 +4533,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFramebufferAttac
     {
         const VkFramebufferAttachmentImageInfo& decoded_value = *data->decoded_value;
         const Decoded_VkFramebufferAttachmentImageInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(VkImageUsageFlags_t(),jdata["usage"], decoded_value.usage, options);
@@ -4290,6 +4552,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFramebufferAttac
     {
         const VkFramebufferAttachmentsCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkFramebufferAttachmentsCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["attachmentImageInfoCount"], decoded_value.attachmentImageInfoCount, options);
         FieldToJson(jdata["pAttachmentImageInfos"], meta_struct.pAttachmentImageInfos, options);
@@ -4303,6 +4566,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassAttach
     {
         const VkRenderPassAttachmentBeginInfo& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassAttachmentBeginInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["attachmentCount"], decoded_value.attachmentCount, options);
         HandleToJson(jdata["pAttachments"], &meta_struct.pAttachments, options);
@@ -4316,6 +4580,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceUn
     {
         const VkPhysicalDeviceUniformBufferStandardLayoutFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceUniformBufferStandardLayoutFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["uniformBufferStandardLayout"] = static_cast<bool>(decoded_value.uniformBufferStandardLayout);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4328,6 +4593,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderSubgroupExtendedTypes"] = static_cast<bool>(decoded_value.shaderSubgroupExtendedTypes);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4340,6 +4606,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSe
     {
         const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["separateDepthStencilLayouts"] = static_cast<bool>(decoded_value.separateDepthStencilLayouts);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4352,6 +4619,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentRefere
     {
         const VkAttachmentReferenceStencilLayout& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentReferenceStencilLayout& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stencilLayout"], decoded_value.stencilLayout, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4364,6 +4632,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentDescri
     {
         const VkAttachmentDescriptionStencilLayout& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentDescriptionStencilLayout& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stencilInitialLayout"], decoded_value.stencilInitialLayout, options);
         FieldToJson(jdata["stencilFinalLayout"], decoded_value.stencilFinalLayout, options);
@@ -4377,6 +4646,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceHo
     {
         const VkPhysicalDeviceHostQueryResetFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceHostQueryResetFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["hostQueryReset"] = static_cast<bool>(decoded_value.hostQueryReset);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4389,6 +4659,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTi
     {
         const VkPhysicalDeviceTimelineSemaphoreFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTimelineSemaphoreFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["timelineSemaphore"] = static_cast<bool>(decoded_value.timelineSemaphore);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4401,6 +4672,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTi
     {
         const VkPhysicalDeviceTimelineSemaphoreProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTimelineSemaphoreProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxTimelineSemaphoreValueDifference"], decoded_value.maxTimelineSemaphoreValueDifference, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4413,6 +4685,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreTypeCre
     {
         const VkSemaphoreTypeCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreTypeCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["semaphoreType"], decoded_value.semaphoreType, options);
         FieldToJson(jdata["initialValue"], decoded_value.initialValue, options);
@@ -4426,6 +4699,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkTimelineSemaphor
     {
         const VkTimelineSemaphoreSubmitInfo& decoded_value = *data->decoded_value;
         const Decoded_VkTimelineSemaphoreSubmitInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["waitSemaphoreValueCount"], decoded_value.waitSemaphoreValueCount, options);
         FieldToJson(jdata["pWaitSemaphoreValues"], meta_struct.pWaitSemaphoreValues, options);
@@ -4441,6 +4715,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreWaitInf
     {
         const VkSemaphoreWaitInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreWaitInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSemaphoreWaitFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["semaphoreCount"], decoded_value.semaphoreCount, options);
@@ -4456,6 +4731,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreSignalI
     {
         const VkSemaphoreSignalInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreSignalInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(jdata["value"], decoded_value.value, options);
@@ -4469,6 +4745,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceBu
     {
         const VkPhysicalDeviceBufferDeviceAddressFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceBufferDeviceAddressFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["bufferDeviceAddress"] = static_cast<bool>(decoded_value.bufferDeviceAddress);
         jdata["bufferDeviceAddressCaptureReplay"] = static_cast<bool>(decoded_value.bufferDeviceAddressCaptureReplay);
@@ -4483,6 +4760,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferDeviceAddr
     {
         const VkBufferDeviceAddressInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBufferDeviceAddressInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4495,6 +4773,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferOpaqueCapt
     {
         const VkBufferOpaqueCaptureAddressCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkBufferOpaqueCaptureAddressCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["opaqueCaptureAddress"], decoded_value.opaqueCaptureAddress, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4507,6 +4786,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryOpaqueCapt
     {
         const VkMemoryOpaqueCaptureAddressAllocateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryOpaqueCaptureAddressAllocateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["opaqueCaptureAddress"], decoded_value.opaqueCaptureAddress, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4519,6 +4799,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceMemoryOpaq
     {
         const VkDeviceMemoryOpaqueCaptureAddressInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4531,6 +4812,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVu
     {
         const VkPhysicalDeviceVulkan13Features& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVulkan13Features& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["robustImageAccess"] = static_cast<bool>(decoded_value.robustImageAccess);
         jdata["inlineUniformBlock"] = static_cast<bool>(decoded_value.inlineUniformBlock);
@@ -4557,6 +4839,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVu
     {
         const VkPhysicalDeviceVulkan13Properties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVulkan13Properties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minSubgroupSize"], decoded_value.minSubgroupSize, options);
         FieldToJson(jdata["maxSubgroupSize"], decoded_value.maxSubgroupSize, options);
@@ -4613,6 +4896,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCreation
     {
         const VkPipelineCreationFeedback& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCreationFeedback& meta_struct = *data;
+
         FieldToJson(VkPipelineCreationFeedbackFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["duration"], decoded_value.duration, options);
     }
@@ -4624,6 +4908,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCreation
     {
         const VkPipelineCreationFeedbackCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCreationFeedbackCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pPipelineCreationFeedback"], meta_struct.pPipelineCreationFeedback, options);
         FieldToJson(jdata["pipelineStageCreationFeedbackCount"], decoded_value.pipelineStageCreationFeedbackCount, options);
@@ -4638,6 +4923,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderTerminateInvocationFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderTerminateInvocationFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderTerminateInvocation"] = static_cast<bool>(decoded_value.shaderTerminateInvocation);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4650,6 +4936,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTo
     {
         const VkPhysicalDeviceToolProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceToolProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["name"], &meta_struct.name, options);
         FieldToJson(jdata["version"], &meta_struct.version, options);
@@ -4666,6 +4953,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderDemoteToHelperInvocation"] = static_cast<bool>(decoded_value.shaderDemoteToHelperInvocation);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4678,6 +4966,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDevicePrivateDataFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePrivateDataFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["privateData"] = static_cast<bool>(decoded_value.privateData);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4690,6 +4979,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDevicePrivateDat
     {
         const VkDevicePrivateDataCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDevicePrivateDataCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["privateDataSlotRequestCount"], decoded_value.privateDataSlotRequestCount, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4702,6 +4992,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPrivateDataSlotC
     {
         const VkPrivateDataSlotCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPrivateDataSlotCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPrivateDataSlotCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4714,6 +5005,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePi
     {
         const VkPhysicalDevicePipelineCreationCacheControlFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePipelineCreationCacheControlFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["pipelineCreationCacheControl"] = static_cast<bool>(decoded_value.pipelineCreationCacheControl);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4726,6 +5018,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryBarrier2* 
     {
         const VkMemoryBarrier2& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryBarrier2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineStageFlags2_t(),jdata["srcStageMask"], decoded_value.srcStageMask, options);
         FieldToJson(VkAccessFlags2_t(),jdata["srcAccessMask"], decoded_value.srcAccessMask, options);
@@ -4741,6 +5034,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferMemoryBarr
     {
         const VkBufferMemoryBarrier2& decoded_value = *data->decoded_value;
         const Decoded_VkBufferMemoryBarrier2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineStageFlags2_t(),jdata["srcStageMask"], decoded_value.srcStageMask, options);
         FieldToJson(VkAccessFlags2_t(),jdata["srcAccessMask"], decoded_value.srcAccessMask, options);
@@ -4761,6 +5055,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageMemoryBarri
     {
         const VkImageMemoryBarrier2& decoded_value = *data->decoded_value;
         const Decoded_VkImageMemoryBarrier2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineStageFlags2_t(),jdata["srcStageMask"], decoded_value.srcStageMask, options);
         FieldToJson(VkAccessFlags2_t(),jdata["srcAccessMask"], decoded_value.srcAccessMask, options);
@@ -4782,6 +5077,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDependencyInfo* 
     {
         const VkDependencyInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDependencyInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDependencyFlags_t(),jdata["dependencyFlags"], decoded_value.dependencyFlags, options);
         FieldToJson(jdata["memoryBarrierCount"], decoded_value.memoryBarrierCount, options);
@@ -4800,6 +5096,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreSubmitI
     {
         const VkSemaphoreSubmitInfo& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreSubmitInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(jdata["value"], decoded_value.value, options);
@@ -4815,6 +5112,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferSub
     {
         const VkCommandBufferSubmitInfo& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferSubmitInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["commandBuffer"], meta_struct.commandBuffer, options);
         FieldToJson(jdata["deviceMask"], decoded_value.deviceMask, options);
@@ -4828,6 +5126,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubmitInfo2* dat
     {
         const VkSubmitInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkSubmitInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSubmitFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["waitSemaphoreInfoCount"], decoded_value.waitSemaphoreInfoCount, options);
@@ -4846,6 +5145,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSy
     {
         const VkPhysicalDeviceSynchronization2Features& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSynchronization2Features& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["synchronization2"] = static_cast<bool>(decoded_value.synchronization2);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4858,6 +5158,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceZe
     {
         const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderZeroInitializeWorkgroupMemory"] = static_cast<bool>(decoded_value.shaderZeroInitializeWorkgroupMemory);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4870,6 +5171,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageRobustnessFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageRobustnessFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["robustImageAccess"] = static_cast<bool>(decoded_value.robustImageAccess);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -4882,6 +5184,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferCopy2* dat
     {
         const VkBufferCopy2& decoded_value = *data->decoded_value;
         const Decoded_VkBufferCopy2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["srcOffset"], decoded_value.srcOffset, options);
         FieldToJson(jdata["dstOffset"], decoded_value.dstOffset, options);
@@ -4896,6 +5199,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyBufferInfo2*
     {
         const VkCopyBufferInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkCopyBufferInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["srcBuffer"], meta_struct.srcBuffer, options);
         HandleToJson(jdata["dstBuffer"], meta_struct.dstBuffer, options);
@@ -4911,6 +5215,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageCopy2* data
     {
         const VkImageCopy2& decoded_value = *data->decoded_value;
         const Decoded_VkImageCopy2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["srcSubresource"], meta_struct.srcSubresource, options);
         FieldToJson(jdata["srcOffset"], meta_struct.srcOffset, options);
@@ -4927,6 +5232,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyImageInfo2* 
     {
         const VkCopyImageInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkCopyImageInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["srcImage"], meta_struct.srcImage, options);
         FieldToJson(jdata["srcImageLayout"], decoded_value.srcImageLayout, options);
@@ -4944,6 +5250,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferImageCopy2
     {
         const VkBufferImageCopy2& decoded_value = *data->decoded_value;
         const Decoded_VkBufferImageCopy2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["bufferOffset"], decoded_value.bufferOffset, options);
         FieldToJson(jdata["bufferRowLength"], decoded_value.bufferRowLength, options);
@@ -4961,6 +5268,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyBufferToImag
     {
         const VkCopyBufferToImageInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkCopyBufferToImageInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["srcBuffer"], meta_struct.srcBuffer, options);
         HandleToJson(jdata["dstImage"], meta_struct.dstImage, options);
@@ -4977,6 +5285,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyImageToBuffe
     {
         const VkCopyImageToBufferInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkCopyImageToBufferInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["srcImage"], meta_struct.srcImage, options);
         FieldToJson(jdata["srcImageLayout"], decoded_value.srcImageLayout, options);
@@ -4993,6 +5302,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageBlit2* data
     {
         const VkImageBlit2& decoded_value = *data->decoded_value;
         const Decoded_VkImageBlit2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["srcSubresource"], meta_struct.srcSubresource, options);
         FieldToJson(jdata["srcOffsets"], meta_struct.srcOffsets, options);
@@ -5008,6 +5318,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBlitImageInfo2* 
     {
         const VkBlitImageInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkBlitImageInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["srcImage"], meta_struct.srcImage, options);
         FieldToJson(jdata["srcImageLayout"], decoded_value.srcImageLayout, options);
@@ -5026,6 +5337,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageResolve2* d
     {
         const VkImageResolve2& decoded_value = *data->decoded_value;
         const Decoded_VkImageResolve2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["srcSubresource"], meta_struct.srcSubresource, options);
         FieldToJson(jdata["srcOffset"], meta_struct.srcOffset, options);
@@ -5042,6 +5354,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkResolveImageInfo
     {
         const VkResolveImageInfo2& decoded_value = *data->decoded_value;
         const Decoded_VkResolveImageInfo2& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["srcImage"], meta_struct.srcImage, options);
         FieldToJson(jdata["srcImageLayout"], decoded_value.srcImageLayout, options);
@@ -5059,6 +5372,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSu
     {
         const VkPhysicalDeviceSubgroupSizeControlFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSubgroupSizeControlFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["subgroupSizeControl"] = static_cast<bool>(decoded_value.subgroupSizeControl);
         jdata["computeFullSubgroups"] = static_cast<bool>(decoded_value.computeFullSubgroups);
@@ -5072,6 +5386,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSu
     {
         const VkPhysicalDeviceSubgroupSizeControlProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSubgroupSizeControlProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minSubgroupSize"], decoded_value.minSubgroupSize, options);
         FieldToJson(jdata["maxSubgroupSize"], decoded_value.maxSubgroupSize, options);
@@ -5087,6 +5402,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineShaderSt
     {
         const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["requiredSubgroupSize"], decoded_value.requiredSubgroupSize, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5099,6 +5415,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIn
     {
         const VkPhysicalDeviceInlineUniformBlockFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceInlineUniformBlockFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["inlineUniformBlock"] = static_cast<bool>(decoded_value.inlineUniformBlock);
         jdata["descriptorBindingInlineUniformBlockUpdateAfterBind"] = static_cast<bool>(decoded_value.descriptorBindingInlineUniformBlockUpdateAfterBind);
@@ -5112,6 +5429,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIn
     {
         const VkPhysicalDeviceInlineUniformBlockProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceInlineUniformBlockProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxInlineUniformBlockSize"], decoded_value.maxInlineUniformBlockSize, options);
         FieldToJson(jdata["maxPerStageDescriptorInlineUniformBlocks"], decoded_value.maxPerStageDescriptorInlineUniformBlocks, options);
@@ -5128,6 +5446,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWriteDescriptorS
     {
         const VkWriteDescriptorSetInlineUniformBlock& decoded_value = *data->decoded_value;
         const Decoded_VkWriteDescriptorSetInlineUniformBlock& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["dataSize"], decoded_value.dataSize, options);
         FieldToJson(jdata["pData"], meta_struct.pData, options);
@@ -5141,6 +5460,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorPoolIn
     {
         const VkDescriptorPoolInlineUniformBlockCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorPoolInlineUniformBlockCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxInlineUniformBlockBindings"], decoded_value.maxInlineUniformBlockBindings, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5153,6 +5473,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTe
     {
         const VkPhysicalDeviceTextureCompressionASTCHDRFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTextureCompressionASTCHDRFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["textureCompressionASTC_HDR"] = static_cast<bool>(decoded_value.textureCompressionASTC_HDR);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5165,6 +5486,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderingAttachm
     {
         const VkRenderingAttachmentInfo& decoded_value = *data->decoded_value;
         const Decoded_VkRenderingAttachmentInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["imageView"], meta_struct.imageView, options);
         FieldToJson(jdata["imageLayout"], decoded_value.imageLayout, options);
@@ -5184,6 +5506,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderingInfo* d
     {
         const VkRenderingInfo& decoded_value = *data->decoded_value;
         const Decoded_VkRenderingInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkRenderingFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["renderArea"], meta_struct.renderArea, options);
@@ -5203,6 +5526,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRenderin
     {
         const VkPipelineRenderingCreateInfo& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRenderingCreateInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["viewMask"], decoded_value.viewMask, options);
         FieldToJson(jdata["colorAttachmentCount"], decoded_value.colorAttachmentCount, options);
@@ -5219,6 +5543,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDy
     {
         const VkPhysicalDeviceDynamicRenderingFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDynamicRenderingFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["dynamicRendering"] = static_cast<bool>(decoded_value.dynamicRendering);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5231,6 +5556,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferInh
     {
         const VkCommandBufferInheritanceRenderingInfo& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferInheritanceRenderingInfo& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkRenderingFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["viewMask"], decoded_value.viewMask, options);
@@ -5249,6 +5575,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderIntegerDotProductFeatures& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderIntegerDotProductFeatures& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderIntegerDotProduct"] = static_cast<bool>(decoded_value.shaderIntegerDotProduct);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5261,6 +5588,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderIntegerDotProductProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderIntegerDotProductProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["integerDotProduct8BitUnsignedAccelerated"] = static_cast<bool>(decoded_value.integerDotProduct8BitUnsignedAccelerated);
         jdata["integerDotProduct8BitSignedAccelerated"] = static_cast<bool>(decoded_value.integerDotProduct8BitSignedAccelerated);
@@ -5302,6 +5630,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTe
     {
         const VkPhysicalDeviceTexelBufferAlignmentProperties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTexelBufferAlignmentProperties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["storageTexelBufferOffsetAlignmentBytes"], decoded_value.storageTexelBufferOffsetAlignmentBytes, options);
         jdata["storageTexelBufferOffsetSingleTexelAlignment"] = static_cast<bool>(decoded_value.storageTexelBufferOffsetSingleTexelAlignment);
@@ -5317,6 +5646,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFormatProperties
     {
         const VkFormatProperties3& decoded_value = *data->decoded_value;
         const Decoded_VkFormatProperties3& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkFormatFeatureFlags2_t(),jdata["linearTilingFeatures"], decoded_value.linearTilingFeatures, options);
         FieldToJson(VkFormatFeatureFlags2_t(),jdata["optimalTilingFeatures"], decoded_value.optimalTilingFeatures, options);
@@ -5331,6 +5661,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMa
     {
         const VkPhysicalDeviceMaintenance4Features& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMaintenance4Features& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["maintenance4"] = static_cast<bool>(decoded_value.maintenance4);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5343,6 +5674,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMa
     {
         const VkPhysicalDeviceMaintenance4Properties& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMaintenance4Properties& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxBufferSize"], decoded_value.maxBufferSize, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5355,6 +5687,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceBufferMemo
     {
         const VkDeviceBufferMemoryRequirements& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceBufferMemoryRequirements& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pCreateInfo"], meta_struct.pCreateInfo, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5367,6 +5700,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceImageMemor
     {
         const VkDeviceImageMemoryRequirements& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceImageMemoryRequirements& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pCreateInfo"], meta_struct.pCreateInfo, options);
         FieldToJson(jdata["planeAspect"], decoded_value.planeAspect, options);
@@ -5380,6 +5714,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceCapabilit
     {
         const VkSurfaceCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["minImageCount"], decoded_value.minImageCount, options);
         FieldToJson(jdata["maxImageCount"], decoded_value.maxImageCount, options);
         FieldToJson(jdata["currentExtent"], meta_struct.currentExtent, options);
@@ -5399,6 +5734,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceFormatKHR
     {
         const VkSurfaceFormatKHR& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceFormatKHR& meta_struct = *data;
+
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["colorSpace"], decoded_value.colorSpace, options);
     }
@@ -5410,6 +5746,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainCreateI
     {
         const VkSwapchainCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSwapchainCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["surface"], meta_struct.surface, options);
@@ -5437,6 +5774,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPresentInfoKHR* 
     {
         const VkPresentInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPresentInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["waitSemaphoreCount"], decoded_value.waitSemaphoreCount, options);
         HandleToJson(jdata["pWaitSemaphores"], &meta_struct.pWaitSemaphores, options);
@@ -5454,6 +5792,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageSwapchainCr
     {
         const VkImageSwapchainCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkImageSwapchainCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["swapchain"], meta_struct.swapchain, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5466,6 +5805,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindImageMemoryS
     {
         const VkBindImageMemorySwapchainInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkBindImageMemorySwapchainInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["swapchain"], meta_struct.swapchain, options);
         FieldToJson(jdata["imageIndex"], decoded_value.imageIndex, options);
@@ -5479,6 +5819,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAcquireNextImage
     {
         const VkAcquireNextImageInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAcquireNextImageInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["swapchain"], meta_struct.swapchain, options);
         FieldToJson(jdata["timeout"], decoded_value.timeout, options);
@@ -5495,6 +5836,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupPrese
     {
         const VkDeviceGroupPresentCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupPresentCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["presentMask"], &meta_struct.presentMask, options);
         FieldToJson(VkDeviceGroupPresentModeFlagsKHR_t(),jdata["modes"], decoded_value.modes, options);
@@ -5508,6 +5850,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupPrese
     {
         const VkDeviceGroupPresentInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupPresentInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["swapchainCount"], decoded_value.swapchainCount, options);
         FieldToJson(jdata["pDeviceMasks"], meta_struct.pDeviceMasks, options);
@@ -5522,6 +5865,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceGroupSwapc
     {
         const VkDeviceGroupSwapchainCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceGroupSwapchainCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceGroupPresentModeFlagsKHR_t(),jdata["modes"], decoded_value.modes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5534,6 +5878,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayModeParam
     {
         const VkDisplayModeParametersKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayModeParametersKHR& meta_struct = *data;
+
         FieldToJson(jdata["visibleRegion"], meta_struct.visibleRegion, options);
         FieldToJson(jdata["refreshRate"], decoded_value.refreshRate, options);
     }
@@ -5545,6 +5890,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayModeCreat
     {
         const VkDisplayModeCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayModeCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDisplayModeCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["parameters"], meta_struct.parameters, options);
@@ -5558,6 +5904,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayModePrope
     {
         const VkDisplayModePropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayModePropertiesKHR& meta_struct = *data;
+
         HandleToJson(jdata["displayMode"], meta_struct.displayMode, options);
         FieldToJson(jdata["parameters"], meta_struct.parameters, options);
     }
@@ -5569,6 +5916,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPlaneCapa
     {
         const VkDisplayPlaneCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPlaneCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(VkDisplayPlaneAlphaFlagsKHR_t(),jdata["supportedAlpha"], decoded_value.supportedAlpha, options);
         FieldToJson(jdata["minSrcPosition"], meta_struct.minSrcPosition, options);
         FieldToJson(jdata["maxSrcPosition"], meta_struct.maxSrcPosition, options);
@@ -5587,6 +5935,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPlaneProp
     {
         const VkDisplayPlanePropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPlanePropertiesKHR& meta_struct = *data;
+
         HandleToJson(jdata["currentDisplay"], meta_struct.currentDisplay, options);
         FieldToJson(jdata["currentStackIndex"], decoded_value.currentStackIndex, options);
     }
@@ -5598,6 +5947,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPropertie
     {
         const VkDisplayPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPropertiesKHR& meta_struct = *data;
+
         HandleToJson(jdata["display"], meta_struct.display, options);
         FieldToJson(jdata["displayName"], &meta_struct.displayName, options);
         FieldToJson(jdata["physicalDimensions"], meta_struct.physicalDimensions, options);
@@ -5614,6 +5964,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplaySurfaceCr
     {
         const VkDisplaySurfaceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplaySurfaceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDisplaySurfaceCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["displayMode"], meta_struct.displayMode, options);
@@ -5633,6 +5984,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPresentIn
     {
         const VkDisplayPresentInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPresentInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["srcRect"], meta_struct.srcRect, options);
         FieldToJson(jdata["dstRect"], meta_struct.dstRect, options);
@@ -5647,6 +5999,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkXlibSurfaceCreat
     {
         const VkXlibSurfaceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkXlibSurfaceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkXlibSurfaceCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["dpy"], meta_struct.dpy, options);
@@ -5661,6 +6014,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkXcbSurfaceCreate
     {
         const VkXcbSurfaceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkXcbSurfaceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkXcbSurfaceCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["connection"], meta_struct.connection, options);
@@ -5675,6 +6029,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWaylandSurfaceCr
     {
         const VkWaylandSurfaceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkWaylandSurfaceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkWaylandSurfaceCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["display"], meta_struct.display, options);
@@ -5689,6 +6044,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAndroidSurfaceCr
     {
         const VkAndroidSurfaceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAndroidSurfaceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkAndroidSurfaceCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["window"], meta_struct.window, options);
@@ -5702,6 +6058,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWin32SurfaceCrea
     {
         const VkWin32SurfaceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkWin32SurfaceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkWin32SurfaceCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["hinstance"], meta_struct.hinstance, options);
@@ -5716,6 +6073,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueueFamilyQuery
     {
         const VkQueueFamilyQueryResultStatusPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkQueueFamilyQueryResultStatusPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["queryResultStatusSupport"] = static_cast<bool>(decoded_value.queryResultStatusSupport);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5728,6 +6086,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueueFamilyVideo
     {
         const VkQueueFamilyVideoPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkQueueFamilyVideoPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoCodecOperationFlagsKHR_t(),jdata["videoCodecOperations"], decoded_value.videoCodecOperations, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5740,6 +6099,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoProfileInfo
     {
         const VkVideoProfileInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoProfileInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["videoCodecOperation"], decoded_value.videoCodecOperation, options);
         FieldToJson(VkVideoChromaSubsamplingFlagsKHR_t(),jdata["chromaSubsampling"], decoded_value.chromaSubsampling, options);
@@ -5755,6 +6115,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoProfileList
     {
         const VkVideoProfileListInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoProfileListInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["profileCount"], decoded_value.profileCount, options);
         FieldToJson(jdata["pProfiles"], meta_struct.pProfiles, options);
@@ -5768,6 +6129,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoCapabilitie
     {
         const VkVideoCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoCapabilityFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["minBitstreamBufferOffsetAlignment"], decoded_value.minBitstreamBufferOffsetAlignment, options);
@@ -5788,6 +6150,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVi
     {
         const VkPhysicalDeviceVideoFormatInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVideoFormatInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageUsageFlags_t(),jdata["imageUsage"], decoded_value.imageUsage, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5800,6 +6163,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoFormatPrope
     {
         const VkVideoFormatPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoFormatPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["componentMapping"], meta_struct.componentMapping, options);
@@ -5817,6 +6181,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoPictureReso
     {
         const VkVideoPictureResourceInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoPictureResourceInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["codedOffset"], meta_struct.codedOffset, options);
         FieldToJson(jdata["codedExtent"], meta_struct.codedExtent, options);
@@ -5832,6 +6197,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoReferenceSl
     {
         const VkVideoReferenceSlotInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoReferenceSlotInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["slotIndex"], decoded_value.slotIndex, options);
         FieldToJson(jdata["pPictureResource"], meta_struct.pPictureResource, options);
@@ -5845,6 +6211,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoSessionMemo
     {
         const VkVideoSessionMemoryRequirementsKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoSessionMemoryRequirementsKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryBindIndex"], decoded_value.memoryBindIndex, options);
         FieldToJson(jdata["memoryRequirements"], meta_struct.memoryRequirements, options);
@@ -5858,6 +6225,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindVideoSession
     {
         const VkBindVideoSessionMemoryInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkBindVideoSessionMemoryInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryBindIndex"], decoded_value.memoryBindIndex, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
@@ -5873,6 +6241,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoSessionCrea
     {
         const VkVideoSessionCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoSessionCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["queueFamilyIndex"], decoded_value.queueFamilyIndex, options);
         FieldToJson(VkVideoSessionCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
@@ -5893,6 +6262,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoSessionPara
     {
         const VkVideoSessionParametersCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoSessionParametersCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoSessionParametersCreateFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["videoSessionParametersTemplate"], meta_struct.videoSessionParametersTemplate, options);
@@ -5907,6 +6277,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoSessionPara
     {
         const VkVideoSessionParametersUpdateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoSessionParametersUpdateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["updateSequenceCount"], decoded_value.updateSequenceCount, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5919,6 +6290,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoBeginCoding
     {
         const VkVideoBeginCodingInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoBeginCodingInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoBeginCodingFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["videoSession"], meta_struct.videoSession, options);
@@ -5935,6 +6307,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEndCodingIn
     {
         const VkVideoEndCodingInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEndCodingInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEndCodingFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5947,6 +6320,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoCodingContr
     {
         const VkVideoCodingControlInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoCodingControlInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoCodingControlFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5959,6 +6333,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeCapab
     {
         const VkVideoDecodeCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoDecodeCapabilityFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5971,6 +6346,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeUsage
     {
         const VkVideoDecodeUsageInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeUsageInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoDecodeUsageFlagsKHR_t(),jdata["videoUsageHints"], decoded_value.videoUsageHints, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -5983,6 +6359,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeInfoK
     {
         const VkVideoDecodeInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoDecodeFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["srcBuffer"], meta_struct.srcBuffer, options);
@@ -6002,6 +6379,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH264P
     {
         const VkVideoDecodeH264ProfileInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH264ProfileInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdProfileIdc"], decoded_value.stdProfileIdc, options);
         FieldToJson(jdata["pictureLayout"], decoded_value.pictureLayout, options);
@@ -6015,6 +6393,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH264C
     {
         const VkVideoDecodeH264CapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH264CapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxLevelIdc"], decoded_value.maxLevelIdc, options);
         FieldToJson(jdata["fieldOffsetGranularity"], meta_struct.fieldOffsetGranularity, options);
@@ -6028,6 +6407,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH264S
     {
         const VkVideoDecodeH264SessionParametersAddInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH264SessionParametersAddInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdSPSCount"], decoded_value.stdSPSCount, options);
         FieldToJson(jdata["pStdSPSs"], meta_struct.pStdSPSs, options);
@@ -6043,6 +6423,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH264S
     {
         const VkVideoDecodeH264SessionParametersCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH264SessionParametersCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxStdSPSCount"], decoded_value.maxStdSPSCount, options);
         FieldToJson(jdata["maxStdPPSCount"], decoded_value.maxStdPPSCount, options);
@@ -6057,6 +6438,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH264P
     {
         const VkVideoDecodeH264PictureInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH264PictureInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pStdPictureInfo"], meta_struct.pStdPictureInfo, options);
         FieldToJson(jdata["sliceCount"], decoded_value.sliceCount, options);
@@ -6071,6 +6453,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH264D
     {
         const VkVideoDecodeH264DpbSlotInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH264DpbSlotInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pStdReferenceInfo"], meta_struct.pStdReferenceInfo, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6083,6 +6466,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderingFragmen
     {
         const VkRenderingFragmentShadingRateAttachmentInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["imageView"], meta_struct.imageView, options);
         FieldToJson(jdata["imageLayout"], decoded_value.imageLayout, options);
@@ -6097,6 +6481,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderingFragmen
     {
         const VkRenderingFragmentDensityMapAttachmentInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["imageView"], meta_struct.imageView, options);
         FieldToJson(jdata["imageLayout"], decoded_value.imageLayout, options);
@@ -6110,6 +6495,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentSample
     {
         const VkAttachmentSampleCountInfoAMD& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentSampleCountInfoAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["colorAttachmentCount"], decoded_value.colorAttachmentCount, options);
         FieldToJson(jdata["pColorAttachmentSamples"], meta_struct.pColorAttachmentSamples, options);
@@ -6124,6 +6510,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMultiviewPerView
     {
         const VkMultiviewPerViewAttributesInfoNVX& decoded_value = *data->decoded_value;
         const Decoded_VkMultiviewPerViewAttributesInfoNVX& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["perViewAttributes"] = static_cast<bool>(decoded_value.perViewAttributes);
         jdata["perViewAttributesPositionXOnly"] = static_cast<bool>(decoded_value.perViewAttributesPositionXOnly);
@@ -6137,6 +6524,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportMemoryWin3
     {
         const VkImportMemoryWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkImportMemoryWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["handle"], meta_struct.handle, options);
@@ -6151,6 +6539,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportMemoryWin3
     {
         const VkExportMemoryWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkExportMemoryWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pAttributes"], meta_struct.pAttributes, options);
         FieldToJson(jdata["dwAccess"], decoded_value.dwAccess, options);
@@ -6165,6 +6554,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryWin32Handl
     {
         const VkMemoryWin32HandlePropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryWin32HandlePropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryTypeBits"], decoded_value.memoryTypeBits, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6177,6 +6567,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryGetWin32Ha
     {
         const VkMemoryGetWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryGetWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -6190,6 +6581,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportMemoryFdIn
     {
         const VkImportMemoryFdInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkImportMemoryFdInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["fd"], decoded_value.fd, options);
@@ -6203,6 +6595,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryFdProperti
     {
         const VkMemoryFdPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryFdPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryTypeBits"], decoded_value.memoryTypeBits, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6215,6 +6608,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryGetFdInfoK
     {
         const VkMemoryGetFdInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryGetFdInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -6228,6 +6622,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWin32KeyedMutexA
     {
         const VkWin32KeyedMutexAcquireReleaseInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["acquireCount"], decoded_value.acquireCount, options);
         HandleToJson(jdata["pAcquireSyncs"], &meta_struct.pAcquireSyncs, options);
@@ -6246,6 +6641,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportSemaphoreW
     {
         const VkImportSemaphoreWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkImportSemaphoreWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(VkSemaphoreImportFlags_t(),jdata["flags"], decoded_value.flags, options);
@@ -6262,6 +6658,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportSemaphoreW
     {
         const VkExportSemaphoreWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkExportSemaphoreWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pAttributes"], meta_struct.pAttributes, options);
         FieldToJson(jdata["dwAccess"], decoded_value.dwAccess, options);
@@ -6276,6 +6673,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkD3D12FenceSubmit
     {
         const VkD3D12FenceSubmitInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkD3D12FenceSubmitInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["waitSemaphoreValuesCount"], decoded_value.waitSemaphoreValuesCount, options);
         FieldToJson(jdata["pWaitSemaphoreValues"], meta_struct.pWaitSemaphoreValues, options);
@@ -6291,6 +6689,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreGetWin3
     {
         const VkSemaphoreGetWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreGetWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -6304,6 +6703,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportSemaphoreF
     {
         const VkImportSemaphoreFdInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkImportSemaphoreFdInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(VkSemaphoreImportFlags_t(),jdata["flags"], decoded_value.flags, options);
@@ -6319,6 +6719,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreGetFdIn
     {
         const VkSemaphoreGetFdInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreGetFdInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -6332,6 +6733,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePu
     {
         const VkPhysicalDevicePushDescriptorPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxPushDescriptors"], decoded_value.maxPushDescriptors, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6344,6 +6746,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRectLayerKHR* da
     {
         const VkRectLayerKHR& decoded_value = *data->decoded_value;
         const Decoded_VkRectLayerKHR& meta_struct = *data;
+
         FieldToJson(jdata["offset"], meta_struct.offset, options);
         FieldToJson(jdata["extent"], meta_struct.extent, options);
         FieldToJson(jdata["layer"], decoded_value.layer, options);
@@ -6356,6 +6759,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPresentRegionKHR
     {
         const VkPresentRegionKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPresentRegionKHR& meta_struct = *data;
+
         FieldToJson(jdata["rectangleCount"], decoded_value.rectangleCount, options);
         FieldToJson(jdata["pRectangles"], meta_struct.pRectangles, options);
     }
@@ -6367,6 +6771,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPresentRegionsKH
     {
         const VkPresentRegionsKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPresentRegionsKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["swapchainCount"], decoded_value.swapchainCount, options);
         FieldToJson(jdata["pRegions"], meta_struct.pRegions, options);
@@ -6380,6 +6785,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSharedPresentSur
     {
         const VkSharedPresentSurfaceCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkSharedPresentSurfaceCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageUsageFlags_t(),jdata["sharedPresentSupportedUsageFlags"], decoded_value.sharedPresentSupportedUsageFlags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6392,6 +6798,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportFenceWin32
     {
         const VkImportFenceWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkImportFenceWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["fence"], meta_struct.fence, options);
         FieldToJson(VkFenceImportFlags_t(),jdata["flags"], decoded_value.flags, options);
@@ -6408,6 +6815,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportFenceWin32
     {
         const VkExportFenceWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkExportFenceWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pAttributes"], meta_struct.pAttributes, options);
         FieldToJson(jdata["dwAccess"], decoded_value.dwAccess, options);
@@ -6422,6 +6830,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFenceGetWin32Han
     {
         const VkFenceGetWin32HandleInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkFenceGetWin32HandleInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["fence"], meta_struct.fence, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -6435,6 +6844,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportFenceFdInf
     {
         const VkImportFenceFdInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkImportFenceFdInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["fence"], meta_struct.fence, options);
         FieldToJson(VkFenceImportFlags_t(),jdata["flags"], decoded_value.flags, options);
@@ -6450,6 +6860,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFenceGetFdInfoKH
     {
         const VkFenceGetFdInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkFenceGetFdInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["fence"], meta_struct.fence, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -6463,6 +6874,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePe
     {
         const VkPhysicalDevicePerformanceQueryFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePerformanceQueryFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["performanceCounterQueryPools"] = static_cast<bool>(decoded_value.performanceCounterQueryPools);
         jdata["performanceCounterMultipleQueryPools"] = static_cast<bool>(decoded_value.performanceCounterMultipleQueryPools);
@@ -6476,6 +6888,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePe
     {
         const VkPhysicalDevicePerformanceQueryPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePerformanceQueryPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["allowCommandBufferQueryCopies"] = static_cast<bool>(decoded_value.allowCommandBufferQueryCopies);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6488,6 +6901,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPerformanceCount
     {
         const VkPerformanceCounterKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPerformanceCounterKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["unit"], decoded_value.unit, options);
         FieldToJson(jdata["scope"], decoded_value.scope, options);
@@ -6503,6 +6917,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPerformanceCount
     {
         const VkPerformanceCounterDescriptionKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPerformanceCounterDescriptionKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPerformanceCounterDescriptionFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["name"], &meta_struct.name, options);
@@ -6518,6 +6933,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueryPoolPerform
     {
         const VkQueryPoolPerformanceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkQueryPoolPerformanceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["queueFamilyIndex"], decoded_value.queueFamilyIndex, options);
         FieldToJson(jdata["counterIndexCount"], decoded_value.counterIndexCount, options);
@@ -6532,6 +6948,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAcquireProfiling
     {
         const VkAcquireProfilingLockInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAcquireProfilingLockInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkAcquireProfilingLockFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["timeout"], decoded_value.timeout, options);
@@ -6545,6 +6962,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPerformanceQuery
     {
         const VkPerformanceQuerySubmitInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPerformanceQuerySubmitInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["counterPassIndex"], decoded_value.counterPassIndex, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6557,6 +6975,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSu
     {
         const VkPhysicalDeviceSurfaceInfo2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSurfaceInfo2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["surface"], meta_struct.surface, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6569,6 +6988,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceCapabilit
     {
         const VkSurfaceCapabilities2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceCapabilities2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["surfaceCapabilities"], meta_struct.surfaceCapabilities, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6581,6 +7001,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceFormat2KH
     {
         const VkSurfaceFormat2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceFormat2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["surfaceFormat"], meta_struct.surfaceFormat, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6593,6 +7014,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPropertie
     {
         const VkDisplayProperties2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayProperties2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["displayProperties"], meta_struct.displayProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6605,6 +7027,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPlaneProp
     {
         const VkDisplayPlaneProperties2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPlaneProperties2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["displayPlaneProperties"], meta_struct.displayPlaneProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6617,6 +7040,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayModePrope
     {
         const VkDisplayModeProperties2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayModeProperties2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["displayModeProperties"], meta_struct.displayModeProperties, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6629,6 +7053,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPlaneInfo
     {
         const VkDisplayPlaneInfo2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPlaneInfo2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["mode"], meta_struct.mode, options);
         FieldToJson(jdata["planeIndex"], decoded_value.planeIndex, options);
@@ -6642,6 +7067,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPlaneCapa
     {
         const VkDisplayPlaneCapabilities2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPlaneCapabilities2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["capabilities"], meta_struct.capabilities, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6654,6 +7080,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePo
     {
         const VkPhysicalDevicePortabilitySubsetFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePortabilitySubsetFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["constantAlphaColorBlendFactors"] = static_cast<bool>(decoded_value.constantAlphaColorBlendFactors);
         jdata["events"] = static_cast<bool>(decoded_value.events);
@@ -6680,6 +7107,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePo
     {
         const VkPhysicalDevicePortabilitySubsetPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePortabilitySubsetPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minVertexInputBindingStrideAlignment"], decoded_value.minVertexInputBindingStrideAlignment, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6692,6 +7120,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderClockFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderClockFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderSubgroupClock"] = static_cast<bool>(decoded_value.shaderSubgroupClock);
         jdata["shaderDeviceClock"] = static_cast<bool>(decoded_value.shaderDeviceClock);
@@ -6705,6 +7134,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH265P
     {
         const VkVideoDecodeH265ProfileInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH265ProfileInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdProfileIdc"], decoded_value.stdProfileIdc, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6717,6 +7147,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH265C
     {
         const VkVideoDecodeH265CapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH265CapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxLevelIdc"], decoded_value.maxLevelIdc, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6729,6 +7160,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH265S
     {
         const VkVideoDecodeH265SessionParametersAddInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH265SessionParametersAddInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdVPSCount"], decoded_value.stdVPSCount, options);
         FieldToJson(jdata["pStdVPSs"], meta_struct.pStdVPSs, options);
@@ -6746,6 +7178,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH265S
     {
         const VkVideoDecodeH265SessionParametersCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH265SessionParametersCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxStdVPSCount"], decoded_value.maxStdVPSCount, options);
         FieldToJson(jdata["maxStdSPSCount"], decoded_value.maxStdSPSCount, options);
@@ -6761,6 +7194,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH265P
     {
         const VkVideoDecodeH265PictureInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH265PictureInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pStdPictureInfo"], meta_struct.pStdPictureInfo, options);
         FieldToJson(jdata["sliceSegmentCount"], decoded_value.sliceSegmentCount, options);
@@ -6775,6 +7209,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoDecodeH265D
     {
         const VkVideoDecodeH265DpbSlotInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoDecodeH265DpbSlotInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pStdReferenceInfo"], meta_struct.pStdReferenceInfo, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6787,6 +7222,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceQueueGloba
     {
         const VkDeviceQueueGlobalPriorityCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceQueueGlobalPriorityCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["globalPriority"], decoded_value.globalPriority, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6799,6 +7235,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceGl
     {
         const VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["globalPriorityQuery"] = static_cast<bool>(decoded_value.globalPriorityQuery);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6811,6 +7248,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueueFamilyGloba
     {
         const VkQueueFamilyGlobalPriorityPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkQueueFamilyGlobalPriorityPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["priorityCount"], decoded_value.priorityCount, options);
         FieldToJson(jdata["priorities"], &meta_struct.priorities, options);
@@ -6824,6 +7262,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFragmentShadingR
     {
         const VkFragmentShadingRateAttachmentInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkFragmentShadingRateAttachmentInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pFragmentShadingRateAttachment"], meta_struct.pFragmentShadingRateAttachment, options);
         FieldToJson(jdata["shadingRateAttachmentTexelSize"], meta_struct.shadingRateAttachmentTexelSize, options);
@@ -6837,6 +7276,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineFragment
     {
         const VkPipelineFragmentShadingRateStateCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["fragmentSize"], meta_struct.fragmentSize, options);
         FieldToJson(jdata["combinerOps"], &meta_struct.combinerOps, options);
@@ -6850,6 +7290,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShadingRateFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShadingRateFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["pipelineFragmentShadingRate"] = static_cast<bool>(decoded_value.pipelineFragmentShadingRate);
         jdata["primitiveFragmentShadingRate"] = static_cast<bool>(decoded_value.primitiveFragmentShadingRate);
@@ -6864,6 +7305,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShadingRatePropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minFragmentShadingRateAttachmentTexelSize"], meta_struct.minFragmentShadingRateAttachmentTexelSize, options);
         FieldToJson(jdata["maxFragmentShadingRateAttachmentTexelSize"], meta_struct.maxFragmentShadingRateAttachmentTexelSize, options);
@@ -6892,6 +7334,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShadingRateKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShadingRateKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSampleCountFlags_t(),jdata["sampleCounts"], decoded_value.sampleCounts, options);
         FieldToJson(jdata["fragmentSize"], meta_struct.fragmentSize, options);
@@ -6905,6 +7348,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceProtected
     {
         const VkSurfaceProtectedCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceProtectedCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["supportsProtected"] = static_cast<bool>(decoded_value.supportsProtected);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6917,6 +7361,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDevicePresentWaitFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePresentWaitFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["presentWait"] = static_cast<bool>(decoded_value.presentWait);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6929,6 +7374,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePi
     {
         const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["pipelineExecutableInfo"] = static_cast<bool>(decoded_value.pipelineExecutableInfo);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6941,6 +7387,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineInfoKHR*
     {
         const VkPipelineInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["pipeline"], meta_struct.pipeline, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -6953,6 +7400,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineExecutab
     {
         const VkPipelineExecutablePropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineExecutablePropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkShaderStageFlags_t(),jdata["stages"], decoded_value.stages, options);
         FieldToJson(jdata["name"], &meta_struct.name, options);
@@ -6968,6 +7416,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineExecutab
     {
         const VkPipelineExecutableInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineExecutableInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["pipeline"], meta_struct.pipeline, options);
         FieldToJson(jdata["executableIndex"], decoded_value.executableIndex, options);
@@ -6981,6 +7430,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineExecutab
     {
         const VkPipelineExecutableInternalRepresentationKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineExecutableInternalRepresentationKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["name"], &meta_struct.name, options);
         FieldToJson(jdata["description"], &meta_struct.description, options);
@@ -6997,6 +7447,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryMapInfoKHR
     {
         const VkMemoryMapInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryMapInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkMemoryMapFlags_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
@@ -7012,6 +7463,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryUnmapInfoK
     {
         const VkMemoryUnmapInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryUnmapInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkMemoryUnmapFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
@@ -7025,6 +7477,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineLibraryC
     {
         const VkPipelineLibraryCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineLibraryCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["libraryCount"], decoded_value.libraryCount, options);
         HandleToJson(jdata["pLibraries"], &meta_struct.pLibraries, options);
@@ -7038,6 +7491,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPresentIdKHR* da
     {
         const VkPresentIdKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPresentIdKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["swapchainCount"], decoded_value.swapchainCount, options);
         FieldToJson(jdata["pPresentIds"], meta_struct.pPresentIds, options);
@@ -7051,6 +7505,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDevicePresentIdFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePresentIdFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["presentId"] = static_cast<bool>(decoded_value.presentId);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7063,6 +7518,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeInfoK
     {
         const VkVideoEncodeInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["dstBuffer"], meta_struct.dstBuffer, options);
@@ -7083,6 +7539,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeCapab
     {
         const VkVideoEncodeCapabilitiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeCapabilitiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeCapabilityFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(VkVideoEncodeRateControlModeFlagsKHR_t(),jdata["rateControlModes"], decoded_value.rateControlModes, options);
@@ -7101,6 +7558,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueryPoolVideoEn
     {
         const VkQueryPoolVideoEncodeFeedbackCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkQueryPoolVideoEncodeFeedbackCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeFeedbackFlagsKHR_t(),jdata["encodeFeedbackFlags"], decoded_value.encodeFeedbackFlags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7113,6 +7571,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeUsage
     {
         const VkVideoEncodeUsageInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeUsageInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeUsageFlagsKHR_t(),jdata["videoUsageHints"], decoded_value.videoUsageHints, options);
         FieldToJson(VkVideoEncodeContentFlagsKHR_t(),jdata["videoContentHints"], decoded_value.videoContentHints, options);
@@ -7127,6 +7586,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeRateC
     {
         const VkVideoEncodeRateControlLayerInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeRateControlLayerInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["averageBitrate"], decoded_value.averageBitrate, options);
         FieldToJson(jdata["maxBitrate"], decoded_value.maxBitrate, options);
@@ -7142,6 +7602,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeRateC
     {
         const VkVideoEncodeRateControlInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeRateControlInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeRateControlFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["rateControlMode"], decoded_value.rateControlMode, options);
@@ -7159,6 +7620,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVi
     {
         const VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pVideoProfile"], meta_struct.pVideoProfile, options);
         FieldToJson(jdata["qualityLevel"], decoded_value.qualityLevel, options);
@@ -7172,6 +7634,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeQuali
     {
         const VkVideoEncodeQualityLevelPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeQualityLevelPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["preferredRateControlMode"], decoded_value.preferredRateControlMode, options);
         FieldToJson(jdata["preferredRateControlLayerCount"], decoded_value.preferredRateControlLayerCount, options);
@@ -7185,6 +7648,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeQuali
     {
         const VkVideoEncodeQualityLevelInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeQualityLevelInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["qualityLevel"], decoded_value.qualityLevel, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7197,6 +7661,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeSessi
     {
         const VkVideoEncodeSessionParametersGetInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeSessionParametersGetInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["videoSessionParameters"], meta_struct.videoSessionParameters, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7209,6 +7674,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeSessi
     {
         const VkVideoEncodeSessionParametersFeedbackInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeSessionParametersFeedbackInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["hasOverrides"] = static_cast<bool>(decoded_value.hasOverrides);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7221,6 +7687,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueueFamilyCheck
     {
         const VkQueueFamilyCheckpointProperties2NV& decoded_value = *data->decoded_value;
         const Decoded_VkQueueFamilyCheckpointProperties2NV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineStageFlags2_t(),jdata["checkpointExecutionStageMask"], decoded_value.checkpointExecutionStageMask, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7233,6 +7700,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCheckpointData2N
     {
         const VkCheckpointData2NV& decoded_value = *data->decoded_value;
         const Decoded_VkCheckpointData2NV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineStageFlags2_t(),jdata["stage"], decoded_value.stage, options);
         FieldToJson(jdata["pCheckpointMarker"], meta_struct.pCheckpointMarker, options);
@@ -7246,6 +7714,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["fragmentShaderBarycentric"] = static_cast<bool>(decoded_value.fragmentShaderBarycentric);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7258,6 +7727,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["triStripVertexOrderIndependentOfProvokingVertex"] = static_cast<bool>(decoded_value.triStripVertexOrderIndependentOfProvokingVertex);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7270,6 +7740,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderSubgroupUniformControlFlow"] = static_cast<bool>(decoded_value.shaderSubgroupUniformControlFlow);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7282,6 +7753,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceWo
     {
         const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["workgroupMemoryExplicitLayout"] = static_cast<bool>(decoded_value.workgroupMemoryExplicitLayout);
         jdata["workgroupMemoryExplicitLayoutScalarBlockLayout"] = static_cast<bool>(decoded_value.workgroupMemoryExplicitLayoutScalarBlockLayout);
@@ -7297,6 +7769,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rayTracingMaintenance1"] = static_cast<bool>(decoded_value.rayTracingMaintenance1);
         jdata["rayTracingPipelineTraceRaysIndirect2"] = static_cast<bool>(decoded_value.rayTracingPipelineTraceRaysIndirect2);
@@ -7310,6 +7783,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkTraceRaysIndirec
     {
         const VkTraceRaysIndirectCommand2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkTraceRaysIndirectCommand2KHR& meta_struct = *data;
+
         FieldToJson(jdata["raygenShaderRecordAddress"], to_hex_variable_width(decoded_value.raygenShaderRecordAddress), options);
         FieldToJson(jdata["raygenShaderRecordSize"], decoded_value.raygenShaderRecordSize, options);
         FieldToJson(jdata["missShaderBindingTableAddress"], to_hex_variable_width(decoded_value.missShaderBindingTableAddress), options);
@@ -7333,6 +7807,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMa
     {
         const VkPhysicalDeviceMaintenance5FeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMaintenance5FeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["maintenance5"] = static_cast<bool>(decoded_value.maintenance5);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7345,6 +7820,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMa
     {
         const VkPhysicalDeviceMaintenance5PropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMaintenance5PropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["earlyFragmentMultisampleCoverageAfterSampleCounting"] = static_cast<bool>(decoded_value.earlyFragmentMultisampleCoverageAfterSampleCounting);
         jdata["earlyFragmentSampleMaskTestBeforeSampleCounting"] = static_cast<bool>(decoded_value.earlyFragmentSampleMaskTestBeforeSampleCounting);
@@ -7362,6 +7838,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderingAreaInf
     {
         const VkRenderingAreaInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkRenderingAreaInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["viewMask"], decoded_value.viewMask, options);
         FieldToJson(jdata["colorAttachmentCount"], decoded_value.colorAttachmentCount, options);
@@ -7378,6 +7855,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageSubresource
     {
         const VkImageSubresource2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkImageSubresource2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["imageSubresource"], meta_struct.imageSubresource, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7390,6 +7868,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceImageSubre
     {
         const VkDeviceImageSubresourceInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceImageSubresourceInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pCreateInfo"], meta_struct.pCreateInfo, options);
         FieldToJson(jdata["pSubresource"], meta_struct.pSubresource, options);
@@ -7403,6 +7882,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubresourceLayou
     {
         const VkSubresourceLayout2KHR& decoded_value = *data->decoded_value;
         const Decoded_VkSubresourceLayout2KHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["subresourceLayout"], meta_struct.subresourceLayout, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7415,6 +7895,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCreateFl
     {
         const VkPipelineCreateFlags2CreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCreateFlags2CreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCreateFlags2KHR_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7427,6 +7908,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferUsageFlags
     {
         const VkBufferUsageFlags2CreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkBufferUsageFlags2CreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkBufferUsageFlags2KHR_t(),jdata["usage"], decoded_value.usage, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7439,6 +7921,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rayTracingPositionFetch"] = static_cast<bool>(decoded_value.rayTracingPositionFetch);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7451,6 +7934,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCooperativeMatri
     {
         const VkCooperativeMatrixPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkCooperativeMatrixPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["MSize"], decoded_value.MSize, options);
         FieldToJson(jdata["NSize"], decoded_value.NSize, options);
@@ -7471,6 +7955,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceCooperativeMatrixFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["cooperativeMatrix"] = static_cast<bool>(decoded_value.cooperativeMatrix);
         jdata["cooperativeMatrixRobustBufferAccess"] = static_cast<bool>(decoded_value.cooperativeMatrixRobustBufferAccess);
@@ -7484,6 +7969,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceCooperativeMatrixPropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkShaderStageFlags_t(),jdata["cooperativeMatrixSupportedStages"], decoded_value.cooperativeMatrixSupportedStages, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7496,6 +7982,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugReportCallb
     {
         const VkDebugReportCallbackCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugReportCallbackCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDebugReportFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pfnCallback"], to_hex_variable_width(meta_struct.pfnCallback), options);
@@ -7510,6 +7997,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRasteriz
     {
         const VkPipelineRasterizationStateRasterizationOrderAMD& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRasterizationStateRasterizationOrderAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["rasterizationOrder"], decoded_value.rasterizationOrder, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7522,6 +8010,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugMarkerObjec
     {
         const VkDebugMarkerObjectNameInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugMarkerObjectNameInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["objectType"], decoded_value.objectType, options);
         FieldToJson(jdata["object"], decoded_value.object, options);
@@ -7536,6 +8025,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugMarkerObjec
     {
         const VkDebugMarkerObjectTagInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugMarkerObjectTagInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["objectType"], decoded_value.objectType, options);
         FieldToJson(jdata["object"], decoded_value.object, options);
@@ -7552,6 +8042,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugMarkerMarke
     {
         const VkDebugMarkerMarkerInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugMarkerMarkerInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pMarkerName"], &meta_struct.pMarkerName, options);
         FieldToJson(jdata["color"], &meta_struct.color, options);
@@ -7565,6 +8056,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDedicatedAllocat
     {
         const VkDedicatedAllocationImageCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkDedicatedAllocationImageCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["dedicatedAllocation"] = static_cast<bool>(decoded_value.dedicatedAllocation);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7577,6 +8069,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDedicatedAllocat
     {
         const VkDedicatedAllocationBufferCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkDedicatedAllocationBufferCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["dedicatedAllocation"] = static_cast<bool>(decoded_value.dedicatedAllocation);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7589,6 +8082,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDedicatedAllocat
     {
         const VkDedicatedAllocationMemoryAllocateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkDedicatedAllocationMemoryAllocateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["image"], meta_struct.image, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
@@ -7602,6 +8096,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTr
     {
         const VkPhysicalDeviceTransformFeedbackFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["transformFeedback"] = static_cast<bool>(decoded_value.transformFeedback);
         jdata["geometryStreams"] = static_cast<bool>(decoded_value.geometryStreams);
@@ -7615,6 +8110,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTr
     {
         const VkPhysicalDeviceTransformFeedbackPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxTransformFeedbackStreams"], decoded_value.maxTransformFeedbackStreams, options);
         FieldToJson(jdata["maxTransformFeedbackBuffers"], decoded_value.maxTransformFeedbackBuffers, options);
@@ -7636,6 +8132,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRasteriz
     {
         const VkPipelineRasterizationStateStreamCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineRasterizationStateStreamCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["rasterizationStream"], decoded_value.rasterizationStream, options);
@@ -7649,6 +8146,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewHandleI
     {
         const VkImageViewHandleInfoNVX& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewHandleInfoNVX& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["imageView"], meta_struct.imageView, options);
         FieldToJson(jdata["descriptorType"], decoded_value.descriptorType, options);
@@ -7663,6 +8161,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewAddress
     {
         const VkImageViewAddressPropertiesNVX& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewAddressPropertiesNVX& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceAddress"], to_hex_variable_width(decoded_value.deviceAddress), options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -7676,6 +8175,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264C
     {
         const VkVideoEncodeH264CapabilitiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264CapabilitiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeH264CapabilityFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["maxLevelIdc"], decoded_value.maxLevelIdc, options);
@@ -7700,6 +8200,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264Q
     {
         const VkVideoEncodeH264QpEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264QpEXT& meta_struct = *data;
+
         FieldToJson(jdata["qpI"], decoded_value.qpI, options);
         FieldToJson(jdata["qpP"], decoded_value.qpP, options);
         FieldToJson(jdata["qpB"], decoded_value.qpB, options);
@@ -7712,6 +8213,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264Q
     {
         const VkVideoEncodeH264QualityLevelPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264QualityLevelPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeH264RateControlFlagsEXT_t(),jdata["preferredRateControlFlags"], decoded_value.preferredRateControlFlags, options);
         FieldToJson(jdata["preferredGopFrameCount"], decoded_value.preferredGopFrameCount, options);
@@ -7732,6 +8234,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264S
     {
         const VkVideoEncodeH264SessionCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264SessionCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["useMaxLevelIdc"] = static_cast<bool>(decoded_value.useMaxLevelIdc);
         FieldToJson(jdata["maxLevelIdc"], decoded_value.maxLevelIdc, options);
@@ -7745,6 +8248,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264S
     {
         const VkVideoEncodeH264SessionParametersAddInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264SessionParametersAddInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdSPSCount"], decoded_value.stdSPSCount, options);
         FieldToJson(jdata["pStdSPSs"], meta_struct.pStdSPSs, options);
@@ -7760,6 +8264,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264S
     {
         const VkVideoEncodeH264SessionParametersCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264SessionParametersCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxStdSPSCount"], decoded_value.maxStdSPSCount, options);
         FieldToJson(jdata["maxStdPPSCount"], decoded_value.maxStdPPSCount, options);
@@ -7774,6 +8279,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264S
     {
         const VkVideoEncodeH264SessionParametersGetInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264SessionParametersGetInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["writeStdSPS"] = static_cast<bool>(decoded_value.writeStdSPS);
         jdata["writeStdPPS"] = static_cast<bool>(decoded_value.writeStdPPS);
@@ -7789,6 +8295,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264S
     {
         const VkVideoEncodeH264SessionParametersFeedbackInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264SessionParametersFeedbackInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["hasStdSPSOverrides"] = static_cast<bool>(decoded_value.hasStdSPSOverrides);
         jdata["hasStdPPSOverrides"] = static_cast<bool>(decoded_value.hasStdPPSOverrides);
@@ -7802,6 +8309,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264N
     {
         const VkVideoEncodeH264NaluSliceInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264NaluSliceInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["constantQp"], decoded_value.constantQp, options);
         FieldToJson(jdata["pStdSliceHeader"], meta_struct.pStdSliceHeader, options);
@@ -7815,6 +8323,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264P
     {
         const VkVideoEncodeH264PictureInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264PictureInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["naluSliceEntryCount"], decoded_value.naluSliceEntryCount, options);
         FieldToJson(jdata["pNaluSliceEntries"], meta_struct.pNaluSliceEntries, options);
@@ -7830,6 +8339,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264D
     {
         const VkVideoEncodeH264DpbSlotInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264DpbSlotInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pStdReferenceInfo"], meta_struct.pStdReferenceInfo, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7842,6 +8352,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264P
     {
         const VkVideoEncodeH264ProfileInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264ProfileInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdProfileIdc"], decoded_value.stdProfileIdc, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -7854,6 +8365,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264R
     {
         const VkVideoEncodeH264RateControlInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264RateControlInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeH264RateControlFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["gopFrameCount"], decoded_value.gopFrameCount, options);
@@ -7870,6 +8382,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264F
     {
         const VkVideoEncodeH264FrameSizeEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264FrameSizeEXT& meta_struct = *data;
+
         FieldToJson(jdata["frameISize"], decoded_value.frameISize, options);
         FieldToJson(jdata["framePSize"], decoded_value.framePSize, options);
         FieldToJson(jdata["frameBSize"], decoded_value.frameBSize, options);
@@ -7882,6 +8395,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264R
     {
         const VkVideoEncodeH264RateControlLayerInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264RateControlLayerInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["useMinQp"] = static_cast<bool>(decoded_value.useMinQp);
         FieldToJson(jdata["minQp"], meta_struct.minQp, options);
@@ -7899,6 +8413,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH264G
     {
         const VkVideoEncodeH264GopRemainingFrameInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH264GopRemainingFrameInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["useGopRemainingFrames"] = static_cast<bool>(decoded_value.useGopRemainingFrames);
         FieldToJson(jdata["gopRemainingI"], decoded_value.gopRemainingI, options);
@@ -7914,6 +8429,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265C
     {
         const VkVideoEncodeH265CapabilitiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265CapabilitiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeH265CapabilityFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["maxLevelIdc"], decoded_value.maxLevelIdc, options);
@@ -7941,6 +8457,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265S
     {
         const VkVideoEncodeH265SessionCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265SessionCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["useMaxLevelIdc"] = static_cast<bool>(decoded_value.useMaxLevelIdc);
         FieldToJson(jdata["maxLevelIdc"], decoded_value.maxLevelIdc, options);
@@ -7954,6 +8471,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265Q
     {
         const VkVideoEncodeH265QpEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265QpEXT& meta_struct = *data;
+
         FieldToJson(jdata["qpI"], decoded_value.qpI, options);
         FieldToJson(jdata["qpP"], decoded_value.qpP, options);
         FieldToJson(jdata["qpB"], decoded_value.qpB, options);
@@ -7966,6 +8484,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265Q
     {
         const VkVideoEncodeH265QualityLevelPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265QualityLevelPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeH265RateControlFlagsEXT_t(),jdata["preferredRateControlFlags"], decoded_value.preferredRateControlFlags, options);
         FieldToJson(jdata["preferredGopFrameCount"], decoded_value.preferredGopFrameCount, options);
@@ -7985,6 +8504,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265S
     {
         const VkVideoEncodeH265SessionParametersAddInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265SessionParametersAddInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdVPSCount"], decoded_value.stdVPSCount, options);
         FieldToJson(jdata["pStdVPSs"], meta_struct.pStdVPSs, options);
@@ -8002,6 +8522,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265S
     {
         const VkVideoEncodeH265SessionParametersCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265SessionParametersCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxStdVPSCount"], decoded_value.maxStdVPSCount, options);
         FieldToJson(jdata["maxStdSPSCount"], decoded_value.maxStdSPSCount, options);
@@ -8017,6 +8538,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265S
     {
         const VkVideoEncodeH265SessionParametersGetInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265SessionParametersGetInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["writeStdVPS"] = static_cast<bool>(decoded_value.writeStdVPS);
         jdata["writeStdSPS"] = static_cast<bool>(decoded_value.writeStdSPS);
@@ -8034,6 +8556,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265S
     {
         const VkVideoEncodeH265SessionParametersFeedbackInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265SessionParametersFeedbackInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["hasStdVPSOverrides"] = static_cast<bool>(decoded_value.hasStdVPSOverrides);
         jdata["hasStdSPSOverrides"] = static_cast<bool>(decoded_value.hasStdSPSOverrides);
@@ -8048,6 +8571,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265N
     {
         const VkVideoEncodeH265NaluSliceSegmentInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265NaluSliceSegmentInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["constantQp"], decoded_value.constantQp, options);
         FieldToJson(jdata["pStdSliceSegmentHeader"], meta_struct.pStdSliceSegmentHeader, options);
@@ -8061,6 +8585,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265P
     {
         const VkVideoEncodeH265PictureInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265PictureInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["naluSliceSegmentEntryCount"], decoded_value.naluSliceSegmentEntryCount, options);
         FieldToJson(jdata["pNaluSliceSegmentEntries"], meta_struct.pNaluSliceSegmentEntries, options);
@@ -8075,6 +8600,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265D
     {
         const VkVideoEncodeH265DpbSlotInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265DpbSlotInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pStdReferenceInfo"], meta_struct.pStdReferenceInfo, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8087,6 +8613,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265P
     {
         const VkVideoEncodeH265ProfileInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265ProfileInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stdProfileIdc"], decoded_value.stdProfileIdc, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8099,6 +8626,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265R
     {
         const VkVideoEncodeH265RateControlInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265RateControlInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkVideoEncodeH265RateControlFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["gopFrameCount"], decoded_value.gopFrameCount, options);
@@ -8115,6 +8643,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265F
     {
         const VkVideoEncodeH265FrameSizeEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265FrameSizeEXT& meta_struct = *data;
+
         FieldToJson(jdata["frameISize"], decoded_value.frameISize, options);
         FieldToJson(jdata["framePSize"], decoded_value.framePSize, options);
         FieldToJson(jdata["frameBSize"], decoded_value.frameBSize, options);
@@ -8127,6 +8656,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265R
     {
         const VkVideoEncodeH265RateControlLayerInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265RateControlLayerInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["useMinQp"] = static_cast<bool>(decoded_value.useMinQp);
         FieldToJson(jdata["minQp"], meta_struct.minQp, options);
@@ -8144,6 +8674,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVideoEncodeH265G
     {
         const VkVideoEncodeH265GopRemainingFrameInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVideoEncodeH265GopRemainingFrameInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["useGopRemainingFrames"] = static_cast<bool>(decoded_value.useGopRemainingFrames);
         FieldToJson(jdata["gopRemainingI"], decoded_value.gopRemainingI, options);
@@ -8159,6 +8690,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkTextureLODGather
     {
         const VkTextureLODGatherFormatPropertiesAMD& decoded_value = *data->decoded_value;
         const Decoded_VkTextureLODGatherFormatPropertiesAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["supportsTextureGatherLODBiasAMD"] = static_cast<bool>(decoded_value.supportsTextureGatherLODBiasAMD);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8171,6 +8703,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkShaderResourceUs
     {
         const VkShaderResourceUsageAMD& decoded_value = *data->decoded_value;
         const Decoded_VkShaderResourceUsageAMD& meta_struct = *data;
+
         FieldToJson(jdata["numUsedVgprs"], decoded_value.numUsedVgprs, options);
         FieldToJson(jdata["numUsedSgprs"], decoded_value.numUsedSgprs, options);
         FieldToJson(jdata["ldsSizePerLocalWorkGroup"], decoded_value.ldsSizePerLocalWorkGroup, options);
@@ -8185,6 +8718,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkShaderStatistics
     {
         const VkShaderStatisticsInfoAMD& decoded_value = *data->decoded_value;
         const Decoded_VkShaderStatisticsInfoAMD& meta_struct = *data;
+
         FieldToJson(VkShaderStageFlags_t(),jdata["shaderStageMask"], decoded_value.shaderStageMask, options);
         FieldToJson(jdata["resourceUsage"], meta_struct.resourceUsage, options);
         FieldToJson(jdata["numPhysicalVgprs"], decoded_value.numPhysicalVgprs, options);
@@ -8201,6 +8735,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkStreamDescriptor
     {
         const VkStreamDescriptorSurfaceCreateInfoGGP& decoded_value = *data->decoded_value;
         const Decoded_VkStreamDescriptorSurfaceCreateInfoGGP& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkStreamDescriptorSurfaceCreateFlagsGGP_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["streamDescriptor"], decoded_value.streamDescriptor, options);
@@ -8214,6 +8749,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceCornerSampledImageFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["cornerSampledImage"] = static_cast<bool>(decoded_value.cornerSampledImage);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8226,6 +8762,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalImageFor
     {
         const VkExternalImageFormatPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkExternalImageFormatPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["imageFormatProperties"], meta_struct.imageFormatProperties, options);
         FieldToJson(VkExternalMemoryFeatureFlagsNV_t(),jdata["externalMemoryFeatures"], decoded_value.externalMemoryFeatures, options);
         FieldToJson(VkExternalMemoryHandleTypeFlagsNV_t(),jdata["exportFromImportedHandleTypes"], decoded_value.exportFromImportedHandleTypes, options);
@@ -8239,6 +8776,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalMemoryIm
     {
         const VkExternalMemoryImageCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkExternalMemoryImageCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalMemoryHandleTypeFlagsNV_t(),jdata["handleTypes"], decoded_value.handleTypes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8251,6 +8789,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportMemoryAllo
     {
         const VkExportMemoryAllocateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkExportMemoryAllocateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalMemoryHandleTypeFlagsNV_t(),jdata["handleTypes"], decoded_value.handleTypes, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8263,6 +8802,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportMemoryWin3
     {
         const VkImportMemoryWin32HandleInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkImportMemoryWin32HandleInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkExternalMemoryHandleTypeFlagsNV_t(),jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["handle"], meta_struct.handle, options);
@@ -8276,6 +8816,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExportMemoryWin3
     {
         const VkExportMemoryWin32HandleInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkExportMemoryWin32HandleInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pAttributes"], meta_struct.pAttributes, options);
         FieldToJson(jdata["dwAccess"], decoded_value.dwAccess, options);
@@ -8289,6 +8830,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWin32KeyedMutexA
     {
         const VkWin32KeyedMutexAcquireReleaseInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["acquireCount"], decoded_value.acquireCount, options);
         HandleToJson(jdata["pAcquireSyncs"], &meta_struct.pAcquireSyncs, options);
@@ -8307,6 +8849,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkValidationFlagsE
     {
         const VkValidationFlagsEXT& decoded_value = *data->decoded_value;
         const Decoded_VkValidationFlagsEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["disabledValidationCheckCount"], decoded_value.disabledValidationCheckCount, options);
         FieldToJson(jdata["pDisabledValidationChecks"], meta_struct.pDisabledValidationChecks, options);
@@ -8320,6 +8863,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkViSurfaceCreateI
     {
         const VkViSurfaceCreateInfoNN& decoded_value = *data->decoded_value;
         const Decoded_VkViSurfaceCreateInfoNN& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkViSurfaceCreateFlagsNN_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["window"], meta_struct.window, options);
@@ -8333,6 +8877,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewASTCDec
     {
         const VkImageViewASTCDecodeModeEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewASTCDecodeModeEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["decodeMode"], decoded_value.decodeMode, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8345,6 +8890,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceAS
     {
         const VkPhysicalDeviceASTCDecodeFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["decodeModeSharedExponent"] = static_cast<bool>(decoded_value.decodeModeSharedExponent);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8357,6 +8903,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePi
     {
         const VkPhysicalDevicePipelineRobustnessFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePipelineRobustnessFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["pipelineRobustness"] = static_cast<bool>(decoded_value.pipelineRobustness);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8369,6 +8916,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePi
     {
         const VkPhysicalDevicePipelineRobustnessPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePipelineRobustnessPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["defaultRobustnessStorageBuffers"], decoded_value.defaultRobustnessStorageBuffers, options);
         FieldToJson(jdata["defaultRobustnessUniformBuffers"], decoded_value.defaultRobustnessUniformBuffers, options);
@@ -8384,6 +8932,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRobustne
     {
         const VkPipelineRobustnessCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRobustnessCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["storageBuffers"], decoded_value.storageBuffers, options);
         FieldToJson(jdata["uniformBuffers"], decoded_value.uniformBuffers, options);
@@ -8399,6 +8948,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkConditionalRende
     {
         const VkConditionalRenderingBeginInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkConditionalRenderingBeginInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
         FieldToJson(jdata["offset"], decoded_value.offset, options);
@@ -8413,6 +8963,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceConditionalRenderingFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["conditionalRendering"] = static_cast<bool>(decoded_value.conditionalRendering);
         jdata["inheritedConditionalRendering"] = static_cast<bool>(decoded_value.inheritedConditionalRendering);
@@ -8426,6 +8977,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferInh
     {
         const VkCommandBufferInheritanceConditionalRenderingInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["conditionalRenderingEnable"] = static_cast<bool>(decoded_value.conditionalRenderingEnable);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8438,6 +8990,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkViewportWScaling
     {
         const VkViewportWScalingNV& decoded_value = *data->decoded_value;
         const Decoded_VkViewportWScalingNV& meta_struct = *data;
+
         FieldToJson(jdata["xcoeff"], decoded_value.xcoeff, options);
         FieldToJson(jdata["ycoeff"], decoded_value.ycoeff, options);
     }
@@ -8449,6 +9002,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineViewport
     {
         const VkPipelineViewportWScalingStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineViewportWScalingStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["viewportWScalingEnable"] = static_cast<bool>(decoded_value.viewportWScalingEnable);
         FieldToJson(jdata["viewportCount"], decoded_value.viewportCount, options);
@@ -8463,6 +9017,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceCapabilit
     {
         const VkSurfaceCapabilities2EXT& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceCapabilities2EXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minImageCount"], decoded_value.minImageCount, options);
         FieldToJson(jdata["maxImageCount"], decoded_value.maxImageCount, options);
@@ -8485,6 +9040,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayPowerInfo
     {
         const VkDisplayPowerInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayPowerInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["powerState"], decoded_value.powerState, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8497,6 +9053,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceEventInfoE
     {
         const VkDeviceEventInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceEventInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceEvent"], decoded_value.deviceEvent, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8509,6 +9066,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayEventInfo
     {
         const VkDisplayEventInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayEventInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["displayEvent"], decoded_value.displayEvent, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8521,6 +9079,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainCounter
     {
         const VkSwapchainCounterCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainCounterCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSurfaceCounterFlagsEXT_t(),jdata["surfaceCounters"], decoded_value.surfaceCounters, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8533,6 +9092,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRefreshCycleDura
     {
         const VkRefreshCycleDurationGOOGLE& decoded_value = *data->decoded_value;
         const Decoded_VkRefreshCycleDurationGOOGLE& meta_struct = *data;
+
         FieldToJson(jdata["refreshDuration"], decoded_value.refreshDuration, options);
     }
 }
@@ -8543,6 +9103,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPastPresentation
     {
         const VkPastPresentationTimingGOOGLE& decoded_value = *data->decoded_value;
         const Decoded_VkPastPresentationTimingGOOGLE& meta_struct = *data;
+
         FieldToJson(jdata["presentID"], decoded_value.presentID, options);
         FieldToJson(jdata["desiredPresentTime"], decoded_value.desiredPresentTime, options);
         FieldToJson(jdata["actualPresentTime"], decoded_value.actualPresentTime, options);
@@ -8557,6 +9118,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPresentTimeGOOGL
     {
         const VkPresentTimeGOOGLE& decoded_value = *data->decoded_value;
         const Decoded_VkPresentTimeGOOGLE& meta_struct = *data;
+
         FieldToJson(jdata["presentID"], decoded_value.presentID, options);
         FieldToJson(jdata["desiredPresentTime"], decoded_value.desiredPresentTime, options);
     }
@@ -8568,6 +9130,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPresentTimesInfo
     {
         const VkPresentTimesInfoGOOGLE& decoded_value = *data->decoded_value;
         const Decoded_VkPresentTimesInfoGOOGLE& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["swapchainCount"], decoded_value.swapchainCount, options);
         FieldToJson(jdata["pTimes"], meta_struct.pTimes, options);
@@ -8581,6 +9144,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["perViewPositionAllComponents"] = static_cast<bool>(decoded_value.perViewPositionAllComponents);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8593,6 +9157,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkViewportSwizzleN
     {
         const VkViewportSwizzleNV& decoded_value = *data->decoded_value;
         const Decoded_VkViewportSwizzleNV& meta_struct = *data;
+
         FieldToJson(jdata["x"], decoded_value.x, options);
         FieldToJson(jdata["y"], decoded_value.y, options);
         FieldToJson(jdata["z"], decoded_value.z, options);
@@ -8606,6 +9171,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineViewport
     {
         const VkPipelineViewportSwizzleStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineViewportSwizzleStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineViewportSwizzleStateCreateFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["viewportCount"], decoded_value.viewportCount, options);
@@ -8620,6 +9186,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDi
     {
         const VkPhysicalDeviceDiscardRectanglePropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxDiscardRectangles"], decoded_value.maxDiscardRectangles, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8632,6 +9199,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineDiscardR
     {
         const VkPipelineDiscardRectangleStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineDiscardRectangleStateCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["discardRectangleMode"], decoded_value.discardRectangleMode, options);
@@ -8647,6 +9215,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceConservativeRasterizationPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["primitiveOverestimationSize"], decoded_value.primitiveOverestimationSize, options);
         FieldToJson(jdata["maxExtraPrimitiveOverestimationSize"], decoded_value.maxExtraPrimitiveOverestimationSize, options);
@@ -8667,6 +9236,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRasteriz
     {
         const VkPipelineRasterizationConservativeStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineRasterizationConservativeStateCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["conservativeRasterizationMode"], decoded_value.conservativeRasterizationMode, options);
@@ -8681,6 +9251,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDepthClipEnableFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["depthClipEnable"] = static_cast<bool>(decoded_value.depthClipEnable);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8693,6 +9264,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRasteriz
     {
         const VkPipelineRasterizationDepthClipStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineRasterizationDepthClipStateCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         jdata["depthClipEnable"] = static_cast<bool>(decoded_value.depthClipEnable);
@@ -8706,6 +9278,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkXYColorEXT* data
     {
         const VkXYColorEXT& decoded_value = *data->decoded_value;
         const Decoded_VkXYColorEXT& meta_struct = *data;
+
         FieldToJson(jdata["x"], decoded_value.x, options);
         FieldToJson(jdata["y"], decoded_value.y, options);
     }
@@ -8717,6 +9290,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkHdrMetadataEXT* 
     {
         const VkHdrMetadataEXT& decoded_value = *data->decoded_value;
         const Decoded_VkHdrMetadataEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["displayPrimaryRed"], meta_struct.displayPrimaryRed, options);
         FieldToJson(jdata["displayPrimaryGreen"], meta_struct.displayPrimaryGreen, options);
@@ -8736,6 +9310,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkIOSSurfaceCreate
     {
         const VkIOSSurfaceCreateInfoMVK& decoded_value = *data->decoded_value;
         const Decoded_VkIOSSurfaceCreateInfoMVK& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkIOSSurfaceCreateFlagsMVK_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pView"], meta_struct.pView, options);
@@ -8749,6 +9324,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMacOSSurfaceCrea
     {
         const VkMacOSSurfaceCreateInfoMVK& decoded_value = *data->decoded_value;
         const Decoded_VkMacOSSurfaceCreateInfoMVK& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkMacOSSurfaceCreateFlagsMVK_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pView"], meta_struct.pView, options);
@@ -8762,6 +9338,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugUtilsLabelE
     {
         const VkDebugUtilsLabelEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugUtilsLabelEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pLabelName"], &meta_struct.pLabelName, options);
         FieldToJson(jdata["color"], &meta_struct.color, options);
@@ -8775,6 +9352,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugUtilsObject
     {
         const VkDebugUtilsObjectNameInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugUtilsObjectNameInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["objectType"], decoded_value.objectType, options);
         HandleToJson(jdata["objectHandle"], meta_struct.objectHandle, options);
@@ -8789,6 +9367,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugUtilsMessen
     {
         const VkDebugUtilsMessengerCallbackDataEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugUtilsMessengerCallbackDataEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDebugUtilsMessengerCallbackDataFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pMessageIdName"], &meta_struct.pMessageIdName, options);
@@ -8810,6 +9389,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugUtilsMessen
     {
         const VkDebugUtilsMessengerCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugUtilsMessengerCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDebugUtilsMessengerCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(VkDebugUtilsMessageSeverityFlagsEXT_t(),jdata["messageSeverity"], decoded_value.messageSeverity, options);
@@ -8826,6 +9406,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugUtilsObject
     {
         const VkDebugUtilsObjectTagInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDebugUtilsObjectTagInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["objectType"], decoded_value.objectType, options);
         HandleToJson(jdata["objectHandle"], meta_struct.objectHandle, options);
@@ -8842,6 +9423,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAndroidHardwareB
     {
         const VkAndroidHardwareBufferUsageANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkAndroidHardwareBufferUsageANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["androidHardwareBufferUsage"], decoded_value.androidHardwareBufferUsage, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8854,6 +9436,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAndroidHardwareB
     {
         const VkAndroidHardwareBufferPropertiesANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkAndroidHardwareBufferPropertiesANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["allocationSize"], decoded_value.allocationSize, options);
         FieldToJson(jdata["memoryTypeBits"], decoded_value.memoryTypeBits, options);
@@ -8867,6 +9450,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAndroidHardwareB
     {
         const VkAndroidHardwareBufferFormatPropertiesANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["externalFormat"], decoded_value.externalFormat, options);
@@ -8886,6 +9470,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportAndroidHar
     {
         const VkImportAndroidHardwareBufferInfoANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkImportAndroidHardwareBufferInfoANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["buffer"], meta_struct.buffer, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8898,6 +9483,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryGetAndroid
     {
         const VkMemoryGetAndroidHardwareBufferInfoANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8910,6 +9496,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalFormatAN
     {
         const VkExternalFormatANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkExternalFormatANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["externalFormat"], decoded_value.externalFormat, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -8922,6 +9509,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAndroidHardwareB
     {
         const VkAndroidHardwareBufferFormatProperties2ANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkAndroidHardwareBufferFormatProperties2ANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["externalFormat"], decoded_value.externalFormat, options);
@@ -8941,6 +9529,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSampleLocationEX
     {
         const VkSampleLocationEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSampleLocationEXT& meta_struct = *data;
+
         FieldToJson(jdata["x"], decoded_value.x, options);
         FieldToJson(jdata["y"], decoded_value.y, options);
     }
@@ -8952,6 +9541,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSampleLocationsI
     {
         const VkSampleLocationsInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSampleLocationsInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["sampleLocationsPerPixel"], decoded_value.sampleLocationsPerPixel, options);
         FieldToJson(jdata["sampleLocationGridSize"], meta_struct.sampleLocationGridSize, options);
@@ -8967,6 +9557,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAttachmentSample
     {
         const VkAttachmentSampleLocationsEXT& decoded_value = *data->decoded_value;
         const Decoded_VkAttachmentSampleLocationsEXT& meta_struct = *data;
+
         FieldToJson(jdata["attachmentIndex"], decoded_value.attachmentIndex, options);
         FieldToJson(jdata["sampleLocationsInfo"], meta_struct.sampleLocationsInfo, options);
     }
@@ -8978,6 +9569,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassSampleLoc
     {
         const VkSubpassSampleLocationsEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassSampleLocationsEXT& meta_struct = *data;
+
         FieldToJson(jdata["subpassIndex"], decoded_value.subpassIndex, options);
         FieldToJson(jdata["sampleLocationsInfo"], meta_struct.sampleLocationsInfo, options);
     }
@@ -8989,6 +9581,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassSample
     {
         const VkRenderPassSampleLocationsBeginInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassSampleLocationsBeginInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["attachmentInitialSampleLocationsCount"], decoded_value.attachmentInitialSampleLocationsCount, options);
         FieldToJson(jdata["pAttachmentInitialSampleLocations"], meta_struct.pAttachmentInitialSampleLocations, options);
@@ -9004,6 +9597,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineSampleLo
     {
         const VkPipelineSampleLocationsStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineSampleLocationsStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["sampleLocationsEnable"] = static_cast<bool>(decoded_value.sampleLocationsEnable);
         FieldToJson(jdata["sampleLocationsInfo"], meta_struct.sampleLocationsInfo, options);
@@ -9017,6 +9611,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSa
     {
         const VkPhysicalDeviceSampleLocationsPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkSampleCountFlags_t(),jdata["sampleLocationSampleCounts"], decoded_value.sampleLocationSampleCounts, options);
         FieldToJson(jdata["maxSampleLocationGridSize"], meta_struct.maxSampleLocationGridSize, options);
@@ -9033,6 +9628,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMultisamplePrope
     {
         const VkMultisamplePropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMultisamplePropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxSampleLocationGridSize"], meta_struct.maxSampleLocationGridSize, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9045,6 +9641,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceBl
     {
         const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["advancedBlendCoherentOperations"] = static_cast<bool>(decoded_value.advancedBlendCoherentOperations);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9057,6 +9654,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceBl
     {
         const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["advancedBlendMaxColorAttachments"], decoded_value.advancedBlendMaxColorAttachments, options);
         jdata["advancedBlendIndependentBlend"] = static_cast<bool>(decoded_value.advancedBlendIndependentBlend);
@@ -9074,6 +9672,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineColorBle
     {
         const VkPipelineColorBlendAdvancedStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["srcPremultiplied"] = static_cast<bool>(decoded_value.srcPremultiplied);
         jdata["dstPremultiplied"] = static_cast<bool>(decoded_value.dstPremultiplied);
@@ -9088,6 +9687,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCoverage
     {
         const VkPipelineCoverageToColorStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCoverageToColorStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCoverageToColorStateCreateFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
         jdata["coverageToColorEnable"] = static_cast<bool>(decoded_value.coverageToColorEnable);
@@ -9102,6 +9702,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCoverage
     {
         const VkPipelineCoverageModulationStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCoverageModulationStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCoverageModulationStateCreateFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["coverageModulationMode"], decoded_value.coverageModulationMode, options);
@@ -9118,6 +9719,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shaderSMCount"], decoded_value.shaderSMCount, options);
         FieldToJson(jdata["shaderWarpsPerSM"], decoded_value.shaderWarpsPerSM, options);
@@ -9131,6 +9733,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderSMBuiltins"] = static_cast<bool>(decoded_value.shaderSMBuiltins);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9143,6 +9746,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrmFormatModifie
     {
         const VkDrmFormatModifierPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDrmFormatModifierPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["drmFormatModifier"], decoded_value.drmFormatModifier, options);
         FieldToJson(jdata["drmFormatModifierPlaneCount"], decoded_value.drmFormatModifierPlaneCount, options);
         FieldToJson(VkFormatFeatureFlags_t(),jdata["drmFormatModifierTilingFeatures"], decoded_value.drmFormatModifierTilingFeatures, options);
@@ -9155,6 +9759,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrmFormatModifie
     {
         const VkDrmFormatModifierPropertiesListEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDrmFormatModifierPropertiesListEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["drmFormatModifierCount"], decoded_value.drmFormatModifierCount, options);
         FieldToJson(jdata["pDrmFormatModifierProperties"], meta_struct.pDrmFormatModifierProperties, options);
@@ -9168,6 +9773,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageDrmFormatModifierInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["drmFormatModifier"], decoded_value.drmFormatModifier, options);
         FieldToJson(jdata["sharingMode"], decoded_value.sharingMode, options);
@@ -9183,6 +9789,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageDrmFormatMo
     {
         const VkImageDrmFormatModifierListCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageDrmFormatModifierListCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["drmFormatModifierCount"], decoded_value.drmFormatModifierCount, options);
         FieldToJson(jdata["pDrmFormatModifiers"], meta_struct.pDrmFormatModifiers, options);
@@ -9196,6 +9803,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageDrmFormatMo
     {
         const VkImageDrmFormatModifierExplicitCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["drmFormatModifier"], decoded_value.drmFormatModifier, options);
         FieldToJson(jdata["drmFormatModifierPlaneCount"], decoded_value.drmFormatModifierPlaneCount, options);
@@ -9210,6 +9818,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageDrmFormatMo
     {
         const VkImageDrmFormatModifierPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageDrmFormatModifierPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["drmFormatModifier"], decoded_value.drmFormatModifier, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9222,6 +9831,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrmFormatModifie
     {
         const VkDrmFormatModifierProperties2EXT& decoded_value = *data->decoded_value;
         const Decoded_VkDrmFormatModifierProperties2EXT& meta_struct = *data;
+
         FieldToJson(jdata["drmFormatModifier"], decoded_value.drmFormatModifier, options);
         FieldToJson(jdata["drmFormatModifierPlaneCount"], decoded_value.drmFormatModifierPlaneCount, options);
         FieldToJson(VkFormatFeatureFlags2_t(),jdata["drmFormatModifierTilingFeatures"], decoded_value.drmFormatModifierTilingFeatures, options);
@@ -9234,6 +9844,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrmFormatModifie
     {
         const VkDrmFormatModifierPropertiesList2EXT& decoded_value = *data->decoded_value;
         const Decoded_VkDrmFormatModifierPropertiesList2EXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["drmFormatModifierCount"], decoded_value.drmFormatModifierCount, options);
         FieldToJson(jdata["pDrmFormatModifierProperties"], meta_struct.pDrmFormatModifierProperties, options);
@@ -9247,6 +9858,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkValidationCacheC
     {
         const VkValidationCacheCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkValidationCacheCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkValidationCacheCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["initialDataSize"], decoded_value.initialDataSize, options);
@@ -9261,6 +9873,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkShaderModuleVali
     {
         const VkShaderModuleValidationCacheCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkShaderModuleValidationCacheCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["validationCache"], meta_struct.validationCache, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9273,6 +9886,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkShadingRatePalet
     {
         const VkShadingRatePaletteNV& decoded_value = *data->decoded_value;
         const Decoded_VkShadingRatePaletteNV& meta_struct = *data;
+
         FieldToJson(jdata["shadingRatePaletteEntryCount"], decoded_value.shadingRatePaletteEntryCount, options);
         FieldToJson(jdata["pShadingRatePaletteEntries"], meta_struct.pShadingRatePaletteEntries, options);
     }
@@ -9284,6 +9898,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineViewport
     {
         const VkPipelineViewportShadingRateImageStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shadingRateImageEnable"] = static_cast<bool>(decoded_value.shadingRateImageEnable);
         FieldToJson(jdata["viewportCount"], decoded_value.viewportCount, options);
@@ -9298,6 +9913,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShadingRateImageFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shadingRateImage"] = static_cast<bool>(decoded_value.shadingRateImage);
         jdata["shadingRateCoarseSampleOrder"] = static_cast<bool>(decoded_value.shadingRateCoarseSampleOrder);
@@ -9311,6 +9927,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShadingRateImagePropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shadingRateTexelSize"], meta_struct.shadingRateTexelSize, options);
         FieldToJson(jdata["shadingRatePaletteSize"], decoded_value.shadingRatePaletteSize, options);
@@ -9325,6 +9942,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCoarseSampleLoca
     {
         const VkCoarseSampleLocationNV& decoded_value = *data->decoded_value;
         const Decoded_VkCoarseSampleLocationNV& meta_struct = *data;
+
         FieldToJson(jdata["pixelX"], decoded_value.pixelX, options);
         FieldToJson(jdata["pixelY"], decoded_value.pixelY, options);
         FieldToJson(jdata["sample"], decoded_value.sample, options);
@@ -9337,6 +9955,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCoarseSampleOrde
     {
         const VkCoarseSampleOrderCustomNV& decoded_value = *data->decoded_value;
         const Decoded_VkCoarseSampleOrderCustomNV& meta_struct = *data;
+
         FieldToJson(jdata["shadingRate"], decoded_value.shadingRate, options);
         FieldToJson(jdata["sampleCount"], decoded_value.sampleCount, options);
         FieldToJson(jdata["sampleLocationCount"], decoded_value.sampleLocationCount, options);
@@ -9350,6 +9969,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineViewport
     {
         const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["sampleOrderType"], decoded_value.sampleOrderType, options);
         FieldToJson(jdata["customSampleOrderCount"], decoded_value.customSampleOrderCount, options);
@@ -9364,6 +9984,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRayTracingShader
     {
         const VkRayTracingShaderGroupCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkRayTracingShaderGroupCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         FieldToJson(jdata["generalShader"], decoded_value.generalShader, options);
@@ -9380,6 +10001,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRayTracingPipeli
     {
         const VkRayTracingPipelineCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkRayTracingPipelineCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["stageCount"], decoded_value.stageCount, options);
@@ -9400,6 +10022,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGeometryTriangle
     {
         const VkGeometryTrianglesNV& decoded_value = *data->decoded_value;
         const Decoded_VkGeometryTrianglesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["vertexData"], meta_struct.vertexData, options);
         FieldToJson(jdata["vertexOffset"], decoded_value.vertexOffset, options);
@@ -9422,6 +10045,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGeometryAABBNV* 
     {
         const VkGeometryAABBNV& decoded_value = *data->decoded_value;
         const Decoded_VkGeometryAABBNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["aabbData"], meta_struct.aabbData, options);
         FieldToJson(jdata["numAABBs"], decoded_value.numAABBs, options);
@@ -9437,6 +10061,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGeometryDataNV* 
     {
         const VkGeometryDataNV& decoded_value = *data->decoded_value;
         const Decoded_VkGeometryDataNV& meta_struct = *data;
+
         FieldToJson(jdata["triangles"], meta_struct.triangles, options);
         FieldToJson(jdata["aabbs"], meta_struct.aabbs, options);
     }
@@ -9448,6 +10073,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGeometryNV* data
     {
         const VkGeometryNV& decoded_value = *data->decoded_value;
         const Decoded_VkGeometryNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["geometryType"], decoded_value.geometryType, options);
         FieldToJson(jdata["geometry"], meta_struct.geometry, options);
@@ -9462,6 +10088,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         FieldToJson(VkBuildAccelerationStructureFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
@@ -9478,6 +10105,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["compactedSize"], decoded_value.compactedSize, options);
         FieldToJson(jdata["info"], meta_struct.info, options);
@@ -9491,6 +10119,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindAcceleration
     {
         const VkBindAccelerationStructureMemoryInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkBindAccelerationStructureMemoryInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["accelerationStructure"], meta_struct.accelerationStructure, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
@@ -9507,6 +10136,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWriteDescriptorS
     {
         const VkWriteDescriptorSetAccelerationStructureNV& decoded_value = *data->decoded_value;
         const Decoded_VkWriteDescriptorSetAccelerationStructureNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["accelerationStructureCount"], decoded_value.accelerationStructureCount, options);
         HandleToJson(jdata["pAccelerationStructures"], &meta_struct.pAccelerationStructures, options);
@@ -9520,6 +10150,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureMemoryRequirementsInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureMemoryRequirementsInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         HandleToJson(jdata["accelerationStructure"], meta_struct.accelerationStructure, options);
@@ -9533,6 +10164,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shaderGroupHandleSize"], decoded_value.shaderGroupHandleSize, options);
         FieldToJson(jdata["maxRecursionDepth"], decoded_value.maxRecursionDepth, options);
@@ -9552,6 +10184,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkTransformMatrixK
     {
         const VkTransformMatrixKHR& decoded_value = *data->decoded_value;
         const Decoded_VkTransformMatrixKHR& meta_struct = *data;
+
         FieldToJson(jdata["matrix"], &meta_struct.matrix, options);
     }
 }
@@ -9562,6 +10195,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAabbPositionsKHR
     {
         const VkAabbPositionsKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAabbPositionsKHR& meta_struct = *data;
+
         FieldToJson(jdata["minX"], decoded_value.minX, options);
         FieldToJson(jdata["minY"], decoded_value.minY, options);
         FieldToJson(jdata["minZ"], decoded_value.minZ, options);
@@ -9577,6 +10211,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureInstanceKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureInstanceKHR& meta_struct = *data;
+
         FieldToJson(jdata["transform"], meta_struct.transform, options);
         FieldToJson(jdata["instanceCustomIndex"], decoded_value.instanceCustomIndex, options);
         FieldToJson(jdata["mask"], decoded_value.mask, options);
@@ -9592,6 +10227,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRe
     {
         const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["representativeFragmentTest"] = static_cast<bool>(decoded_value.representativeFragmentTest);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9604,6 +10240,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRepresen
     {
         const VkPipelineRepresentativeFragmentTestStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["representativeFragmentTestEnable"] = static_cast<bool>(decoded_value.representativeFragmentTestEnable);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9616,6 +10253,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageViewImageFormatInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["imageViewType"], decoded_value.imageViewType, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9628,6 +10266,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFilterCubicImage
     {
         const VkFilterCubicImageViewImageFormatPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["filterCubic"] = static_cast<bool>(decoded_value.filterCubic);
         jdata["filterCubicMinmax"] = static_cast<bool>(decoded_value.filterCubicMinmax);
@@ -9641,6 +10280,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportMemoryHost
     {
         const VkImportMemoryHostPointerInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImportMemoryHostPointerInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["pHostPointer"], meta_struct.pHostPointer, options);
@@ -9654,6 +10294,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryHostPointe
     {
         const VkMemoryHostPointerPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryHostPointerPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryTypeBits"], decoded_value.memoryTypeBits, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9666,6 +10307,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalMemoryHostPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minImportedHostPointerAlignment"], decoded_value.minImportedHostPointerAlignment, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9678,6 +10320,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCompiler
     {
         const VkPipelineCompilerControlCreateInfoAMD& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCompilerControlCreateInfoAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCompilerControlFlagsAMD_t(),jdata["compilerControlFlags"], decoded_value.compilerControlFlags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9690,6 +10333,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCalibratedTimest
     {
         const VkCalibratedTimestampInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCalibratedTimestampInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["timeDomain"], decoded_value.timeDomain, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9702,6 +10346,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderCorePropertiesAMD& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderCorePropertiesAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shaderEngineCount"], decoded_value.shaderEngineCount, options);
         FieldToJson(jdata["shaderArraysPerEngineCount"], decoded_value.shaderArraysPerEngineCount, options);
@@ -9727,6 +10372,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceMemoryOver
     {
         const VkDeviceMemoryOverallocationCreateInfoAMD& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceMemoryOverallocationCreateInfoAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["overallocationBehavior"], decoded_value.overallocationBehavior, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9739,6 +10385,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVe
     {
         const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxVertexAttribDivisor"], decoded_value.maxVertexAttribDivisor, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9751,6 +10398,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVertexInputBindi
     {
         const VkVertexInputBindingDivisorDescriptionEXT& decoded_value = *data->decoded_value;
         const Decoded_VkVertexInputBindingDivisorDescriptionEXT& meta_struct = *data;
+
         FieldToJson(jdata["binding"], decoded_value.binding, options);
         FieldToJson(jdata["divisor"], decoded_value.divisor, options);
     }
@@ -9762,6 +10410,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineVertexIn
     {
         const VkPipelineVertexInputDivisorStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["vertexBindingDivisorCount"], decoded_value.vertexBindingDivisorCount, options);
         FieldToJson(jdata["pVertexBindingDivisors"], meta_struct.pVertexBindingDivisors, options);
@@ -9775,6 +10424,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVe
     {
         const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["vertexAttributeInstanceRateDivisor"] = static_cast<bool>(decoded_value.vertexAttributeInstanceRateDivisor);
         jdata["vertexAttributeInstanceRateZeroDivisor"] = static_cast<bool>(decoded_value.vertexAttributeInstanceRateZeroDivisor);
@@ -9788,6 +10438,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPresentFrameToke
     {
         const VkPresentFrameTokenGGP& decoded_value = *data->decoded_value;
         const Decoded_VkPresentFrameTokenGGP& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["frameToken"], decoded_value.frameToken, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9800,6 +10451,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["computeDerivativeGroupQuads"] = static_cast<bool>(decoded_value.computeDerivativeGroupQuads);
         jdata["computeDerivativeGroupLinear"] = static_cast<bool>(decoded_value.computeDerivativeGroupLinear);
@@ -9813,6 +10465,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMeshShaderFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMeshShaderFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["taskShader"] = static_cast<bool>(decoded_value.taskShader);
         jdata["meshShader"] = static_cast<bool>(decoded_value.meshShader);
@@ -9826,6 +10479,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMeshShaderPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMeshShaderPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxDrawMeshTasksCount"], decoded_value.maxDrawMeshTasksCount, options);
         FieldToJson(jdata["maxTaskWorkGroupInvocations"], decoded_value.maxTaskWorkGroupInvocations, options);
@@ -9850,6 +10504,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrawMeshTasksInd
     {
         const VkDrawMeshTasksIndirectCommandNV& decoded_value = *data->decoded_value;
         const Decoded_VkDrawMeshTasksIndirectCommandNV& meta_struct = *data;
+
         FieldToJson(jdata["taskCount"], decoded_value.taskCount, options);
         FieldToJson(jdata["firstTask"], decoded_value.firstTask, options);
     }
@@ -9861,6 +10516,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderImageFootprintFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["imageFootprint"] = static_cast<bool>(decoded_value.imageFootprint);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9873,6 +10529,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineViewport
     {
         const VkPipelineViewportExclusiveScissorStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["exclusiveScissorCount"], decoded_value.exclusiveScissorCount, options);
         FieldToJson(jdata["pExclusiveScissors"], meta_struct.pExclusiveScissors, options);
@@ -9886,6 +10543,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExclusiveScissorFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["exclusiveScissor"] = static_cast<bool>(decoded_value.exclusiveScissor);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9898,6 +10556,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueueFamilyCheck
     {
         const VkQueueFamilyCheckpointPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkQueueFamilyCheckpointPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineStageFlags_t(),jdata["checkpointExecutionStageMask"], decoded_value.checkpointExecutionStageMask, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9910,6 +10569,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCheckpointDataNV
     {
         const VkCheckpointDataNV& decoded_value = *data->decoded_value;
         const Decoded_VkCheckpointDataNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stage"], decoded_value.stage, options);
         FieldToJson(jdata["pCheckpointMarker"], meta_struct.pCheckpointMarker, options);
@@ -9923,6 +10583,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderIntegerFunctions2"] = static_cast<bool>(decoded_value.shaderIntegerFunctions2);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9935,6 +10596,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkInitializePerfor
     {
         const VkInitializePerformanceApiInfoINTEL& decoded_value = *data->decoded_value;
         const Decoded_VkInitializePerformanceApiInfoINTEL& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pUserData"], to_hex_variable_width(meta_struct.pUserData), options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9947,6 +10609,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueryPoolPerform
     {
         const VkQueryPoolPerformanceQueryCreateInfoINTEL& decoded_value = *data->decoded_value;
         const Decoded_VkQueryPoolPerformanceQueryCreateInfoINTEL& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["performanceCountersSampling"], decoded_value.performanceCountersSampling, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9959,6 +10622,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPerformanceMarke
     {
         const VkPerformanceMarkerInfoINTEL& decoded_value = *data->decoded_value;
         const Decoded_VkPerformanceMarkerInfoINTEL& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["marker"], decoded_value.marker, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9971,6 +10635,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPerformanceStrea
     {
         const VkPerformanceStreamMarkerInfoINTEL& decoded_value = *data->decoded_value;
         const Decoded_VkPerformanceStreamMarkerInfoINTEL& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["marker"], decoded_value.marker, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -9983,6 +10648,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPerformanceOverr
     {
         const VkPerformanceOverrideInfoINTEL& decoded_value = *data->decoded_value;
         const Decoded_VkPerformanceOverrideInfoINTEL& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         jdata["enable"] = static_cast<bool>(decoded_value.enable);
@@ -9997,6 +10663,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPerformanceConfi
     {
         const VkPerformanceConfigurationAcquireInfoINTEL& decoded_value = *data->decoded_value;
         const Decoded_VkPerformanceConfigurationAcquireInfoINTEL& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10009,6 +10676,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePC
     {
         const VkPhysicalDevicePCIBusInfoPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pciDomain"], decoded_value.pciDomain, options);
         FieldToJson(jdata["pciBus"], decoded_value.pciBus, options);
@@ -10024,6 +10692,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDisplayNativeHdr
     {
         const VkDisplayNativeHdrSurfaceCapabilitiesAMD& decoded_value = *data->decoded_value;
         const Decoded_VkDisplayNativeHdrSurfaceCapabilitiesAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["localDimmingSupport"] = static_cast<bool>(decoded_value.localDimmingSupport);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10036,6 +10705,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainDisplay
     {
         const VkSwapchainDisplayNativeHdrCreateInfoAMD& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainDisplayNativeHdrCreateInfoAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["localDimmingEnable"] = static_cast<bool>(decoded_value.localDimmingEnable);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10048,6 +10718,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImagePipeSurface
     {
         const VkImagePipeSurfaceCreateInfoFUCHSIA& decoded_value = *data->decoded_value;
         const Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImagePipeSurfaceCreateFlagsFUCHSIA_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["imagePipeHandle"], decoded_value.imagePipeHandle, options);
@@ -10061,6 +10732,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMetalSurfaceCrea
     {
         const VkMetalSurfaceCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMetalSurfaceCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkMetalSurfaceCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pLayer"], meta_struct.pLayer, options);
@@ -10074,6 +10746,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["fragmentDensityMap"] = static_cast<bool>(decoded_value.fragmentDensityMap);
         jdata["fragmentDensityMapDynamic"] = static_cast<bool>(decoded_value.fragmentDensityMapDynamic);
@@ -10088,6 +10761,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentDensityMapPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minFragmentDensityTexelSize"], meta_struct.minFragmentDensityTexelSize, options);
         FieldToJson(jdata["maxFragmentDensityTexelSize"], meta_struct.maxFragmentDensityTexelSize, options);
@@ -10102,6 +10776,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassFragme
     {
         const VkRenderPassFragmentDensityMapCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["fragmentDensityMapAttachment"], meta_struct.fragmentDensityMapAttachment, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10114,6 +10789,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderCoreProperties2AMD& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderCoreProperties2AMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkShaderCorePropertiesFlagsAMD_t(),jdata["shaderCoreFeatures"], decoded_value.shaderCoreFeatures, options);
         FieldToJson(jdata["activeComputeUnitCount"], decoded_value.activeComputeUnitCount, options);
@@ -10127,6 +10803,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceCoherentMemoryFeaturesAMD& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCoherentMemoryFeaturesAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["deviceCoherentMemory"] = static_cast<bool>(decoded_value.deviceCoherentMemory);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10139,6 +10816,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderImageInt64Atomics"] = static_cast<bool>(decoded_value.shaderImageInt64Atomics);
         jdata["sparseImageInt64Atomics"] = static_cast<bool>(decoded_value.sparseImageInt64Atomics);
@@ -10152,6 +10830,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMemoryBudgetPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["heapBudget"], &meta_struct.heapBudget, options);
         FieldToJson(jdata["heapUsage"], &meta_struct.heapUsage, options);
@@ -10165,6 +10844,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMemoryPriorityFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["memoryPriority"] = static_cast<bool>(decoded_value.memoryPriority);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10177,6 +10857,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryPriorityAl
     {
         const VkMemoryPriorityAllocateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryPriorityAllocateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["priority"], decoded_value.priority, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10189,6 +10870,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["dedicatedAllocationImageAliasing"] = static_cast<bool>(decoded_value.dedicatedAllocationImageAliasing);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10201,6 +10883,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceBu
     {
         const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["bufferDeviceAddress"] = static_cast<bool>(decoded_value.bufferDeviceAddress);
         jdata["bufferDeviceAddressCaptureReplay"] = static_cast<bool>(decoded_value.bufferDeviceAddressCaptureReplay);
@@ -10215,6 +10898,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBufferDeviceAddr
     {
         const VkBufferDeviceAddressCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkBufferDeviceAddressCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceAddress"], to_hex_variable_width(decoded_value.deviceAddress), options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10227,6 +10911,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkValidationFeatur
     {
         const VkValidationFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkValidationFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["enabledValidationFeatureCount"], decoded_value.enabledValidationFeatureCount, options);
         FieldToJson(jdata["pEnabledValidationFeatures"], meta_struct.pEnabledValidationFeatures, options);
@@ -10242,6 +10927,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCooperativeMatri
     {
         const VkCooperativeMatrixPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkCooperativeMatrixPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["MSize"], decoded_value.MSize, options);
         FieldToJson(jdata["NSize"], decoded_value.NSize, options);
@@ -10261,6 +10947,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceCooperativeMatrixFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["cooperativeMatrix"] = static_cast<bool>(decoded_value.cooperativeMatrix);
         jdata["cooperativeMatrixRobustBufferAccess"] = static_cast<bool>(decoded_value.cooperativeMatrixRobustBufferAccess);
@@ -10274,6 +10961,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceCooperativeMatrixPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkShaderStageFlags_t(),jdata["cooperativeMatrixSupportedStages"], decoded_value.cooperativeMatrixSupportedStages, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10286,6 +10974,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceCoverageReductionModeFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCoverageReductionModeFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["coverageReductionMode"] = static_cast<bool>(decoded_value.coverageReductionMode);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10298,6 +10987,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineCoverage
     {
         const VkPipelineCoverageReductionStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineCoverageReductionStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCoverageReductionStateCreateFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["coverageReductionMode"], decoded_value.coverageReductionMode, options);
@@ -10311,6 +11001,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFramebufferMixed
     {
         const VkFramebufferMixedSamplesCombinationNV& decoded_value = *data->decoded_value;
         const Decoded_VkFramebufferMixedSamplesCombinationNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["coverageReductionMode"], decoded_value.coverageReductionMode, options);
         FieldToJson(jdata["rasterizationSamples"], decoded_value.rasterizationSamples, options);
@@ -10326,6 +11017,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["fragmentShaderSampleInterlock"] = static_cast<bool>(decoded_value.fragmentShaderSampleInterlock);
         jdata["fragmentShaderPixelInterlock"] = static_cast<bool>(decoded_value.fragmentShaderPixelInterlock);
@@ -10340,6 +11032,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceYc
     {
         const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["ycbcrImageArrays"] = static_cast<bool>(decoded_value.ycbcrImageArrays);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10352,6 +11045,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDeviceProvokingVertexFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceProvokingVertexFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["provokingVertexLast"] = static_cast<bool>(decoded_value.provokingVertexLast);
         jdata["transformFeedbackPreservesProvokingVertex"] = static_cast<bool>(decoded_value.transformFeedbackPreservesProvokingVertex);
@@ -10365,6 +11059,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDeviceProvokingVertexPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceProvokingVertexPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["provokingVertexModePerPipeline"] = static_cast<bool>(decoded_value.provokingVertexModePerPipeline);
         jdata["transformFeedbackPreservesTriangleFanProvokingVertex"] = static_cast<bool>(decoded_value.transformFeedbackPreservesTriangleFanProvokingVertex);
@@ -10378,6 +11073,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRasteriz
     {
         const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["provokingVertexMode"], decoded_value.provokingVertexMode, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10390,6 +11086,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceFullScree
     {
         const VkSurfaceFullScreenExclusiveInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceFullScreenExclusiveInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["fullScreenExclusive"], decoded_value.fullScreenExclusive, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10402,6 +11099,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceCapabilit
     {
         const VkSurfaceCapabilitiesFullScreenExclusiveEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceCapabilitiesFullScreenExclusiveEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["fullScreenExclusiveSupported"] = static_cast<bool>(decoded_value.fullScreenExclusiveSupported);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10414,6 +11112,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceFullScree
     {
         const VkSurfaceFullScreenExclusiveWin32InfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceFullScreenExclusiveWin32InfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["hmonitor"], meta_struct.hmonitor, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10426,6 +11125,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkHeadlessSurfaceC
     {
         const VkHeadlessSurfaceCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkHeadlessSurfaceCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkHeadlessSurfaceCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10438,6 +11138,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceLi
     {
         const VkPhysicalDeviceLineRasterizationFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceLineRasterizationFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rectangularLines"] = static_cast<bool>(decoded_value.rectangularLines);
         jdata["bresenhamLines"] = static_cast<bool>(decoded_value.bresenhamLines);
@@ -10455,6 +11156,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceLi
     {
         const VkPhysicalDeviceLineRasterizationPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceLineRasterizationPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["lineSubPixelPrecisionBits"], decoded_value.lineSubPixelPrecisionBits, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10467,6 +11169,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineRasteriz
     {
         const VkPipelineRasterizationLineStateCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineRasterizationLineStateCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["lineRasterizationMode"], decoded_value.lineRasterizationMode, options);
         jdata["stippledLineEnable"] = static_cast<bool>(decoded_value.stippledLineEnable);
@@ -10482,6 +11185,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderBufferFloat32Atomics"] = static_cast<bool>(decoded_value.shaderBufferFloat32Atomics);
         jdata["shaderBufferFloat32AtomicAdd"] = static_cast<bool>(decoded_value.shaderBufferFloat32AtomicAdd);
@@ -10505,6 +11209,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIn
     {
         const VkPhysicalDeviceIndexTypeUint8FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceIndexTypeUint8FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["indexTypeUint8"] = static_cast<bool>(decoded_value.indexTypeUint8);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10517,6 +11222,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["extendedDynamicState"] = static_cast<bool>(decoded_value.extendedDynamicState);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10529,6 +11235,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceHo
     {
         const VkPhysicalDeviceHostImageCopyFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceHostImageCopyFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["hostImageCopy"] = static_cast<bool>(decoded_value.hostImageCopy);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10541,6 +11248,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceHo
     {
         const VkPhysicalDeviceHostImageCopyPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceHostImageCopyPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["copySrcLayoutCount"], decoded_value.copySrcLayoutCount, options);
         FieldToJson(jdata["pCopySrcLayouts"], meta_struct.pCopySrcLayouts, options);
@@ -10558,6 +11266,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryToImageCop
     {
         const VkMemoryToImageCopyEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryToImageCopyEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pHostPointer"], meta_struct.pHostPointer, options);
         FieldToJson(jdata["memoryRowLength"], decoded_value.memoryRowLength, options);
@@ -10575,6 +11284,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageToMemoryCop
     {
         const VkImageToMemoryCopyEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageToMemoryCopyEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pHostPointer"], meta_struct.pHostPointer, options);
         FieldToJson(jdata["memoryRowLength"], decoded_value.memoryRowLength, options);
@@ -10592,6 +11302,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyMemoryToImag
     {
         const VkCopyMemoryToImageInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCopyMemoryToImageInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkHostImageCopyFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["dstImage"], meta_struct.dstImage, options);
@@ -10608,6 +11319,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyImageToMemor
     {
         const VkCopyImageToMemoryInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCopyImageToMemoryInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkHostImageCopyFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["srcImage"], meta_struct.srcImage, options);
@@ -10624,6 +11336,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyImageToImage
     {
         const VkCopyImageToImageInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCopyImageToImageInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkHostImageCopyFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         HandleToJson(jdata["srcImage"], meta_struct.srcImage, options);
@@ -10642,6 +11355,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkHostImageLayoutT
     {
         const VkHostImageLayoutTransitionInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkHostImageLayoutTransitionInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["image"], meta_struct.image, options);
         FieldToJson(jdata["oldLayout"], decoded_value.oldLayout, options);
@@ -10657,6 +11371,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubresourceHostM
     {
         const VkSubresourceHostMemcpySizeEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSubresourceHostMemcpySizeEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10669,6 +11384,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkHostImageCopyDev
     {
         const VkHostImageCopyDevicePerformanceQueryEXT& decoded_value = *data->decoded_value;
         const Decoded_VkHostImageCopyDevicePerformanceQueryEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["optimalDeviceAccess"] = static_cast<bool>(decoded_value.optimalDeviceAccess);
         jdata["identicalMemoryLayout"] = static_cast<bool>(decoded_value.identicalMemoryLayout);
@@ -10682,6 +11398,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderBufferFloat16Atomics"] = static_cast<bool>(decoded_value.shaderBufferFloat16Atomics);
         jdata["shaderBufferFloat16AtomicAdd"] = static_cast<bool>(decoded_value.shaderBufferFloat16AtomicAdd);
@@ -10705,6 +11422,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfacePresentMo
     {
         const VkSurfacePresentModeEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSurfacePresentModeEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["presentMode"], decoded_value.presentMode, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10717,6 +11435,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfacePresentSc
     {
         const VkSurfacePresentScalingCapabilitiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSurfacePresentScalingCapabilitiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPresentScalingFlagsEXT_t(),jdata["supportedPresentScaling"], decoded_value.supportedPresentScaling, options);
         FieldToJson(VkPresentGravityFlagsEXT_t(),jdata["supportedPresentGravityX"], decoded_value.supportedPresentGravityX, options);
@@ -10733,6 +11452,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfacePresentMo
     {
         const VkSurfacePresentModeCompatibilityEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSurfacePresentModeCompatibilityEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["presentModeCount"], decoded_value.presentModeCount, options);
         FieldToJson(jdata["pPresentModes"], meta_struct.pPresentModes, options);
@@ -10746,6 +11466,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSw
     {
         const VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["swapchainMaintenance1"] = static_cast<bool>(decoded_value.swapchainMaintenance1);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10758,6 +11479,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainPresent
     {
         const VkSwapchainPresentFenceInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainPresentFenceInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["swapchainCount"], decoded_value.swapchainCount, options);
         HandleToJson(jdata["pFences"], &meta_struct.pFences, options);
@@ -10771,6 +11493,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainPresent
     {
         const VkSwapchainPresentModesCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainPresentModesCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["presentModeCount"], decoded_value.presentModeCount, options);
         FieldToJson(jdata["pPresentModes"], meta_struct.pPresentModes, options);
@@ -10784,6 +11507,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainPresent
     {
         const VkSwapchainPresentModeInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainPresentModeInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["swapchainCount"], decoded_value.swapchainCount, options);
         FieldToJson(jdata["pPresentModes"], meta_struct.pPresentModes, options);
@@ -10797,6 +11521,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainPresent
     {
         const VkSwapchainPresentScalingCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainPresentScalingCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPresentScalingFlagsEXT_t(),jdata["scalingBehavior"], decoded_value.scalingBehavior, options);
         FieldToJson(VkPresentGravityFlagsEXT_t(),jdata["presentGravityX"], decoded_value.presentGravityX, options);
@@ -10811,6 +11536,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkReleaseSwapchain
     {
         const VkReleaseSwapchainImagesInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkReleaseSwapchainImagesInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["swapchain"], meta_struct.swapchain, options);
         FieldToJson(jdata["imageIndexCount"], decoded_value.imageIndexCount, options);
@@ -10825,6 +11551,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxGraphicsShaderGroupCount"], decoded_value.maxGraphicsShaderGroupCount, options);
         FieldToJson(jdata["maxIndirectSequenceCount"], decoded_value.maxIndirectSequenceCount, options);
@@ -10845,6 +11572,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["deviceGeneratedCommands"] = static_cast<bool>(decoded_value.deviceGeneratedCommands);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -10857,6 +11585,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGraphicsShaderGr
     {
         const VkGraphicsShaderGroupCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkGraphicsShaderGroupCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["stageCount"], decoded_value.stageCount, options);
         FieldToJson(jdata["pStages"], meta_struct.pStages, options);
@@ -10872,6 +11601,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGraphicsPipeline
     {
         const VkGraphicsPipelineShaderGroupsCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["groupCount"], decoded_value.groupCount, options);
         FieldToJson(jdata["pGroups"], meta_struct.pGroups, options);
@@ -10887,6 +11617,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindShaderGroupI
     {
         const VkBindShaderGroupIndirectCommandNV& decoded_value = *data->decoded_value;
         const Decoded_VkBindShaderGroupIndirectCommandNV& meta_struct = *data;
+
         FieldToJson(jdata["groupIndex"], decoded_value.groupIndex, options);
     }
 }
@@ -10897,6 +11628,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindIndexBufferI
     {
         const VkBindIndexBufferIndirectCommandNV& decoded_value = *data->decoded_value;
         const Decoded_VkBindIndexBufferIndirectCommandNV& meta_struct = *data;
+
         FieldToJson(jdata["bufferAddress"], to_hex_variable_width(decoded_value.bufferAddress), options);
         FieldToJson(jdata["size"], decoded_value.size, options);
         FieldToJson(jdata["indexType"], decoded_value.indexType, options);
@@ -10909,6 +11641,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindVertexBuffer
     {
         const VkBindVertexBufferIndirectCommandNV& decoded_value = *data->decoded_value;
         const Decoded_VkBindVertexBufferIndirectCommandNV& meta_struct = *data;
+
         FieldToJson(jdata["bufferAddress"], to_hex_variable_width(decoded_value.bufferAddress), options);
         FieldToJson(jdata["size"], decoded_value.size, options);
         FieldToJson(jdata["stride"], decoded_value.stride, options);
@@ -10921,6 +11654,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSetStateFlagsInd
     {
         const VkSetStateFlagsIndirectCommandNV& decoded_value = *data->decoded_value;
         const Decoded_VkSetStateFlagsIndirectCommandNV& meta_struct = *data;
+
         FieldToJson(jdata["data"], decoded_value.data, options);
     }
 }
@@ -10931,6 +11665,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkIndirectCommands
     {
         const VkIndirectCommandsStreamNV& decoded_value = *data->decoded_value;
         const Decoded_VkIndirectCommandsStreamNV& meta_struct = *data;
+
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
         FieldToJson(jdata["offset"], decoded_value.offset, options);
     }
@@ -10942,6 +11677,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkIndirectCommands
     {
         const VkIndirectCommandsLayoutTokenNV& decoded_value = *data->decoded_value;
         const Decoded_VkIndirectCommandsLayoutTokenNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["tokenType"], decoded_value.tokenType, options);
         FieldToJson(jdata["stream"], decoded_value.stream, options);
@@ -10966,6 +11702,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkIndirectCommands
     {
         const VkIndirectCommandsLayoutCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkIndirectCommandsLayoutCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkIndirectCommandsLayoutUsageFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pipelineBindPoint"], decoded_value.pipelineBindPoint, options);
@@ -10983,6 +11720,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGeneratedCommand
     {
         const VkGeneratedCommandsInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkGeneratedCommandsInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pipelineBindPoint"], decoded_value.pipelineBindPoint, options);
         HandleToJson(jdata["pipeline"], meta_struct.pipeline, options);
@@ -11007,6 +11745,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGeneratedCommand
     {
         const VkGeneratedCommandsMemoryRequirementsInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pipelineBindPoint"], decoded_value.pipelineBindPoint, options);
         HandleToJson(jdata["pipeline"], meta_struct.pipeline, options);
@@ -11022,6 +11761,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIn
     {
         const VkPhysicalDeviceInheritedViewportScissorFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceInheritedViewportScissorFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["inheritedViewportScissor2D"] = static_cast<bool>(decoded_value.inheritedViewportScissor2D);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11034,6 +11774,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferInh
     {
         const VkCommandBufferInheritanceViewportScissorInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferInheritanceViewportScissorInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["viewportScissor2D"] = static_cast<bool>(decoded_value.viewportScissor2D);
         FieldToJson(jdata["viewportDepthCount"], decoded_value.viewportDepthCount, options);
@@ -11048,6 +11789,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTe
     {
         const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["texelBufferAlignment"] = static_cast<bool>(decoded_value.texelBufferAlignment);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11060,6 +11802,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassTransf
     {
         const VkRenderPassTransformBeginInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassTransformBeginInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["transform"], decoded_value.transform, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11072,6 +11815,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCommandBufferInh
     {
         const VkCommandBufferInheritanceRenderPassTransformInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["transform"], decoded_value.transform, options);
         FieldToJson(jdata["renderArea"], meta_struct.renderArea, options);
@@ -11085,6 +11829,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDepthBiasControlFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDepthBiasControlFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["depthBiasControl"] = static_cast<bool>(decoded_value.depthBiasControl);
         jdata["leastRepresentableValueForceUnormRepresentation"] = static_cast<bool>(decoded_value.leastRepresentableValueForceUnormRepresentation);
@@ -11100,6 +11845,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDepthBiasInfoEXT
     {
         const VkDepthBiasInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDepthBiasInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["depthBiasConstantFactor"], decoded_value.depthBiasConstantFactor, options);
         FieldToJson(jdata["depthBiasClamp"], decoded_value.depthBiasClamp, options);
@@ -11114,6 +11860,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDepthBiasReprese
     {
         const VkDepthBiasRepresentationInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDepthBiasRepresentationInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["depthBiasRepresentation"], decoded_value.depthBiasRepresentation, options);
         jdata["depthBiasExact"] = static_cast<bool>(decoded_value.depthBiasExact);
@@ -11127,6 +11874,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["deviceMemoryReport"] = static_cast<bool>(decoded_value.deviceMemoryReport);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11139,6 +11887,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceMemoryRepo
     {
         const VkDeviceMemoryReportCallbackDataEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceMemoryReportCallbackDataEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceMemoryReportFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
@@ -11157,6 +11906,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceDeviceMemo
     {
         const VkDeviceDeviceMemoryReportCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceDeviceMemoryReportCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceMemoryReportFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pfnUserCallback"], to_hex_variable_width(meta_struct.pfnUserCallback), options);
@@ -11171,6 +11921,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRo
     {
         const VkPhysicalDeviceRobustness2FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRobustness2FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["robustBufferAccess2"] = static_cast<bool>(decoded_value.robustBufferAccess2);
         jdata["robustImageAccess2"] = static_cast<bool>(decoded_value.robustImageAccess2);
@@ -11185,6 +11936,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRo
     {
         const VkPhysicalDeviceRobustness2PropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRobustness2PropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["robustStorageBufferAccessSizeAlignment"], decoded_value.robustStorageBufferAccessSizeAlignment, options);
         FieldToJson(jdata["robustUniformBufferAccessSizeAlignment"], decoded_value.robustUniformBufferAccessSizeAlignment, options);
@@ -11198,6 +11950,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerCustomBor
     {
         const VkSamplerCustomBorderColorCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerCustomBorderColorCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["customBorderColor"], meta_struct.customBorderColor, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
@@ -11211,6 +11964,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCu
     {
         const VkPhysicalDeviceCustomBorderColorPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCustomBorderColorPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxCustomBorderColorSamplers"], decoded_value.maxCustomBorderColorSamplers, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11223,6 +11977,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCu
     {
         const VkPhysicalDeviceCustomBorderColorFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCustomBorderColorFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["customBorderColors"] = static_cast<bool>(decoded_value.customBorderColors);
         jdata["customBorderColorWithoutFormat"] = static_cast<bool>(decoded_value.customBorderColorWithoutFormat);
@@ -11236,6 +11991,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDevicePresentBarrierFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePresentBarrierFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["presentBarrier"] = static_cast<bool>(decoded_value.presentBarrier);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11248,6 +12004,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSurfaceCapabilit
     {
         const VkSurfaceCapabilitiesPresentBarrierNV& decoded_value = *data->decoded_value;
         const Decoded_VkSurfaceCapabilitiesPresentBarrierNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["presentBarrierSupported"] = static_cast<bool>(decoded_value.presentBarrierSupported);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11260,6 +12017,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSwapchainPresent
     {
         const VkSwapchainPresentBarrierCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkSwapchainPresentBarrierCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["presentBarrierEnable"] = static_cast<bool>(decoded_value.presentBarrierEnable);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11272,6 +12030,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDi
     {
         const VkPhysicalDeviceDiagnosticsConfigFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDiagnosticsConfigFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["diagnosticsConfig"] = static_cast<bool>(decoded_value.diagnosticsConfig);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11284,6 +12043,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceDiagnostic
     {
         const VkDeviceDiagnosticsConfigCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceDiagnosticsConfigCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceDiagnosticsConfigFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11296,6 +12056,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkQueryLowLatencyS
     {
         const VkQueryLowLatencySupportNV& decoded_value = *data->decoded_value;
         const Decoded_VkQueryLowLatencySupportNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pQueriedLowLatencyData"], meta_struct.pQueriedLowLatencyData, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11308,6 +12069,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceGr
     {
         const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["graphicsPipelineLibrary"] = static_cast<bool>(decoded_value.graphicsPipelineLibrary);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11320,6 +12082,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceGr
     {
         const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["graphicsPipelineLibraryFastLinking"] = static_cast<bool>(decoded_value.graphicsPipelineLibraryFastLinking);
         jdata["graphicsPipelineLibraryIndependentInterpolationDecoration"] = static_cast<bool>(decoded_value.graphicsPipelineLibraryIndependentInterpolationDecoration);
@@ -11333,6 +12096,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkGraphicsPipeline
     {
         const VkGraphicsPipelineLibraryCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkGraphicsPipelineLibraryCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkGraphicsPipelineLibraryFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11345,6 +12109,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderEarlyAndLateFragmentTests"] = static_cast<bool>(decoded_value.shaderEarlyAndLateFragmentTests);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11357,6 +12122,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["fragmentShadingRateEnums"] = static_cast<bool>(decoded_value.fragmentShadingRateEnums);
         jdata["supersampleFragmentShadingRates"] = static_cast<bool>(decoded_value.supersampleFragmentShadingRates);
@@ -11371,6 +12137,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxFragmentShadingRateInvocationCount"], decoded_value.maxFragmentShadingRateInvocationCount, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11383,6 +12150,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineFragment
     {
         const VkPipelineFragmentShadingRateEnumStateCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineFragmentShadingRateEnumStateCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shadingRateType"], decoded_value.shadingRateType, options);
         FieldToJson(jdata["shadingRate"], decoded_value.shadingRate, options);
@@ -11397,6 +12165,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureGeometryMotionTrianglesDataNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureGeometryMotionTrianglesDataNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["vertexData"], meta_struct.vertexData, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11409,6 +12178,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureMotionInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureMotionInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxInstances"], decoded_value.maxInstances, options);
         FieldToJson(VkAccelerationStructureMotionInfoFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
@@ -11422,6 +12192,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureMatrixMotionInstanceNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureMatrixMotionInstanceNV& meta_struct = *data;
+
         FieldToJson(jdata["transformT0"], meta_struct.transformT0, options);
         FieldToJson(jdata["transformT1"], meta_struct.transformT1, options);
         FieldToJson(jdata["instanceCustomIndex"], decoded_value.instanceCustomIndex, options);
@@ -11438,6 +12209,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSRTDataNV* data,
     {
         const VkSRTDataNV& decoded_value = *data->decoded_value;
         const Decoded_VkSRTDataNV& meta_struct = *data;
+
         FieldToJson(jdata["sx"], decoded_value.sx, options);
         FieldToJson(jdata["a"], decoded_value.a, options);
         FieldToJson(jdata["b"], decoded_value.b, options);
@@ -11463,6 +12235,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureSRTMotionInstanceNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureSRTMotionInstanceNV& meta_struct = *data;
+
         FieldToJson(jdata["transformT0"], meta_struct.transformT0, options);
         FieldToJson(jdata["transformT1"], meta_struct.transformT1, options);
         FieldToJson(jdata["instanceCustomIndex"], decoded_value.instanceCustomIndex, options);
@@ -11479,6 +12252,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rayTracingMotionBlur"] = static_cast<bool>(decoded_value.rayTracingMotionBlur);
         jdata["rayTracingMotionBlurPipelineTraceRaysIndirect"] = static_cast<bool>(decoded_value.rayTracingMotionBlurPipelineTraceRaysIndirect);
@@ -11492,6 +12266,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceYc
     {
         const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["ycbcr2plane444Formats"] = static_cast<bool>(decoded_value.ycbcr2plane444Formats);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11504,6 +12279,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["fragmentDensityMapDeferred"] = static_cast<bool>(decoded_value.fragmentDensityMapDeferred);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11516,6 +12292,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentDensityMap2PropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["subsampledLoads"] = static_cast<bool>(decoded_value.subsampledLoads);
         jdata["subsampledCoarseReconstructionEarlyAccess"] = static_cast<bool>(decoded_value.subsampledCoarseReconstructionEarlyAccess);
@@ -11531,6 +12308,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyCommandTrans
     {
         const VkCopyCommandTransformInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkCopyCommandTransformInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["transform"], decoded_value.transform, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11543,6 +12321,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageCompressionControlFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageCompressionControlFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["imageCompressionControl"] = static_cast<bool>(decoded_value.imageCompressionControl);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11555,6 +12334,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageCompression
     {
         const VkImageCompressionControlEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageCompressionControlEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageCompressionFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["compressionControlPlaneCount"], decoded_value.compressionControlPlaneCount, options);
@@ -11569,6 +12349,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageCompression
     {
         const VkImageCompressionPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageCompressionPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkImageCompressionFlagsEXT_t(),jdata["imageCompressionFlags"], decoded_value.imageCompressionFlags, options);
         FieldToJson(VkImageCompressionFixedRateFlagsEXT_t(),jdata["imageCompressionFixedRateFlags"], decoded_value.imageCompressionFixedRateFlags, options);
@@ -11582,6 +12363,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceAt
     {
         const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["attachmentFeedbackLoopLayout"] = static_cast<bool>(decoded_value.attachmentFeedbackLoopLayout);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11594,6 +12376,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevice44
     {
         const VkPhysicalDevice4444FormatsFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevice4444FormatsFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["formatA4R4G4B4"] = static_cast<bool>(decoded_value.formatA4R4G4B4);
         jdata["formatA4B4G4R4"] = static_cast<bool>(decoded_value.formatA4B4G4R4);
@@ -11607,6 +12390,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFa
     {
         const VkPhysicalDeviceFaultFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFaultFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["deviceFault"] = static_cast<bool>(decoded_value.deviceFault);
         jdata["deviceFaultVendorBinary"] = static_cast<bool>(decoded_value.deviceFaultVendorBinary);
@@ -11620,6 +12404,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceFaultCount
     {
         const VkDeviceFaultCountsEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceFaultCountsEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["addressInfoCount"], decoded_value.addressInfoCount, options);
         FieldToJson(jdata["vendorInfoCount"], decoded_value.vendorInfoCount, options);
@@ -11634,6 +12419,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceFaultAddre
     {
         const VkDeviceFaultAddressInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceFaultAddressInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["addressType"], decoded_value.addressType, options);
         FieldToJson(jdata["reportedAddress"], to_hex_variable_width(decoded_value.reportedAddress), options);
         FieldToJson(jdata["addressPrecision"], decoded_value.addressPrecision, options);
@@ -11646,6 +12432,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceFaultVendo
     {
         const VkDeviceFaultVendorInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceFaultVendorInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["description"], &meta_struct.description, options);
         FieldToJson(jdata["vendorFaultCode"], decoded_value.vendorFaultCode, options);
         FieldToJson(jdata["vendorFaultData"], decoded_value.vendorFaultData, options);
@@ -11658,6 +12445,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceFaultInfoE
     {
         const VkDeviceFaultInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceFaultInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["description"], &meta_struct.description, options);
         FieldToJson(jdata["pAddressInfos"], meta_struct.pAddressInfos, options);
@@ -11673,6 +12461,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceFaultVendo
     {
         const VkDeviceFaultVendorBinaryHeaderVersionOneEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceFaultVendorBinaryHeaderVersionOneEXT& meta_struct = *data;
+
         FieldToJson(jdata["headerSize"], decoded_value.headerSize, options);
         FieldToJson(jdata["headerVersion"], decoded_value.headerVersion, options);
         FieldToJson(jdata["vendorID"], decoded_value.vendorID, options);
@@ -11693,6 +12482,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rasterizationOrderColorAttachmentAccess"] = static_cast<bool>(decoded_value.rasterizationOrderColorAttachmentAccess);
         jdata["rasterizationOrderDepthAttachmentAccess"] = static_cast<bool>(decoded_value.rasterizationOrderDepthAttachmentAccess);
@@ -11707,6 +12497,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRG
     {
         const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["formatRgba10x6WithoutYCbCrSampler"] = static_cast<bool>(decoded_value.formatRgba10x6WithoutYCbCrSampler);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11719,6 +12510,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDirectFBSurfaceC
     {
         const VkDirectFBSurfaceCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDirectFBSurfaceCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDirectFBSurfaceCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["dfb"], meta_struct.dfb, options);
@@ -11733,6 +12525,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["mutableDescriptorType"] = static_cast<bool>(decoded_value.mutableDescriptorType);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11745,6 +12538,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMutableDescripto
     {
         const VkMutableDescriptorTypeListEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMutableDescriptorTypeListEXT& meta_struct = *data;
+
         FieldToJson(jdata["descriptorTypeCount"], decoded_value.descriptorTypeCount, options);
         FieldToJson(jdata["pDescriptorTypes"], meta_struct.pDescriptorTypes, options);
     }
@@ -11756,6 +12550,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMutableDescripto
     {
         const VkMutableDescriptorTypeCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMutableDescriptorTypeCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["mutableDescriptorTypeListCount"], decoded_value.mutableDescriptorTypeListCount, options);
         FieldToJson(jdata["pMutableDescriptorTypeLists"], meta_struct.pMutableDescriptorTypeLists, options);
@@ -11769,6 +12564,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceVe
     {
         const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["vertexInputDynamicState"] = static_cast<bool>(decoded_value.vertexInputDynamicState);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11781,6 +12577,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVertexInputBindi
     {
         const VkVertexInputBindingDescription2EXT& decoded_value = *data->decoded_value;
         const Decoded_VkVertexInputBindingDescription2EXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["binding"], decoded_value.binding, options);
         FieldToJson(jdata["stride"], decoded_value.stride, options);
@@ -11796,6 +12593,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkVertexInputAttri
     {
         const VkVertexInputAttributeDescription2EXT& decoded_value = *data->decoded_value;
         const Decoded_VkVertexInputAttributeDescription2EXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["location"], decoded_value.location, options);
         FieldToJson(jdata["binding"], decoded_value.binding, options);
@@ -11811,6 +12609,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDr
     {
         const VkPhysicalDeviceDrmPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDrmPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["hasPrimary"] = static_cast<bool>(decoded_value.hasPrimary);
         jdata["hasRender"] = static_cast<bool>(decoded_value.hasRender);
@@ -11828,6 +12627,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceAd
     {
         const VkPhysicalDeviceAddressBindingReportFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceAddressBindingReportFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["reportAddressBinding"] = static_cast<bool>(decoded_value.reportAddressBinding);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11840,6 +12640,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDeviceAddressBin
     {
         const VkDeviceAddressBindingCallbackDataEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDeviceAddressBindingCallbackDataEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDeviceAddressBindingFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["baseAddress"], to_hex_variable_width(decoded_value.baseAddress), options);
@@ -11855,6 +12656,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDepthClipControlFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDepthClipControlFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["depthClipControl"] = static_cast<bool>(decoded_value.depthClipControl);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11867,6 +12669,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineViewport
     {
         const VkPipelineViewportDepthClipControlCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineViewportDepthClipControlCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["negativeOneToOne"] = static_cast<bool>(decoded_value.negativeOneToOne);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11879,6 +12682,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["primitiveTopologyListRestart"] = static_cast<bool>(decoded_value.primitiveTopologyListRestart);
         jdata["primitiveTopologyPatchListRestart"] = static_cast<bool>(decoded_value.primitiveTopologyPatchListRestart);
@@ -11892,6 +12696,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportMemoryZirc
     {
         const VkImportMemoryZirconHandleInfoFUCHSIA& decoded_value = *data->decoded_value;
         const Decoded_VkImportMemoryZirconHandleInfoFUCHSIA& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
         FieldToJson(jdata["handle"], decoded_value.handle, options);
@@ -11905,6 +12710,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryZirconHand
     {
         const VkMemoryZirconHandlePropertiesFUCHSIA& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryZirconHandlePropertiesFUCHSIA& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["memoryTypeBits"], decoded_value.memoryTypeBits, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11917,6 +12723,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryGetZirconH
     {
         const VkMemoryGetZirconHandleInfoFUCHSIA& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryGetZirconHandleInfoFUCHSIA& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -11930,6 +12737,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImportSemaphoreZ
     {
         const VkImportSemaphoreZirconHandleInfoFUCHSIA& decoded_value = *data->decoded_value;
         const Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(VkSemaphoreImportFlags_t(),jdata["flags"], decoded_value.flags, options);
@@ -11945,6 +12753,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSemaphoreGetZirc
     {
         const VkSemaphoreGetZirconHandleInfoFUCHSIA& decoded_value = *data->decoded_value;
         const Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["semaphore"], meta_struct.semaphore, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -11958,6 +12767,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIn
     {
         const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["invocationMask"] = static_cast<bool>(decoded_value.invocationMask);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11970,6 +12780,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMemoryGetRemoteA
     {
         const VkMemoryGetRemoteAddressInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkMemoryGetRemoteAddressInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["memory"], meta_struct.memory, options);
         FieldToJson(jdata["handleType"], decoded_value.handleType, options);
@@ -11983,6 +12794,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["externalMemoryRDMA"] = static_cast<bool>(decoded_value.externalMemoryRDMA);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -11995,6 +12807,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFrameBoundaryFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFrameBoundaryFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["frameBoundary"] = static_cast<bool>(decoded_value.frameBoundary);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12007,6 +12820,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkFrameBoundaryEXT
     {
         const VkFrameBoundaryEXT& decoded_value = *data->decoded_value;
         const Decoded_VkFrameBoundaryEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkFrameBoundaryFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["frameID"], decoded_value.frameID, options);
@@ -12027,6 +12841,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["multisampledRenderToSingleSampled"] = static_cast<bool>(decoded_value.multisampledRenderToSingleSampled);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12039,6 +12854,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassResolvePe
     {
         const VkSubpassResolvePerformanceQueryEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassResolvePerformanceQueryEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["optimal"] = static_cast<bool>(decoded_value.optimal);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12051,6 +12867,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMultisampledRend
     {
         const VkMultisampledRenderToSingleSampledInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMultisampledRenderToSingleSampledInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["multisampledRenderToSingleSampledEnable"] = static_cast<bool>(decoded_value.multisampledRenderToSingleSampledEnable);
         FieldToJson(jdata["rasterizationSamples"], decoded_value.rasterizationSamples, options);
@@ -12064,6 +12881,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExtendedDynamicState2FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["extendedDynamicState2"] = static_cast<bool>(decoded_value.extendedDynamicState2);
         jdata["extendedDynamicState2LogicOp"] = static_cast<bool>(decoded_value.extendedDynamicState2LogicOp);
@@ -12078,6 +12896,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkScreenSurfaceCre
     {
         const VkScreenSurfaceCreateInfoQNX& decoded_value = *data->decoded_value;
         const Decoded_VkScreenSurfaceCreateInfoQNX& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkScreenSurfaceCreateFlagsQNX_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["context"], meta_struct.context, options);
@@ -12092,6 +12911,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCo
     {
         const VkPhysicalDeviceColorWriteEnableFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceColorWriteEnableFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["colorWriteEnable"] = static_cast<bool>(decoded_value.colorWriteEnable);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12104,6 +12924,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineColorWri
     {
         const VkPipelineColorWriteCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineColorWriteCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["attachmentCount"], decoded_value.attachmentCount, options);
         VkBool32ToJson(jdata["pColorWriteEnables"], &meta_struct.pColorWriteEnables);
@@ -12117,6 +12938,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePr
     {
         const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["primitivesGeneratedQuery"] = static_cast<bool>(decoded_value.primitivesGeneratedQuery);
         jdata["primitivesGeneratedQueryWithRasterizerDiscard"] = static_cast<bool>(decoded_value.primitivesGeneratedQueryWithRasterizerDiscard);
@@ -12131,6 +12953,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageViewMinLodFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageViewMinLodFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["minLod"] = static_cast<bool>(decoded_value.minLod);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12143,6 +12966,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewMinLodC
     {
         const VkImageViewMinLodCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewMinLodCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["minLod"], decoded_value.minLod, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12155,6 +12979,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultiDrawFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultiDrawFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["multiDraw"] = static_cast<bool>(decoded_value.multiDraw);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12167,6 +12992,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultiDrawPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultiDrawPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxMultiDrawCount"], decoded_value.maxMultiDrawCount, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12179,6 +13005,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMultiDrawInfoEXT
     {
         const VkMultiDrawInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMultiDrawInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["firstVertex"], decoded_value.firstVertex, options);
         FieldToJson(jdata["vertexCount"], decoded_value.vertexCount, options);
     }
@@ -12190,6 +13017,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMultiDrawIndexed
     {
         const VkMultiDrawIndexedInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMultiDrawIndexedInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["firstIndex"], decoded_value.firstIndex, options);
         FieldToJson(jdata["indexCount"], decoded_value.indexCount, options);
         FieldToJson(jdata["vertexOffset"], decoded_value.vertexOffset, options);
@@ -12202,6 +13030,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["image2DViewOf3D"] = static_cast<bool>(decoded_value.image2DViewOf3D);
         jdata["sampler2DViewOf3D"] = static_cast<bool>(decoded_value.sampler2DViewOf3D);
@@ -12215,6 +13044,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderTileImageFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderTileImageFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderTileImageColorReadAccess"] = static_cast<bool>(decoded_value.shaderTileImageColorReadAccess);
         jdata["shaderTileImageDepthReadAccess"] = static_cast<bool>(decoded_value.shaderTileImageDepthReadAccess);
@@ -12229,6 +13059,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderTileImagePropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderTileImagePropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderTileImageCoherentReadAccelerated"] = static_cast<bool>(decoded_value.shaderTileImageCoherentReadAccelerated);
         jdata["shaderTileImageReadSampleFromPixelRateInvocation"] = static_cast<bool>(decoded_value.shaderTileImageReadSampleFromPixelRateInvocation);
@@ -12243,6 +13074,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMicromapUsageEXT
     {
         const VkMicromapUsageEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMicromapUsageEXT& meta_struct = *data;
+
         FieldToJson(jdata["count"], decoded_value.count, options);
         FieldToJson(jdata["subdivisionLevel"], decoded_value.subdivisionLevel, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
@@ -12255,6 +13087,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMicromapBuildInf
     {
         const VkMicromapBuildInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMicromapBuildInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         FieldToJson(VkBuildMicromapFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
@@ -12277,6 +13110,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMicromapCreateIn
     {
         const VkMicromapCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMicromapCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkMicromapCreateFlagsEXT_t(),jdata["createFlags"], decoded_value.createFlags, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
@@ -12294,6 +13128,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceOp
     {
         const VkPhysicalDeviceOpacityMicromapFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceOpacityMicromapFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["micromap"] = static_cast<bool>(decoded_value.micromap);
         jdata["micromapCaptureReplay"] = static_cast<bool>(decoded_value.micromapCaptureReplay);
@@ -12308,6 +13143,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceOp
     {
         const VkPhysicalDeviceOpacityMicromapPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceOpacityMicromapPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxOpacity2StateSubdivisionLevel"], decoded_value.maxOpacity2StateSubdivisionLevel, options);
         FieldToJson(jdata["maxOpacity4StateSubdivisionLevel"], decoded_value.maxOpacity4StateSubdivisionLevel, options);
@@ -12321,6 +13157,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMicromapVersionI
     {
         const VkMicromapVersionInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMicromapVersionInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pVersionData"], meta_struct.pVersionData, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12333,6 +13170,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyMicromapToMe
     {
         const VkCopyMicromapToMemoryInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCopyMicromapToMemoryInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["src"], meta_struct.src, options);
         FieldToJson(jdata["dst"], meta_struct.dst, options);
@@ -12347,6 +13185,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyMemoryToMicr
     {
         const VkCopyMemoryToMicromapInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCopyMemoryToMicromapInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["src"], meta_struct.src, options);
         HandleToJson(jdata["dst"], meta_struct.dst, options);
@@ -12361,6 +13200,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyMicromapInfo
     {
         const VkCopyMicromapInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkCopyMicromapInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["src"], meta_struct.src, options);
         HandleToJson(jdata["dst"], meta_struct.dst, options);
@@ -12375,6 +13215,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMicromapBuildSiz
     {
         const VkMicromapBuildSizesInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMicromapBuildSizesInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["micromapSize"], decoded_value.micromapSize, options);
         FieldToJson(jdata["buildScratchSize"], decoded_value.buildScratchSize, options);
@@ -12389,6 +13230,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureTrianglesOpacityMicromapEXT& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["indexType"], decoded_value.indexType, options);
         FieldToJson(jdata["indexBuffer"], meta_struct.indexBuffer, options);
@@ -12408,6 +13250,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMicromapTriangle
     {
         const VkMicromapTriangleEXT& decoded_value = *data->decoded_value;
         const Decoded_VkMicromapTriangleEXT& meta_struct = *data;
+
         FieldToJson(jdata["dataOffset"], decoded_value.dataOffset, options);
         FieldToJson(jdata["subdivisionLevel"], decoded_value.subdivisionLevel, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
@@ -12420,6 +13263,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDi
     {
         const VkPhysicalDeviceDisplacementMicromapFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDisplacementMicromapFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["displacementMicromap"] = static_cast<bool>(decoded_value.displacementMicromap);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12432,6 +13276,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDi
     {
         const VkPhysicalDeviceDisplacementMicromapPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDisplacementMicromapPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxDisplacementMicromapSubdivisionLevel"], decoded_value.maxDisplacementMicromapSubdivisionLevel, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12444,6 +13289,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureTrianglesDisplacementMicromapNV& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureTrianglesDisplacementMicromapNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["displacementBiasAndScaleFormat"], decoded_value.displacementBiasAndScaleFormat, options);
         FieldToJson(jdata["displacementVectorFormat"], decoded_value.displacementVectorFormat, options);
@@ -12471,6 +13317,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCl
     {
         const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["clustercullingShader"] = static_cast<bool>(decoded_value.clustercullingShader);
         jdata["multiviewClusterCullingShader"] = static_cast<bool>(decoded_value.multiviewClusterCullingShader);
@@ -12484,6 +13331,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCl
     {
         const VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxWorkGroupCount"], &meta_struct.maxWorkGroupCount, options);
         FieldToJson(jdata["maxWorkGroupSize"], &meta_struct.maxWorkGroupSize, options);
@@ -12499,6 +13347,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceBo
     {
         const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["borderColorSwizzle"] = static_cast<bool>(decoded_value.borderColorSwizzle);
         jdata["borderColorSwizzleFromImage"] = static_cast<bool>(decoded_value.borderColorSwizzleFromImage);
@@ -12512,6 +13361,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerBorderCol
     {
         const VkSamplerBorderColorComponentMappingCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerBorderColorComponentMappingCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["components"], meta_struct.components, options);
         jdata["srgb"] = static_cast<bool>(decoded_value.srgb);
@@ -12525,6 +13375,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePa
     {
         const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["pageableDeviceLocalMemory"] = static_cast<bool>(decoded_value.pageableDeviceLocalMemory);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12537,6 +13388,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderCorePropertiesARM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderCorePropertiesARM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pixelRate"], decoded_value.pixelRate, options);
         FieldToJson(jdata["texelRate"], decoded_value.texelRate, options);
@@ -12551,6 +13403,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["imageSlicedViewOf3D"] = static_cast<bool>(decoded_value.imageSlicedViewOf3D);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12563,6 +13416,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewSlicedC
     {
         const VkImageViewSlicedCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewSlicedCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["sliceOffset"], decoded_value.sliceOffset, options);
         FieldToJson(jdata["sliceCount"], decoded_value.sliceCount, options);
@@ -12576,6 +13430,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["descriptorSetHostMapping"] = static_cast<bool>(decoded_value.descriptorSetHostMapping);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12588,6 +13443,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetBin
     {
         const VkDescriptorSetBindingReferenceVALVE& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetBindingReferenceVALVE& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["descriptorSetLayout"], meta_struct.descriptorSetLayout, options);
         FieldToJson(jdata["binding"], decoded_value.binding, options);
@@ -12601,6 +13457,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDescriptorSetLay
     {
         const VkDescriptorSetLayoutHostMappingInfoVALVE& decoded_value = *data->decoded_value;
         const Decoded_VkDescriptorSetLayoutHostMappingInfoVALVE& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["descriptorOffset"], decoded_value.descriptorOffset, options);
         FieldToJson(jdata["descriptorSize"], decoded_value.descriptorSize, options);
@@ -12614,6 +13471,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDepthClampZeroOneFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDepthClampZeroOneFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["depthClampZeroOne"] = static_cast<bool>(decoded_value.depthClampZeroOne);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12626,6 +13484,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceNo
     {
         const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["nonSeamlessCubeMap"] = static_cast<bool>(decoded_value.nonSeamlessCubeMap);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12638,6 +13497,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["fragmentDensityMapOffset"] = static_cast<bool>(decoded_value.fragmentDensityMapOffset);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12650,6 +13510,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceFr
     {
         const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["fragmentDensityOffsetGranularity"], meta_struct.fragmentDensityOffsetGranularity, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12662,6 +13523,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSubpassFragmentD
     {
         const VkSubpassFragmentDensityMapOffsetEndInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkSubpassFragmentDensityMapOffsetEndInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["fragmentDensityOffsetCount"], decoded_value.fragmentDensityOffsetCount, options);
         FieldToJson(jdata["pFragmentDensityOffsets"], meta_struct.pFragmentDensityOffsets, options);
@@ -12675,6 +13537,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["deviceGeneratedCompute"] = static_cast<bool>(decoded_value.deviceGeneratedCompute);
         jdata["deviceGeneratedComputePipelines"] = static_cast<bool>(decoded_value.deviceGeneratedComputePipelines);
@@ -12689,6 +13552,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkComputePipelineI
     {
         const VkComputePipelineIndirectBufferInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkComputePipelineIndirectBufferInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["deviceAddress"], to_hex_variable_width(decoded_value.deviceAddress), options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -12703,6 +13567,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineIndirect
     {
         const VkPipelineIndirectDeviceAddressInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineIndirectDeviceAddressInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pipelineBindPoint"], decoded_value.pipelineBindPoint, options);
         HandleToJson(jdata["pipeline"], meta_struct.pipeline, options);
@@ -12716,6 +13581,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindPipelineIndi
     {
         const VkBindPipelineIndirectCommandNV& decoded_value = *data->decoded_value;
         const Decoded_VkBindPipelineIndirectCommandNV& meta_struct = *data;
+
         FieldToJson(jdata["pipelineAddress"], to_hex_variable_width(decoded_value.pipelineAddress), options);
     }
 }
@@ -12726,6 +13592,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceLi
     {
         const VkPhysicalDeviceLinearColorAttachmentFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceLinearColorAttachmentFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["linearColorAttachment"] = static_cast<bool>(decoded_value.linearColorAttachment);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12738,6 +13605,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["imageCompressionControlSwapchain"] = static_cast<bool>(decoded_value.imageCompressionControlSwapchain);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12750,6 +13618,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkImageViewSampleW
     {
         const VkImageViewSampleWeightCreateInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkImageViewSampleWeightCreateInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["filterCenter"], meta_struct.filterCenter, options);
         FieldToJson(jdata["filterSize"], meta_struct.filterSize, options);
@@ -12764,6 +13633,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageProcessingFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageProcessingFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["textureSampleWeighted"] = static_cast<bool>(decoded_value.textureSampleWeighted);
         jdata["textureBoxFilter"] = static_cast<bool>(decoded_value.textureBoxFilter);
@@ -12778,6 +13648,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageProcessingPropertiesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageProcessingPropertiesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxWeightFilterPhases"], decoded_value.maxWeightFilterPhases, options);
         FieldToJson(jdata["maxWeightFilterDimension"], meta_struct.maxWeightFilterDimension, options);
@@ -12793,6 +13664,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceNe
     {
         const VkPhysicalDeviceNestedCommandBufferFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceNestedCommandBufferFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["nestedCommandBuffer"] = static_cast<bool>(decoded_value.nestedCommandBuffer);
         jdata["nestedCommandBufferRendering"] = static_cast<bool>(decoded_value.nestedCommandBufferRendering);
@@ -12807,6 +13679,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceNe
     {
         const VkPhysicalDeviceNestedCommandBufferPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceNestedCommandBufferPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxCommandBufferNestingLevel"], decoded_value.maxCommandBufferNestingLevel, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12819,6 +13692,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkExternalMemoryAc
     {
         const VkExternalMemoryAcquireUnmodifiedEXT& decoded_value = *data->decoded_value;
         const Decoded_VkExternalMemoryAcquireUnmodifiedEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["acquireUnmodifiedMemory"] = static_cast<bool>(decoded_value.acquireUnmodifiedMemory);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12831,6 +13705,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExtendedDynamicState3FeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["extendedDynamicState3TessellationDomainOrigin"] = static_cast<bool>(decoded_value.extendedDynamicState3TessellationDomainOrigin);
         jdata["extendedDynamicState3DepthClampEnable"] = static_cast<bool>(decoded_value.extendedDynamicState3DepthClampEnable);
@@ -12873,6 +13748,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExtendedDynamicState3PropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExtendedDynamicState3PropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["dynamicPrimitiveTopologyUnrestricted"] = static_cast<bool>(decoded_value.dynamicPrimitiveTopologyUnrestricted);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12885,6 +13761,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkColorBlendEquati
     {
         const VkColorBlendEquationEXT& decoded_value = *data->decoded_value;
         const Decoded_VkColorBlendEquationEXT& meta_struct = *data;
+
         FieldToJson(jdata["srcColorBlendFactor"], decoded_value.srcColorBlendFactor, options);
         FieldToJson(jdata["dstColorBlendFactor"], decoded_value.dstColorBlendFactor, options);
         FieldToJson(jdata["colorBlendOp"], decoded_value.colorBlendOp, options);
@@ -12900,6 +13777,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkColorBlendAdvanc
     {
         const VkColorBlendAdvancedEXT& decoded_value = *data->decoded_value;
         const Decoded_VkColorBlendAdvancedEXT& meta_struct = *data;
+
         FieldToJson(jdata["advancedBlendOp"], decoded_value.advancedBlendOp, options);
         jdata["srcPremultiplied"] = static_cast<bool>(decoded_value.srcPremultiplied);
         jdata["dstPremultiplied"] = static_cast<bool>(decoded_value.dstPremultiplied);
@@ -12914,6 +13792,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSu
     {
         const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["subpassMergeFeedback"] = static_cast<bool>(decoded_value.subpassMergeFeedback);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12926,6 +13805,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassCreati
     {
         const VkRenderPassCreationControlEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassCreationControlEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["disallowMerging"] = static_cast<bool>(decoded_value.disallowMerging);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12938,6 +13818,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassCreati
     {
         const VkRenderPassCreationFeedbackInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassCreationFeedbackInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["postMergeSubpassCount"], decoded_value.postMergeSubpassCount, options);
     }
 }
@@ -12948,6 +13829,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassCreati
     {
         const VkRenderPassCreationFeedbackCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassCreationFeedbackCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pRenderPassFeedback"], meta_struct.pRenderPassFeedback, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12960,6 +13842,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassSubpas
     {
         const VkRenderPassSubpassFeedbackInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassSubpassFeedbackInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["subpassMergeStatus"], decoded_value.subpassMergeStatus, options);
         FieldToJson(jdata["description"], &meta_struct.description, options);
         FieldToJson(jdata["postMergeIndex"], decoded_value.postMergeIndex, options);
@@ -12972,6 +13855,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRenderPassSubpas
     {
         const VkRenderPassSubpassFeedbackCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkRenderPassSubpassFeedbackCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pSubpassFeedback"], meta_struct.pSubpassFeedback, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -12984,6 +13868,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDirectDriverLoad
     {
         const VkDirectDriverLoadingInfoLUNARG& decoded_value = *data->decoded_value;
         const Decoded_VkDirectDriverLoadingInfoLUNARG& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkDirectDriverLoadingFlagsLUNARG_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["pfnGetInstanceProcAddr"], to_hex_variable_width(meta_struct.pfnGetInstanceProcAddr), options);
@@ -12997,6 +13882,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDirectDriverLoad
     {
         const VkDirectDriverLoadingListLUNARG& decoded_value = *data->decoded_value;
         const Decoded_VkDirectDriverLoadingListLUNARG& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["mode"], decoded_value.mode, options);
         FieldToJson(jdata["driverCount"], decoded_value.driverCount, options);
@@ -13011,6 +13897,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderModuleIdentifier"] = static_cast<bool>(decoded_value.shaderModuleIdentifier);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13023,6 +13910,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shaderModuleIdentifierAlgorithmUUID"], uuid_to_string(sizeof(decoded_value.shaderModuleIdentifierAlgorithmUUID), decoded_value.shaderModuleIdentifierAlgorithmUUID), options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13035,6 +13923,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPipelineShaderSt
     {
         const VkPipelineShaderStageModuleIdentifierCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPipelineShaderStageModuleIdentifierCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["identifierSize"], decoded_value.identifierSize, options);
         FieldToJson(jdata["pIdentifier"], meta_struct.pIdentifier, options);
@@ -13048,6 +13937,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkShaderModuleIden
     {
         const VkShaderModuleIdentifierEXT& decoded_value = *data->decoded_value;
         const Decoded_VkShaderModuleIdentifierEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["identifierSize"], decoded_value.identifierSize, options);
         FieldToJson(jdata["identifier"], &meta_struct.identifier, options);
@@ -13061,6 +13951,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceOp
     {
         const VkPhysicalDeviceOpticalFlowFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceOpticalFlowFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["opticalFlow"] = static_cast<bool>(decoded_value.opticalFlow);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13073,6 +13964,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceOp
     {
         const VkPhysicalDeviceOpticalFlowPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceOpticalFlowPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkOpticalFlowGridSizeFlagsNV_t(),jdata["supportedOutputGridSizes"], decoded_value.supportedOutputGridSizes, options);
         FieldToJson(VkOpticalFlowGridSizeFlagsNV_t(),jdata["supportedHintGridSizes"], decoded_value.supportedHintGridSizes, options);
@@ -13095,6 +13987,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkOpticalFlowImage
     {
         const VkOpticalFlowImageFormatInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkOpticalFlowImageFormatInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkOpticalFlowUsageFlagsNV_t(),jdata["usage"], decoded_value.usage, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13107,6 +14000,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkOpticalFlowImage
     {
         const VkOpticalFlowImageFormatPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkOpticalFlowImageFormatPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["format"], decoded_value.format, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13119,6 +14013,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkOpticalFlowSessi
     {
         const VkOpticalFlowSessionCreateInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkOpticalFlowSessionCreateInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["width"], decoded_value.width, options);
         FieldToJson(jdata["height"], decoded_value.height, options);
@@ -13139,6 +14034,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkOpticalFlowSessi
     {
         const VkOpticalFlowSessionCreatePrivateDataInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkOpticalFlowSessionCreatePrivateDataInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["id"], decoded_value.id, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -13153,6 +14049,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkOpticalFlowExecu
     {
         const VkOpticalFlowExecuteInfoNV& decoded_value = *data->decoded_value;
         const Decoded_VkOpticalFlowExecuteInfoNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkOpticalFlowExecuteFlagsNV_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["regionCount"], decoded_value.regionCount, options);
@@ -13167,6 +14064,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceLe
     {
         const VkPhysicalDeviceLegacyDitheringFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceLegacyDitheringFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["legacyDithering"] = static_cast<bool>(decoded_value.legacyDithering);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13179,6 +14077,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePi
     {
         const VkPhysicalDevicePipelineProtectedAccessFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePipelineProtectedAccessFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["pipelineProtectedAccess"] = static_cast<bool>(decoded_value.pipelineProtectedAccess);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13191,6 +14090,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalFormatResolveFeaturesANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["externalFormatResolve"] = static_cast<bool>(decoded_value.externalFormatResolve);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13203,6 +14103,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExternalFormatResolvePropertiesANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExternalFormatResolvePropertiesANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["nullColorAttachmentWithExternalFormatResolve"] = static_cast<bool>(decoded_value.nullColorAttachmentWithExternalFormatResolve);
         FieldToJson(jdata["externalFormatResolveChromaOffsetX"], decoded_value.externalFormatResolveChromaOffsetX, options);
@@ -13217,6 +14118,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAndroidHardwareB
     {
         const VkAndroidHardwareBufferFormatResolvePropertiesANDROID& decoded_value = *data->decoded_value;
         const Decoded_VkAndroidHardwareBufferFormatResolvePropertiesANDROID& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["colorAttachmentFormat"], decoded_value.colorAttachmentFormat, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13229,6 +14131,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderObjectFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderObjectFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderObject"] = static_cast<bool>(decoded_value.shaderObject);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13241,6 +14144,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderObjectPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderObjectPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shaderBinaryUUID"], uuid_to_string(sizeof(decoded_value.shaderBinaryUUID), decoded_value.shaderBinaryUUID), options);
         FieldToJson(jdata["shaderBinaryVersion"], decoded_value.shaderBinaryVersion, options);
@@ -13254,6 +14158,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkShaderCreateInfo
     {
         const VkShaderCreateInfoEXT& decoded_value = *data->decoded_value;
         const Decoded_VkShaderCreateInfoEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkShaderCreateFlagsEXT_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["stage"], decoded_value.stage, options);
@@ -13277,6 +14182,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceTi
     {
         const VkPhysicalDeviceTilePropertiesFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceTilePropertiesFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["tileProperties"] = static_cast<bool>(decoded_value.tileProperties);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13289,6 +14195,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkTilePropertiesQC
     {
         const VkTilePropertiesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkTilePropertiesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["tileSize"], meta_struct.tileSize, options);
         FieldToJson(jdata["apronSize"], meta_struct.apronSize, options);
@@ -13303,6 +14210,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceAm
     {
         const VkPhysicalDeviceAmigoProfilingFeaturesSEC& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceAmigoProfilingFeaturesSEC& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["amigoProfiling"] = static_cast<bool>(decoded_value.amigoProfiling);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13315,6 +14223,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAmigoProfilingSu
     {
         const VkAmigoProfilingSubmitInfoSEC& decoded_value = *data->decoded_value;
         const Decoded_VkAmigoProfilingSubmitInfoSEC& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["firstDrawTimestamp"], decoded_value.firstDrawTimestamp, options);
         FieldToJson(jdata["swapBufferTimestamp"], decoded_value.swapBufferTimestamp, options);
@@ -13328,6 +14237,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["multiviewPerViewViewports"] = static_cast<bool>(decoded_value.multiviewPerViewViewports);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13340,6 +14250,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["rayTracingInvocationReorderReorderingHint"], decoded_value.rayTracingInvocationReorderReorderingHint, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13352,6 +14263,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rayTracingInvocationReorder"] = static_cast<bool>(decoded_value.rayTracingInvocationReorder);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13364,6 +14276,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["extendedSparseAddressSpace"] = static_cast<bool>(decoded_value.extendedSparseAddressSpace);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13376,6 +14289,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceEx
     {
         const VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["extendedSparseAddressSpaceSize"], decoded_value.extendedSparseAddressSpaceSize, options);
         FieldToJson(VkImageUsageFlags_t(),jdata["extendedSparseImageUsageFlags"], decoded_value.extendedSparseImageUsageFlags, options);
@@ -13390,6 +14304,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["shaderCoreBuiltins"] = static_cast<bool>(decoded_value.shaderCoreBuiltins);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13402,6 +14317,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceSh
     {
         const VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shaderCoreMask"], decoded_value.shaderCoreMask, options);
         FieldToJson(jdata["shaderCoreCount"], decoded_value.shaderCoreCount, options);
@@ -13416,6 +14332,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDevicePi
     {
         const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["pipelineLibraryGroupHandles"] = static_cast<bool>(decoded_value.pipelineLibraryGroupHandles);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13428,6 +14345,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDy
     {
         const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["dynamicRenderingUnusedAttachments"] = static_cast<bool>(decoded_value.dynamicRenderingUnusedAttachments);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13440,6 +14358,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMu
     {
         const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["multiviewPerViewRenderAreas"] = static_cast<bool>(decoded_value.multiviewPerViewRenderAreas);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13452,6 +14371,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkMultiviewPerView
     {
         const VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["perViewRenderAreaCount"], decoded_value.perViewRenderAreaCount, options);
         FieldToJson(jdata["pPerViewRenderAreas"], meta_struct.pPerViewRenderAreas, options);
@@ -13465,6 +14385,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageProcessing2FeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageProcessing2FeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["textureBlockMatch2"] = static_cast<bool>(decoded_value.textureBlockMatch2);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13477,6 +14398,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceIm
     {
         const VkPhysicalDeviceImageProcessing2PropertiesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceImageProcessing2PropertiesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxBlockMatchWindow"], meta_struct.maxBlockMatchWindow, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13489,6 +14411,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerBlockMatc
     {
         const VkSamplerBlockMatchWindowCreateInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerBlockMatchWindowCreateInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["windowExtent"], meta_struct.windowExtent, options);
         FieldToJson(jdata["windowCompareMode"], decoded_value.windowCompareMode, options);
@@ -13502,6 +14425,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCu
     {
         const VkPhysicalDeviceCubicWeightsFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCubicWeightsFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["selectableCubicWeights"] = static_cast<bool>(decoded_value.selectableCubicWeights);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13514,6 +14438,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerCubicWeig
     {
         const VkSamplerCubicWeightsCreateInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerCubicWeightsCreateInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["cubicWeights"], decoded_value.cubicWeights, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13526,6 +14451,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBlitImageCubicWe
     {
         const VkBlitImageCubicWeightsInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkBlitImageCubicWeightsInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["cubicWeights"], decoded_value.cubicWeights, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13538,6 +14464,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceYc
     {
         const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceYcbcrDegammaFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["ycbcrDegamma"] = static_cast<bool>(decoded_value.ycbcrDegamma);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13550,6 +14477,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSamplerYcbcrConv
     {
         const VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["enableYDegamma"] = static_cast<bool>(decoded_value.enableYDegamma);
         jdata["enableCbCrDegamma"] = static_cast<bool>(decoded_value.enableCbCrDegamma);
@@ -13563,6 +14491,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceCu
     {
         const VkPhysicalDeviceCubicClampFeaturesQCOM& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceCubicClampFeaturesQCOM& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["cubicRangeClamp"] = static_cast<bool>(decoded_value.cubicRangeClamp);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13575,6 +14504,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceAt
     {
         const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["attachmentFeedbackLoopDynamicState"] = static_cast<bool>(decoded_value.attachmentFeedbackLoopDynamicState);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13587,6 +14517,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceLa
     {
         const VkPhysicalDeviceLayeredDriverPropertiesMSFT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceLayeredDriverPropertiesMSFT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["underlyingAPI"], decoded_value.underlyingAPI, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13599,6 +14530,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceDe
     {
         const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["descriptorPoolOverallocation"] = static_cast<bool>(decoded_value.descriptorPoolOverallocation);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13611,6 +14543,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureBuildRangeInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureBuildRangeInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["primitiveCount"], decoded_value.primitiveCount, options);
         FieldToJson(jdata["primitiveOffset"], decoded_value.primitiveOffset, options);
         FieldToJson(jdata["firstVertex"], decoded_value.firstVertex, options);
@@ -13624,6 +14557,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureGeometryTrianglesDataKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureGeometryTrianglesDataKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["vertexFormat"], decoded_value.vertexFormat, options);
         FieldToJson(jdata["vertexData"], meta_struct.vertexData, options);
@@ -13642,6 +14576,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureGeometryAabbsDataKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureGeometryAabbsDataKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["data"], meta_struct.data, options);
         FieldToJson(jdata["stride"], decoded_value.stride, options);
@@ -13655,6 +14590,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureGeometryInstancesDataKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureGeometryInstancesDataKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["arrayOfPointers"] = static_cast<bool>(decoded_value.arrayOfPointers);
         FieldToJson(jdata["data"], meta_struct.data, options);
@@ -13668,6 +14604,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureBuildGeometryInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureBuildGeometryInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         FieldToJson(VkBuildAccelerationStructureFlagsKHR_t(),jdata["flags"], decoded_value.flags, options);
@@ -13688,6 +14625,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkAccelerationStructureCreateFlagsKHR_t(),jdata["createFlags"], decoded_value.createFlags, options);
         HandleToJson(jdata["buffer"], meta_struct.buffer, options);
@@ -13705,6 +14643,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWriteDescriptorS
     {
         const VkWriteDescriptorSetAccelerationStructureKHR& decoded_value = *data->decoded_value;
         const Decoded_VkWriteDescriptorSetAccelerationStructureKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["accelerationStructureCount"], decoded_value.accelerationStructureCount, options);
         HandleToJson(jdata["pAccelerationStructures"], &meta_struct.pAccelerationStructures, options);
@@ -13718,6 +14657,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceAc
     {
         const VkPhysicalDeviceAccelerationStructureFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceAccelerationStructureFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["accelerationStructure"] = static_cast<bool>(decoded_value.accelerationStructure);
         jdata["accelerationStructureCaptureReplay"] = static_cast<bool>(decoded_value.accelerationStructureCaptureReplay);
@@ -13734,6 +14674,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceAc
     {
         const VkPhysicalDeviceAccelerationStructurePropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceAccelerationStructurePropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxGeometryCount"], decoded_value.maxGeometryCount, options);
         FieldToJson(jdata["maxInstanceCount"], decoded_value.maxInstanceCount, options);
@@ -13753,6 +14694,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureDeviceAddressInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureDeviceAddressInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["accelerationStructure"], meta_struct.accelerationStructure, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13765,6 +14707,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureVersionInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureVersionInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["pVersionData"], meta_struct.pVersionData, options);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13777,6 +14720,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyAcceleration
     {
         const VkCopyAccelerationStructureToMemoryInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkCopyAccelerationStructureToMemoryInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["src"], meta_struct.src, options);
         FieldToJson(jdata["dst"], meta_struct.dst, options);
@@ -13791,6 +14735,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyMemoryToAcce
     {
         const VkCopyMemoryToAccelerationStructureInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkCopyMemoryToAccelerationStructureInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["src"], meta_struct.src, options);
         HandleToJson(jdata["dst"], meta_struct.dst, options);
@@ -13805,6 +14750,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkCopyAcceleration
     {
         const VkCopyAccelerationStructureInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkCopyAccelerationStructureInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         HandleToJson(jdata["src"], meta_struct.src, options);
         HandleToJson(jdata["dst"], meta_struct.dst, options);
@@ -13819,6 +14765,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkAccelerationStru
     {
         const VkAccelerationStructureBuildSizesInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkAccelerationStructureBuildSizesInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["accelerationStructureSize"], decoded_value.accelerationStructureSize, options);
         FieldToJson(jdata["updateScratchSize"], decoded_value.updateScratchSize, options);
@@ -13833,6 +14780,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRayTracingShader
     {
         const VkRayTracingShaderGroupCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkRayTracingShaderGroupCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["type"], decoded_value.type, options);
         FieldToJson(jdata["generalShader"], decoded_value.generalShader, options);
@@ -13850,6 +14798,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRayTracingPipeli
     {
         const VkRayTracingPipelineInterfaceCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkRayTracingPipelineInterfaceCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxPipelineRayPayloadSize"], decoded_value.maxPipelineRayPayloadSize, options);
         FieldToJson(jdata["maxPipelineRayHitAttributeSize"], decoded_value.maxPipelineRayHitAttributeSize, options);
@@ -13863,6 +14812,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkRayTracingPipeli
     {
         const VkRayTracingPipelineCreateInfoKHR& decoded_value = *data->decoded_value;
         const Decoded_VkRayTracingPipelineCreateInfoKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(VkPipelineCreateFlags_t(),jdata["flags"], decoded_value.flags, options);
         FieldToJson(jdata["stageCount"], decoded_value.stageCount, options);
@@ -13886,6 +14836,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingPipelineFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingPipelineFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rayTracingPipeline"] = static_cast<bool>(decoded_value.rayTracingPipeline);
         jdata["rayTracingPipelineShaderGroupHandleCaptureReplay"] = static_cast<bool>(decoded_value.rayTracingPipelineShaderGroupHandleCaptureReplay);
@@ -13902,6 +14853,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayTracingPipelinePropertiesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayTracingPipelinePropertiesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["shaderGroupHandleSize"], decoded_value.shaderGroupHandleSize, options);
         FieldToJson(jdata["maxRayRecursionDepth"], decoded_value.maxRayRecursionDepth, options);
@@ -13921,6 +14873,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkStridedDeviceAdd
     {
         const VkStridedDeviceAddressRegionKHR& decoded_value = *data->decoded_value;
         const Decoded_VkStridedDeviceAddressRegionKHR& meta_struct = *data;
+
         FieldToJson(jdata["deviceAddress"], to_hex_variable_width(decoded_value.deviceAddress), options);
         FieldToJson(jdata["stride"], decoded_value.stride, options);
         FieldToJson(jdata["size"], decoded_value.size, options);
@@ -13933,6 +14886,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkTraceRaysIndirec
     {
         const VkTraceRaysIndirectCommandKHR& decoded_value = *data->decoded_value;
         const Decoded_VkTraceRaysIndirectCommandKHR& meta_struct = *data;
+
         FieldToJson(jdata["width"], decoded_value.width, options);
         FieldToJson(jdata["height"], decoded_value.height, options);
         FieldToJson(jdata["depth"], decoded_value.depth, options);
@@ -13945,6 +14899,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
     {
         const VkPhysicalDeviceRayQueryFeaturesKHR& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceRayQueryFeaturesKHR& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["rayQuery"] = static_cast<bool>(decoded_value.rayQuery);
         FieldToJson(jdata["pNext"], meta_struct.pNext, options);
@@ -13957,6 +14912,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMeshShaderFeaturesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMeshShaderFeaturesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         jdata["taskShader"] = static_cast<bool>(decoded_value.taskShader);
         jdata["meshShader"] = static_cast<bool>(decoded_value.meshShader);
@@ -13973,6 +14929,7 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMe
     {
         const VkPhysicalDeviceMeshShaderPropertiesEXT& decoded_value = *data->decoded_value;
         const Decoded_VkPhysicalDeviceMeshShaderPropertiesEXT& meta_struct = *data;
+
         FieldToJson(jdata["sType"], decoded_value.sType, options);
         FieldToJson(jdata["maxTaskWorkGroupTotalCount"], decoded_value.maxTaskWorkGroupTotalCount, options);
         FieldToJson(jdata["maxTaskWorkGroupCount"], &meta_struct.maxTaskWorkGroupCount, options);
@@ -14012,12 +14969,12 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrawMeshTasksInd
     {
         const VkDrawMeshTasksIndirectCommandEXT& decoded_value = *data->decoded_value;
         const Decoded_VkDrawMeshTasksIndirectCommandEXT& meta_struct = *data;
+
         FieldToJson(jdata["groupCountX"], decoded_value.groupCountX, options);
         FieldToJson(jdata["groupCountY"], decoded_value.groupCountY, options);
         FieldToJson(jdata["groupCountZ"], decoded_value.groupCountZ, options);
     }
 }
-
 
 void FieldToJson(nlohmann::ordered_json& jdata, const PNextNode* data, const JsonOptions& options)
 {
@@ -14026,3496 +14983,3499 @@ void FieldToJson(nlohmann::ordered_json& jdata, const PNextNode* data, const Jso
         const auto s_type = reinterpret_cast<const VkBaseInStructure*>(data->GetPointer())->sType;
         switch (s_type)
         {
-
             case VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkShaderModuleCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkShaderModuleCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubgroupProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubgroupProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevice16BitStorageFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevice16BitStorageFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMemoryDedicatedRequirements*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMemoryDedicatedRequirements*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMemoryDedicatedAllocateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMemoryDedicatedAllocateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMemoryAllocateFlagsInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMemoryAllocateFlagsInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupRenderPassBeginInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupRenderPassBeginInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupCommandBufferBeginInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupCommandBufferBeginInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupSubmitInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupSubmitInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupBindSparseInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupBindSparseInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBindBufferMemoryDeviceGroupInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBindBufferMemoryDeviceGroupInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBindImageMemoryDeviceGroupInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBindImageMemoryDeviceGroupInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupDeviceCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupDeviceCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFeatures2*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFeatures2*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePointClippingProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePointClippingProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassInputAttachmentAspectCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassInputAttachmentAspectCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageViewUsageCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageViewUsageCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineTessellationDomainOriginStateCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineTessellationDomainOriginStateCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassMultiviewCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassMultiviewCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVariablePointersFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVariablePointersFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProtectedMemoryFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProtectedMemoryFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProtectedMemoryProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProtectedMemoryProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkProtectedSubmitInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkProtectedSubmitInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerYcbcrConversionInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerYcbcrConversionInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBindImagePlaneMemoryInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBindImagePlaneMemoryInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImagePlaneMemoryRequirementsInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImagePlaneMemoryRequirementsInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerYcbcrConversionImageFormatProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerYcbcrConversionImageFormatProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalImageFormatInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalImageFormatInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExternalImageFormatProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExternalImageFormatProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceIDProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceIDProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryImageCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryImageCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryBufferCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryBufferCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryAllocateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryAllocateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportFenceCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportFenceCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportSemaphoreCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportSemaphoreCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance3Properties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance3Properties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderDrawParametersFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderDrawParametersFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan11Features*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan11Features*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan11Properties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan11Properties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan12Features*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan12Features*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan12Properties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan12Properties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageFormatListCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageFormatListCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevice8BitStorageFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevice8BitStorageFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDriverProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDriverProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderAtomicInt64Features*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderAtomicInt64Features*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderFloat16Int8Features*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderFloat16Int8Features*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFloatControlsProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFloatControlsProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorIndexingFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorIndexingFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorIndexingProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorIndexingProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupport*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupport*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSubpassDescriptionDepthStencilResolve*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSubpassDescriptionDepthStencilResolve*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthStencilResolveProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthStencilResolveProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageStencilUsageCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageStencilUsageCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerReductionModeCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerReductionModeCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSamplerFilterMinmaxProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSamplerFilterMinmaxProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkanMemoryModelFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkanMemoryModelFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImagelessFramebufferFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImagelessFramebufferFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkFramebufferAttachmentsCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkFramebufferAttachmentsCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassAttachmentBeginInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassAttachmentBeginInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAttachmentReferenceStencilLayout*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAttachmentReferenceStencilLayout*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAttachmentDescriptionStencilLayout*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAttachmentDescriptionStencilLayout*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceHostQueryResetFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceHostQueryResetFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTimelineSemaphoreFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTimelineSemaphoreFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTimelineSemaphoreProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTimelineSemaphoreProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSemaphoreTypeCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSemaphoreTypeCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkTimelineSemaphoreSubmitInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkTimelineSemaphoreSubmitInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBufferDeviceAddressFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBufferDeviceAddressFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBufferOpaqueCaptureAddressCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBufferOpaqueCaptureAddressCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMemoryOpaqueCaptureAddressAllocateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMemoryOpaqueCaptureAddressAllocateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan13Features*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan13Features*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan13Properties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVulkan13Properties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCreationFeedbackCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCreationFeedbackCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderTerminateInvocationFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderTerminateInvocationFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePrivateDataFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePrivateDataFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDevicePrivateDataCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDevicePrivateDataCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineCreationCacheControlFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineCreationCacheControlFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MEMORY_BARRIER_2:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMemoryBarrier2*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMemoryBarrier2*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSynchronization2Features*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSynchronization2Features*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageRobustnessFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageRobustnessFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubgroupSizeControlFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubgroupSizeControlFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubgroupSizeControlProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubgroupSizeControlProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInlineUniformBlockFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInlineUniformBlockFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInlineUniformBlockProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInlineUniformBlockProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkWriteDescriptorSetInlineUniformBlock*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkWriteDescriptorSetInlineUniformBlock*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorPoolInlineUniformBlockCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDescriptorPoolInlineUniformBlockCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRenderingCreateInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRenderingCreateInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDynamicRenderingFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDynamicRenderingFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDERING_INFO:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceRenderingInfo*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceRenderingInfo*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderIntegerDotProductFeatures*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderIntegerDotProductFeatures*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderIntegerDotProductProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderIntegerDotProductProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTexelBufferAlignmentProperties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTexelBufferAlignmentProperties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkFormatProperties3*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkFormatProperties3*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance4Features*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance4Features*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance4Properties*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance4Properties*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageSwapchainCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageSwapchainCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBindImageMemorySwapchainInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBindImageMemorySwapchainInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupPresentInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupPresentInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupSwapchainCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceGroupSwapchainCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDisplayPresentInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDisplayPresentInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUEUE_FAMILY_QUERY_RESULT_STATUS_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyQueryResultStatusPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyQueryResultStatusPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUEUE_FAMILY_VIDEO_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyVideoPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyVideoPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoProfileInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoProfileInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoProfileListInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoProfileListInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeCapabilitiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeCapabilitiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_USAGE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeUsageInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeUsageInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264ProfileInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264ProfileInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264CapabilitiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264CapabilitiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264SessionParametersAddInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264SessionParametersAddInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264SessionParametersCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264SessionParametersCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PICTURE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264PictureInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264PictureInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_DPB_SLOT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264DpbSlotInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH264DpbSlotInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderingFragmentShadingRateAttachmentInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderingFragmentDensityMapAttachmentInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ATTACHMENT_SAMPLE_COUNT_INFO_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAttachmentSampleCountInfoAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAttachmentSampleCountInfoAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_ATTRIBUTES_INFO_NVX:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMultiviewPerViewAttributesInfoNVX*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMultiviewPerViewAttributesInfoNVX*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryWin32HandleInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryWin32HandleInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryWin32HandleInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryWin32HandleInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryFdInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryFdInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportSemaphoreWin32HandleInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportSemaphoreWin32HandleInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkD3D12FenceSubmitInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkD3D12FenceSubmitInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPresentRegionsKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPresentRegionsKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSharedPresentSurfaceCapabilitiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSharedPresentSurfaceCapabilitiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportFenceWin32HandleInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportFenceWin32HandleInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePerformanceQueryFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePerformanceQueryFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePerformanceQueryPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePerformanceQueryPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueryPoolPerformanceCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueryPoolPerformanceCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_SUBMIT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPerformanceQuerySubmitInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPerformanceQuerySubmitInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePortabilitySubsetPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePortabilitySubsetPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderClockFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderClockFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265ProfileInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265ProfileInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265CapabilitiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265CapabilitiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265SessionParametersAddInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265SessionParametersAddInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265SessionParametersCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265SessionParametersCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PICTURE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265PictureInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265PictureInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_DPB_SLOT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265DpbSlotInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoDecodeH265DpbSlotInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceQueueGlobalPriorityCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceQueueGlobalPriorityCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyGlobalPriorityPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyGlobalPriorityPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkFragmentShadingRateAttachmentInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkFragmentShadingRateAttachmentInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceProtectedCapabilitiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceProtectedCapabilitiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePresentWaitFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePresentWaitFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineLibraryCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineLibraryCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PRESENT_ID_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPresentIdKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPresentIdKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePresentIdFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePresentIdFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeCapabilitiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeCapabilitiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueryPoolVideoEncodeFeedbackCreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueryPoolVideoEncodeFeedbackCreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeUsageInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeUsageInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeRateControlInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeRateControlInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeQualityLevelInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeQualityLevelInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyCheckpointProperties2NV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyCheckpointProperties2NV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance5FeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance5FeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance5PropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMaintenance5PropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCreateFlags2CreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCreateFlags2CreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBufferUsageFlags2CreateInfoKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBufferUsageFlags2CreateInfoKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDebugReportCallbackCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDebugReportCallbackCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationStateRasterizationOrderAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationStateRasterizationOrderAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDedicatedAllocationImageCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDedicatedAllocationImageCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDedicatedAllocationBufferCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDedicatedAllocationBufferCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDedicatedAllocationMemoryAllocateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDedicatedAllocationMemoryAllocateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264CapabilitiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264CapabilitiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264QualityLevelPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264QualityLevelPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersAddInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersAddInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersGetInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersGetInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_FEEDBACK_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersFeedbackInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264SessionParametersFeedbackInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264PictureInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264PictureInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264DpbSlotInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264DpbSlotInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264ProfileInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264ProfileInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264RateControlInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264RateControlInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264RateControlLayerInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264RateControlLayerInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264GopRemainingFrameInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH264GopRemainingFrameInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265CapabilitiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265CapabilitiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265QualityLevelPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265QualityLevelPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersAddInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersAddInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_GET_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersGetInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersGetInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_FEEDBACK_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersFeedbackInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265SessionParametersFeedbackInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265PictureInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265PictureInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265DpbSlotInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265DpbSlotInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265ProfileInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265ProfileInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265RateControlInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265RateControlInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265RateControlLayerInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265RateControlLayerInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_GOP_REMAINING_FRAME_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265GopRemainingFrameInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkVideoEncodeH265GopRemainingFrameInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkTextureLODGatherFormatPropertiesAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkTextureLODGatherFormatPropertiesAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryImageCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryImageCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryAllocateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryAllocateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryWin32HandleInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryWin32HandleInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryWin32HandleInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExportMemoryWin32HandleInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkValidationFlagsEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkValidationFlagsEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageViewASTCDecodeModeEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageViewASTCDecodeModeEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineRobustnessFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineRobustnessFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineRobustnessPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineRobustnessPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_ROBUSTNESS_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRobustnessCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRobustnessCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportWScalingStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportWScalingStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainCounterCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainCounterCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPresentTimesInfoGOOGLE*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPresentTimesInfoGOOGLE*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportSwizzleStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportSwizzleStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDebugUtilsObjectNameInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDebugUtilsObjectNameInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDebugUtilsMessengerCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDebugUtilsMessengerCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferUsageANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferUsageANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImportAndroidHardwareBufferInfoANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImportAndroidHardwareBufferInfoANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExternalFormatANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExternalFormatANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferFormatProperties2ANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferFormatProperties2ANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSampleLocationsInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSampleLocationsInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassSampleLocationsBeginInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassSampleLocationsBeginInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineSampleLocationsStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineSampleLocationsStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCoverageToColorStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCoverageToColorStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCoverageModulationStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCoverageModulationStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDrmFormatModifierPropertiesListEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDrmFormatModifierPropertiesListEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageDrmFormatModifierListCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageDrmFormatModifierListCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDrmFormatModifierPropertiesList2EXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDrmFormatModifierPropertiesList2EXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkShaderModuleValidationCacheCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkShaderModuleValidationCacheCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkWriteDescriptorSetAccelerationStructureNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkWriteDescriptorSetAccelerationStructureNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryHostPointerInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryHostPointerInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCompilerControlCreateInfoAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCompilerControlCreateInfoAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCorePropertiesAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCorePropertiesAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceMemoryOverallocationCreateInfoAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceMemoryOverallocationCreateInfoAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPresentFrameTokenGGP*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPresentFrameTokenGGP*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyCheckpointPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueueFamilyCheckpointPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueryPoolPerformanceQueryCreateInfoINTEL*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueryPoolPerformanceQueryCreateInfoINTEL*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDisplayNativeHdrSurfaceCapabilitiesAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDisplayNativeHdrSurfaceCapabilitiesAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainDisplayNativeHdrCreateInfoAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainDisplayNativeHdrCreateInfoAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCoreProperties2AMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCoreProperties2AMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMemoryPriorityAllocateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMemoryPriorityAllocateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBufferDeviceAddressCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBufferDeviceAddressCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkValidationFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkValidationFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCoverageReductionStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineCoverageReductionStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProvokingVertexFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProvokingVertexFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProvokingVertexPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceProvokingVertexPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationProvokingVertexStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceFullScreenExclusiveInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceFullScreenExclusiveInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceCapabilitiesFullScreenExclusiveEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceCapabilitiesFullScreenExclusiveEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceFullScreenExclusiveWin32InfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceFullScreenExclusiveWin32InfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLineRasterizationFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLineRasterizationFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLineRasterizationPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLineRasterizationPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationLineStateCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineRasterizationLineStateCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceIndexTypeUint8FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceIndexTypeUint8FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceHostImageCopyFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceHostImageCopyFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceHostImageCopyPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceHostImageCopyPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSubresourceHostMemcpySizeEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSubresourceHostMemcpySizeEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkHostImageCopyDevicePerformanceQueryEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkHostImageCopyDevicePerformanceQueryEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfacePresentModeEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfacePresentModeEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfacePresentScalingCapabilitiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfacePresentScalingCapabilitiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfacePresentModeCompatibilityEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfacePresentModeCompatibilityEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentFenceInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentFenceInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentModesCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentModesCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentModeInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentModeInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_SCALING_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentScalingCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentScalingCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_SHADER_GROUPS_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceViewportScissorInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceViewportScissorInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassTransformBeginInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassTransformBeginInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDepthBiasRepresentationInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDepthBiasRepresentationInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceDeviceMemoryReportCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceDeviceMemoryReportCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRobustness2FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRobustness2FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRobustness2PropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRobustness2PropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerCustomBorderColorCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerCustomBorderColorCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCustomBorderColorPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCustomBorderColorPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePresentBarrierFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePresentBarrierFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_BARRIER_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceCapabilitiesPresentBarrierNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSurfaceCapabilitiesPresentBarrierNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_BARRIER_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentBarrierCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSwapchainPresentBarrierCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceDiagnosticsConfigCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceDiagnosticsConfigCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_QUERY_LOW_LATENCY_SUPPORT_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkQueryLowLatencySupportNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkQueryLowLatencySupportNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkGraphicsPipelineLibraryCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkGraphicsPipelineLibraryCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineFragmentShadingRateEnumStateCreateInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineFragmentShadingRateEnumStateCreateInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MOTION_TRIANGLES_DATA_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureGeometryMotionTrianglesDataNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureGeometryMotionTrianglesDataNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MOTION_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureMotionInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureMotionInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_COPY_COMMAND_TRANSFORM_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkCopyCommandTransformInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkCopyCommandTransformInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageCompressionControlEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageCompressionControlEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageCompressionPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageCompressionPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevice4444FormatsFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevice4444FormatsFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFaultFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFaultFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MUTABLE_DESCRIPTOR_TYPE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMutableDescriptorTypeCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMutableDescriptorTypeCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDrmPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDrmPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DEVICE_ADDRESS_BINDING_CALLBACK_DATA_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDeviceAddressBindingCallbackDataEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDeviceAddressBindingCallbackDataEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthClipControlFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthClipControlFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportDepthClipControlCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineViewportDepthClipControlCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryZirconHandleInfoFUCHSIA*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImportMemoryZirconHandleInfoFUCHSIA*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkFrameBoundaryEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkFrameBoundaryEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SUBPASS_RESOLVE_PERFORMANCE_QUERY_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSubpassResolvePerformanceQueryEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSubpassResolvePerformanceQueryEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMultisampledRenderToSingleSampledInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMultisampledRenderToSingleSampledInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_COLOR_WRITE_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineColorWriteCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineColorWriteCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageViewMinLodCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageViewMinLodCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiDrawFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiDrawFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiDrawPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiDrawPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderTileImageFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderTileImageFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderTileImagePropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderTileImagePropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpacityMicromapPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpacityMicromapPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureTrianglesOpacityMicromapEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDisplacementMicromapPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDisplacementMicromapPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureTrianglesDisplacementMicromapNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAccelerationStructureTrianglesDisplacementMicromapNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerBorderColorComponentMappingCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerBorderColorComponentMappingCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCorePropertiesARM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCorePropertiesARM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageViewSlicedCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageViewSlicedCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthClampZeroOneFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDepthClampZeroOneFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_PROPERTIES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SUBPASS_FRAGMENT_DENSITY_MAP_OFFSET_END_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSubpassFragmentDensityMapOffsetEndInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSubpassFragmentDensityMapOffsetEndInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_IMAGE_VIEW_SAMPLE_WEIGHT_CREATE_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkImageViewSampleWeightCreateInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkImageViewSampleWeightCreateInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessingFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessingFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_PROPERTIES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessingPropertiesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessingPropertiesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceNestedCommandBufferPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceNestedCommandBufferPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryAcquireUnmodifiedEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkExternalMemoryAcquireUnmodifiedEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicState3PropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedDynamicState3PropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_CONTROL_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassCreationControlEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassCreationControlEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_FEEDBACK_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassCreationFeedbackCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassCreationFeedbackCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_RENDER_PASS_SUBPASS_FEEDBACK_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassSubpassFeedbackCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkRenderPassSubpassFeedbackCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkDirectDriverLoadingListLUNARG*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkDirectDriverLoadingListLUNARG*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPipelineShaderStageModuleIdentifierCreateInfoEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPipelineShaderStageModuleIdentifierCreateInfoEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpticalFlowFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpticalFlowFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpticalFlowPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceOpticalFlowPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkOpticalFlowImageFormatInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkOpticalFlowImageFormatInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_OPTICAL_FLOW_SESSION_CREATE_PRIVATE_DATA_INFO_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkOpticalFlowSessionCreatePrivateDataInfoNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkOpticalFlowSessionCreatePrivateDataInfoNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineProtectedAccessFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineProtectedAccessFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_PROPERTIES_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalFormatResolvePropertiesANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExternalFormatResolvePropertiesANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_RESOLVE_PROPERTIES_ANDROID:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferFormatResolvePropertiesANDROID*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAndroidHardwareBufferFormatResolvePropertiesANDROID*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderObjectFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderObjectFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderObjectPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderObjectPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_AMIGO_PROFILING_SUBMIT_INFO_SEC:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkAmigoProfilingSubmitInfoSEC*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkAmigoProfilingSubmitInfoSEC*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_PROPERTIES_ARM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_RENDER_AREAS_RENDER_PASS_BEGIN_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_PROPERTIES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessing2PropertiesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceImageProcessing2PropertiesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerBlockMatchWindowCreateInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerBlockMatchWindowCreateInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerCubicWeightsCreateInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerCubicWeightsCreateInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkBlitImageCubicWeightsInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkBlitImageCubicWeightsInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_YCBCR_DEGAMMA_CREATE_INFO_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCubicClampFeaturesQCOM*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceCubicClampFeaturesQCOM*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_DRIVER_PROPERTIES_MSFT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLayeredDriverPropertiesMSFT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceLayeredDriverPropertiesMSFT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkWriteDescriptorSetAccelerationStructureKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkWriteDescriptorSetAccelerationStructureKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAccelerationStructurePropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceAccelerationStructurePropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPipelinePropertiesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayTracingPipelinePropertiesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayQueryFeaturesKHR*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceRayQueryFeaturesKHR*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderFeaturesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderFeaturesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
-            
+
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT:
             {
-               const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderPropertiesEXT*>(data->GetMetaStructPointer());
-               FieldToJson(jdata, pnext, options);
-               break;
+                const auto* pnext = reinterpret_cast<const Decoded_VkPhysicalDeviceMeshShaderPropertiesEXT*>(data->GetMetaStructPointer());
+                FieldToJson(jdata, pnext, options);
+                break;
             }
+
             default:
+            {
                 GFXRECON_LOG_WARNING("Unknown pnext node type: %u.", (unsigned) s_type);
+            }
         }
     }
 }
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_struct_to_json.h
+++ b/framework/generated/generated_vulkan_struct_to_json.h
@@ -33,6 +33,7 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264SpsVuiFlags* data, const JsonOptions& options = JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264HrdParameters* data, const JsonOptions& options = JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_StdVideoH264SequenceParameterSetVui* data, const JsonOptions& options = JsonOptions());
@@ -989,6 +990,9 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceRa
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMeshShaderFeaturesEXT* data, const JsonOptions& options = JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPhysicalDeviceMeshShaderPropertiesEXT* data, const JsonOptions& options = JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDrawMeshTasksIndirectCommandEXT* data, const JsonOptions& options = JsonOptions());
+
+/// Works out the type of the struct at the end of a pNext pointer and dispatches
+/// recursively to the FieldToJson for that.
 void FieldToJson(nlohmann::ordered_json& jdata, const PNextNode* data, const JsonOptions& options = JsonOptions());
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/vulkan_generators/vulkan_enum_to_json_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_enum_to_json_body_generator.py
@@ -20,9 +20,10 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os, re, sys, inspect, textwrap
+import sys, textwrap
 from pickle import NONE
 from base_generator import *
+from reformat_code import format_cpp_code
 
 
 class VulkanEnumToJsonBodyGeneratorOptions(BaseGeneratorOptions):
@@ -85,7 +86,7 @@ class VulkanEnumToJsonBodyGenerator(BaseGenerator):
     # yapf: disable
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
-        body = inspect.cleandoc('''
+        body = format_cpp_code('''
             #include "generated_vulkan_enum_to_json.h"
 
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -114,8 +115,7 @@ class VulkanEnumToJsonBodyGenerator(BaseGenerator):
                 }
                 return ostr.str();
             }
-
-            ''')
+        ''')
         write(body, file=self.outFile)
     # yapf: enable
 
@@ -124,10 +124,10 @@ class VulkanEnumToJsonBodyGenerator(BaseGenerator):
     def endFile(self):
         write('\n', file=self.outFile)
         self.make_decls()
-        body = inspect.cleandoc('''
+        body = format_cpp_code('''
             GFXRECON_END_NAMESPACE(decode)
             GFXRECON_END_NAMESPACE(gfxrecon)
-            ''')
+        ''')
         write(body, file=self.outFile)
 
         # Finish processing in superclass
@@ -190,7 +190,8 @@ class VulkanEnumToJsonBodyGenerator(BaseGenerator):
                     body += '    jdata = to_hex_fixed_width(value);\n'
 
                 body += '}}\n'
-                write(body.format(enum, bitwidth), file=self.outFile)
+                body = body.format(enum, bitwidth)
+                write(body, file=self.outFile)
 
         for enum in sorted(self.flagsType):
             bittype = None

--- a/framework/generated/vulkan_generators/vulkan_enum_to_json_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_enum_to_json_header_generator.py
@@ -20,9 +20,9 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os, re, sys, inspect
+import sys
 from base_generator import *
-
+from reformat_code import format_cpp_code
 
 class VulkanEnumToJsonHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan ToString() functions"""
@@ -85,34 +85,31 @@ class VulkanEnumToJsonHeaderGenerator(BaseGenerator):
     # yapf: disable
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
-        includes = inspect.cleandoc(
-            '''
+        includes = format_cpp_code('''
             #include "format/platform_types.h"
             #include "decode/vulkan_json_util.h"
-
-            '''
-        )
+        ''')
         write(includes, file=self.outFile)
         self.includeVulkanHeaders(genOpts)
-        namespace = inspect.cleandoc(
-            '''
+        write("", file=self.outFile)
+        namespace = format_cpp_code('''
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
             GFXRECON_BEGIN_NAMESPACE(decode)
-            '''
-        )
+            ''')
         write(namespace, file=self.outFile)
     # yapf: enable
 
     # Method override
     # yapf: disable
     def endFile(self):
-        write('\n', file=self.outFile)
+        self.newline()
         self.make_decls()
 
-        body = inspect.cleandoc('''
+        self.newline()
+        body = format_cpp_code('''
             GFXRECON_END_NAMESPACE(decode)
             GFXRECON_END_NAMESPACE(gfxrecon)
-            ''')
+        ''')
         write(body, file=self.outFile)
 
         # Finish processing in superclass
@@ -158,7 +155,7 @@ class VulkanEnumToJsonHeaderGenerator(BaseGenerator):
                     body = 'struct {0}_t {{ }};'
                     write(body.format(enum), file=self.outFile)
 
-        write('\n', file=self.outFile)
+        self.newline()
         for enum in sorted(self.enum_names):
             if not enum in self.processedEnums and not enum in self.SKIP_ENUM:
                 self.processedEnums.add(enum)

--- a/framework/generated/vulkan_generators/vulkan_export_json_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_export_json_consumer_body_generator.py
@@ -20,8 +20,9 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import sys, inspect
+import sys
 from base_generator import BaseGenerator, BaseGeneratorOptions, write
+from reformat_code import format_cpp_code, indent_cpp_code, remove_trailing_empty_lines
 
 
 class VulkanExportJsonConsumerBodyGeneratorOptions(BaseGeneratorOptions):
@@ -104,31 +105,25 @@ class VulkanExportJsonConsumerBodyGenerator(BaseGenerator):
         """Method override."""
         BaseGenerator.beginFile(self, gen_opts)
 
-        includes = inspect.cleandoc(
-            '''
+        includes = format_cpp_code('''
             #include "util/defines.h"
             #include "generated/generated_vulkan_export_json_consumer.h"
             #include "decode/custom_vulkan_struct_to_json.h"
-            '''
-        )
+        ''')
         write(includes, file=self.outFile)
         self.includeVulkanHeaders(gen_opts)
-        namespace = inspect.cleandoc(
-            '''
+        namespace = remove_trailing_empty_lines(indent_cpp_code('''
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
             GFXRECON_BEGIN_NAMESPACE(decode)
-            '''
-        )
+        '''))
         write(namespace, file=self.outFile)
 
     def endFile(self):
         """Method override."""
-        body = inspect.cleandoc(
-            '''
+        body = format_cpp_code('''
             GFXRECON_END_NAMESPACE(decode)
             GFXRECON_END_NAMESPACE(gfxrecon)
-            '''
-        )
+        ''')
         write(body, file=self.outFile)
 
         # Finish processing in superclass
@@ -153,22 +148,18 @@ class VulkanExportJsonConsumerBodyGenerator(BaseGenerator):
                 cmddef += self.make_consumer_func_decl(
                     return_type, 'VulkanExportJsonConsumer::Process_' + cmd, values
                 ) + '\n'
-                cmddef += inspect.cleandoc(
-                    '''
+                cmddef += format_cpp_code('''
                     {{
                         nlohmann::ordered_json& jdata = WriteApiCallStart(call_info, "{0}");
-                    '''.format(cmd)
-                )
+                '''.format(cmd))
                 cmddef += '\n'
                 cmddef += self.make_consumer_func_body(
                     return_type, cmd, values
                 )
-                cmddef += inspect.cleandoc(
-                    '''
+                cmddef += format_cpp_code('''
                         WriteBlockEnd();
                     }
-                    '''
-                )
+                ''', 1)
                 write(cmddef, file=self.outFile)
                 first = False
 

--- a/framework/generated/vulkan_generators/vulkan_struct_to_json_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_to_json_body_generator.py
@@ -21,9 +21,9 @@
 # IN THE SOFTWARE.
 #
 
-import os, re, sys, inspect
+import sys
 from base_generator import *
-
+from reformat_code import format_cpp_code, indent_cpp_code, remove_leading_empty_lines, remove_trailing_empty_lines
 
 class VulkanStructToJsonBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for serializing Vulkan structures to JSON"""
@@ -100,43 +100,42 @@ class VulkanStructToJsonBodyGenerator(BaseGenerator):
     # yapf: disable
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
-        body = inspect.cleandoc('''
+        body = format_cpp_code('''
             #include "generated_vulkan_struct_to_json.h"
             #include "generated_vulkan_enum_to_json.h"
 
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
             GFXRECON_BEGIN_NAMESPACE(decode)
             ''')
+        body += "\n"
         write(body, file=self.outFile)
     # yapf: enable
 
     # Method override
     # yapf: disable
     def endFile(self):
-        body = "\n"
-        body += inspect.cleandoc('''
-                void FieldToJson(nlohmann::ordered_json& jdata, const PNextNode* data, const JsonOptions& options)
+        body = '''
+            void FieldToJson(nlohmann::ordered_json& jdata, const PNextNode* data, const JsonOptions& options)
+            {
+                if (data && data->GetPointer())
                 {
-                    if (data && data->GetPointer())
-                    {
-                        const auto s_type = reinterpret_cast<const VkBaseInStructure*>(data->GetPointer())->sType;
-                        switch (s_type)
-                        {
-            ''')
-        body += "\n"
+                    const auto s_type = reinterpret_cast<const VkBaseInStructure*>(data->GetPointer())->sType;
+                    switch (s_type)
+                    {'''
         body += self.make_pnext_body()
-        body += inspect.cleandoc('''
-                default:
-                                GFXRECON_LOG_WARNING("Unknown pnext node type: %u.", (unsigned) s_type);
+        body += '''
+                        default:
+                        {
+                            GFXRECON_LOG_WARNING("Unknown pnext node type: %u.", (unsigned) s_type);
                         }
                     }
                 }
-            ''')
-        body += "\n"
-        body += inspect.cleandoc('''
+            }
+
             GFXRECON_END_NAMESPACE(decode)
             GFXRECON_END_NAMESPACE(gfxrecon)
-            ''')
+        '''
+        body = remove_trailing_empty_lines(indent_cpp_code(body))
         write(body, file=self.outFile)
 
         # Finish processing in superclass
@@ -157,21 +156,21 @@ class VulkanStructToJsonBodyGenerator(BaseGenerator):
     def generate_feature(self):
         for struct in self.get_filtered_struct_names():
             if not struct in self.customImplementationRequired:
-                body = inspect.cleandoc('''
+                body = '''
                     void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_{0}* data, const JsonOptions& options)
                     {{
                         if (data && data->decoded_value)
                         {{
                             const {0}& decoded_value = *data->decoded_value;
                             const Decoded_{0}& meta_struct = *data;
-                    '''.format(struct))
-                body += '\n'
+
+                    '''.format(struct)
                 body += self.makeStructBody(struct, self.feature_struct_members[struct])
-                body += inspect.cleandoc('''
+                body += remove_leading_empty_lines('''
                         }
                     }
                     ''')
-                body += '\n'
+                body = remove_trailing_empty_lines(indent_cpp_code(body))
                 write(body, file=self.outFile)
     # yapf: enable
 

--- a/framework/generated/vulkan_generators/vulkan_struct_to_json_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_to_json_header_generator.py
@@ -21,8 +21,9 @@
 # IN THE SOFTWARE.
 #
 
-import os, re, sys, inspect
+import sys
 from base_generator import *
+from reformat_code import format_cpp_code, indent_cpp_code, remove_trailing_empty_lines
 
 
 class VulkanStructToJsonHeaderGeneratorOptions(BaseGeneratorOptions):
@@ -80,24 +81,27 @@ class VulkanStructToJsonHeaderGenerator(BaseGenerator):
     # yapf: disable
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
-        body = inspect.cleandoc('''
+        body = format_cpp_code('''
             #include "decode/custom_vulkan_struct_to_json.h"
 
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
             GFXRECON_BEGIN_NAMESPACE(decode)
             ''')
+        body += "\n"
         write(body, file=self.outFile)
     # yapf: enable
 
     # Method override
     # yapf: disable
     def endFile(self):
-        body = inspect.cleandoc('''
+        body = remove_trailing_empty_lines(indent_cpp_code('''
+            /// Works out the type of the struct at the end of a pNext pointer and dispatches
+            /// recursively to the FieldToJson for that.
             void FieldToJson(nlohmann::ordered_json& jdata, const PNextNode* data, const JsonOptions& options = JsonOptions());
 
             GFXRECON_END_NAMESPACE(decode)
             GFXRECON_END_NAMESPACE(gfxrecon)
-            ''')
+            '''))
         write(body, file=self.outFile)
 
         # Finish processing in superclass
@@ -118,9 +122,7 @@ class VulkanStructToJsonHeaderGenerator(BaseGenerator):
     def generate_feature(self):
         for struct in self.get_filtered_struct_names():
             if not struct in self.customImplementationRequired:
-                body = inspect.cleandoc('''
-                    void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_{0}* data, const JsonOptions& options = JsonOptions());
-                    '''.format(struct))
+                body = "void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_{0}* data, const JsonOptions& options = JsonOptions());".format(struct)
                 write(body, file=self.outFile)
     # yapf: enable
 


### PR DESCRIPTION
I made this function for Dx12 Convert\* because `inspect.cleandoc` was infuriatingly not doing what I needed. I've pulled it out and applied it on the Vulkan side of JSON generation to try to keep the DX12 branch manageable. If this lands in dev, that other branch will rebase on these changes and simplify for future reviewers.

For anyone reviewing this it might be helpful to note the changes in the generated files are whitespace-only.

\* https://github.com/andrew-lunarg/gfxreconstruct/tree/andy-enhance-better-d3d12-convert