### PR TITLE
Better handle for RT applications from optimize tool

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -189,6 +189,9 @@ class ApiDecoder
     virtual void DispatchGetDx12RuntimeInfo(const format::Dx12RuntimeInfoCommandHeader& runtime_info_header){};
 
     virtual void SetCurrentBlockIndex(uint64_t block_index){};
+
+    virtual void DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,
+                                                        const std::vector<format::HandleId>& blases){};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/referenced_resource_table.h
+++ b/framework/decode/referenced_resource_table.h
@@ -25,6 +25,7 @@
 
 #include "format/format.h"
 #include "util/defines.h"
+#include "util/logging.h"
 
 #include "vulkan/vulkan.h"
 
@@ -41,7 +42,7 @@ class ReferencedResourceTable
   public:
     void AddResource(format::HandleId resource_id);
 
-    void AddResource(format::HandleId parent_id, format::HandleId resource_id);
+    void AddResource(format::HandleId parent_id, format::HandleId resource_id, bool add_children = false);
 
     void AddResource(size_t parent_id_count, const format::HandleId* parent_ids, format::HandleId resource_id);
 
@@ -92,9 +93,9 @@ class ReferencedResourceTable
     // Track the referenced/used state of a resource (buffer, image, view, framebuffer).
     struct ResourceInfo
     {
-        bool                                     used{ false };
-        bool                                     is_child{ false };
-        std::vector<std::weak_ptr<ResourceInfo>> child_infos;
+        bool                                                              used{ false };
+        bool                                                              is_child{ false };
+        std::unordered_map<format::HandleId, std::weak_ptr<ResourceInfo>> child_infos;
     };
 
     // Track the referenced/used state of a resource container (descriptor set).

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -76,6 +76,9 @@ class VulkanConsumerBase : public MetadataConsumerBase, public MarkerConsumerBas
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData)
     {}
+
+    virtual void ProcessSetTlasToBlasRelationCommand(format::HandleId tlas, const std::vector<format::HandleId>& blases)
+    {}
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -503,5 +503,14 @@ void VulkanDecoderBase::DecodeFunctionCall(format::ApiCallId  call_id,
     }
 }
 
+void VulkanDecoderBase::DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,
+                                                               const std::vector<format::HandleId>& blases)
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessSetTlasToBlasRelationCommand(tlas, blases);
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -182,6 +182,9 @@ class VulkanDecoderBase : public ApiDecoder
     virtual void DispatchInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
                                                 const uint8_t*                              data) override;
 
+    virtual void DispatchSetTlasToBlasDependencyCommand(format::HandleId                     tlas,
+                                                        const std::vector<format::HandleId>& blases) override;
+
     virtual void DispatchInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&       command_header,
         std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -129,6 +129,14 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
         StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>*                   pDescriptorUpdateTemplate) override;
 
+    virtual void Process_vkCreateAccelerationStructureKHR(
+        const ApiCallInfo&                                                  call_info,
+        VkResult                                                            returnValue,
+        format::HandleId                                                    device,
+        StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
+        HandlePointerDecoder<VkAccelerationStructureKHR>*                   pAccelerationStructure) override;
+
     virtual void
     Process_vkDestroyDescriptorPool(const ApiCallInfo&                                   call_info,
                                     format::HandleId                                     device,
@@ -217,6 +225,30 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
                                               format::HandleId          commandBuffer,
                                               VkCommandBufferResetFlags flags) override;
 
+    virtual void ProcessSetTlasToBlasRelationCommand(format::HandleId                     tlas,
+                                                     const std::vector<format::HandleId>& blases) override;
+
+    virtual void Process_vkCmdTraceRaysKHR(
+        const ApiCallInfo&                                             call_info,
+        format::HandleId                                               commandBuffer,
+        StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pHitShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pCallableShaderBindingTable,
+        uint32_t                                                       width,
+        uint32_t                                                       height,
+        uint32_t                                                       depth) override;
+
+    virtual void
+    ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address) override;
+
+    virtual void Process_vkBindBufferMemory(const ApiCallInfo& call_info,
+                                            VkResult           returnValue,
+                                            format::HandleId   device,
+                                            format::HandleId   buffer,
+                                            format::HandleId   memory,
+                                            VkDeviceSize       memoryOffset) override;
+
   protected:
     bool IsStateLoading() const { return loading_state_; }
 
@@ -237,6 +269,7 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
         std::vector<UpdateTemplateEntryInfo> image_infos;
         std::vector<UpdateTemplateEntryInfo> buffer_infos;
         std::vector<UpdateTemplateEntryInfo> texel_buffer_view_infos;
