### PR TITLE
Add replay option with user specified window location

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -208,6 +208,7 @@ Usage:
                         [--onhb | --omit-null-hardware-buffers]
                         [-m <mode> | --memory-translation <mode>]
                         [--fw <width,height> | --force-windowed <width,height>]
+                        [--fwo <x,y> | --force-windowed-origin <x,y>]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
                         [--batching-memory-usage <pct>]
                         [--api <api>] <file>
@@ -277,6 +278,8 @@ Windows-only:
                             d3d12       Replay with the Direct3D API enabled.
                             all         Replay with both the Vulkan and Direct3D 12 APIs
                                         enabled. This is the default.
+  --fwo <x,y>           Force windowed mode if not already, and allow setting of a custom window location.
+                        (Same as --force-windowed-origin)
 
 Vulkan-only:
   --sfa                 Skip vkAllocateMemory, vkAllocateCommandBuffers, and

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -525,6 +525,8 @@ gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
                         [--surface-index <N>] [--remove-unsupported] [--validate]
                         [-m <mode> | --memory-translation <mode>]
+                        [--fwo <x,y> | --force-windowed-origin <x,y>]
+                        [--use-captured-swapchain-indices]
                         [--swapchain MODE] [--use-captured-swapchain-indices]
                         [--mfr|--measurement-frame-range <start-frame>-<end-frame>]
                         [--measurement-file <file>] [--quit-after-measurement-range]
@@ -631,6 +633,8 @@ Optional arguments:
                                         to different allocations with different
                                         offsets.  Uses VMA to manage allocations
                                         and suballocations.
+  --fwo <x,y>           Force windowed mode if not already, and allow setting of a custom window location.
+                        (Same as --force-windowed-origin)
   --api <api>           Use the specified API for replay (Windows only).
                         Available values are:
                             vulkan      Replay with the Vulkan API enabled.

--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -148,13 +149,14 @@ AndroidWindowFactory::AndroidWindowFactory(AndroidContext* android_context) : an
 
 AndroidWindowFactory::~AndroidWindowFactory() {}
 
-decode::Window*
-AndroidWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+decode::Window* AndroidWindowFactory::Create(
+    const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     GFXRECON_UNREFERENCED_PARAMETER(x);
     GFXRECON_UNREFERENCED_PARAMETER(y);
     GFXRECON_UNREFERENCED_PARAMETER(width);
     GFXRECON_UNREFERENCED_PARAMETER(height);
+    GFXRECON_UNREFERENCED_PARAMETER(force_windowed);
 
     return android_context_->GetWindow();
 }

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -41,7 +42,12 @@ class AndroidWindow : public decode::Window
 
     virtual ~AndroidWindow() override {}
 
-    virtual bool Create(const std::string&, const int32_t, const int32_t, const uint32_t, const uint32_t) override
+    virtual bool Create(const std::string&,
+                        const int32_t,
+                        const int32_t,
+                        const uint32_t,
+                        const uint32_t,
+                        bool force_windowed = false) override
     {
         return true;
     }
@@ -90,8 +96,11 @@ class AndroidWindowFactory : public decode::WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t  x,
+                                   const int32_t  y,
+                                   const uint32_t width,
+                                   const uint32_t height,
+                                   bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/display_window.cpp
+++ b/framework/application/display_window.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2021 Broadcom, Inc.
 ** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -279,13 +280,14 @@ DisplayWindowFactory::DisplayWindowFactory(DisplayContext* display_context) : di
 
 DisplayWindowFactory::~DisplayWindowFactory() {}
 
