### PR TITLE
ci: Use lukka/get-cmake 3.16.3 in actions runs & Update Github CI to actions/checkout@v4

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -33,7 +33,7 @@ jobs:
           }
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Install build dependencies
       run: |
         sudo apt-get update
@@ -93,7 +93,7 @@ jobs:
           }
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - uses: lukka/get-cmake@latest
     - name: Run build script
       run: |
@@ -126,7 +126,7 @@ jobs:
           }
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Update submodules
       run: |
         git submodule update --init

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -94,6 +94,7 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v1
+    - uses: lukka/get-cmake@latest
     - name: Run build script
       run: |
         python scripts\build.py --skip-check-code-style --skip-tests --config ${{ matrix.config.type }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -46,6 +46,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libx11-xcb-dev libxcb-keysyms1-dev libwayland-dev libxrandr-dev liblz4-dev libzstd-dev
+    - uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: 3.16.3
     - name: Run build script
       run: |
         python3 scripts/build.py --skip-check-code-style --skip-tests
@@ -80,6 +83,7 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v1
+    - uses: lukka/get-cmake@latest
     - name: Run build script
       run: |
         python scripts\build.py --skip-check-code-style --skip-tests

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -41,7 +41,7 @@ jobs:
           }
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -82,7 +82,7 @@ jobs:
           }
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - uses: lukka/get-cmake@latest
     - name: Run build script
       run: |
@@ -115,7 +115,7 @@ jobs:
           }
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Update submodules
       run: |
         git submodule update --init
@@ -148,7 +148,7 @@ jobs:
     needs: [ linux, windows, android ]
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Get tag body
       id: get_tag_body
       run: |

--- a/.github/workflows/sdk_android_build.yml
+++ b/.github/workflows/sdk_android_build.yml
@@ -35,7 +35,7 @@ jobs:
           }
     steps:
     - name: Clone repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Update submodules
       run: |
         git submodule update --init


### PR DESCRIPTION
The version of CMake used by NDK is not able to be specified by lukka/get-cmake. Thus the sdk_android_build.yml can't be updated using it.

Fixes #1283 