+        std::vector<UpdateTemplateEntryInfo> acceleration_structure_infos;
     };
 
     // Table of descriptor update template info, keyed by VkDescriptorUpdateTemplate ID.
@@ -271,11 +304,11 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
                                uint32_t                              count,
                                const Decoded_VkDescriptorBufferInfo* buffer_infos);
 
-    void AddTexelBufferViewsToContainer(format::HandleId        container_id,
-                                        int32_t                 binding,
-                                        uint32_t                element,
-                                        uint32_t                count,
-                                        const format::HandleId* view_ids);
+    void AddResourcesToContainer(format::HandleId        container_id,
+                                 int32_t                 binding,
+                                 uint32_t                element,
+                                 uint32_t                count,
+                                 const format::HandleId* resource_ids);
 
     void AddImagesToUser(format::HandleId user_id, size_t count, const Decoded_VkDescriptorImageInfo* image_info);
 
@@ -302,6 +335,9 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
     LayoutBindingCounts     layout_binding_counts_;
     SetLayouts              set_layouts_;
     UpdateTemplateInfos     template_infos_;
+
+    std::unordered_map<format::HandleId, VkDeviceAddress> dev_address_to_resource_map;
+    std::unordered_map<VkDeviceAddress, format::HandleId> dev_address_to_buffers_map;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -287,6 +287,12 @@ class VulkanCaptureManager : public CaptureManager
                                                     const VkAllocationCallbacks*                pAllocator,
                                                     VkAccelerationStructureKHR* pAccelerationStructureKHR);
 
+    void
+    OverrideCmdBuildAccelerationStructuresKHR(VkCommandBuffer                                        commandBuffer,
+                                              uint32_t                                               infoCount,
+                                              const VkAccelerationStructureBuildGeometryInfoKHR*     pInfos,
+                                              const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos);
+
     VkResult OverrideAllocateMemory(VkDevice                     device,
                                     const VkMemoryAllocateInfo*  pAllocateInfo,
                                     const VkAllocationCallbacks* pAllocator,

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -77,7 +77,7 @@ format::HandleId GetWrappedId(const typename Wrapper::HandleType& handle)
 {
     if (handle == VK_NULL_HANDLE)
     {
-        return 0;
+        return format::kNullHandleId;
     }
     auto temp_id = GetTempWrapperId<Wrapper>(handle);
     if (temp_id != 0)
@@ -90,7 +90,7 @@ format::HandleId GetWrappedId(const typename Wrapper::HandleType& handle)
     {
         GFXRECON_LOG_WARNING("GetWrappedId() couldn't find Handle: %" PRIu64 "'s wrapper. It might have been destroyed",
                              handle);
-        return 0;
+        return format::kNullHandleId;
     }
     return wrapper->handle_id;
 }

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -264,6 +264,7 @@ struct RenderPassWrapper : public HandleWrapper<VkRenderPass>
     std::vector<VkImageLayout> attachment_final_layouts;
 };
 
+struct AccelerationStructureKHRWrapper;
 struct CommandPoolWrapper;
 struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
 {
@@ -296,6 +297,21 @@ struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
 
     // Treat the sumbission of this command buffer as a frame boundary.
     bool is_frame_boundary{ false };
+
+    // Corellation between TLASes that are being build in this command buffer and the device addresses
+    // used to reference BLASes.
+    struct tlas_build_info
+    {
+        // The device address that points to the VkAccelerationStructureInstanceKHR used to build this TLAS
+        VkDeviceAddress address;
+
+        // The number of BLASes this TLAS is using
+        uint32_t blas_count;
+
+        // The offset from the above address to start reading the VkAccelerationStructureInstanceKHR structures
+        uint32_t offset;
+    };
+    std::vector<std::pair<AccelerationStructureKHRWrapper*, tlas_build_info>> tlas_build_info_map;
 };
 
 struct PipelineLayoutWrapper : public HandleWrapper<VkPipelineLayout>
@@ -458,6 +474,9 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
     // State tracking info for buffers with device addresses.
     format::HandleId device_id{ format::kNullHandleId };
     VkDeviceAddress  address{ 0 };
+
+    // List of BLASes this AS references. Used only while tracking.
+    std::vector<AccelerationStructureKHRWrapper*> blas;
 };
 
 struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStructureNV>

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -387,6 +387,11 @@ class VulkanStateTracker
                                                     VkAccelerationStructureKHR accel_struct,
                                                     VkDeviceAddress            address);
 