-decode::Window*
-DisplayWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+decode::Window* DisplayWindowFactory::Create(
+    const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     GFXRECON_UNREFERENCED_PARAMETER(x);
     GFXRECON_UNREFERENCED_PARAMETER(y);
     GFXRECON_UNREFERENCED_PARAMETER(width);
     GFXRECON_UNREFERENCED_PARAMETER(height);
+    GFXRECON_UNREFERENCED_PARAMETER(force_windowed);
 
     // Display has a single "window" whose lifetime is managed by DisplayContext.
     return display_context_->GetWindow();

--- a/framework/application/display_window.h
+++ b/framework/application/display_window.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2021 Broadcom, Inc.
 ** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -38,7 +39,12 @@ class DisplayWindow : public decode::Window
 
     virtual ~DisplayWindow() override {}
 
-    virtual bool Create(const std::string&, const int32_t, const int32_t, const uint32_t, const uint32_t) override
+    virtual bool Create(const std::string&,
+                        const int32_t,
+                        const int32_t,
+                        const uint32_t,
+                        const uint32_t,
+                        bool force_windowed = false) override
     {
         return true;
     }
@@ -99,8 +105,11 @@ class DisplayWindowFactory : public decode::WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_DISPLAY_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t  x,
+                                   const int32_t  y,
+                                   const uint32_t width,
+                                   const uint32_t height,
+                                   bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2021, Arm Limited.
 ** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -36,14 +37,19 @@ HeadlessWindow::HeadlessWindow(HeadlessContext* headless_context) : headless_con
 
 HeadlessWindow::~HeadlessWindow() {}
 
-bool HeadlessWindow::Create(
-    const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height)
+bool HeadlessWindow::Create(const std::string& title,
+                            const int32_t      xpos,
+                            const int32_t      ypos,
+                            const uint32_t     width,
+                            const uint32_t     height,
+                            bool               force_windowed)
 {
     GFXRECON_UNREFERENCED_PARAMETER(title);
     GFXRECON_UNREFERENCED_PARAMETER(xpos);
     GFXRECON_UNREFERENCED_PARAMETER(ypos);
     GFXRECON_UNREFERENCED_PARAMETER(width);
     GFXRECON_UNREFERENCED_PARAMETER(height);
+    GFXRECON_UNREFERENCED_PARAMETER(force_windowed);
 
     return true;
 }
@@ -126,14 +132,14 @@ HeadlessWindowFactory::HeadlessWindowFactory(HeadlessContext* headless_context) 
     assert(headless_context_ != nullptr);
 }
 
-decode::Window*
-HeadlessWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+decode::Window* HeadlessWindowFactory::Create(
+    const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     assert(headless_context_);
     decode::Window* window      = new HeadlessWindow(headless_context_);
     auto            application = headless_context_->GetApplication();
     assert(application);
-    window->Create(application->GetName(), x, y, width, height);
+    window->Create(application->GetName(), x, y, width, height, force_windowed);
     return window;
 }
 

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2021, Arm Limited.
 ** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -42,7 +43,8 @@ class HeadlessWindow : public decode::Window
                         const int32_t      xpos,
                         const int32_t      ypos,
                         const uint32_t     width,
-                        const uint32_t     height) override;
+                        const uint32_t     height,
+                        bool               force_windowed = false) override;
 
     virtual bool Destroy() override;
 
@@ -82,8 +84,11 @@ class HeadlessWindowFactory : public decode::WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t  x,
+                                   const int32_t  y,
+                                   const uint32_t width,
+                                   const uint32_t height,
+                                   bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/metal_window.h
+++ b/framework/application/metal_window.h
@@ -45,7 +45,8 @@ public:
                 const int32_t      xpos,
                 const int32_t      ypos,
                 const uint32_t     width,
-                const uint32_t     height) override;
+                const uint32_t     height,
+                bool               force_windowed = false) override;
 
     bool Destroy() override;
 
@@ -88,7 +89,7 @@ public:
 
     const char* GetSurfaceExtensionName() const override { return VK_EXT_METAL_SURFACE_EXTENSION_NAME; }
 
-    decode::Window* Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    decode::Window* Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -101,7 +101,7 @@ MetalWindow::MetalWindow(MetalContext* metal_context)
 
 MetalWindow::~MetalWindow() = default;
 
-bool MetalWindow::Create(const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height, bool force_windowed = false)
+bool MetalWindow::Create(const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     @autoreleasepool
     {
@@ -264,7 +264,7 @@ MetalWindowFactory::MetalWindowFactory(MetalContext* metal_context) : metal_cont
     assert(metal_context_);
 }
 
-decode::Window* MetalWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed = false)
+decode::Window* MetalWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     assert(metal_context_);
     decode::Window* window = new MetalWindow(metal_context_);

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -101,7 +101,7 @@ MetalWindow::MetalWindow(MetalContext* metal_context)
 
 MetalWindow::~MetalWindow() = default;
 
