### PR TITLE
Renamed Field of Decoded_D3D12_STATE_SUBOBJECT

### DIFF
--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -996,9 +996,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_STA
     bytes_read +=
         ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->subobject_stride));
 
-    wrapper->subobjects = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_D3D12_STATE_SUBOBJECT>>();
-    bytes_read += wrapper->subobjects->Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pSubobjects = wrapper->subobjects->GetPointer();
+    wrapper->pSubobjects = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_D3D12_STATE_SUBOBJECT>>();
+    bytes_read += wrapper->pSubobjects->Decode((buffer + bytes_read), (buffer_size - bytes_read));
+    value->pSubobjects = wrapper->pSubobjects->GetPointer();
 
     return bytes_read;
 }

--- a/framework/decode/custom_dx12_struct_decoders.h
+++ b/framework/decode/custom_dx12_struct_decoders.h
@@ -238,7 +238,7 @@ struct Decoded_D3D12_STATE_OBJECT_DESC
     D3D12_STATE_OBJECT_DESC* decoded_value{ nullptr };
 
     size_t                                               subobject_stride{ 0 };
-    StructPointerDecoder<Decoded_D3D12_STATE_SUBOBJECT>* subobjects{ nullptr };
+    StructPointerDecoder<Decoded_D3D12_STATE_SUBOBJECT>* pSubobjects{ nullptr };
 };
 
 struct Decoded_D3D12_STATE_SUBOBJECT

--- a/framework/decode/custom_dx12_struct_object_mappers.cpp
+++ b/framework/decode/custom_dx12_struct_object_mappers.cpp
@@ -204,13 +204,13 @@ void MapStructObjects(Decoded_D3D12_STATE_OBJECT_DESC* wrapper,
 {
     if (wrapper != nullptr)
     {
-        auto length   = wrapper->subobjects->GetLength();
-        auto wrappers = wrapper->subobjects->GetMetaStructPointer();
+        auto length   = wrapper->pSubobjects->GetLength();
+        auto wrappers = wrapper->pSubobjects->GetMetaStructPointer();
 
         for (size_t i = 0; i < length; ++i)
         {
             MapStructObjects(
-                &wrappers[i], wrapper->subobjects, wrapper->subobject_stride, object_info_table, gpu_va_map);
+                &wrappers[i], wrapper->pSubobjects, wrapper->subobject_stride, object_info_table, gpu_va_map);
         }
     }
 }

--- a/framework/decode/dx12_resource_value_mapper.cpp
+++ b/framework/decode/dx12_resource_value_mapper.cpp
@@ -1531,7 +1531,7 @@ void Dx12ResourceValueMapper::GetStateObjectLrsAssociationInfo(
     std::map<std::wstring, format::HandleId>&              lrs_associations_map)
 {
     const auto* desc               = desc_decoder->GetPointer();
-    const auto* subobject_decoders = desc_decoder->GetMetaStructPointer()->subobjects;
+    const auto* subobject_decoders = desc_decoder->GetMetaStructPointer()->pSubobjects;
 
     for (UINT i = 0; i < desc->NumSubobjects; ++i)
     {


### PR DESCRIPTION
Made it the same as the underlying D3D12_STATE_SUBOBJECT field. Although it is a custom struct, it should have the same name as the raw struct field so that codegen sees it correctly.

Will be used by feature: https://github.com/andrew-lunarg/gfxreconstruct/tree/andy-enhance-better-d3d12-convert