+    void TrackTLASBuildCommand(VkCommandBuffer                                        command_buffer,
+                               uint32_t                                               info_count,
+                               const VkAccelerationStructureBuildGeometryInfoKHR*     infos,
+                               const VkAccelerationStructureBuildRangeInfoKHR* const* pp_buildRange_infos);
+
     void TrackDeviceMemoryDeviceAddress(VkDevice device, VkDeviceMemory memory, VkDeviceAddress address);
 
     void TrackRayTracingShaderGroupHandles(VkDevice device, VkPipeline pipeline, size_t data_size, const void* data);
@@ -402,6 +407,8 @@ class VulkanStateTracker
                              uint64_t          data);
 
     void TrackSetLocalDimmingAMD(VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable);
+
+    void TrackTlasToBlasDependencies(uint32_t command_buffer_count, const VkCommandBuffer* command_buffers);
 
   private:
     template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
@@ -464,11 +471,20 @@ class VulkanStateTracker
 
     void DestroyState(SwapchainKHRWrapper* wrapper);
 
-  private:
+    void DestroyState(DeviceMemoryWrapper* wrapper);
+
+    void DestroyState(AccelerationStructureKHRWrapper* wrapper);
+
     void TrackQuerySubmissions(CommandBufferWrapper* command_wrapper);
 
     std::mutex       state_table_mutex_;
     VulkanStateTable state_table_;
+
+    // Keeps track of device memories' device addresses
+    std::unordered_map<VkDeviceAddress, const DeviceMemoryWrapper*> device_memory_addresses_map;
+
+    // Keeps track of acceleration structures' device addresses
+    std::unordered_map<VkDeviceAddress, AccelerationStructureKHRWrapper*> as_device_addresses_map;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -377,6 +377,8 @@ class VulkanStateWriter
 
     bool IsFramebufferValid(const FramebufferWrapper* framebuffer_wrapper, const VulkanStateTable& state_table);
 
+    void WriteTlasToBlasDependenciesMetadata(const VulkanStateTable& state_table);
+
   private:
     util::FileOutputStream*  output_stream_;
     util::Compressor*        compressor_;

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -138,6 +138,7 @@ enum class MetaDataType : uint16_t
     kCreateHardwareBufferCommand            = 24,
     kReserved25                             = 25,
     kDx12RuntimeInfoCommand                 = 26,
+    kParentToChildDependency                = 27,
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.
@@ -339,9 +340,9 @@ struct DriverInfoBlock
 
 struct ExeFileInfoBlock
 {
-    MetaDataHeader              meta_header;
-    format::ThreadId            thread_id;
-    util::filepath::FileInfo    info_record;
+    MetaDataHeader           meta_header;
+    format::ThreadId         thread_id;
+    util::filepath::FileInfo info_record;
 };
 
 // Not a header because this command does not include a variable length data payload.
@@ -616,6 +617,21 @@ struct Dx12RuntimeInfoCommandHeader
     MetaDataHeader   meta_header;
     format::ThreadId thread_id;
     Dx12RuntimeInfo  runtime_info;
+};
+
+enum ParentToChildDependencyType : uint32_t
+{
+    kUnknownDependency                = 0,
+    kAccelerationStructuresDependency = 1
+};
+
+struct ParentToChildDependencyHeader
+{
+    MetaDataHeader              meta_header;
+    format::ThreadId            thread_id;
+    ParentToChildDependencyType dependency_type;
+    format::HandleId            parent_id;
+    uint32_t                    child_count;
 };
 
 // Restore size_t to normal behavior.

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -23552,10 +23552,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBuildAccelerationStructuresKHRHandles, infoCount, pInfos);
     }
 