-bool MetalWindow::Create(const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height)
+bool MetalWindow::Create(const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height, bool force_windowed = false)
 {
     @autoreleasepool
     {
@@ -264,12 +264,12 @@ MetalWindowFactory::MetalWindowFactory(MetalContext* metal_context) : metal_cont
     assert(metal_context_);
 }
 
-decode::Window* MetalWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+decode::Window* MetalWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed = false)
 {
     assert(metal_context_);
     decode::Window* window = new MetalWindow(metal_context_);
     Application* application = metal_context_->GetApplication();
-    window->Create(application->GetName(), x, y, width, height);
+    window->Create(application->GetName(), x, y, width, height, force_windowed);
     return window;
 }
 

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -76,11 +77,16 @@ WaylandWindow::~WaylandWindow()
     }
 }
 
-bool WaylandWindow::Create(
-    const std::string& title, const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+bool WaylandWindow::Create(const std::string& title,
+                           const int32_t      x,
+                           const int32_t      y,
+                           const uint32_t     width,
+                           const uint32_t     height,
+                           bool               force_windowed)
 {
     GFXRECON_UNREFERENCED_PARAMETER(x);
     GFXRECON_UNREFERENCED_PARAMETER(y);
+    GFXRECON_UNREFERENCED_PARAMETER(force_windowed);
 
     auto& wl = wayland_context_->GetWaylandFunctionTable();
     surface_ = wl.compositor_create_surface(wayland_context_->GetCompositor());
@@ -351,14 +357,14 @@ WaylandWindowFactory::WaylandWindowFactory(WaylandContext* wayland_context) : wa
     assert(wayland_context_ != nullptr);
 }
 
-decode::Window*
-WaylandWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+decode::Window* WaylandWindowFactory::Create(
+    const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     assert(wayland_context_);
     decode::Window* window      = new WaylandWindow(wayland_context_);
     auto            application = wayland_context_->GetApplication();
     assert(application);
-    window->Create(application->GetName(), x, y, width, height);
+    window->Create(application->GetName(), x, y, width, height, force_windowed);
     return window;
 }
 

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -50,7 +51,8 @@ class WaylandWindow : public decode::Window
                         const int32_t      x,
                         const int32_t      y,
                         const uint32_t     width,
-                        const uint32_t     height) override;
+                        const uint32_t     height,
+                        bool               force_windowed = false) override;
 
     virtual bool Destroy() override;
 
@@ -120,8 +122,11 @@ class WaylandWindowFactory : public decode::WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t  x,
+                                   const int32_t  y,
+                                   const uint32_t width,
+                                   const uint32_t height,
+                                   bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -98,6 +98,7 @@ bool Win32Window::Create(const std::string& title,
     int32_t  x            = xpos;
     int32_t  y            = ypos;
     fullscreen_           = false;
+    force_windowed_       = force_windowed;
 
     if ((screen_height_ <= ypos) || (screen_width_ <= xpos))
     {
@@ -213,8 +214,17 @@ void Win32Window::SetSize(const uint32_t width, const uint32_t height)
                     screen_height_);
             }
 
-            uint32_t swp_flags    = SWP_NOMOVE | SWP_NOZORDER;
+            uint32_t swp_flags = SWP_NOMOVE | SWP_NOZORDER;
+
+            uint32_t current_window_style = GetWindowLong(hwnd_, GWL_STYLE);
             uint32_t window_style = fullscreen_ ? (WS_VISIBLE | kFullscreenStyle) : (WS_VISIBLE | kWindowedStyle);
+
+            if (((current_window_style & kFullscreenStyle) != kFullscreenStyle) && (force_windowed_ == false))
+            {
+                window_style = WS_VISIBLE | kFullscreenStyle;
+                SetWindowLong(hwnd_, GWL_STYLE, window_style);
+                swp_flags |= SWP_FRAMECHANGED;
+            }
 
             AdjustWindowRect(&wr, window_style, FALSE);
 

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -85,6 +85,7 @@ class Win32Window : public decode::Window
     uint32_t      screen_height_;
     bool          fullscreen_;
     HINSTANCE     hinstance_;
