### PR TITLE
Don't batch resource data reads for trim capture

### DIFF
--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -290,7 +290,6 @@ void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    
                                                        D3D12_RESOURCE_DIMENSION dimension,
                                                        D3D12_TEXTURE_LAYOUT     layout,
                                                        UINT64                   width,
-                                                       UINT64                   size,
                                                        D3D12_HEAP_TYPE          heap_type,
                                                        D3D12_CPU_PAGE_PROPERTY  page_property,
                                                        D3D12_MEMORY_POOL        memory_pool,
@@ -309,7 +308,6 @@ void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    
     info->page_property   = page_property;
     info->memory_pool     = memory_pool;
     info->has_write_watch = has_write_watch;
-    info->size_in_bytes   = size;
     info->dimension       = dimension;
     info->layout          = layout;
     info->heap_offset     = heap_offset;
@@ -814,14 +812,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateCommittedResource(
     {
         auto resource_wrapper = reinterpret_cast<ID3D12Resource_Wrapper*>(*resource);
 
-        uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
-
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
                                      desc->Layout,
                                      desc->Width,
-                                     total_size_in_bytes,
                                      heap_properties->Type,
                                      heap_properties->CPUPageProperty,
                                      heap_properties->MemoryPoolPreference,
@@ -856,14 +851,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreatePlacedResource(ID3D12De
         auto heap_info        = heap_wrapper->GetObjectInfo();
         assert(heap_info != nullptr);
 
-        uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
-
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
                                      desc->Layout,
                                      desc->Width,
-                                     total_size_in_bytes,
                                      heap_info->heap_type,
                                      heap_info->page_property,
                                      heap_info->memory_pool,
@@ -891,14 +883,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateReservedResource(
     {
         auto resource_wrapper = reinterpret_cast<ID3D12Resource_Wrapper*>(*resource);
 
-        uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
-
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
                                      desc->Layout,
                                      desc->Width,
-                                     total_size_in_bytes,
                                      D3D12_HEAP_TYPE_DEFAULT,
                                      D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
                                      D3D12_MEMORY_POOL_UNKNOWN,
@@ -928,14 +917,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateReservedResource1(
     {
         auto resource_wrapper = reinterpret_cast<ID3D12Resource_Wrapper*>(*resource);
 
-        uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
-
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
                                      desc->Layout,
                                      desc->Width,
-                                     total_size_in_bytes,
                                      D3D12_HEAP_TYPE_DEFAULT,
                                      D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
                                      D3D12_MEMORY_POOL_UNKNOWN,
@@ -1034,14 +1020,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateCommittedResource1(
     {
         auto resource_wrapper = reinterpret_cast<ID3D12Resource_Wrapper*>(*resource);
 
-        uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
-
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
                                      desc->Layout,
                                      desc->Width,
-                                     total_size_in_bytes,
                                      heap_properties->Type,
                                      heap_properties->CPUPageProperty,
                                      heap_properties->MemoryPoolPreference,
@@ -1075,14 +1058,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreateCommittedResource2(
     {
         auto resource_wrapper = reinterpret_cast<ID3D12Resource_Wrapper*>(*resource);
 
-        uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
-
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
                                      desc->Layout,
                                      desc->Width,
-                                     total_size_in_bytes,
                                      heap_properties->Type,
                                      heap_properties->CPUPageProperty,
                                      heap_properties->MemoryPoolPreference,
@@ -1118,14 +1098,11 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreatePlacedResource1(
         auto heap_info        = heap_wrapper->GetObjectInfo();
         assert(heap_info != nullptr);
 
-        uint64_t total_size_in_bytes = GetResourceSizeInBytes(wrapper, desc);
-
         InitializeID3D12ResourceInfo(wrapper,
                                      resource_wrapper,
                                      desc->Dimension,
                                      desc->Layout,
                                      desc->Width,
-                                     total_size_in_bytes,
                                      heap_info->heap_type,
                                      heap_info->page_property,
                                      heap_info->memory_pool,

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -710,7 +710,6 @@ class D3D12CaptureManager : public CaptureManager
                                       D3D12_RESOURCE_DIMENSION dimension,
                                       D3D12_TEXTURE_LAYOUT     layout,
                                       UINT64                   width,
-                                      UINT64                   size,
                                       D3D12_HEAP_TYPE          heap_type,
                                       D3D12_CPU_PAGE_PROPERTY  page_property,
                                       D3D12_MEMORY_POOL        memory_pool,

--- a/framework/encode/dx12_object_wrapper_info.h
+++ b/framework/encode/dx12_object_wrapper_info.h
@@ -368,7 +368,6 @@ struct ID3D12ResourceInfo : public DxWrapperInfo
     D3D12_HEAP_TYPE                      heap_type{};
     D3D12_CPU_PAGE_PROPERTY              page_property{};
     D3D12_MEMORY_POOL                    memory_pool{};
-    uint64_t                             size_in_bytes{ 0 };
     D3D12_RESOURCE_DIMENSION             dimension{ D3D12_RESOURCE_DIMENSION_UNKNOWN };
     D3D12_TEXTURE_LAYOUT                 layout{ D3D12_TEXTURE_LAYOUT_UNKNOWN };
     //// State tracking data:
@@ -386,17 +385,6 @@ struct ID3D12ResourceInfo : public DxWrapperInfo
 
     // Track acceleration structures that were built to this resource
     std::map<D3D12_GPU_VIRTUAL_ADDRESS, DxAccelerationStructureBuildInfo> acceleration_structure_builds;
-
-    graphics::dx12::ID3D12ResourceComPtr staging_buffer{ nullptr };
-    struct
-    {
-        size_t                                          subresource_count;
-        std::vector<uint64_t>                           subresource_offsets;
-        std::vector<uint64_t>                           subresource_sizes;
-        std::vector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> layouts;
-        uint64_t                                        required_data_size;
-        std::vector<BYTE>                               staging_buffer_data;
-    } staging_buffer_info;
 
     ID3D12Heap_Wrapper* heap_wrapper{ nullptr };
     uint64_t            heap_offset;

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -681,28 +681,6 @@ void Dx12StateWriter::WriteResourceCreationState(
     }
 }
 
-void Dx12StateWriter::FlushStagingBuffersData(graphics::Dx12ResourceDataUtil*       resource_data_util,
-                                              std::vector<ID3D12Resource_Wrapper*>& submitted_resources)
-{
-    GFXRECON_ASSERT(resource_data_util);
-    for (auto res : submitted_resources)
-    {
-        auto resource_info = res->GetObjectInfo();
-        if (resource_info->staging_buffer != nullptr)
-        {
-            resource_data_util->MapSubresourceAndReadData(
-                reinterpret_cast<ID3D12Resource*>(resource_info.get()->staging_buffer.GetInterfacePtr()),
-                0,
-                static_cast<size_t>(resource_info.get()->staging_buffer_info.required_data_size),
-                resource_info.get()->staging_buffer_info.staging_buffer_data.data());
-            WriteBufferData(res);
-            resource_info->staging_buffer_info.staging_buffer_data = std::vector<BYTE>();
-            resource_info->staging_buffer                          = nullptr;
-        }
-    }
-    submitted_resources.clear();
-}
-
 void Dx12StateWriter::WriteResourceSnapshots(
     const std::unordered_map<format::HandleId, std::vector<ResourceSnapshotInfo>>& snapshots,
     const std::unordered_map<format::HandleId, uint64_t>&                          max_resource_sizes)
@@ -743,22 +721,17 @@ void Dx12StateWriter::WriteResourceSnapshots(
 
             output_stream_->Write(&begin_cmd, sizeof(begin_cmd));
 
-            // Download the resource data over to staging buffer
-            // Once memory full, dump staging buffer to trace file
-            UINT64                               total_required_memory = 0;
-            std::vector<ID3D12Resource_Wrapper*> submit_vector;
+            // Write each resource snapshot to the capture file.
             for (auto snapshot : kvp.second)
             {
                 // Iterate to be dumped resources
                 auto resource_wrapper = snapshot.resource_wrapper;
                 auto resource_info    = resource_wrapper->GetObjectInfo();
 
-                ID3D12Device_Wrapper* device_wrapper =
-                    reinterpret_cast<ID3D12Device_Wrapper*>(resource_info.get()->device_wrapper);
-                GFXRECON_ASSERT(device_wrapper != nullptr);
-
                 if (resource_data_util == nullptr)
                 {
+                    ID3D12Device_Wrapper* device_wrapper = resource_info->device_wrapper;
+                    GFXRECON_ASSERT(device_wrapper != nullptr);
                     ID3D12Device* device = device_wrapper->GetWrappedObjectAs<ID3D12Device>();
                     if (device != nullptr)
                     {
@@ -773,81 +746,10 @@ void Dx12StateWriter::WriteResourceSnapshots(
                                            resource_wrapper->GetCaptureId());
                         continue;
                     }
-                    resource_data_util->ResetCommandList();
                 }
 
-                uint64_t size_in_bytes = resource_info.get()->size_in_bytes;
-                auto     device_info   = device_wrapper->GetObjectInfo();
-
-                const double max_mem_usage = 7.0 / 8.0;
-
-                const bool is_uma = device_wrapper->GetObjectInfo()->is_uma;
-                if (!graphics::dx12::IsMemoryAvailable(
-                        size_in_bytes, device_info.get()->adapter3, max_mem_usage, is_uma))
-                {
-                    // If neither system memory or GPU memory are able to accommodate next resource,
-                    // execute the existing Copy() calls and release temp buffer to free memory
-                    resource_data_util->CloseCommandList();
-                    resource_data_util->ExecuteAndWaitForCommandList();
-                    FlushStagingBuffersData(resource_data_util.get(), submit_vector);
-                    resource_data_util->ResetCommandList();
-                }
-
-                auto resource = resource_wrapper->GetWrappedObjectAs<ID3D12Resource>();
-                resource_data_util->GetResourceCopyInfo(resource,
-                                                        resource_info.get()->staging_buffer_info.subresource_count,
-                                                        resource_info.get()->staging_buffer_info.subresource_offsets,
-                                                        resource_info.get()->staging_buffer_info.subresource_sizes,
-                                                        resource_info.get()->staging_buffer_info.layouts,
-                                                        resource_info.get()->staging_buffer_info.required_data_size);
-                resource_info->staging_buffer_info.staging_buffer_data.clear();
-                resource_info->staging_buffer_info.staging_buffer_data.resize(
-                    static_cast<size_t>(resource_info.get()->staging_buffer_info.required_data_size));
-
-                bool is_cpu_accessible =
-                    (resource_info.get()->heap_type == D3D12_HEAP_TYPE_READBACK ||
-                     (resource_info.get()->heap_type == D3D12_HEAP_TYPE_CUSTOM &&
-                      (resource_info.get()->page_property == D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE ||
-                       resource_info.get()->page_property == D3D12_CPU_PAGE_PROPERTY_WRITE_BACK)) &&
-                         ((resource_info.get()->create_call_id !=
-                           format::ApiCall_ID3D12Device_CreateReservedResource) &&
-                          (resource_info.get()->create_call_id !=
-                           format::ApiCall_ID3D12Device4_CreateReservedResource1)));
-
-                bool target_texture_with_unknown_layout = graphics::dx12::IsTextureWithUnknownLayout(
-                    resource_info.get()->dimension, resource_info.get()->layout);
-
-                if ((is_cpu_accessible == false) || (is_cpu_accessible && target_texture_with_unknown_layout))
-                {
-                    // If the resource is non CPU accessible resource, create staging buffer for it
-                    // And issue Copy() to download the data over to the staging buffer
-                    CreateStagingBuffer(resource_data_util.get(),
-                                        resource_wrapper->GetWrappedObjectAs<ID3D12Resource>(),
-                                        resource_info.get());
-                    resource_data_util->ExecuteCopyCommandList(
-                        resource_wrapper->GetWrappedObjectAs<ID3D12Resource>(),
-                        graphics::Dx12ResourceDataUtil::CopyType::kCopyTypeRead,
-                        resource_info.get()->staging_buffer_info.required_data_size,
-                        resource_info.get()->staging_buffer_info.layouts,
-                        resource_info->subresource_transitions,
-                        resource_info->subresource_transitions,
-                        reinterpret_cast<ID3D12Resource*>(resource_info.get()->staging_buffer.GetInterfacePtr()),
-                        true);
-                    submit_vector.push_back(resource_wrapper);
-                }
-                else
-                {
-                    // If the resource is mappable resource, direct map out the resource data
-                    // and dump to trace file.
-                    WriteMappableResource(resource_data_util.get(), snapshot);
-                    resource_info->staging_buffer_info.staging_buffer_data.clear();
-                }
+                WriteResourceSnapshot(resource_data_util.get(), snapshot);
             }
-
-            // Execute the existing Copy() calls and flush temp buffer data.
-            resource_data_util->CloseCommandList();
-            resource_data_util->ExecuteAndWaitForCommandList();
-            FlushStagingBuffersData(resource_data_util.get(), submit_vector);
 
             // Write the block indicating resource processing end.
             format::EndResourceInitCommand end_cmd;
@@ -863,85 +765,86 @@ void Dx12StateWriter::WriteResourceSnapshots(
     }
 }
 
-void Dx12StateWriter::CreateStagingBuffer(graphics::Dx12ResourceDataUtil* resource_data_util,
-                                          ID3D12Resource*                 target_resource,
-                                          ID3D12ResourceInfo*             resource_info)
-{
-    resource_info->staging_buffer = resource_data_util->CreateStagingBuffer(
-        graphics::Dx12ResourceDataUtil::CopyType::kCopyTypeRead,
-        std::max(resource_info->size_in_bytes, resource_info->staging_buffer_info.required_data_size));
-}
-
-void Dx12StateWriter::WriteBufferData(ID3D12Resource_Wrapper* resource_wrapper)
-{
-    auto resource_info = resource_wrapper->GetObjectInfo();
-    for (uint32_t i = 0; i < resource_info.get()->staging_buffer_info.subresource_sizes.size(); ++i)
-    {
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, resource_info.get()->staging_buffer_info.subresource_sizes[i]);
-
-        uint8_t* subresource_data = resource_info.get()->staging_buffer_info.staging_buffer_data.data() +
-                                    resource_info.get()->staging_buffer_info.subresource_offsets[i];
-        size_t subresource_size = static_cast<size_t>(resource_info.get()->staging_buffer_info.subresource_sizes[i]);
-
-        // Create subresource upload data block.
-        format::InitSubresourceCommandHeader upload_cmd;
-        upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
-        upload_cmd.meta_header.meta_data_id =
-            format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_D3D12, format::MetaDataType::kInitSubresourceCommand);
-        upload_cmd.thread_id       = thread_id_;
-        format::HandleId device_id = format::kNullHandleId;
-        if (resource_info->device_wrapper != nullptr)
-        {
-            device_id = resource_info->device_wrapper->GetCaptureId();
-        }
-        upload_cmd.device_id      = device_id;
-        upload_cmd.resource_id    = resource_wrapper->GetCaptureId();
-        upload_cmd.subresource    = i;
-        upload_cmd.initial_state  = resource_info->initial_state;
-        upload_cmd.resource_state = resource_info->subresource_transitions[i].states;
-        upload_cmd.barrier_flags  = resource_info->subresource_transitions[i].barrier_flags;
-        upload_cmd.data_size      = subresource_size;
-
-        // Compress block data.
-        if (compressor_ != nullptr)
-        {
-            size_t compressed_size =
-                compressor_->Compress(subresource_size, subresource_data, &compressed_parameter_buffer_, 0);
-
-            if ((compressed_size > 0) && (compressed_size < subresource_size))
-            {
-                upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
-
-                subresource_data = compressed_parameter_buffer_.data();
-                subresource_size = compressed_size;
-            }
-        }
-
-        // Calculate size of packet with compressed or uncompressed data size.
-        upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd) + subresource_size;
-
-        // Write upload block to file.
-        output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
-        output_stream_->Write(subresource_data, subresource_size);
-    }
-}
-
-void Dx12StateWriter::WriteMappableResource(graphics::Dx12ResourceDataUtil* resource_data_util,
+void Dx12StateWriter::WriteResourceSnapshot(graphics::Dx12ResourceDataUtil* resource_data_util,
                                             const ResourceSnapshotInfo&     snapshot)
 {
     auto resource_wrapper = snapshot.resource_wrapper;
     auto resource_info    = resource_wrapper->GetObjectInfo();
     auto resource         = resource_wrapper->GetWrappedObjectAs<ID3D12Resource>();
-    if (resource_data_util->CopyMappableResource(resource,
-                                                 resource_info->subresource_transitions,
-                                                 resource_info->subresource_transitions,
-                                                 graphics::Dx12ResourceDataUtil::CopyType::kCopyTypeRead,
-                                                 &resource_info->staging_buffer_info.staging_buffer_data,
-                                                 nullptr,
-                                                 resource_info.get()->staging_buffer_info.subresource_offsets,
-                                                 resource_info.get()->staging_buffer_info.subresource_sizes))
+
+    uint64_t subresource_count      = 0;
+    uint64_t total_subresource_size = 0;
+    temp_subresource_data_.clear();
+    temp_subresource_sizes_.clear();
+    temp_subresource_offsets_.clear();
+
+    bool is_reserved_resouce = (resource_info->create_call_id == format::ApiCall_ID3D12Device_CreateReservedResource) ||
+                               (resource_info->create_call_id == format::ApiCall_ID3D12Device4_CreateReservedResource1);
+    bool is_texture_with_unknown_layout =
+        graphics::dx12::IsTextureWithUnknownLayout(resource_info->dimension, resource_info->layout);
+
+    bool try_map_and_copy = !is_reserved_resouce && !is_texture_with_unknown_layout;
+
+    // Read the data from the resource.
+    HRESULT result = resource_data_util->ReadFromResource(resource,
+                                                          try_map_and_copy,
+                                                          resource_info->subresource_transitions,
+                                                          resource_info->subresource_transitions,
+                                                          temp_subresource_data_,
+                                                          temp_subresource_offsets_,
+                                                          temp_subresource_sizes_);
+
+    if (SUCCEEDED(result))
     {
-        WriteBufferData(resource_wrapper);
+        // Write the subresource data to the output.
+        for (uint32_t i = 0; i < temp_subresource_sizes_.size(); ++i)
+        {
+            GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, temp_subresource_sizes_[i]);
+
+            uint8_t* subresource_data = temp_subresource_data_.data() + temp_subresource_offsets_[i];
+            size_t   subresource_size = static_cast<size_t>(temp_subresource_sizes_[i]);
+
+            // Create subresource upload data block.
+            format::InitSubresourceCommandHeader upload_cmd;
+            upload_cmd.meta_header.block_header.type = format::kMetaDataBlock;
+            upload_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(format::ApiFamilyId::ApiFamily_D3D12,
+                                                                         format::MetaDataType::kInitSubresourceCommand);
+            upload_cmd.thread_id                     = thread_id_;
+            format::HandleId device_id               = format::kNullHandleId;
+            if (resource_info->device_wrapper != nullptr)
+            {
+                device_id = resource_info->device_wrapper->GetCaptureId();
+            }
+            upload_cmd.device_id      = device_id;
+            upload_cmd.resource_id    = resource_wrapper->GetCaptureId();
+            upload_cmd.subresource    = i;
+            upload_cmd.initial_state  = resource_info->initial_state;
+            upload_cmd.resource_state = resource_info->subresource_transitions[i].states;
+            upload_cmd.barrier_flags  = resource_info->subresource_transitions[i].barrier_flags;
+            upload_cmd.data_size      = subresource_size;
+
+            // Compress block data.
+            if (compressor_ != nullptr)
+            {
+                size_t compressed_size =
+                    compressor_->Compress(subresource_size, subresource_data, &compressed_parameter_buffer_, 0);
+
+                if ((compressed_size > 0) && (compressed_size < subresource_size))
+                {
+                    upload_cmd.meta_header.block_header.type = format::BlockType::kCompressedMetaDataBlock;
+
+                    subresource_data = compressed_parameter_buffer_.data();
+                    subresource_size = compressed_size;
+                }
+            }
+
+            // Calculate size of packet with compressed or uncompressed data size.
+            upload_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(upload_cmd) + subresource_size;
+
+            // Write upload block to file.
+            output_stream_->Write(&upload_cmd, sizeof(upload_cmd));
+            output_stream_->Write(subresource_data, subresource_size);
+        }
     }
     else
     {

--- a/framework/encode/dx12_state_writer.h
+++ b/framework/encode/dx12_state_writer.h
@@ -134,21 +134,12 @@ class Dx12StateWriter
 
     void WriteTileMappings(const Dx12StateTable& state_table, ID3D12ResourceInfo* resource_info);
 
-    void FlushStagingBuffersData(graphics::Dx12ResourceDataUtil*       resource_data_util,
-                                 std::vector<ID3D12Resource_Wrapper*>& submitted_resources);
-
     void
     WriteResourceSnapshots(const std::unordered_map<format::HandleId, std::vector<ResourceSnapshotInfo>>& snapshots,
                            const std::unordered_map<format::HandleId, uint64_t>& max_resource_sizes);
 
-    void WriteMappableResource(graphics::Dx12ResourceDataUtil* resource_data_util,
+    void WriteResourceSnapshot(graphics::Dx12ResourceDataUtil* resource_data_util,
                                const ResourceSnapshotInfo&     snapshot);
-
-    void WriteBufferData(ID3D12Resource_Wrapper* resource_wrapper);
-
-    void CreateStagingBuffer(graphics::Dx12ResourceDataUtil* resource_data_util,
-                             ID3D12Resource*                 target_resource,
-                             ID3D12ResourceInfo*             resource_info);
 
     // Sync to ensure all pending command queues are completed before processing state writing.
     void WaitForCommandQueues(const Dx12StateTable& state_table);


### PR DESCRIPTION
Don't batch command list executions for reading resource data from GPU for trimmed state capture. May reduce memory use during activation of trimming. Reverts some changes from 0103dcf800