### PR TITLE
Fix optimize tool's exit code on error

### DIFF
--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -281,6 +281,8 @@ int main(int argc, const char** argv)
             else
             {
                 GFXRECON_LOG_ERROR("Could not detect graphics API. Aborting optimization.")
+                gfxrecon::util::Log::Release();
+                return -1;
             }
         }
         // Manual mode. Follow user instructions.


### PR DESCRIPTION
gfxrecon-optimize tool should now return -1 when it fails to recognise input file. Previously it was returning 0 which can be misleading.