+    bool          force_windowed_;
 };
 
 class Win32WindowFactory : public decode::WindowFactory

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -45,7 +46,8 @@ class Win32Window : public decode::Window
                         const int32_t      xpos,
                         const int32_t      ypos,
                         const uint32_t     width,
-                        const uint32_t     height) override;
+                        const uint32_t     height,
+                        bool               force_windowed = false) override;
 
     virtual bool Destroy() override;
 
@@ -92,8 +94,11 @@ class Win32WindowFactory : public decode::WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_WIN32_SURFACE_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t  x,
+                                   const int32_t  y,
+                                   const uint32_t width,
+                                   const uint32_t height,
+                                   bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -64,9 +65,14 @@ XcbWindow::~XcbWindow()
     }
 }
 
-bool XcbWindow::Create(
-    const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height)
+bool XcbWindow::Create(const std::string& title,
+                       const int32_t      xpos,
+                       const int32_t      ypos,
+                       const uint32_t     width,
+                       const uint32_t     height,
+                       bool               force_windowed)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(force_windowed);
     auto&             xcb        = xcb_context_->GetXcbFunctionTable();
     xcb_connection_t* connection = xcb_context_->GetConnection();
     xcb_screen_t*     screen     = xcb_context_->GetScreen();
@@ -515,13 +521,14 @@ XcbWindowFactory::XcbWindowFactory(XcbContext* xcb_context) : xcb_context_(xcb_c
     assert(xcb_context_ != nullptr);
 }
 
-decode::Window* XcbWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+decode::Window* XcbWindowFactory::Create(
+    const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     assert(xcb_context_);
     decode::Window* window      = new XcbWindow(xcb_context_);
     auto            application = xcb_context_->GetApplication();
     assert(application);
-    window->Create(application->GetName(), x, y, width, height);
+    window->Create(application->GetName(), x, y, width, height, force_windowed);
     return window;
 }
 

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -63,7 +64,8 @@ class XcbWindow : public decode::Window
                         const int32_t      xpos,
                         const int32_t      ypos,
                         const uint32_t     width,
-                        const uint32_t     height) override;
+                        const uint32_t     height,
+                        bool               force_windowed = false) override;
 
     virtual bool Destroy() override;
 
@@ -138,8 +140,11 @@ class XcbWindowFactory : public decode::WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_XCB_SURFACE_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t  x,
+                                   const int32_t  y,
+                                   const uint32_t width,
+                                   const uint32_t height,
+                                   bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -44,9 +45,14 @@ XlibWindow::XlibWindow(XlibContext* xlib_context) :
 
 XlibWindow::~XlibWindow() {}
 
-bool XlibWindow::Create(
-    const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height)
+bool XlibWindow::Create(const std::string& title,
+                        const int32_t      xpos,
+                        const int32_t      ypos,
+                        const uint32_t     width,
+                        const uint32_t     height,
+                        bool               force_windowed)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(force_windowed);
     display_ = xlib_context_->OpenDisplay();
 
     const auto xlib   = xlib_context_->GetXlibFunctionTable();
@@ -323,13 +329,14 @@ XlibWindowFactory::XlibWindowFactory(XlibContext* context) : xlib_context_(conte
     assert(xlib_context_ != nullptr);
 }
 
-decode::Window* XlibWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+decode::Window* XlibWindowFactory::Create(
+    const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     assert(xlib_context_);
     decode::Window* window      = new XlibWindow(xlib_context_);
     auto            application = xlib_context_->GetApplication();
     assert(application);
-    window->Create(application->GetName(), x, y, width, height);
+    window->Create(application->GetName(), x, y, width, height, force_windowed);
     return window;
 }
 

--- a/framework/application/xlib_window.h
+++ b/framework/application/xlib_window.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -41,7 +42,8 @@ class XlibWindow : public decode::Window
                         const int32_t      xpos,
                         const int32_t      ypos,
                         const uint32_t     width,
-                        const uint32_t     height) override;
+                        const uint32_t     height,
+                        bool               force_windowed = false) override;
 
     virtual bool Destroy() override;
 
