### PR TITLE
Factored out Metadata and Marker Consumer Bases From Vulkan and D3D12 Consumer Bases

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/struct_pointer_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/swapchain_image_tracker.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/value_decoder.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/metadata_consumer_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_consumer_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_decoder_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_decoder_base.cpp

--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/swapchain_image_tracker.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/value_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/metadata_consumer_base.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/marker_consumer_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_consumer_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_decoder_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_decoder_base.cpp

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/struct_pointer_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/swapchain_image_tracker.h
                     ${CMAKE_CURRENT_LIST_DIR}/value_decoder.h
+                    ${CMAKE_CURRENT_LIST_DIR}/marker_consumer_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/metadata_consumer_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_consumer_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_stats_consumer.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/struct_pointer_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/swapchain_image_tracker.h
                     ${CMAKE_CURRENT_LIST_DIR}/value_decoder.h
+                    ${CMAKE_CURRENT_LIST_DIR}/metadata_consumer_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_consumer_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_stats_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/stat_decoder_base.h

--- a/framework/decode/dx12_consumer_base.h
+++ b/framework/decode/dx12_consumer_base.h
@@ -1,5 +1,6 @@
 /*
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 Valve Corporation
+** Copyright (c) 2021, 2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -23,6 +24,7 @@
 #ifndef GFXRECON_DECODE_DX12_CONSUMER_BASE_H
 #define GFXRECON_DECODE_DX12_CONSUMER_BASE_H
 
+#include "decode/metadata_consumer_base.h"
 #include "decode/api_decoder.h"
 #include "decode/handle_pointer_decoder.h"
 #include "decode/struct_pointer_decoder.h"
@@ -33,8 +35,9 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-// TODO: Dx12ConsumerBase is very similar to VulkanConsumerBase. It might be able to merge into a shared class.
-class Dx12ConsumerBase
+/// @todo Dx12ConsumerBase is very similar to VulkanConsumerBase. It might be possible to merge them into a shared class
+/// or to factor parts of them out into separate base classes that they can both derive from.
+class Dx12ConsumerBase : public MetadataConsumerBase /// @todo , public StateMarkerConsumerBase
 {
   public:
     Dx12ConsumerBase() {}
@@ -51,92 +54,6 @@ class Dx12ConsumerBase
     virtual void ProcessStateEndMarker(uint64_t frame_number) {}
 
     virtual void ProcessFrameEndMarker(uint64_t frame_number) {}
-
-    virtual void ProcessDisplayMessageCommand(const std::string& message) {}
-
-    virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
-
-    virtual void
-    ProcessFillMemoryResourceValueCommand(const format::FillMemoryResourceValueCommandHeader& command_header,
-                                          const uint8_t*                                      data)
-    {}
-
-    virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}
-
-    virtual void
-    ProcessResizeWindowCommand2(format::HandleId surface_id, uint32_t width, uint32_t height, uint32_t pre_transform)
-    {}
-
-    virtual void ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
-                                                    uint64_t                                            buffer_id,
-                                                    uint32_t                                            format,
-                                                    uint32_t                                            width,
-                                                    uint32_t                                            height,
-                                                    uint32_t                                            stride,
-                                                    uint64_t                                            usage,
-                                                    uint32_t                                            layers,
-                                                    const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
-    {}
-
-    virtual void ProcessDestroyHardwareBufferCommand(uint64_t buffer_id) {}
-
-    virtual void ProcessCreateHeapAllocationCommand(uint64_t allocation_id, uint64_t allocation_size) {}
-
-    virtual void ProcessSetDevicePropertiesCommand(format::HandleId   physical_device_id,
-                                                   uint32_t           api_version,
-                                                   uint32_t           driver_version,
-                                                   uint32_t           vendor_id,
-                                                   uint32_t           device_id,
-                                                   uint32_t           device_type,
-                                                   const uint8_t      pipeline_cache_uuid[format::kUuidSize],
-                                                   const std::string& device_name)
-    {}
-
-    virtual void ProcessSetDeviceMemoryPropertiesCommand(format::HandleId physical_device_id,
-                                                         const std::vector<format::DeviceMemoryType>& memory_types,
-                                                         const std::vector<format::DeviceMemoryHeap>& memory_heaps)
-    {}
-
-    virtual void
-    ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address)
-    {}
-
-    virtual void ProcessSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
-                                                               format::HandleId pipeline_id,
-                                                               size_t           data_size,
-                                                               const uint8_t*   data)
-    {}
-
-    virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
-                                                      format::HandleId swapchain_id,
-                                                      uint32_t         current_buffer_index,
-                                                      const std::vector<format::SwapchainImageStateInfo>& image_state)
-    {}
-
-    virtual void
-    ProcessBeginResourceInitCommand(format::HandleId device_id, uint64_t max_resource_size, uint64_t max_copy_size)
-    {}
-
-    virtual void ProcessEndResourceInitCommand(format::HandleId device_id) {}
-
-    virtual void ProcessInitBufferCommand(format::HandleId device_id,
-                                          format::HandleId buffer_id,
-                                          uint64_t         data_size,
-                                          const uint8_t*   data)
-    {}
-
-    virtual void ProcessInitImageCommand(format::HandleId             device_id,
-                                         format::HandleId             image_id,
-                                         uint64_t                     data_size,
-                                         uint32_t                     aspect,
-                                         uint32_t                     layout,
-                                         const std::vector<uint64_t>& level_sizes,
-                                         const uint8_t*               data)
-    {}
-
-    virtual void ProcessInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
-                                               const uint8_t*                              data)
-    {}
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&       command_header,

--- a/framework/decode/dx12_consumer_base.h
+++ b/framework/decode/dx12_consumer_base.h
@@ -25,6 +25,7 @@
 #define GFXRECON_DECODE_DX12_CONSUMER_BASE_H
 
 #include "decode/metadata_consumer_base.h"
+#include "decode/marker_consumer_base.h"
 #include "decode/api_decoder.h"
 #include "decode/handle_pointer_decoder.h"
 #include "decode/struct_pointer_decoder.h"
@@ -35,9 +36,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-/// @todo Dx12ConsumerBase is very similar to VulkanConsumerBase. It might be possible to merge them into a shared class
-/// or to factor parts of them out into separate base classes that they can both derive from.
-class Dx12ConsumerBase : public MetadataConsumerBase /// @todo , public StateMarkerConsumerBase
+class Dx12ConsumerBase : public MetadataConsumerBase, public MarkerConsumerBase
 {
   public:
     Dx12ConsumerBase() {}
@@ -48,12 +47,6 @@ class Dx12ConsumerBase : public MetadataConsumerBase /// @todo , public StateMar
     virtual void Process_ExeFileInfo(util::filepath::FileInfo& info_record) {}
 
     virtual bool IsComplete(uint64_t block_index) { return false; }
-
-    virtual void ProcessStateBeginMarker(uint64_t frame_number) {}
-
-    virtual void ProcessStateEndMarker(uint64_t frame_number) {}
-
-    virtual void ProcessFrameEndMarker(uint64_t frame_number) {}
 
     virtual void ProcessInitDx12AccelerationStructureCommand(
         const format::InitDx12AccelerationStructureCommandHeader&       command_header,

--- a/framework/decode/marker_consumer_base.h
+++ b/framework/decode/marker_consumer_base.h
@@ -1,0 +1,49 @@
+/*
+** Copyright (c) 2018-2023 Valve Corporation
+** Copyright (c) 2018-2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_MARKER_CONSUMER_BASE_H
+#define GFXRECON_DECODE_MARKER_CONSUMER_BASE_H
+
+#include "util/defines.h"
+#include "format/format.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+/// Base class for consumers of frame and state markers.
+/// These are decoded from blocks of types kFrameMarkerBlock and
+/// kStateMarkerBlock.
+class MarkerConsumerBase
+{
+  public:
+    virtual void ProcessStateBeginMarker(uint64_t frame_number) {}
+
+    virtual void ProcessStateEndMarker(uint64_t frame_number) {}
+
+    virtual void ProcessFrameEndMarker(uint64_t frame_number) {}
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_MARKER_CONSUMER_BASE_H

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -1,0 +1,111 @@
+/*
+** Copyright (c) 2018-2023 Valve Corporation
+** Copyright (c) 2018-2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_METADATA_CONSUMER_BASE_H
+#define GFXRECON_DECODE_METADATA_CONSUMER_BASE_H
+
+#include "util/defines.h"
+#include "format/format.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+/// @brief Base class defining the virtual functions that consumers need to
+/// implement to handle metacommands.
+class MetadataConsumerBase
+{
+  public:
+    virtual void ProcessDisplayMessageCommand(const std::string& message) {}
+    virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
+    virtual void
+    ProcessFillMemoryResourceValueCommand(const format::FillMemoryResourceValueCommandHeader& command_header,
+                                          const uint8_t*                                      data)
+    {}
+    virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}
+    virtual void
+    ProcessResizeWindowCommand2(format::HandleId surface_id, uint32_t width, uint32_t height, uint32_t pre_transform)
+    {}
+    virtual void ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
+                                                    uint64_t                                            buffer_id,
+                                                    uint32_t                                            format,
+                                                    uint32_t                                            width,
+                                                    uint32_t                                            height,
+                                                    uint32_t                                            stride,
+                                                    uint64_t                                            usage,
+                                                    uint32_t                                            layers,
+                                                    const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
+    {}
+    virtual void ProcessDestroyHardwareBufferCommand(uint64_t buffer_id) {}
+    virtual void ProcessCreateHeapAllocationCommand(uint64_t allocation_id, uint64_t allocation_size) {}
+    virtual void ProcessSetDevicePropertiesCommand(format::HandleId   physical_device_id,
+                                                   uint32_t           api_version,
+                                                   uint32_t           driver_version,
+                                                   uint32_t           vendor_id,
+                                                   uint32_t           device_id,
+                                                   uint32_t           device_type,
+                                                   const uint8_t      pipeline_cache_uuid[format::kUuidSize],
+                                                   const std::string& device_name)
+    {}
+    virtual void ProcessSetDeviceMemoryPropertiesCommand(format::HandleId physical_device_id,
+                                                         const std::vector<format::DeviceMemoryType>& memory_types,
+                                                         const std::vector<format::DeviceMemoryHeap>& memory_heaps)
+    {}
+    virtual void
+    ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address)
+    {}
+    virtual void ProcessSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
+                                                               format::HandleId pipeline_id,
+                                                               size_t           data_size,
+                                                               const uint8_t*   data)
+    {}
+    virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
+                                                      format::HandleId swapchain_id,
+                                                      uint32_t         last_presented_image,
+                                                      const std::vector<format::SwapchainImageStateInfo>& image_state)
+    {}
+    virtual void
+    ProcessBeginResourceInitCommand(format::HandleId device_id, uint64_t max_resource_size, uint64_t max_copy_size)
+    {}
+    virtual void ProcessEndResourceInitCommand(format::HandleId device_id) {}
+    virtual void ProcessInitBufferCommand(format::HandleId device_id,
+                                          format::HandleId buffer_id,
+                                          uint64_t         data_size,
+                                          const uint8_t*   data)
+    {}
+    virtual void ProcessInitImageCommand(format::HandleId             device_id,
+                                         format::HandleId             image_id,
+                                         uint64_t                     data_size,
+                                         uint32_t                     aspect,
+                                         uint32_t                     layout,
+                                         const std::vector<uint64_t>& level_sizes,
+                                         const uint8_t*               data)
+    {}
+    virtual void ProcessInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
+                                               const uint8_t*                              data)
+    {}
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_METADATA_CONSUMER_BASE_H

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -25,6 +25,7 @@
 #define GFXRECON_DECODE_VULKAN_CONSUMER_BASE_H
 
 #include "decode/metadata_consumer_base.h"
+#include "decode/marker_consumer_base.h"
 #include "decode/api_decoder.h"
 #include "decode/custom_vulkan_struct_decoders.h"
 #include "decode/descriptor_update_template_decoder.h"
@@ -41,7 +42,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-class VulkanConsumerBase : public MetadataConsumerBase /// @todo , public StateMarkerConsumerBase
+class VulkanConsumerBase : public MetadataConsumerBase, public MarkerConsumerBase
 {
   public:
     VulkanConsumerBase() {}
@@ -53,12 +54,6 @@ class VulkanConsumerBase : public MetadataConsumerBase /// @todo , public StateM
     virtual bool IsComplete(uint64_t block_index) { return false; }
 
     virtual void Process_ExeFileInfo(util::filepath::FileInfo& info_record) {}
-
-    virtual void ProcessStateBeginMarker(uint64_t frame_number) {}
-
-    virtual void ProcessStateEndMarker(uint64_t frame_number) {}
-
-    virtual void ProcessFrameEndMarker(uint64_t frame_number) {}
 
     virtual void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
                                                            format::HandleId                 device,

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2020 Valve Corporation
-** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2018-2023 Valve Corporation
+** Copyright (c) 2018-2023 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 #ifndef GFXRECON_DECODE_VULKAN_CONSUMER_BASE_H
 #define GFXRECON_DECODE_VULKAN_CONSUMER_BASE_H
 
-#include "format/platform_types.h"
+#include "decode/metadata_consumer_base.h"
 #include "decode/api_decoder.h"
 #include "decode/custom_vulkan_struct_decoders.h"
 #include "decode/descriptor_update_template_decoder.h"
@@ -33,6 +33,7 @@
 #include "decode/string_decoder.h"
 #include "decode/struct_pointer_decoder.h"
 #include "generated/generated_vulkan_struct_decoders.h"
+#include "format/platform_types.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -40,7 +41,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-class VulkanConsumerBase
+class VulkanConsumerBase : public MetadataConsumerBase /// @todo , public StateMarkerConsumerBase
 {
   public:
     VulkanConsumerBase() {}
@@ -58,98 +59,6 @@ class VulkanConsumerBase
     virtual void ProcessStateEndMarker(uint64_t frame_number) {}
 
     virtual void ProcessFrameEndMarker(uint64_t frame_number) {}
-
-    virtual void ProcessDisplayMessageCommand(const std::string& message) {}
-
-    virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
-
-    virtual void
-    ProcessFillMemoryResourceValueCommand(const format::FillMemoryResourceValueCommandHeader& command_header,
-                                          const uint8_t*                                      data)
-    {}
-
-    virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}
-
-    virtual void
-    ProcessResizeWindowCommand2(format::HandleId surface_id, uint32_t width, uint32_t height, uint32_t pre_transform)
-    {}
-
-    virtual void ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
-                                                    uint64_t                                            buffer_id,
-                                                    uint32_t                                            format,
-                                                    uint32_t                                            width,
-                                                    uint32_t                                            height,
-                                                    uint32_t                                            stride,
-                                                    uint64_t                                            usage,
-                                                    uint32_t                                            layers,
-                                                    const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
-    {}
-
-    virtual void ProcessDestroyHardwareBufferCommand(uint64_t buffer_id) {}
-
-    virtual void ProcessCreateHeapAllocationCommand(uint64_t allocation_id, uint64_t allocation_size) {}
-
-    virtual void ProcessSetDevicePropertiesCommand(format::HandleId   physical_device_id,
-                                                   uint32_t           api_version,
-                                                   uint32_t           driver_version,
-                                                   uint32_t           vendor_id,
-                                                   uint32_t           device_id,
-                                                   uint32_t           device_type,
-                                                   const uint8_t      pipeline_cache_uuid[format::kUuidSize],
-                                                   const std::string& device_name)
-    {}
-
-    virtual void ProcessSetDeviceMemoryPropertiesCommand(format::HandleId physical_device_id,
-                                                         const std::vector<format::DeviceMemoryType>& memory_types,
-                                                         const std::vector<format::DeviceMemoryHeap>& memory_heaps)
-    {}
-
-    virtual void
-    ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address)
-    {}
-
-    virtual void ProcessSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
-                                                               format::HandleId pipeline_id,
-                                                               size_t           data_size,
-                                                               const uint8_t*   data)
-    {}
-
-    virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
-                                                      format::HandleId swapchain_id,
-                                                      uint32_t         last_presented_image,
-                                                      const std::vector<format::SwapchainImageStateInfo>& image_state)
-    {}
-
-    virtual void
-    ProcessBeginResourceInitCommand(format::HandleId device_id, uint64_t max_resource_size, uint64_t max_copy_size)
-    {}
-
-    virtual void ProcessEndResourceInitCommand(format::HandleId device_id) {}
-
-    virtual void ProcessInitBufferCommand(format::HandleId device_id,
-                                          format::HandleId buffer_id,
-                                          uint64_t         data_size,
-                                          const uint8_t*   data)
-    {}
-
-    virtual void ProcessInitImageCommand(format::HandleId             device_id,
-                                         format::HandleId             image_id,
-                                         uint64_t                     data_size,
-                                         uint32_t                     aspect,
-                                         uint32_t                     layout,
-                                         const std::vector<uint64_t>& level_sizes,
-                                         const uint8_t*               data)
-    {}
-
-    virtual void ProcessInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
-                                               const uint8_t*                              data)
-    {}
-
-    virtual void ProcessInitDx12AccelerationStructureCommand(
-        const format::InitDx12AccelerationStructureCommandHeader&       command_header,
-        std::vector<format::InitDx12AccelerationStructureGeometryDesc>& geometry_descs,
-        const uint8_t*                                                  build_inputs_data)
-    {}
 
     virtual void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
                                                            format::HandleId                 device,


### PR DESCRIPTION
Give these functions one shared definition rather than two copies duplicated between the DX12 and Vulkan classes.

Fixes #1335. 
