### PR TITLE
Fix rename playback hang

### DIFF
--- a/scripts/gfxrecon-replay-renamed.py
+++ b/scripts/gfxrecon-replay-renamed.py
@@ -53,14 +53,10 @@ def rename_replayer(encoded_app_executable):
     return replayer_name_renamed
 
 def run_command(command):
-    process = subprocess.Popen(command, 
-                                shell=True,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                universal_newlines=True)
-    while process.poll() is None:
-        line = process.stdout.readline()
-        print(line)
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as e:
+        print ("subprocess returncode: ", e.returncode)
 
 # Run the replayer
 def run_replayer(replay_tool_path, args):


### PR DESCRIPTION
**The problem**
When run gfxrecon-replay-rename.py with some gfxr traces, the playback may stuck (hang). The issue seems to be related to stdout and stderr PIPE for subprocess.Popen().
Manually rename `gfxrecon-replay.exe` to the application name, playback does not have the hang issue.
If gfxrecon replay displays many messages in the console, the rename Python script could fail. Some applications output many `No ID3D12StateObject was set on the command list before DispatchRays was called. Unable to map the values in the shader table. Replay may fail.` errors to console 'stdout' and replay hangs. 

**The solution**
According to documentation using poll with `stdout = PIPE` can lead to deadlock. `subprocess.run(command, check=True)` can be used to solve this problem. 

**Result**
Playback of traces no longer hangs.