### PR TITLE
Support for `VK_EXT_frame_boundary` and usage in offscreen swapchain

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -867,6 +867,15 @@ optional arguments:
                         Swap the swapchain color space if unsupported by replay device.
                         Check if color space is not supported by replay device and swap
                         to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).
+  --offscreen-swapchain-frame-boundary
+                        Should only be used with offscreen swapchain. Activates
+                        the extension VK_EXT_frame_boundary (always supported
+                        if trimming, checks for driver support otherwise) and
+                        inserts command buffer submission with
+                        VkFrameBoundaryEXT where vkQueuePresentKHR was called
+                        in the original capture. This allows preserving frames
+                        when capturing a replay that uses. offscreen swapchain.
+                        (forwarded to replay tool)
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -540,6 +540,14 @@ Optional arguments:
               Swap the swapchain color space if unsupported by replay device.
               Check if color space is not supported by replay device and
               fallback to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR.
+  --offscreen-swapchain-frame-boundary
+              Should only be used with offscreen swapchain.
+              Activates the extension VK_EXT_frame_boundary (always supported if
+              trimming, checks for driver support otherwise) and inserts command
+              buffer submission with VkFrameBoundaryEXT where vkQueuePresentKHR
+              was called in the original capture.
+              This allows preserving frames when capturing a replay that uses.
+              offscreen swapchain.
 ```
 
 ### Key Controls

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -85,6 +85,7 @@ def CreateReplayParser():
     parser.add_argument('--validate', action='store_true', default=False, help='Enables the Khronos Vulkan validation layer (forwarded to replay tool)')
     parser.add_argument('--onhb', '--omit-null-hardware-buffers', action='store_true', default=False, help='Omit Vulkan calls that would pass a NULL AHardwareBuffer* (forwarded to replay tool)')
     parser.add_argument('--use-colorspace-fallback', action='store_true', default=False, help='Swap the swapchain color space if unsupported by replay device. Check if color space is not supported by replay device and swap to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).')
+    parser.add_argument('--offscreen-swapchain-frame-boundary', action='store_true', default=False, help='Should only be used with offscreen swapchain. Activates the extension VK_EXT_frame_boundary (always supported if trimming, checks for driver support otherwise) and inserts command buffer submission with VkFrameBoundaryEXT where vkQueuePresentKHR was called in the original capture. This allows preserving frames when capturing a replay that uses. offscreen swapchain. (forwarded to replay tool)')
     parser.add_argument('--mfr', '--measurement-frame-range', metavar='START-END', help='Custom framerange to measure FPS for. This range will include the start frame but not the end frame. The measurement frame range defaults to all frames except the loading frame but can be configured for any range. If the end frame is past the last frame in the trace it will be clamped to the frame after the last (so in that case the results would include the last frame). (forwarded to replay tool)')
     parser.add_argument('--measurement-file', metavar='DEVICE_FILE', help='Write measurements to a file at the specified path. Default is: \'/sdcard/gfxrecon-measurements.json\' on android and \'./gfxrecon-measurements.json\' on desktop. (forwarded to replay tool)')
     parser.add_argument('--quit-after-measurement-range', action='store_true', default=False, help='If this is specified the replayer will abort when it reaches the <end_frame> specified in the --measurement-frame-range argument. (forwarded to replay tool)')
@@ -194,6 +195,9 @@ def MakeExtrasString(args):
     if args.swapchain:
         arg_list.append('--swapchain')
         arg_list.append('{}'.format(args.swapchain))
+    
+    if args.offscreen_swapchain_frame_boundary:
+        arg_list.append('--offscreen-swapchain-frame-boundary')
 
     if args.memory_translation:
         arg_list.append('-m')

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -100,6 +100,10 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
     VkDevice device = device_info->handle;
     device_table_->GetDeviceQueue(device, default_queue_family_index_, 0, &default_queue_);
 
+    // If this option is set, a command buffer submission with a `VkFrameBoundaryEXT` must be called each time
+    // `vkQueuePresentKHR` should have been called by the offscreen swapchain. So a maximum of work must be done at
+    // swapchain creation: Allocation and recording of an empty command buffer, initialization of a `VkFrameBoundaryEXT`
+    // structure... (Don't forget to free everything at swapchain destruction)
     if (insert_frame_boundary_)
     {
         VkResult result;

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -33,13 +33,14 @@ VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                       
                                                  HandlePointerDecoder<VkSurfaceKHR>* surface,
                                                  const encode::InstanceTable*        instance_table,
                                                  application::Application*           application,
-                                                 int32_t                             options_surface_index)
+                                                 const VulkanReplayOptions&          replay_options)
 {
     GFXRECON_ASSERT(surface);
 
     instance_table_        = instance_table;
     application_           = application;
-    options_surface_index_ = options_surface_index;
+    options_surface_index_ = replay_options.surface_index;
+    insert_frame_boundary_ = replay_options.offscreen_swapchain_frame_boundary;
 
     // For multi-surface captures, when replay is restricted to a specific surface, only create a surface for
     // the specified index.
@@ -96,8 +97,56 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    VkDevice device = device = device_info->handle;
+    VkDevice device = device_info->handle;
     device_table_->GetDeviceQueue(device, default_queue_family_index_, 0, &default_queue_);
+
+    if (insert_frame_boundary_)
+    {
+        VkResult result;
+
+        VkCommandPoolCreateInfo commandPoolCreateInfo;
+        commandPoolCreateInfo.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        commandPoolCreateInfo.pNext            = nullptr;
+        commandPoolCreateInfo.queueFamilyIndex = default_queue_family_index_;
+        commandPoolCreateInfo.flags            = 0;
+
+        result = device_table_->CreateCommandPool(device, &commandPoolCreateInfo, nullptr, &command_pool_);
+        GFXRECON_ASSERT(result == VK_SUCCESS);
+
+        VkCommandBufferAllocateInfo commandBufferAllocateInfo;
+        commandBufferAllocateInfo.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        commandBufferAllocateInfo.pNext              = nullptr;
+        commandBufferAllocateInfo.commandPool        = command_pool_;
+        commandBufferAllocateInfo.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        commandBufferAllocateInfo.commandBufferCount = 1;
+
+        result = device_table_->AllocateCommandBuffers(device, &commandBufferAllocateInfo, &command_buffer_);
+        GFXRECON_ASSERT(result == VK_SUCCESS);
+
+        VkCommandBufferBeginInfo commandBufferBeginInfo;
+        commandBufferBeginInfo.sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        commandBufferBeginInfo.pNext            = nullptr;
+        commandBufferBeginInfo.flags            = 0;
+        commandBufferBeginInfo.pInheritanceInfo = nullptr;
+
+        result = device_table_->BeginCommandBuffer(command_buffer_, &commandBufferBeginInfo);
+        GFXRECON_ASSERT(result == VK_SUCCESS);
+
+        result = device_table_->EndCommandBuffer(command_buffer_);
+        GFXRECON_ASSERT(result == VK_SUCCESS);
+
+        frame_boundary_.sType       = VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT;
+        frame_boundary_.pNext       = nullptr;
+        frame_boundary_.flags       = VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT;
+        frame_boundary_.frameID     = 0;
+        frame_boundary_.imageCount  = 0;
+        frame_boundary_.pImages     = nullptr;
+        frame_boundary_.bufferCount = 0;
+        frame_boundary_.pBuffers    = nullptr;
+        frame_boundary_.tagName     = 0;
+        frame_boundary_.tagSize     = 0;
+        frame_boundary_.pTag        = nullptr;
+    }
 
     return original_result;
 }
@@ -110,6 +159,11 @@ void VulkanOffscreenSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    
     if ((device_info != nullptr) && (swapchain_info != nullptr))
     {
         CleanSwapchainResourceData(device_info, swapchain_info);
+    }
+
+    if (insert_frame_boundary_ && command_pool_ != VK_NULL_HANDLE)
+    {
+        device_table_->DestroyCommandPool(device_info->handle, command_pool_, nullptr);
     }
 }
 
@@ -222,7 +276,36 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
                                                    const QueueInfo*                      queue_info,
                                                    const VkPresentInfoKHR*               present_info)
 {
-    if (present_info->waitSemaphoreCount > 0)
+    if (insert_frame_boundary_ && command_buffer_ != VK_NULL_HANDLE)
+    {
+        std::vector<VkImage> images(present_info->swapchainCount);
+        for (uint32_t i = 0; i < images.size(); ++i)
+        {
+            images[i] = swapchain_resources_[present_info->pSwapchains[i]]
+                            ->virtual_swapchain_images[present_info->pImageIndices[i]]
+                            .image;
+        }
+        frame_boundary_.imageCount = images.size();
+        frame_boundary_.pImages    = images.data();
+        ++frame_boundary_.frameID;
+
+        std::vector<VkPipelineStageFlags> dstStageFlags(present_info->waitSemaphoreCount,
+                                                        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+
+        VkSubmitInfo submitInfo;
+        submitInfo.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submitInfo.pNext                = &frame_boundary_;
+        submitInfo.waitSemaphoreCount   = present_info->waitSemaphoreCount;
+        submitInfo.pWaitSemaphores      = present_info->pWaitSemaphores;
+        submitInfo.pWaitDstStageMask    = dstStageFlags.data();
+        submitInfo.commandBufferCount   = 1;
+        submitInfo.pCommandBuffers      = &command_buffer_;
+        submitInfo.signalSemaphoreCount = 0;
+        submitInfo.pSignalSemaphores    = nullptr;
+
+        device_table_->QueueSubmit(queue_info->handle, 1, &submitInfo, VK_NULL_HANDLE);
+    }
+    else if (present_info->waitSemaphoreCount > 0)
     {
         VkResult result = SignalSemaphoresFence(
             queue_info, present_info->waitSemaphoreCount, present_info->pWaitSemaphores, 0, nullptr, VK_NULL_HANDLE);
@@ -235,6 +318,7 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
             return result;
         }
     }
+
     return original_result;
 }
 

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -106,10 +106,10 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    const VkSemaphore* signal_semaphores,
                                    VkFence            fence);
 
-    bool               insert_frame_boundary_{ false };
-    VkCommandPool      command_pool_{ VK_NULL_HANDLE };
-    VkCommandBuffer    command_buffer_{ VK_NULL_HANDLE };
-    VkFrameBoundaryEXT frame_boundary_;
+    bool                         insert_frame_boundary_{ false };
+    std::vector<VkCommandPool>   command_pools_{ VK_NULL_HANDLE };
+    std::vector<VkCommandBuffer> command_buffers_{ VK_NULL_HANDLE };
+    VkFrameBoundaryEXT           frame_boundary_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -42,7 +42,7 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
                                    const encode::InstanceTable*        instance_table,
                                    application::Application*           application,
-                                   int32_t                             options_surface_index) override;
+                                   const VulkanReplayOptions&          replay_options) override;
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const InstanceInfo*          instance_info,
@@ -105,6 +105,11 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    uint32_t           signal_semaphore_count,
                                    const VkSemaphore* signal_semaphores,
                                    VkFence            fence);
+
+    bool               insert_frame_boundary_{ false };
+    VkCommandPool      command_pool_{ VK_NULL_HANDLE };
+    VkCommandBuffer    command_buffer_{ VK_NULL_HANDLE };
+    VkFrameBoundaryEXT frame_boundary_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2465,6 +2465,25 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
         GFXRECON_LOG_WARNING("The vkCreateInstance parameter pCreateInfo is NULL.");
     }
 
+    if (options_.offscreen_swapchain_frame_boundary)
+    {
+        bool frameBoundaryExtensionFound = false;
+
+        for (const char* extensionName : filtered_extensions)
+        {
+            if (gfxrecon::util::platform::StringCompareNoCase(extensionName, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
+            {
+                frameBoundaryExtensionFound = true;
+                break;
+            }
+        }
+
+        if (!frameBoundaryExtensionFound)
+        {
+            filtered_extensions.push_back(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
+        }
+    }
+
     // Disable layers; any layers needed for replay should be enabled for the replay app with the VK_INSTANCE_LAYERS
     // environment variable or debug.vulkan.layers Android property.
     if (modified_create_info.enabledLayerCount > 0)
@@ -6163,7 +6182,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
@@ -6191,7 +6210,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -6237,7 +6256,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -6287,7 +6306,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -6337,7 +6356,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
@@ -6365,7 +6384,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDisplayPlaneSurfaceKHR(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
@@ -6393,7 +6412,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateHeadlessSurfaceEXT(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -6441,7 +6460,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateMetalSurfaceEXT(
                                      pSurface,
                                      GetInstanceTable(instance_info->handle),
                                      application_.get(),
-                                     options_.surface_index);
+                                     options_);
 }
 
 void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1138,6 +1138,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info) const;
 
     bool CheckCommandBufferInfoForFrameBoundary(const CommandBufferInfo* command_buffer_info);
+    bool CheckPNextChainForFrameBoundary(const DeviceInfo* device_info, const Decoded_VkBaseOutStructure* current);
 
   private:
     struct HardwareBufferInfo

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -48,6 +48,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         omit_pipeline_cache_data{ false };
     bool                         remove_unsupported_features{ false };
     bool                         use_colorspace_fallback{ false };
+    bool                         offscreen_swapchain_frame_boundary{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -57,13 +57,13 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
                                         HandlePointerDecoder<VkSurfaceKHR>* surface,
                                         const encode::InstanceTable*        instance_table,
                                         application::Application*           application,
-                                        int32_t                             options_surface_index)
+                                        const VulkanReplayOptions&          replay_options)
 {
     assert(instance_info != nullptr);
 
     instance_table_        = instance_table;
     application_           = application;
-    options_surface_index_ = options_surface_index;
+    options_surface_index_ = replay_options.surface_index;
 
     VkInstance    instance       = instance_info->handle;
     VkSurfaceKHR* replay_surface = nullptr;

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -28,6 +28,7 @@
 #include "decode/swapchain_image_tracker.h"
 #include "decode/window.h"
 #include "util/defines.h"
+#include "decode/vulkan_replay_options.h"
 
 #include "application/application.h"
 
@@ -54,7 +55,7 @@ class VulkanSwapchain
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
                                    const encode::InstanceTable*        instance_table,
                                    application::Application*           application,
-                                   int32_t                             options_surface_index);
+                                   const VulkanReplayOptions&          replay_options);
 
     virtual void DestroySurface(PFN_vkDestroySurfaceKHR      func,
                                 const InstanceInfo*          instance_info,

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2652,6 +2652,32 @@ bool VulkanCaptureManager::CheckCommandBufferWrapperForFrameBoundary(const Comma
     return false;
 }
 
+bool VulkanCaptureManager::CheckPNextChainForFrameBoundary(const VkBaseInStructure* current)
+{
+    if (current == nullptr)
+    {
+        return false;
+    }
+
+    while (current->sType != VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT && current->pNext != nullptr)
+    {
+        current = current->pNext;
+    }
+
+    if (current->sType == VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT)
+    {
+        const VkFrameBoundaryEXT* frame_boundary = reinterpret_cast<const VkFrameBoundaryEXT*>(current);
+
+        if (frame_boundary->flags & VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT)
+        {
+            EndFrame();
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void VulkanCaptureManager::PreProcess_vkBindBufferMemory(VkDevice       device,
                                                          VkBuffer       buffer,
                                                          VkDeviceMemory memory,

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -933,6 +933,11 @@ class VulkanCaptureManager : public CaptureManager
         // Check whether this queue submission contains a command buffer that should be treated as a frame boundary.
         for (uint32_t i = 0; i < submitCount; ++i)
         {
+            if (CheckPNextChainForFrameBoundary(reinterpret_cast<const VkBaseInStructure*>(pSubmits + i)))
+            {
+                break;
+            }
+
             for (uint32_t j = 0; j < pSubmits[i].commandBufferCount; ++j)
             {
                 auto cmd_buffer_wrapper = GetWrapper<CommandBufferWrapper>(pSubmits[i].pCommandBuffers[j]);
@@ -967,6 +972,11 @@ class VulkanCaptureManager : public CaptureManager
         // Check whether this queue submission contains a command buffer that should be treated as a frame boundary.
         for (uint32_t i = 0; i < submitCount; ++i)
         {
+            if (CheckPNextChainForFrameBoundary(reinterpret_cast<const VkBaseInStructure*>(pSubmits + i)))
+            {
+                break;
+            }
+
             for (uint32_t j = 0; j < pSubmits[i].commandBufferInfoCount; ++j)
             {
                 auto cmd_buffer_wrapper =
@@ -1308,6 +1318,8 @@ class VulkanCaptureManager : public CaptureManager
     bool CheckBindAlignment(VkDeviceSize memoryOffset);
 
     bool CheckCommandBufferWrapperForFrameBoundary(const CommandBufferWrapper* command_buffer_wrapper);
+
+    bool CheckPNextChainForFrameBoundary(const VkBaseInStructure* current);
 
   private:
     void QueueSubmitWriteFillMemoryCmd();

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -71,6 +71,7 @@ const std::vector<struct LayerExtensionProps> kDeviceExtensionProps = {
         "vkDebugMarkerSetObjectNameEXT",
         "vkDebugMarkerSetObjectTagEXT" } },
     { VkExtensionProperties{ "VK_ANDROID_frame_boundary", 1 }, {}, { "vkFrameBoundaryANDROID" } },
+    { VkExtensionProperties{ "VK_EXT_frame_boundary", 1 }, {}, {} },
 };
 
 /// An alphabetical list of device extensions which we do not report upstream if

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -31,7 +31,8 @@ const char kOptions[] =
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-range,--fmr|--flush-"
     "measurement-range,--flush-inside-measurement-range,--use-captured-swapchain-indices,--dcp,--"
-    "discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names";
+    "discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,"
+    "--offscreen-swapchain-frame-boundary";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -65,6 +66,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--swapchain <mode>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-captured-swapchain-indices]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--use-colorspace-fallback]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--offscreen-swapchain-frame-boundary]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--mfr|--measurement-frame-range <start-frame>-<end-frame>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--measurement-file <file>] [--quit-after-measurement-range]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--flush-measurement-range]");
@@ -200,6 +202,14 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --use-captured-swapchain-indices");
     GFXRECON_WRITE_CONSOLE("          \t\tSame as \"--swapchain captured\".");
     GFXRECON_WRITE_CONSOLE("          \t\tIgnored if the \"--swapchain\" option is used.");
+    GFXRECON_WRITE_CONSOLE("  --offscreen-swapchain-frame-boundary");
+    GFXRECON_WRITE_CONSOLE("          \t\tShould only be used with offscreen swapchain.");
+    GFXRECON_WRITE_CONSOLE("          \t\tActivates the extension VK_EXT_frame_boundary (always supported if");
+    GFXRECON_WRITE_CONSOLE("          \t\ttrimming, checks for driver support otherwise) and inserts command");
+    GFXRECON_WRITE_CONSOLE("          \t\tbuffer submission with VkFrameBoundaryEXT where vkQueuePresentKHR");
+    GFXRECON_WRITE_CONSOLE("          \t\twas called in the original capture.");
+    GFXRECON_WRITE_CONSOLE("          \t\tThis allows preserving frames when capturing a replay that uses.");
+    GFXRECON_WRITE_CONSOLE("          \t\toffscreen swapchain.");
     GFXRECON_WRITE_CONSOLE("  --measurement-frame-range <start_frame>-<end_frame>");
     GFXRECON_WRITE_CONSOLE("          \t\tCustom framerange to measure FPS for.");
     GFXRECON_WRITE_CONSOLE("          \t\tThis range will include the start frame but not the end frame.");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -107,11 +107,12 @@ const char kFlushInsideMeasurementRangeOption[]  = "--flush-inside-measurement-r
 const char kSwapchainOption[]                    = "--swapchain";
 const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
-const char kColorspaceFallback[]    = "--use-colorspace-fallback";
-const char kFormatArgument[]        = "--format";
-const char kIncludeBinariesOption[] = "--include-binaries";
-const char kExpandFlagsOption[]     = "--expand-flags";
-const char kFilePerFrameOption[]    = "--file-per-frame";
+const char kColorspaceFallback[]              = "--use-colorspace-fallback";
+const char kOffscreenSwapchainFrameBoundary[] = "--offscreen-swapchain-frame-boundary";
+const char kFormatArgument[]                  = "--format";
+const char kIncludeBinariesOption[]           = "--include-binaries";
+const char kExpandFlagsOption[]               = "--expand-flags";
+const char kFilePerFrameOption[]              = "--file-per-frame";
 #if defined(WIN32)
 const char kApiFamilyOption[]             = "--api";
 const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
@@ -897,6 +898,11 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (arg_parser.IsOptionSet(kColorspaceFallback))
     {
         replay_options.use_colorspace_fallback = true;
+    }
+
+    if (arg_parser.IsOptionSet(kOffscreenSwapchainFrameBoundary))
+    {
+        replay_options.offscreen_swapchain_frame_boundary = true;
     }
 
     replay_options.replace_dir = arg_parser.GetArgumentValue(kShaderReplaceArgument);


### PR DESCRIPTION
This pull request is in fact two PRs with one depending on the other, built in two commits.

## Support for VK_EXT_frame_boundary

Add support for the frame boundary extension `VK_EXT_frame_boundary`. This includes:
- `VkFrameBoundaryEXT` structures found in the pNext chains of `vkSubmitInfo` and `vkSubmitInfo2` are now interpreted as frame delimiters at capture time if `flags` member has the `VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT` bit set.
- The same structures in the same calls support screenshots at replay time by interpreting `pImages` as the rendered frames.
- `VK_EXT_frame_boundary` is now listed as a supported layer device extension (programs that use the layer have access to the extension even if the driver does not support it)

Extended support for this extension that is NOT implemented by this commit could include:
- Interpretation of `VkFrameBoundaryEXT` structure when found in `VkPresentInfoKHR` and `VkBindSparseInfo` (eg. by considering the *real* render frames to be the ones specified by the structures instead of the one presented)
- Support for `VkFrameBoundaryEXT` even when the `VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT` bit is not set (eg. by saving the resources associated in a map/vector to be taken into account when the real frame end is encountered)

This extension should finally normalize what a frame is, what resources are linked to a specific frames etc. Thus it is important for GFXReconstruct to support it for the tracing of applications that do not display graphics to a monitor like offscreen renderers.

## Add `--offscreen-swapchain-frame-boundary` option

This option inserts a `VkFrameBoundaryEXT` from `VK_EXT_frame_boundary` into a command buffer submission called where `vkQueuePresentKHR` should have been called by an offscreen swapchain.

By doing this, it is now possible to capture a trace replayed with the option `--swapchain offscreen` AND to still have frame numbering and the possibility to take screenshots.

This is very important for automated pipelines that run on a server without WSI context and still need to take screenshots, or do
fast forwarding...