@@ -93,8 +95,11 @@ class XlibWindowFactory : public decode::WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_XLIB_SURFACE_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t  x,
+                                   const int32_t  y,
+                                   const uint32_t width,
+                                   const uint32_t height,
+                                   bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2019-2020 Valve Corporation
 ** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -51,6 +52,9 @@ struct ReplayOptions
     bool     force_windowed{ false };
     uint32_t windowed_width{ 0 };
     uint32_t windowed_height{ 0 };
+    bool     force_windowed_origin{ false };
+    int32_t  window_topleft_x{ 0 };
+    int32_t  window_topleft_y{ 0 };
     int32_t  override_gpu_index{ -1 };
 };
 

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -32,7 +32,12 @@ VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                       
                                                  VkFlags                             flags,
                                                  HandlePointerDecoder<VkSurfaceKHR>* surface,
                                                  const encode::VulkanInstanceTable*  instance_table,
-                                                 application::Application*           application)
+                                                 application::Application*           application,
+                                                 const int32_t                       xpos,
+                                                 const int32_t                       ypos,
+                                                 const uint32_t                      width,
+                                                 const uint32_t                      height,
+                                                 bool                                force_windowed)
 {
     GFXRECON_ASSERT(surface);
 

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -41,7 +41,12 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
                                    const encode::VulkanInstanceTable*  instance_table,
-                                   application::Application*           application) override;
+                                   application::Application*           application,
+                                   const int32_t                       xpos,
+                                   const int32_t                       ypos,
+                                   const uint32_t                      width,
+                                   const uint32_t                      height,
+                                   bool                                force_windowed = false) override;
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const InstanceInfo*          instance_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -6368,7 +6368,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
@@ -6395,7 +6400,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -6440,7 +6450,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -6489,7 +6504,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -6538,7 +6558,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
@@ -6565,7 +6590,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
@@ -6592,7 +6622,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -6639,7 +6674,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateMetalSurfaceEXT(
                                      replay_create_info->flags,
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
-                                     application_.get());
+                                     application_.get(),
+                                     options_.window_topleft_x,
+                                     options_.window_topleft_y,
+                                     kDefaultWindowWidth,
+                                     kDefaultWindowHeight,
+                                     options_.force_windowed || options_.force_windowed_origin);
 }
 
 void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -24,11 +25,6 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
-
-const int32_t  kDefaultWindowPositionX = 0;
-const int32_t  kDefaultWindowPositionY = 0;
-const uint32_t kDefaultWindowWidth     = 320;
-const uint32_t kDefaultWindowHeight    = 240;
 
 void VulkanSwapchain::Clean()
 {
@@ -56,7 +52,12 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
                                         VkFlags                             flags,
                                         HandlePointerDecoder<VkSurfaceKHR>* surface,
                                         const encode::VulkanInstanceTable*  instance_table,
-                                        application::Application*           application)
+                                        application::Application*           application,
+                                        const int32_t                       xpos,
+                                        const int32_t                       ypos,
+                                        const uint32_t                      width,
+                                        const uint32_t                      height,
+                                        bool                                force_windowed)
 {
     assert(instance_info != nullptr);
 
@@ -83,11 +84,11 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
         assert(wsi_context);
         auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
         assert(window_factory);
-        auto window =
-            window_factory
-                ? window_factory->Create(
-                      kDefaultWindowPositionX, kDefaultWindowPositionY, kDefaultWindowWidth, kDefaultWindowHeight)
-                : nullptr;
+
+        // By default, the created window will be automatically in full screen mode, and its location will be set to 0,0
+        // if the requested size exceeds or equals the current screen size. If the user specifies "--fw" or "--fwo" this
+        // behavior will change, and replay will instead render in windowed mode.
+        auto window = window_factory ? window_factory->Create(xpos, ypos, width, height, force_windowed) : nullptr;
 
         if (window == nullptr)
         {

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -39,6 +39,11 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+const int32_t  kDefaultWindowPositionX = 0;
+const int32_t  kDefaultWindowPositionY = 0;
+const uint32_t kDefaultWindowWidth     = 320;
+const uint32_t kDefaultWindowHeight    = 240;
+
 class ScreenshotHandler;
 
 struct VulkanSwapchainOptions
@@ -62,7 +67,12 @@ class VulkanSwapchain
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
                                    const encode::VulkanInstanceTable*  instance_table,
-                                   application::Application*           application);
+                                   application::Application*           application,
+                                   const int32_t                       xpos,
+                                   const int32_t                       ypos,
+                                   const uint32_t                      width,
+                                   const uint32_t                      height,
+                                   bool                                force_windowed = false);
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const InstanceInfo*          instance_info,

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -615,8 +615,9 @@ VkResult VulkanVirtualSwapchain::AcquireNextImageKHR(VkResult                  o
     }
 
     result = func(device, swapchain, timeout, semaphore, fence, image_index);
