### PR TITLE
Fix VK_EXT_debug_marker extension not available

### DIFF
--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -616,7 +616,7 @@ void Dx12StateWriter::WriteResourceCreationState(
         else if ((resource_info->initial_state & D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE) ==
                  D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE)
         {
-            // Skip the capture of any ray tracing resource's data. Acceleration structres will be rebuilt from inputs
+            // Skip the capture of any ray tracing resource's data. Acceleration structures will be rebuilt from inputs
             // during replay. See WriteAccelerationStructuresState.
             GFXRECON_LOG_DEBUG_ONCE(
                 "Skipping resource data capture for ray tracing acceleration structure resource(s).");

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         help='\n'.join(
             [
                 'Path to a directory that holds the Vulkan registry file (vk.xml) used to generate Vulkan source.',
-                'If this option is not provide the registry from the external Khronos Vulkan headers sub module will be used.'
+                'If this option is not provided the registry from the external Khronos Vulkan headers sub module will be used.'
             ]
         )
     )

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1290,7 +1290,7 @@ class BaseGenerator(OutputGenerator):
         return 'void {}()'.format(name)
 
     def make_structure_type_enum(self, typeinfo, typename):
-        """Generate the VkStructreType enumeration value for the specified structure type."""
+        """Generate the VkStructureType enumeration value for the specified structure type."""
         members = typeinfo.elem.findall('.//member')
 
         for member in members:

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -63,7 +63,7 @@ struct LayerExtensionProps
 
 const std::vector<struct LayerExtensionProps> kDeviceExtensionProps = {
     { VkExtensionProperties{ "VK_EXT_tooling_info", 1 }, { "vkGetPhysicalDeviceToolPropertiesEXT" }, {} },
-    { VkExtensionProperties{ "VK_EXT_DEBUG_MARKER_EXTENSION_NAME", VK_EXT_DEBUG_MARKER_SPEC_VERSION },
+    { VkExtensionProperties{ VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION },
       {},
       { "vkCmdDebugMarkerBeginEXT",
         "vkCmdDebugMarkerEndEXT",


### PR DESCRIPTION
Fix miscellaneous typos, in particular one in trace_layer.cpp that made VK_EXT_debug_marker extension not available if the driver does not support it (even if supported by the layer).