-    auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
-    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos_unwrapped = UnwrapStructArrayHandles(pInfos, infoCount, handle_unwrap_memory);
-
-    GetDeviceTable(commandBuffer)->CmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos_unwrapped, ppBuildRangeInfos);
+    manager->OverrideCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresKHR>::Dispatch(manager, commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
 }

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -1040,6 +1040,34 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSetKHR(
         size_t pDescriptorWrites_count = pDescriptorWrites->GetLength();
         for (size_t pDescriptorWrites_index = 0; pDescriptorWrites_index < pDescriptorWrites_count; ++pDescriptorWrites_index)
         {
+            const VkBaseInStructure* pnext_header = nullptr;
+            if (pDescriptorWrites_ptr->pNext != nullptr)
+            {
+                pnext_header = reinterpret_cast<const VkBaseInStructure*>(pDescriptorWrites_ptr->pNext->GetPointer());
+            }
+            while (pnext_header)
+            {
+                switch (pnext_header->sType)
+                {
+                    default:
+                        break;
+                    case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR:
+                    {
+                        auto pnext_value = reinterpret_cast<const Decoded_VkWriteDescriptorSetAccelerationStructureKHR*>(pDescriptorWrites_ptr->pNext->GetPointer());
+                        if (!pnext_value->pAccelerationStructures.IsNull() && (pnext_value->pAccelerationStructures.HasData()))
+                        {
+                            auto pAccelerationStructures_ptr = pnext_value->pAccelerationStructures.GetPointer();
+                            size_t pAccelerationStructures_count = pnext_value->pAccelerationStructures.GetLength();
+                            for (size_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pAccelerationStructures_count; ++pAccelerationStructures_index)
+                            {
+                                GetTable().AddResourceToUser(commandBuffer, pAccelerationStructures_ptr[pAccelerationStructures_index]);
+                            }
+                        }
+                        break;
+                    }
+                }
+                pnext_header = pnext_header->pNext;
+            }
             GetTable().AddContainerToUser(commandBuffer, pDescriptorWrites_ptr[pDescriptorWrites_index].dstSet);
 
             if (!pDescriptorWrites_ptr[pDescriptorWrites_index].pImageInfo->IsNull() && (pDescriptorWrites_ptr[pDescriptorWrites_index].pImageInfo->HasData()))
@@ -1810,6 +1838,128 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawClusterIndirectHUAWEI(
     GFXRECON_UNREFERENCED_PARAMETER(offset);
 
     GetTable().AddResourceToUser(commandBuffer, buffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBuildAccelerationStructuresKHR(
+    const ApiCallInfo&                          call_info,
+    format::HandleId                            commandBuffer,
+    uint32_t                                    infoCount,
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(infoCount);
+    GFXRECON_UNREFERENCED_PARAMETER(ppBuildRangeInfos);
+
+    assert(pInfos != nullptr);
+
+    if (!pInfos->IsNull() && (pInfos->HasData()))
+    {
+        auto pInfos_ptr = pInfos->GetMetaStructPointer();
+        size_t pInfos_count = pInfos->GetLength();
+        for (size_t pInfos_index = 0; pInfos_index < pInfos_count; ++pInfos_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pInfos_ptr[pInfos_index].srcAccelerationStructure);
+            GetTable().AddResourceToUser(commandBuffer, pInfos_ptr[pInfos_index].dstAccelerationStructure);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+    const ApiCallInfo&                          call_info,
+    format::HandleId                            commandBuffer,
+    uint32_t                                    infoCount,
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
+    PointerDecoder<VkDeviceAddress>*            pIndirectDeviceAddresses,
+    PointerDecoder<uint32_t>*                   pIndirectStrides,
+    PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(infoCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pIndirectDeviceAddresses);
+    GFXRECON_UNREFERENCED_PARAMETER(pIndirectStrides);
+    GFXRECON_UNREFERENCED_PARAMETER(ppMaxPrimitiveCounts);
+
+    assert(pInfos != nullptr);
+
+    if (!pInfos->IsNull() && (pInfos->HasData()))
+    {
+        auto pInfos_ptr = pInfos->GetMetaStructPointer();
+        size_t pInfos_count = pInfos->GetLength();
+        for (size_t pInfos_index = 0; pInfos_index < pInfos_count; ++pInfos_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pInfos_ptr[pInfos_index].srcAccelerationStructure);
+            GetTable().AddResourceToUser(commandBuffer, pInfos_ptr[pInfos_index].dstAccelerationStructure);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
+{
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pInfo_ptr->src);
+        GetTable().AddResourceToUser(commandBuffer, pInfo_ptr->dst);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+    const ApiCallInfo&                          call_info,
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo)
+{
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pInfo_ptr->src);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo)
+{
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pInfo_ptr->dst);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
+    const ApiCallInfo&                          call_info,
+    format::HandleId                            commandBuffer,
+    uint32_t                                    accelerationStructureCount,
+    HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
+    VkQueryType                                 queryType,
+    format::HandleId                            queryPool,
+    uint32_t                                    firstQuery)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(accelerationStructureCount);
+    GFXRECON_UNREFERENCED_PARAMETER(queryType);
+    GFXRECON_UNREFERENCED_PARAMETER(queryPool);
+    GFXRECON_UNREFERENCED_PARAMETER(firstQuery);
+
+    assert(pAccelerationStructures != nullptr);
+
+    if (!pAccelerationStructures->IsNull() && (pAccelerationStructures->HasData()))
+    {
+        auto pAccelerationStructures_ptr = pAccelerationStructures->GetPointer();
+        size_t pAccelerationStructures_count = pAccelerationStructures->GetLength();
+        for (size_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pAccelerationStructures_count; ++pAccelerationStructures_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pAccelerationStructures_ptr[pAccelerationStructures_index]);
+        }
+    }
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawMeshTasksIndirectEXT(

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -606,6 +606,46 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         format::HandleId                            buffer,
         VkDeviceSize                                offset) override;
 
+    virtual void Process_vkCmdBuildAccelerationStructuresKHR(
+        const ApiCallInfo&                          call_info,
+        format::HandleId                            commandBuffer,
+        uint32_t                                    infoCount,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos) override;
+
+    virtual void Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+        const ApiCallInfo&                          call_info,
+        format::HandleId                            commandBuffer,
+        uint32_t                                    infoCount,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
+        PointerDecoder<VkDeviceAddress>*            pIndirectDeviceAddresses,
+        PointerDecoder<uint32_t>*                   pIndirectStrides,
+        PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts) override;
+
+    virtual void Process_vkCmdCopyAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) override;
+
+    virtual void Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+        const ApiCallInfo&                          call_info,
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) override;
+
+    virtual void Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) override;
+
+    virtual void Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
+        const ApiCallInfo&                          call_info,
+        format::HandleId                            commandBuffer,
+        uint32_t                                    accelerationStructureCount,
+        HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
+        VkQueryType                                 queryType,
+        format::HandleId                            queryPool,
+        uint32_t                                    firstQuery) override;
+
     virtual void Process_vkCmdDrawMeshTasksIndirectEXT(
         const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -9,6 +9,7 @@
         "vkCreateAccelerationStructureKHR": "manager->OverrideCreateAccelerationStructureKHR",
         "vkGetPhysicalDeviceQueueFamilyProperties": "manager->OverrideGetPhysicalDeviceQueueFamilyProperties",
         "vkGetPhysicalDeviceQueueFamilyProperties2": "manager->OverrideGetPhysicalDeviceQueueFamilyProperties2",
-        "vkGetPhysicalDeviceQueueFamilyProperties2KHR": "manager->OverrideGetPhysicalDeviceQueueFamilyProperties2KHR"
+        "vkGetPhysicalDeviceQueueFamilyProperties2KHR": "manager->OverrideGetPhysicalDeviceQueueFamilyProperties2KHR",
+        "vkCmdBuildAccelerationStructuresKHR": "manager->OverrideCmdBuildAccelerationStructuresKHR"
     }
 }

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
@@ -61,7 +61,7 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
     # All resource and resource associated handle types to be processed.
     RESOURCE_HANDLE_TYPES = [
         'VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer',
-        'VkDescriptorSet', 'VkCommandBuffer'
+        'VkDescriptorSet', 'VkCommandBuffer', 'VkAccelerationStructureKHR'
     ]
 
     # Handle types that contain resource and child resource handle types.

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
@@ -61,7 +61,7 @@ class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
     # All resource and resource associated handle types to be processed.
     RESOURCE_HANDLE_TYPES = [
         'VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer',
-        'VkDescriptorSet', 'VkCommandBuffer'
+        'VkDescriptorSet', 'VkCommandBuffer', 'VkAccelerationStructureKHR'
     ]
 
     def __init__(

--- a/framework/util/page_guard_manager.cpp
+++ b/framework/util/page_guard_manager.cpp
@@ -1223,5 +1223,16 @@ bool PageGuardManager::HandleGuardPageViolation(void* address, bool is_write, bo
     return found;
 }
 
+const void* PageGuardManager::GetMappedMemory(uint64_t memory_id) const
+{
+    const auto& mem_info = memory_info_.find(memory_id);
+    if (mem_info != memory_info_.end())
+    {
+        return mem_info->second.mapped_memory;
+    }
+
+    return nullptr;
+}
+
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -117,6 +117,8 @@ class PageGuardManager
 
     void FreePersistentShadowMemory(uintptr_t shadow_memory_handle);
 
+    const void* GetMappedMemory(uint64_t memory_id) const;
+
   protected:
     PageGuardManager();
 


### PR DESCRIPTION
The optimize tool was not taking under consideration ray tracing
features. As a result when applied on a trimmed capture containing such
calls all relative resources were ommited from the optimized tool
leading to corruption during replay.

One key element missing is the relation between top (tlas) and bottom
(blas) level acceleration structures. This relation is described when
the tlas is being build. However when capturing trimmed the tlas build
commands are likely not to be within the capture range and as a result
they are not dumped into the capture file. This makes it impossible for
the optimize tool to deduce from the used descriptors which blases it
should retain in the optimized file.

To solve this a new metacommand is introduced which describes the tlas
to blas dependency and is writted to the capture file during capture.
For each tlas that is built the new metacommand is written to the
capture file and it's essentially a list of all the blas ids the tlas
uses.