-    if (result != VK_SUCCESS)
+    if ((result != VK_SUCCESS) && (result != VK_SUBOPTIMAL_KHR))
     {
+        // TODO: Add some handling of optimization with VK_SUBOPTIMAL_KHR.
         GFXRECON_LOG_ERROR("Virtual swapchain failed AcquireNextImageKHR 0x%08x for swapchain (ID = %" PRIu64 ")",
                            result,
                            swapchain_info->capture_id);
@@ -640,8 +641,9 @@ VkResult VulkanVirtualSwapchain::AcquireNextImage2KHR(VkResult                  
     }
 
     VkResult result = func(device, acquire_info, image_index);
-    if (result != VK_SUCCESS)
+    if ((result != VK_SUCCESS) && (result != VK_SUBOPTIMAL_KHR))
     {
+        // TODO: Add some handling of optimization with VK_SUBOPTIMAL_KHR.
         GFXRECON_LOG_ERROR("Virtual swapchain failed AcquireNextImage2KHR 0x%08x for swapchain (ID = %" PRIu64 ")",
                            result,
                            swapchain_info->capture_id);

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018,2020 Valve Corporation
 ** Copyright (c) 2018,2020 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -60,7 +61,8 @@ class Window
                         const int32_t      xpos,
                         const int32_t      ypos,
                         const uint32_t     width,
-                        const uint32_t     height) = 0;
+                        const uint32_t     height,
+                        bool               force_windowed = false) = 0;
 
     virtual bool Destroy() = 0;
 
@@ -98,7 +100,8 @@ class WindowFactory
 
     virtual const char* GetSurfaceExtensionName() const = 0;
 
-    virtual Window* Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) = 0;
+    virtual Window* Create(
+        const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed = false) = 0;
 
     virtual void Destroy(Window* window) = 0;
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -7267,9 +7267,9 @@ void VulkanReplayConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
     format::HandleId                            device,
     format::HandleId                            swapchain)
 {
-    if (options_.swapchain_option == util::SwapchainOption::kOffscreen)
+    if ((options_.swapchain_option == util::SwapchainOption::kOffscreen) || (options_.force_windowed_origin == true) || (options_.force_windowed == true))
     {
-        GFXRECON_LOG_DEBUG("Skip vkAcquireFullScreenExclusiveModeEXT for offscreen.");
+        GFXRECON_LOG_DEBUG("Skip vkAcquireFullScreenExclusiveModeEXT for offscreen or force windowed mode.");
         return;
     }
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -260,9 +260,15 @@ class VulkanReplayConsumerBodyGenerator(
             for value in values:
                 for key in self.SKIP_FUNCTIONS_OFFSCREEN:
                     if self.is_has_specific_key_word_in_type(value, key):
-                        body += '    if (options_.swapchain_option == util::SwapchainOption::kOffscreen)\n'
+                        if name == 'vkAcquireFullScreenExclusiveModeEXT':
+                            body += '    if ((options_.swapchain_option == util::SwapchainOption::kOffscreen) || (options_.force_windowed_origin == true) || (options_.force_windowed == true))\n'
+                        else:
+                            body += '    if (options_.swapchain_option == util::SwapchainOption::kOffscreen)\n'
                         body += '    {\n'
-                        body += '        GFXRECON_LOG_DEBUG("Skip ' + name + ' for offscreen.");\n'
+                        if name == 'vkAcquireFullScreenExclusiveModeEXT':
+                            body += '        GFXRECON_LOG_DEBUG("Skip ' + name + ' for offscreen or force windowed mode.");\n'
+                        else:
+                            body += '        GFXRECON_LOG_DEBUG("Skip ' + name + ' for offscreen.");\n'
                         body += '        return;\n'
                         body += '    }\n'
                         is_print = True

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -37,7 +37,8 @@ const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
     "screenshot-dir,--screenshot-prefix,--screenshot-size,--screenshot-scale,--mfr|--measurement-frame-range,--fw|--"
-    "force-windowed,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-get-fence-status,--sgfr|--"
+    "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
+    "get-fence-status,--sgfr|--"
     "skip-get-fence-ranges";
 
 static void PrintUsage(const char* exe_name)
@@ -76,6 +77,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfs <status> | --skip-get-fence-status <status>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfr <frame-ranges> | --skip-get-fence-ranges <frame-ranges>]");
 #if defined(WIN32)
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--fwo <x,y> | --force-windowed-origin <x,y>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>] [--log-debugview]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--batching-memory-usage <pct>]");
 #if defined(_DEBUG)
@@ -154,6 +156,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\t    %s\tReplay with the Direct3D API enabled.", kApiFamilyD3D12);
     GFXRECON_WRITE_CONSOLE("          \t\t    %s\t\tReplay with both the Vulkan and Direct3D 12 APIs", kApiFamilyAll);
     GFXRECON_WRITE_CONSOLE("          \t\t         \tenabled. This is the default.");
+    GFXRECON_WRITE_CONSOLE(
+        "  --fwo <x,y>\t\tForce windowed mode if not already, and allow setting of a custom window location.");
+    GFXRECON_WRITE_CONSOLE("          \t\t(Same as --force-windowed-origin)");
 #endif
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("Vulkan-only:")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -98,6 +98,8 @@ const char kScreenshotSizeArgument[]             = "--screenshot-size";
 const char kScreenshotScaleArgument[]            = "--screenshot-scale";
 const char kForceWindowedShortArgument[]         = "--fw";
 const char kForceWindowedLongArgument[]          = "--force-windowed";
+const char kForceWindowWithOriginShortArgument[] = "--fwo";
+const char kForceWindowWithOriginLongArgument[]  = "--force-windowed-origin";
 const char kOutput[]                             = "--output";
 const char kMeasurementRangeArgument[]           = "--measurement-frame-range";
 const char kMeasurementFileArgument[]            = "--measurement-file";
@@ -749,6 +751,29 @@ static void IsForceWindowed(gfxrecon::decode::ReplayOptions& options, const gfxr
     }
 }
 
+static void SetWindowOrigin(gfxrecon::decode::ReplayOptions& options, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    auto value = arg_parser.GetArgumentValue(kForceWindowWithOriginShortArgument);
+
+    if (value.empty())
+    {
+        value = arg_parser.GetArgumentValue(kForceWindowWithOriginLongArgument);
+    }
+    if (!value.empty())
+    {
+        options.force_windowed_origin = true;
+
+        std::istringstream value_input;
+        value_input.str(value);
+        std::string val;
+
+        std::getline(value_input, val, ',');
+        options.window_topleft_x = std::stoi(val);
+        std::getline(value_input, val, ',');
+        options.window_topleft_y = std::stoi(val);
+    }
+}
+
 static std::vector<int32_t> GetFilteredMsgs(const gfxrecon::util::ArgumentParser& arg_parser,
                                             const char*                           filter_messages)
 {
@@ -828,6 +853,7 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions& options, const gfx
     }
 
     IsForceWindowed(options, arg_parser);
+    SetWindowOrigin(options, arg_parser);
 }
 
 static gfxrecon::decode::VulkanReplayOptions


### PR DESCRIPTION
**The problem**
   
Allow user to specified window orgin/starting location and replay GFXR trace in windowed mode without resizing the window resolution (it should be the same size as captured).

**The solution**

Add replay option with user specified window location. The feature is for both D3D12 and Vulkan on Windows platform. It allows user to specify window starting location and force playback in windowed mode with original resolution (instead of full screen).

In addition to the new option, the pull request also includes a bug fix to the following issue:
    --fw option failed to force windowed for full screen resolution. For example, for 4k trace file on 4k screen, the force-windowed option always fails if set --fw 3840,2160, it will always be full-screen mode.
	
**Result**
Tested DX12/Vulkan samples and target title trace file with the build of the pull request, all passed.