### PR TITLE
Testing: Dump DX12 resources for drawcall

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -337,10 +337,12 @@ D3D12-only:
                                for batching and does not guarantee overall max memory usage.
                                Acceptable values range from 0 to 100 (default: 80). 0 means no batching,
                                100 means use all available system and GPU memory.
-  --dump-resources <drawcall-index>
+  --dump-resources <submit-index,command-index,drawcall-index>
                                 Output binaray resources for a specific drawcall.
                                 Include vertex, index, const buffer, shader resource, render target,
                                 and depth stencil. And for before and after drawcall.
+                                Arguments becomes three indices, submit index, command index,
+                                drawcall index. The command index is based on its in ExecuteCommandLists.
 ```
 
 

--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -209,8 +209,8 @@ Usage:
                         [-m <mode> | --memory-translation <mode>]
                         [--fw <width,height> | --force-windowed <width,height>]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
-                        [--batching-memory-usage <pct>]
-                        [--api <api>] <file>
+                        [--batching-memory-usage <pct>] [--api <api>] 
+                        [--dump-resources <drawcall-index>] <file>
 
 Required arguments:
   <file>                Path to the capture file to replay.
@@ -337,6 +337,10 @@ D3D12-only:
                                for batching and does not guarantee overall max memory usage.
                                Acceptable values range from 0 to 100 (default: 80). 0 means no batching,
                                100 means use all available system and GPU memory.
+  --dump-resources <drawcall-index>
+                                Output binaray resources for a specific drawcall.
+                                Include vertex, index, const buffer, shader resource, render target,
+                                and depth stencil. And for before and after drawcall.
 ```
 
 

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(gfxrecon_decode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_dx12_struct_decoders.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_dx12_struct_object_mappers.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_dx12_struct_object_mappers.cpp>
+                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_dx12_replay_commands.h>
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_handle_mappers.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_handle_mappers.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_to_json.h
@@ -126,6 +127,7 @@ target_sources(gfxrecon_decode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_tracking_consumer.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_tracking_consumer.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_tracked_object_info_table.h>
+                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_browse_consumer.h>
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_decoder_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_decoder_base.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_default_allocator.h

--- a/framework/decode/custom_dx12_replay_commands.h
+++ b/framework/decode/custom_dx12_replay_commands.h
@@ -45,6 +45,66 @@ struct CustomReplayPostCall
 };
 
 template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResourceBarrier>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12GraphicsCommandList_ResourceBarrier(args...);
+    }
+};
+
+template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateConstantBufferView>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12Device_CreateConstantBufferView(args...);
+    }
+};
+
+template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateShaderResourceView>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12Device_CreateShaderResourceView(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateRenderTargetView>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12Device_CreateRenderTargetView(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateDepthStencilView>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12Device_CreateDepthStencilView(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetRenderTargets>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12GraphicsCommandList_OMSetRenderTargets(args...);
+    }
+};
+
+template <>
 struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawInstanced>
 {
     template <typename... Args>

--- a/framework/decode/custom_dx12_replay_commands.h
+++ b/framework/decode/custom_dx12_replay_commands.h
@@ -145,6 +145,66 @@ struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList
 };
 
 template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawIndexedInstanced>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12GraphicsCommandList_DrawIndexedInstanced(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawIndexedInstanced>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12GraphicsCommandList_DrawIndexedInstanced(args...);
+    }
+};
+
+template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Dispatch>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12GraphicsCommandList_Dispatch(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Dispatch>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12GraphicsCommandList_Dispatch(args...);
+    }
+};
+
+template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteIndirect>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12GraphicsCommandList_ExecuteIndirect(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteIndirect>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12GraphicsCommandList_ExecuteIndirect(args...);
+    }
+};
+
+template <>
 struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>
 {
     template <typename... Args>

--- a/framework/decode/custom_dx12_replay_commands.h
+++ b/framework/decode/custom_dx12_replay_commands.h
@@ -105,6 +105,26 @@ struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList
 };
 
 template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BeginRenderPass>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12GraphicsCommandList4_BeginRenderPass(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BeginRenderPass>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12GraphicsCommandList4_BeginRenderPass(args...);
+    }
+};
+
+template <>
 struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawInstanced>
 {
     template <typename... Args>

--- a/framework/decode/custom_dx12_replay_commands.h
+++ b/framework/decode/custom_dx12_replay_commands.h
@@ -65,12 +65,22 @@ struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateConstan
 };
 
 template <>
-struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateShaderResourceView>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateConstantBufferView>
 {
     template <typename... Args>
     static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
     {
-        replay->PreCall_ID3D12Device_CreateShaderResourceView(args...);
+        replay->PostCall_ID3D12Device_CreateConstantBufferView(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateShaderResourceView>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12Device_CreateShaderResourceView(args...);
     }
 };
 

--- a/framework/decode/custom_dx12_replay_commands.h
+++ b/framework/decode/custom_dx12_replay_commands.h
@@ -1,0 +1,80 @@
+/*
+** Copyright (c) 2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_ENCODE_CUSTOM_DX12_REPLAY_COMMANDS_H
+#define GFXRECON_ENCODE_CUSTOM_DX12_REPLAY_COMMANDS_H
+
+#include "format/api_call_id.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+template <format::ApiCallId Id>
+struct CustomReplayPreCall
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase*, Args...)
+    {}
+};
+
+template <format::ApiCallId Id>
+struct CustomReplayPostCall
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase*, Args...)
+    {}
+};
+
+template <>
+struct CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawInstanced>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PreCall_ID3D12GraphicsCommandList_DrawInstanced(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawInstanced>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12GraphicsCommandList_DrawInstanced(args...);
+    }
+};
+
+template <>
+struct CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>
+{
+    template <typename... Args>
+    static void Dispatch(Dx12ReplayConsumerBase* replay, Args... args)
+    {
+        replay->PostCall_ID3D12CommandQueue_ExecuteCommandLists(args...);
+    }
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_CUSTOM_DX12_REPLAY_COMMANDS_H

--- a/framework/decode/dx12_browse_consumer.h
+++ b/framework/decode/dx12_browse_consumer.h
@@ -1,0 +1,223 @@
+/*
+** Copyright (c) 2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_DX12_BROWSE_CONSUMER_H
+#define GFXRECON_DECODE_DX12_BROWSE_CONSUMER_H
+
+#include "generated/generated_dx12_decoder.h"
+#include "graphics/dx12_dump_resources.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+struct TrackDumpCommandList
+{
+    uint64_t begin_renderpass_code_index{ 0 };
+    uint64_t set_render_targets_code_index{ 0 };
+    uint64_t drawcall_code_index{ 0 };
+    uint64_t execute_code_index{ 0 };
+
+    // vertex
+    std::vector<D3D12_GPU_VIRTUAL_ADDRESS> captured_vertex_buffer_view_gvas;
+
+    void Clear()
+    {
+        begin_renderpass_code_index = 0;
+        drawcall_code_index         = 0;
+        execute_code_index          = 0;
+        captured_vertex_buffer_view_gvas.clear();
+    }
+};
+
+class Dx12BrowseConsumer : public Dx12Consumer
+{
+  public:
+    Dx12BrowseConsumer() {}
+
+    void SetDumpTarget(DumpResourcesType dump_resources_type, uint64_t dump_resources_argument)
+    {
+        dump_resources_type_     = dump_resources_type;
+        dump_resources_argument_ = dump_resources_argument;
+    }
+    TrackDumpCommandList* GetTrackDumpTarget()
+    {
+        auto it = track_commandlist_infos_.find(target_command_list_);
+        if (it != track_commandlist_infos_.end())
+        {
+            return &(it->second);
+        }
+        return nullptr;
+    }
+
+    virtual void Process_ID3D12GraphicsCommandList_Reset(const ApiCallInfo& call_info,
+                                                         format::HandleId   object_id,
+                                                         HRESULT            return_value,
+                                                         format::HandleId   pAllocator,
+                                                         format::HandleId   pInitialState)
+    {
+        if (!IsFindDumpTarget())
+        {
+            auto it = track_commandlist_infos_.find(object_id);
+            if (it != track_commandlist_infos_.end())
+            {
+                it->second.Clear();
+            }
+            else
+            {
+                TrackDumpCommandList info = {};
+                track_commandlist_infos_.insert({ object_id, std::move(info) });
+            }
+        }
+    }
+
+    virtual void Process_ID3D12GraphicsCommandList4_BeginRenderPass(
+        const ApiCallInfo&                                                  call_info,
+        format::HandleId                                                    object_id,
+        UINT                                                                NumRenderTargets,
+        StructPointerDecoder<Decoded_D3D12_RENDER_PASS_RENDER_TARGET_DESC>* pRenderTargets,
+        StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
+        D3D12_RENDER_PASS_FLAGS                                             Flags)
+    {
+        if (!IsFindDumpTarget())
+        {
+            auto it = track_commandlist_infos_.find(object_id);
+            if (it != track_commandlist_infos_.end())
+            {
+                it->second.begin_renderpass_code_index = call_info.index;
+            }
+        }
+    }
+
+    virtual void Process_ID3D12GraphicsCommandList_OMSetRenderTargets(
+        const ApiCallInfo&                                         call_info,
+        format::HandleId                                           object_id,
+        UINT                                                       NumRenderTargetDescriptors,
+        StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pRenderTargetDescriptors,
+        BOOL                                                       RTsSingleHandleToDescriptorRange,
+        StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
+    {
+        if (!IsFindDumpTarget())
+        {
+            auto it = track_commandlist_infos_.find(object_id);
+            if (it != track_commandlist_infos_.end())
+            {
+                it->second.set_render_targets_code_index = call_info.index;
+            }
+        }
+    }
+
+    virtual void
+    Process_ID3D12GraphicsCommandList_IASetVertexBuffers(const ApiCallInfo& call_info,
+                                                         format::HandleId   object_id,
+                                                         UINT               StartSlot,
+                                                         UINT               NumViews,
+                                                         StructPointerDecoder<Decoded_D3D12_VERTEX_BUFFER_VIEW>* pViews)
+    {
+        if (!IsFindDumpTarget())
+        {
+            auto it = track_commandlist_infos_.find(object_id);
+            if (it != track_commandlist_infos_.end())
+            {
+                it->second.captured_vertex_buffer_view_gvas.resize(NumViews);
+                auto views = pViews->GetMetaStructPointer();
+                for (uint32_t i = 0; i < NumViews; ++i)
+                {
+                    it->second.captured_vertex_buffer_view_gvas[i] = views[i].decoded_value->BufferLocation;
+                }
+            }
+        }
+    }
+
+    virtual void Process_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
+                                                                 format::HandleId   object_id,
+                                                                 UINT               VertexCountPerInstance,
+                                                                 UINT               InstanceCount,
+                                                                 UINT               StartVertexLocation,
+                                                                 UINT               StartInstanceLocation)
+    {
+        if (!IsFindDumpTarget())
+        {
+            auto it = track_commandlist_infos_.find(object_id);
+            if (it != track_commandlist_infos_.end())
+            {
+                if (dump_resources_type_ == DumpResourcesType::kDrawCall)
+                {
+                    if (track_drawcall_index_ == dump_resources_argument_)
+                    {
+                        it->second.drawcall_code_index = call_info.index;
+                        target_command_list_           = object_id;
+                    }
+                }
+            }
+        }
+        ++track_drawcall_index_;
+    }
+
+    virtual void
+    Process_ID3D12CommandQueue_ExecuteCommandLists(const ApiCallInfo&                        call_info,
+                                                   format::HandleId                          object_id,
+                                                   UINT                                      NumCommandLists,
+                                                   HandlePointerDecoder<ID3D12CommandList*>* ppCommandLists)
+    {
+        if (IsFindDumpTarget())
+        {
+            auto command_lists = ppCommandLists->GetPointer();
+            for (uint32_t i = 0; i < NumCommandLists; ++i)
+            {
+                if (command_lists[i] == target_command_list_)
+                {
+                    auto it = track_commandlist_infos_.find(target_command_list_);
+                    if (it != track_commandlist_infos_.end())
+                    {
+                        it->second.execute_code_index = call_info.index;
+                        is_complete                   = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    virtual bool IsComplete(uint64_t block_index) override { return (block_index > kMaxDX12BlockLimit) || is_complete; }
+
+  private:
+    bool IsFindDumpTarget()
+    {
+        return (dump_resources_type_ == DumpResourcesType::kDrawCall &&
+                track_drawcall_index_ > dump_resources_argument_);
+    }
+
+    static int const  kMaxDX12BlockLimit = 1000;
+    DumpResourcesType dump_resources_type_{ DumpResourcesType::kNone };
+    uint64_t          dump_resources_argument_{ 0 };
+    uint64_t          track_drawcall_index_{ 0 };
+    format::HandleId  target_command_list_{ 0 };
+    bool              is_complete{ false };
+    // Key is commandlist_id. We need to know the commandlist of the info because in a commandlist block
+    // between reset and close, it might have the other commandlist's commands.
+    std::map<format::HandleId, TrackDumpCommandList> track_commandlist_infos_;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_DX12_BROWSE_CONSUMER_H

--- a/framework/decode/dx12_browse_consumer.h
+++ b/framework/decode/dx12_browse_consumer.h
@@ -45,6 +45,9 @@ struct TrackDumpCommandList
     // descriptor
     std::vector<format::HandleId> descriptor_heap_ids;
 
+    // ExecuteIndirect
+    format::HandleId exe_indirect_argument_id{ format::kNullHandleId };
+    format::HandleId exe_indirect_count_id{ format::kNullHandleId };
     // render target
     // Track render target info in replay, not here.
     // Because the useful info is replay cpuDescriptor. It's only available in replay.
@@ -80,25 +83,26 @@ class Dx12BrowseConsumer : public Dx12Consumer
         return nullptr;
     }
 
+    virtual void Process_ID3D12Device_CreateCommandList(const ApiCallInfo&           call_info,
+                                                        format::HandleId             object_id,
+                                                        HRESULT                      return_value,
+                                                        UINT                         nodeMask,
+                                                        D3D12_COMMAND_LIST_TYPE      type,
+                                                        format::HandleId             pCommandAllocator,
+                                                        format::HandleId             pInitialState,
+                                                        Decoded_GUID                 riid,
+                                                        HandlePointerDecoder<void*>* ppCommandList)
+    {
+        InitializeTracking(*ppCommandList->GetPointer());
+    }
+
     virtual void Process_ID3D12GraphicsCommandList_Reset(const ApiCallInfo& call_info,
                                                          format::HandleId   object_id,
                                                          HRESULT            return_value,
                                                          format::HandleId   pAllocator,
                                                          format::HandleId   pInitialState)
     {
-        if (!IsFindDumpTarget())
-        {
-            auto it = track_commandlist_infos_.find(object_id);
-            if (it != track_commandlist_infos_.end())
-            {
-                it->second.Clear();
-            }
-            else
-            {
-                TrackDumpCommandList info = {};
-                track_commandlist_infos_.insert({ object_id, std::move(info) });
-            }
-        }
+        InitializeTracking(object_id);
     }
 
     virtual void Process_ID3D12GraphicsCommandList4_BeginRenderPass(
@@ -203,22 +207,39 @@ class Dx12BrowseConsumer : public Dx12Consumer
                                                                  UINT               StartVertexLocation,
                                                                  UINT               StartInstanceLocation)
     {
-        if (!IsFindDumpTarget())
-        {
-            auto it = track_commandlist_infos_.find(object_id);
-            if (it != track_commandlist_infos_.end())
-            {
-                if (dump_resources_type_ == DumpResourcesType::kDrawCall)
-                {
-                    if (track_drawcall_index_ == dump_resources_argument_)
-                    {
-                        it->second.drawcall_code_index = call_info.index;
-                        target_command_list_           = object_id;
-                    }
-                }
-            }
-        }
-        ++track_drawcall_index_;
+        TrackTargetDrawcall(call_info, object_id);
+    }
+
+    virtual void Process_ID3D12GraphicsCommandList_DrawIndexedInstanced(const ApiCallInfo& call_info,
+                                                                        format::HandleId   object_id,
+                                                                        UINT               IndexCountPerInstance,
+                                                                        UINT               InstanceCount,
+                                                                        UINT               StartIndexLocation,
+                                                                        INT                BaseVertexLocation,
+                                                                        UINT               StartInstanceLocation)
+    {
+        TrackTargetDrawcall(call_info, object_id);
+    }
+
+    virtual void Process_ID3D12GraphicsCommandList_Dispatch(const ApiCallInfo& call_info,
+                                                            format::HandleId   object_id,
+                                                            UINT               ThreadGroupCountX,
+                                                            UINT               ThreadGroupCountY,
+                                                            UINT               ThreadGroupCountZ)
+    {
+        TrackTargetDrawcall(call_info, object_id);
+    }
+
+    virtual void Process_ID3D12GraphicsCommandList_ExecuteIndirect(const ApiCallInfo& call_info,
+                                                                   format::HandleId   object_id,
+                                                                   format::HandleId   pCommandSignature,
+                                                                   UINT               MaxCommandCount,
+                                                                   format::HandleId   pArgumentBuffer,
+                                                                   UINT64             ArgumentBufferOffset,
+                                                                   format::HandleId   pCountBuffer,
+                                                                   UINT64             CountBufferOffset)
+    {
+        TrackTargetDrawcall(call_info, object_id, pArgumentBuffer, pCountBuffer);
     }
 
     virtual void
@@ -264,6 +285,48 @@ class Dx12BrowseConsumer : public Dx12Consumer
     // Key is commandlist_id. We need to know the commandlist of the info because in a commandlist block
     // between reset and close, it might have the other commandlist's commands.
     std::map<format::HandleId, TrackDumpCommandList> track_commandlist_infos_;
+
+    void InitializeTracking(format::HandleId object_id)
+    {
+        if (!IsFindDumpTarget())
+        {
+            auto it = track_commandlist_infos_.find(object_id);
+            if (it != track_commandlist_infos_.end())
+            {
+                it->second.Clear();
+            }
+            else
+            {
+                TrackDumpCommandList info = {};
+                track_commandlist_infos_.insert({ object_id, std::move(info) });
+            }
+        }
+    }
+
+    void TrackTargetDrawcall(const ApiCallInfo& call_info,
+                             format::HandleId   object_id,
+                             format::HandleId   exe_indirect_argument_id = format::kNullHandleId,
+                             format::HandleId   exe_indirect_count_id    = format::kNullHandleId)
+    {
+        if (!IsFindDumpTarget())
+        {
+            auto it = track_commandlist_infos_.find(object_id);
+            if (it != track_commandlist_infos_.end())
+            {
+                if (dump_resources_type_ == DumpResourcesType::kDrawCall)
+                {
+                    if (track_drawcall_index_ == dump_resources_argument_)
+                    {
+                        it->second.drawcall_code_index      = call_info.index;
+                        it->second.exe_indirect_argument_id = exe_indirect_argument_id;
+                        it->second.exe_indirect_count_id    = exe_indirect_count_id;
+                        target_command_list_                = object_id;
+                    }
+                }
+            }
+        }
+        ++track_drawcall_index_;
+    }
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -340,7 +340,6 @@ struct D3D12ResourceInfo : DxObjectExtraInfo
 
     D3D12_RESOURCE_DESC1                              desc = {};
     D3D12_RESOURCE_STATES                             current_state{ D3D12_RESOURCE_STATE_COMMON };
-    std::map<format::HandleId, D3D12_RESOURCE_STATES> track_resource_barrier_state_after; // HandleId is CommandList.
 };
 
 struct D3D12CommandSignatureInfo : DxObjectExtraInfo
@@ -366,7 +365,7 @@ struct D3D12CommandListInfo : DxObjectExtraInfo
     ResourceValueInfoMap          resource_value_info_map;
     DxObjectInfo*                 active_state_object{ nullptr };
 
-    std::set<format::HandleId> track_resource_barriers; // HandleId is Resource.
+    std::map<format::HandleId, D3D12_RESOURCE_STATES> pending_resource_states; // HandleId is Resource.
 };
 
 struct D3D12RootSignatureInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -338,8 +338,9 @@ struct D3D12ResourceInfo : DxObjectExtraInfo
     std::map<uint64_t, uint64_t>                       mapped_gpu_addresses;
     std::map<uint64_t, graphics::Dx12ShaderIdentifier> mapped_shader_ids;
 
-    D3D12_RESOURCE_DESC1  desc = {};
-    D3D12_RESOURCE_STATES current_state{ D3D12_RESOURCE_STATE_COMMON };
+    D3D12_RESOURCE_DESC1                              desc = {};
+    D3D12_RESOURCE_STATES                             current_state{ D3D12_RESOURCE_STATE_COMMON };
+    std::map<format::HandleId, D3D12_RESOURCE_STATES> track_resource_barrier_state_after; // HandleId is CommandList.
 };
 
 struct D3D12CommandSignatureInfo : DxObjectExtraInfo
@@ -364,6 +365,8 @@ struct D3D12CommandListInfo : DxObjectExtraInfo
     std::vector<ResourceCopyInfo> resource_copies;
     ResourceValueInfoMap          resource_value_info_map;
     DxObjectInfo*                 active_state_object{ nullptr };
+
+    std::set<format::HandleId> track_resource_barriers; // HandleId is Resource.
 };
 
 struct D3D12RootSignatureInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -149,10 +149,10 @@ struct ArgumentBufferExtraInfo
 
 struct ResourceValueInfo
 {
-    uint64_t              offset{ 0 };
-    ResourceValueType     type{ ResourceValueType::kUnknown };
-    uint64_t              size{ 0 };
-    D3D12StateObjectInfo* state_object{ nullptr }; ///< Used to map values in shader records.
+    uint64_t                offset{ 0 };
+    ResourceValueType       type{ ResourceValueType::kUnknown };
+    uint64_t                size{ 0 };
+    D3D12StateObjectInfo*   state_object{ nullptr }; ///< Used to map values in shader records.
     ArgumentBufferExtraInfo arg_buffer_extra_info;
 
     ResourceValueInfo(uint64_t                in_offset,
@@ -267,6 +267,13 @@ struct D3D12DescriptorHeapInfo : DxObjectExtraInfo
     uint64_t                              capture_gpu_addr_begin{ kNullGpuAddress };
     size_t                                replay_cpu_addr_begin{ kNullCpuAddress };
     uint64_t                              replay_gpu_addr_begin{ kNullGpuAddress };
+
+    std::vector<D3D12_GPU_VIRTUAL_ADDRESS>   captured_constant_buffer_view_desc_gvas;
+    std::vector<format::HandleId>            shader_resource_ids;
+    std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> replay_render_target_handles;
+    std::vector<format::HandleId>            render_target_resource_ids;
+    std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> replay_depth_stencil_handles;
+    std::vector<format::HandleId>            depth_stencil_resource_ids;
 };
 
 struct D3D12FenceInfo : DxObjectExtraInfo
@@ -303,7 +310,8 @@ struct D3D12ResourceInfo : DxObjectExtraInfo
     std::map<uint64_t, uint64_t>                       mapped_gpu_addresses;
     std::map<uint64_t, graphics::Dx12ShaderIdentifier> mapped_shader_ids;
 
-    D3D12_RESOURCE_DESC1 desc = {};
+    D3D12_RESOURCE_DESC1  desc = {};
+    D3D12_RESOURCE_STATES current_state{ D3D12_RESOURCE_STATE_COMMON };
 };
 
 struct D3D12CommandSignatureInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -254,6 +254,36 @@ struct D3D12DeviceInfo : DxObjectExtraInfo
     bool is_uma{ false };
 };
 
+struct ConstantBufferInfo
+{
+    D3D12_CONSTANT_BUFFER_VIEW_DESC captured_view{};
+    D3D12_CPU_DESCRIPTOR_HANDLE     replay_handle{ kNullCpuAddress };
+};
+
+struct ShaderResourceInfo
+{
+    format::HandleId                resource_id{ format::kNullHandleId };
+    D3D12_SHADER_RESOURCE_VIEW_DESC view{};
+    bool                            is_view_null{ false };
+    D3D12_CPU_DESCRIPTOR_HANDLE     replay_handle{ kNullCpuAddress };
+};
+
+struct RenderTargetInfo
+{
+    format::HandleId              resource_id{ format::kNullHandleId };
+    D3D12_RENDER_TARGET_VIEW_DESC view{};
+    bool                          is_view_null{ false };
+    D3D12_CPU_DESCRIPTOR_HANDLE   replay_handle{ kNullCpuAddress };
+};
+
+struct DepthStencilInfo
+{
+    format::HandleId              resource_id{ format::kNullHandleId };
+    D3D12_DEPTH_STENCIL_VIEW_DESC view{};
+    bool                          is_view_null{ false };
+    D3D12_CPU_DESCRIPTOR_HANDLE   replay_handle{ kNullCpuAddress };
+};
+
 struct D3D12DescriptorHeapInfo : DxObjectExtraInfo
 {
     static constexpr DxObjectInfoType kType         = DxObjectInfoType::kID3D12DescriptorHeapInfo;
@@ -268,12 +298,10 @@ struct D3D12DescriptorHeapInfo : DxObjectExtraInfo
     size_t                                replay_cpu_addr_begin{ kNullCpuAddress };
     uint64_t                              replay_gpu_addr_begin{ kNullGpuAddress };
 
-    std::vector<D3D12_GPU_VIRTUAL_ADDRESS>   captured_constant_buffer_view_desc_gvas;
-    std::vector<format::HandleId>            shader_resource_ids;
-    std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> replay_render_target_handles;
-    std::vector<format::HandleId>            render_target_resource_ids;
-    std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> replay_depth_stencil_handles;
-    std::vector<format::HandleId>            depth_stencil_resource_ids;
+    std::vector<ConstantBufferInfo> constant_buffer_infos;
+    std::vector<ShaderResourceInfo> shader_resource_infos;
+    std::vector<RenderTargetInfo>   render_target_infos;
+    std::vector<DepthStencilInfo>   depth_stencil_infos;
 };
 
 struct D3D12FenceInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -298,10 +298,11 @@ struct D3D12DescriptorHeapInfo : DxObjectExtraInfo
     size_t                                replay_cpu_addr_begin{ kNullCpuAddress };
     uint64_t                              replay_gpu_addr_begin{ kNullGpuAddress };
 
-    std::vector<ConstantBufferInfo> constant_buffer_infos;
-    std::vector<ShaderResourceInfo> shader_resource_infos;
-    std::vector<RenderTargetInfo>   render_target_infos;
-    std::vector<DepthStencilInfo>   depth_stencil_infos;
+    // Descriptor info maps. Key is descriptor's uint32_t heap index.
+    std::map<uint32_t, ConstantBufferInfo> constant_buffer_infos;
+    std::map<uint32_t, ShaderResourceInfo> shader_resource_infos;
+    std::map<uint32_t, RenderTargetInfo>   render_target_infos;
+    std::map<uint32_t, DepthStencilInfo>   depth_stencil_infos;
 };
 
 struct D3D12FenceInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_object_mapping_util.cpp
+++ b/framework/decode/dx12_object_mapping_util.cpp
@@ -66,6 +66,14 @@ void MapGpuVirtualAddresses(D3D12_GPU_VIRTUAL_ADDRESS*    addresses,
     }
 }
 
+format::HandleId FindResourceIDbyGpuVA(D3D12_GPU_VIRTUAL_ADDRESS     captured_address,
+                                       const graphics::Dx12GpuVaMap& gpu_va_map)
+{
+    format::HandleId resource_id = format::kNullHandleId;
+    gpu_va_map.Map(captured_address, &resource_id);
+    return resource_id;
+}
+
 GFXRECON_END_NAMESPACE(object_mapping)
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/dx12_object_mapping_util.h
+++ b/framework/decode/dx12_object_mapping_util.h
@@ -52,6 +52,9 @@ void MapGpuVirtualAddresses(D3D12_GPU_VIRTUAL_ADDRESS*    addresses,
                             size_t                        addresses_len,
                             const graphics::Dx12GpuVaMap& gpu_va_map);
 
+format::HandleId FindResourceIDbyGpuVA(D3D12_GPU_VIRTUAL_ADDRESS     captured_address,
+                                       const graphics::Dx12GpuVaMap& gpu_va_map);
+
 template <typename T>
 static T* MapObject(format::HandleId id, const Dx12ObjectInfoTable& object_info_table)
 {

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -3836,10 +3836,26 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateConstantBufferView(
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
     auto desc             = pDesc->GetMetaStructPointer();
-    heap_extra_info->captured_constant_buffer_view_desc_gvas.emplace_back(desc->decoded_value->BufferLocation);
+
+    ConstantBufferInfo info;
+    info.captured_view = *(desc->decoded_value);
+
+    heap_extra_info->constant_buffer_infos.emplace_back(std::move(info));
 }
 
-void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateShaderResourceView(
+void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateConstantBufferView(
+    const ApiCallInfo&                                             call_info,
+    DxObjectInfo*                                                  object_info,
+    StructPointerDecoder<Decoded_D3D12_CONSTANT_BUFFER_VIEW_DESC>* pDesc,
+    Decoded_D3D12_CPU_DESCRIPTOR_HANDLE                            DestDescriptor)
+{
+    auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
+    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+
+    heap_extra_info->constant_buffer_infos.back().replay_handle = (*DestDescriptor.decoded_value);
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
     const ApiCallInfo&                                             call_info,
     DxObjectInfo*                                                  object_info,
     format::HandleId                                               pResource,
@@ -3848,7 +3864,21 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateShaderResourceView(
 {
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
-    heap_extra_info->shader_resource_ids.emplace_back(pResource);
+
+    ShaderResourceInfo info;
+    info.resource_id   = pResource;
+    info.replay_handle = *DestDescriptor.decoded_value;
+    if (pDesc->IsNull())
+    {
+        info.is_view_null = true;
+    }
+    else
+    {
+        info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
+        info.is_view_null = false;
+    }
+
+    heap_extra_info->shader_resource_infos.emplace_back(std::move(info));
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
@@ -3860,8 +3890,21 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
 {
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
-    heap_extra_info->replay_render_target_handles.emplace_back(*DestDescriptor.decoded_value);
-    heap_extra_info->render_target_resource_ids.emplace_back(pResource);
+
+    RenderTargetInfo info;
+    info.resource_id   = pResource;
+    info.replay_handle = *DestDescriptor.decoded_value;
+    if (pDesc->IsNull())
+    {
+        info.is_view_null = true;
+    }
+    else
+    {
+        info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
+        info.is_view_null = false;
+    }
+
+    heap_extra_info->render_target_infos.emplace_back(std::move(info));
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
@@ -3873,8 +3916,20 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
 {
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
-    heap_extra_info->replay_depth_stencil_handles.emplace_back(*DestDescriptor.decoded_value);
-    heap_extra_info->depth_stencil_resource_ids.emplace_back(pResource);
+
+    DepthStencilInfo info;
+    info.resource_id   = pResource;
+    info.replay_handle = *DestDescriptor.decoded_value;
+    if (pDesc->IsNull())
+    {
+        info.is_view_null = true;
+    }
+    else
+    {
+        info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
+        info.is_view_null = false;
+    }
+    heap_extra_info->depth_stencil_infos.emplace_back(std::move(info));
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_OMSetRenderTargets(
@@ -4122,70 +4177,153 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(const ApiC
 void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList* copy_command_list)
 {
     // vertex
-    AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(copy_command_list,
-                                                     track_dump_resources_.target.captured_vertex_buffer_view_gvas,
-                                                     track_dump_resources_.copy_vertex_resources);
-    // index
-    AddCopyResourceCommandForBeforeDrawcallByGPUVA(copy_command_list,
-                                                   track_dump_resources_.target.captured_index_buffer_view_gva,
-                                                   track_dump_resources_.copy_index_resource);
-    // descriptor
-    auto size = track_dump_resources_.target.descriptor_heap_ids.size();
-    track_dump_resources_.descriptor_heap_datas.resize(size);
-    for (uint32_t i = 0; i < size; ++i)
+    for (const auto& view : track_dump_resources_.target.captured_vertex_buffer_views)
     {
-        auto heap_object_info = GetObjectInfo(track_dump_resources_.target.descriptor_heap_ids[i]);
+        graphics::CopyResourceData copy_resource_data;
+        AddCopyResourceCommandForBeforeDrawcallByGPUVA(
+            copy_command_list, view.BufferLocation, view.SizeInBytes, copy_resource_data);
+
+        track_dump_resources_.copy_vertex_resources.emplace_back(std::move(copy_resource_data));
+    }
+
+    // index
+    AddCopyResourceCommandForBeforeDrawcallByGPUVA(
+        copy_command_list,
+        track_dump_resources_.target.captured_index_buffer_view.BufferLocation,
+        track_dump_resources_.target.captured_index_buffer_view.SizeInBytes,
+        track_dump_resources_.copy_index_resource);
+
+    // descriptor
+    auto heap_size = track_dump_resources_.target.descriptor_heap_ids.size();
+    track_dump_resources_.descriptor_heap_datas.resize(heap_size);
+    for (uint32_t heap_index = 0; heap_index < heap_size; ++heap_index)
+    {
+        auto heap_object_info = GetObjectInfo(track_dump_resources_.target.descriptor_heap_ids[heap_index]);
         auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
         // constant buffer
-        AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
-            copy_command_list,
-            heap_extra_info->captured_constant_buffer_view_desc_gvas,
-            track_dump_resources_.descriptor_heap_datas[i].copy_constant_buffer_resources);
+        for (const auto& info : heap_extra_info->constant_buffer_infos)
+        {
+            if (MatchDescriptorCPUGPUHandle(heap_extra_info->replay_cpu_addr_begin,
+                                            info.replay_handle.ptr,
+                                            heap_extra_info->capture_gpu_addr_begin,
+                                            track_dump_resources_.target.captured_descriptor_gpu_handles))
+            {
+                graphics::CopyResourceData copy_resource_data;
+                AddCopyResourceCommandForBeforeDrawcallByGPUVA(copy_command_list,
+                                                               info.captured_view.BufferLocation,
+                                                               info.captured_view.SizeInBytes,
+                                                               copy_resource_data);
+
+                track_dump_resources_.descriptor_heap_datas[heap_index].copy_constant_buffer_resources.emplace_back(
+                    std::move(copy_resource_data));
+            }
+        }
 
         // shader resource
-        AddCopyResourceCommandsForBeforeDrawcall(copy_command_list,
-                                                 heap_extra_info->shader_resource_ids,
-                                                 track_dump_resources_.descriptor_heap_datas[i].copy_shader_resources);
+        for (const auto& info : heap_extra_info->shader_resource_infos)
+        {
+            if (MatchDescriptorCPUGPUHandle(heap_extra_info->replay_cpu_addr_begin,
+                                            info.replay_handle.ptr,
+                                            heap_extra_info->capture_gpu_addr_begin,
+                                            track_dump_resources_.target.captured_descriptor_gpu_handles))
+            {
+
+                uint64_t offset = 0;
+                uint64_t size   = 0;
+                switch (info.view.ViewDimension)
+                {
+                    case D3D12_SRV_DIMENSION_BUFFER:
+                        offset = info.view.Buffer.FirstElement * info.view.Buffer.StructureByteStride;
+                        size   = info.view.Buffer.NumElements * info.view.Buffer.StructureByteStride;
+                        break;
+                    // TODO: Set offset and size fot texture.
+                    default:
+                        break;
+                }
+
+                graphics::CopyResourceData copy_resource_data;
+                AddCopyResourceCommandForBeforeDrawcall(
+                    copy_command_list, info.resource_id, offset, size, copy_resource_data);
+
+                track_dump_resources_.descriptor_heap_datas[heap_index].copy_shader_resources.emplace_back(
+                    std::move(copy_resource_data));
+            }
+        }
     }
 
     // render target
-    AddCopyRenderTargetCommandsForBeforeDrawcall(copy_command_list,
-                                                 track_dump_resources_.render_target_heap_ids,
-                                                 track_dump_resources_.replay_render_target_handles,
-                                                 track_dump_resources_.copy_render_target_resources);
-    AddCopyDepthStencilCommandForBeforeDrawcall(copy_command_list,
-                                                track_dump_resources_.depth_stencil_heap_id,
-                                                track_dump_resources_.replay_depth_stencil_handle,
-                                                track_dump_resources_.copy_depth_stencil_resource);
+    auto rt_size = track_dump_resources_.replay_render_target_handles.size();
+    track_dump_resources_.copy_render_target_resources.resize(rt_size);
+
+    for (uint32_t i = 0; i < rt_size; ++i)
+    {
+        auto heap_object_info = GetObjectInfo(track_dump_resources_.render_target_heap_ids[i]);
+        auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+
+        for (const auto& info : heap_extra_info->render_target_infos)
+        {
+            if (info.replay_handle.ptr == track_dump_resources_.replay_render_target_handles[i].ptr)
+            {
+                // TODO: Set offset and size by info.view.ViewDimension.
+                AddCopyResourceCommandForBeforeDrawcall(
+                    copy_command_list, info.resource_id, 0, 0, track_dump_resources_.copy_render_target_resources[i]);
+                break;
+            }
+        }
+    }
+
+    // depth stencil
+    if (track_dump_resources_.replay_depth_stencil_handle.ptr != decode::kNullCpuAddress)
+    {
+        auto heap_object_info = GetObjectInfo(track_dump_resources_.depth_stencil_heap_id);
+        auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+
+        for (const auto& info : heap_extra_info->depth_stencil_infos)
+        {
+            if (info.replay_handle.ptr == track_dump_resources_.replay_depth_stencil_handle.ptr)
+            {
+                // TODO: Set offset and size by info.view.ViewDimension.
+                AddCopyResourceCommandForBeforeDrawcall(
+                    copy_command_list, info.resource_id, 0, 0, track_dump_resources_.copy_depth_stencil_resource);
+                break;
+            }
+        }
+    }
 
     // ExecuteIndirect
     AddCopyResourceCommandForBeforeDrawcall(copy_command_list,
                                             track_dump_resources_.target.exe_indirect_argument_id,
+                                            track_dump_resources_.target.exe_indirect_argument_offset,
+                                            0,
                                             track_dump_resources_.copy_exe_indirect_argument);
     AddCopyResourceCommandForBeforeDrawcall(copy_command_list,
                                             track_dump_resources_.target.exe_indirect_count_id,
+                                            track_dump_resources_.target.exe_indirect_count_offset,
+                                            0,
                                             track_dump_resources_.copy_exe_indirect_count);
 }
 
-void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
-    ID3D12GraphicsCommandList*                    copy_command_list,
-    const std::vector<D3D12_GPU_VIRTUAL_ADDRESS>& captured_source_gpu_vas,
-    std::vector<graphics::CopyResourceData>&      copy_resource_datas)
+bool Dx12ReplayConsumerBase::MatchDescriptorCPUGPUHandle(size_t   replay_cpu_addr_begin,
+                                                         size_t   replay_target_cpu_addr,
+                                                         uint64_t capture_gpu_addr_begin,
+                                                         std::map<UINT, D3D12_GPU_DESCRIPTOR_HANDLE> captured_gpu_addrs)
 {
-    auto size = captured_source_gpu_vas.size();
-    copy_resource_datas.resize(size);
-
-    for (uint32_t i = 0; i < size; ++i)
+    for (auto gpu_addr : captured_gpu_addrs)
     {
-        AddCopyResourceCommandForBeforeDrawcallByGPUVA(
-            copy_command_list, captured_source_gpu_vas[i], copy_resource_datas[i]);
+        if ((gpu_addr.second.ptr >= capture_gpu_addr_begin) &&
+            ((replay_target_cpu_addr - replay_cpu_addr_begin) == (gpu_addr.second.ptr - capture_gpu_addr_begin)))
+        {
+            return true;
+        }
     }
+    return false;
 }
 
 void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcallByGPUVA(
     ID3D12GraphicsCommandList*  copy_command_list,
     D3D12_GPU_VIRTUAL_ADDRESS   captured_source_gpu_va,
+    uint64_t                    source_size,
     graphics::CopyResourceData& copy_resource_data)
 {
     if (captured_source_gpu_va == 0)
@@ -4194,26 +4332,21 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcallByGPUVA(
     }
     copy_resource_data.source_resource_id = object_mapping::FindResourceIDbyGpuVA(captured_source_gpu_va, gpu_va_map_);
 
-    AddCopyResourceCommandForBeforeDrawcall(
-        copy_command_list, copy_resource_data.source_resource_id, copy_resource_data);
+    auto source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
+    auto source_resource_extra_info  = GetExtraInfo<D3D12ResourceInfo>(source_resource_object_info);
+
+    AddCopyResourceCommandForBeforeDrawcall(copy_command_list,
+                                            copy_resource_data.source_resource_id,
+                                            (captured_source_gpu_va - source_resource_extra_info->capture_address_),
+                                            source_size,
+                                            copy_resource_data);
 }
 
-void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(
-    ID3D12GraphicsCommandList*               copy_command_list,
-    const std::vector<format::HandleId>&     source_resource_ids,
-    std::vector<graphics::CopyResourceData>& copy_resource_datas)
-{
-    auto size = source_resource_ids.size();
-    copy_resource_datas.resize(size);
-
-    for (uint32_t i = 0; i < size; ++i)
-    {
-        AddCopyResourceCommandForBeforeDrawcall(copy_command_list, source_resource_ids[i], copy_resource_datas[i]);
-    }
-}
-
+// If source_size = 0, the meaning is the whole after offset.
 void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
                                                                      format::HandleId            source_resource_id,
+                                                                     uint64_t                    source_offset,
+                                                                     uint64_t                    source_size,
                                                                      graphics::CopyResourceData& copy_resource_data)
 {
     if (source_resource_id == 0)
@@ -4227,67 +4360,21 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(ID3D12Graph
     auto device                      = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(source_resource);
     auto source_desc                 = source_resource->GetDesc();
     copy_resource_data.desc          = source_desc;
+    copy_resource_data.source_offset = source_offset;
+    copy_resource_data.source_size   = source_size;
 
-    D3D12_PLACED_SUBRESOURCE_FOOTPRINT layout            = {};
-    UINT                               num_row           = 0;
-    UINT64                             row_size_in_bytes = 0;
-    UINT64                             total_bytes       = 0;
-    device->GetCopyableFootprints(&source_desc, 0, 1, 0, &layout, &num_row, &row_size_in_bytes, &total_bytes);
-    copy_resource_data.size = total_bytes;
+    UINT   num_row           = 0;
+    UINT64 row_size_in_bytes = 0;
+    UINT64 total_bytes       = 0;
+    device->GetCopyableFootprints(
+        &source_desc, 0, 1, 0, &copy_resource_data.source_footprint, &num_row, &row_size_in_bytes, &total_bytes);
+
+    if (copy_resource_data.source_size == 0)
+    {
+        copy_resource_data.source_size = total_bytes - copy_resource_data.source_offset;
+    }
 
     AddCopyResourceCommand(copy_command_list, copy_resource_data, copy_resource_data.before_resource);
-}
-
-void Dx12ReplayConsumerBase::AddCopyRenderTargetCommandsForBeforeDrawcall(
-    ID3D12GraphicsCommandList*                      copy_command_list,
-    const std::vector<format::HandleId>&            heap_ids,
-    const std::vector<D3D12_CPU_DESCRIPTOR_HANDLE>& replay_render_target_handles,
-    std::vector<graphics::CopyResourceData>&        copy_resource_datas)
-{
-    auto rt_size = replay_render_target_handles.size();
-    copy_resource_datas.resize(rt_size);
-
-    for (uint32_t i = 0; i < rt_size; ++i)
-    {
-        auto heap_object_info = GetObjectInfo(heap_ids[i]);
-        auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
-
-        auto record_size = heap_extra_info->replay_render_target_handles.size();
-        for (uint32_t j = 0; j < record_size; ++j)
-        {
-            if (heap_extra_info->replay_render_target_handles[j].ptr == replay_render_target_handles[i].ptr)
-            {
-                AddCopyResourceCommandForBeforeDrawcall(
-                    copy_command_list, heap_extra_info->render_target_resource_ids[j], copy_resource_datas[i]);
-                break;
-            }
-        }
-    }
-}
-
-void Dx12ReplayConsumerBase::AddCopyDepthStencilCommandForBeforeDrawcall(
-    ID3D12GraphicsCommandList*  copy_command_list,
-    format::HandleId            heap_id,
-    D3D12_CPU_DESCRIPTOR_HANDLE replay_depth_stencil_handle,
-    graphics::CopyResourceData& copy_resource_data)
-{
-    if (replay_depth_stencil_handle.ptr == decode::kNullCpuAddress)
-    {
-        return;
-    }
-    auto heap_object_info = GetObjectInfo(heap_id);
-    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
-
-    auto size = heap_extra_info->replay_depth_stencil_handles.size();
-    for (uint32_t i = 0; i < size; ++i)
-    {
-        if (heap_extra_info->replay_depth_stencil_handles[i].ptr == replay_depth_stencil_handle.ptr)
-        {
-            AddCopyResourceCommandForBeforeDrawcall(
-                copy_command_list, heap_extra_info->depth_stencil_resource_ids[i], copy_resource_data);
-            break;
-        }
-    }
 }
 
 void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(const ApiCallInfo& call_info,
@@ -4396,7 +4483,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*  
     const auto& source_desc                 = copy_resource_data.desc;
 
     copy_resource = graphics::dx12::CreateBufferResource(device,
-                                                         copy_resource_data.size,
+                                                         copy_resource_data.source_size,
                                                          D3D12_HEAP_TYPE_READBACK,
                                                          D3D12_RESOURCE_STATE_COPY_DEST,
                                                          D3D12_RESOURCE_FLAG_NONE);
@@ -4418,19 +4505,16 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*  
 
     if (source_desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
-        copy_command_list->CopyResource(copy_resource, source_resource);
+        copy_command_list->CopyBufferRegion(
+            copy_resource, 0, source_resource, copy_resource_data.source_offset, copy_resource_data.source_size);
     }
     else
     {
-        D3D12_TEXTURE_COPY_LOCATION dst_location        = {};
-        dst_location.pResource                          = copy_resource;
-        dst_location.Type                               = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
-        dst_location.PlacedFootprint.Footprint.Width    = source_desc.Width;
-        dst_location.PlacedFootprint.Footprint.Height   = source_desc.Height;
-        dst_location.PlacedFootprint.Footprint.Depth    = source_desc.DepthOrArraySize;
-        dst_location.PlacedFootprint.Footprint.Format   = source_desc.Format;
-        dst_location.PlacedFootprint.Footprint.RowPitch = graphics::dx12::GetTexturePitch(source_desc.Width);
-        dst_location.PlacedFootprint.Offset             = 0;
+        D3D12_TEXTURE_COPY_LOCATION dst_location = {};
+        dst_location.pResource                   = copy_resource;
+        dst_location.Type                        = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+        dst_location.PlacedFootprint             = copy_resource_data.source_footprint;
+        dst_location.PlacedFootprint.Offset      = copy_resource_data.source_offset;
 
         D3D12_TEXTURE_COPY_LOCATION src_location = {};
         src_location.pResource                   = source_resource;

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -1214,6 +1214,17 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
 
     auto clear_value_pointer = pOptimizedClearValue->GetPointer();
 
+    D3D12_RESOURCE_STATES modified_initial_resource_state = InitialResourceState;
+    if ((options_.dump_resources_type != DumpResourcesType::kNone) &&
+        (modified_initial_resource_state & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE))
+    {
+        // shader resources can't change state after SetGraphicsRootDescriptorTable.
+        // But even if it changes state and copy resources before SetGraphicsRootDescriptorTable,
+        // it can't solve it, because it also has to copy resources after drawcall.
+        // In this case, adding a COPY_SOURCE state here, so it doesn't need to change state for copy resources.
+        modified_initial_resource_state |= D3D12_RESOURCE_STATE_COPY_SOURCE;
+    }
+
     // Create an equivalent but temporary dummy resource
     // This allows us to further validate GFXR, since playback will now use a resource located at a different address
     HRESULT         dummy_result   = E_FAIL;
@@ -1223,7 +1234,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
         dummy_result = replay_object->CreateCommittedResource(heap_properties_pointer,
                                                               HeapFlags,
                                                               desc_pointer,
-                                                              InitialResourceState,
+                                                              modified_initial_resource_state,
                                                               clear_value_pointer,
                                                               IID_PPV_ARGS(&dummy_resource));
 
@@ -1237,7 +1248,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
     auto replay_result = replay_object->CreateCommittedResource(heap_properties_pointer,
                                                                 HeapFlags,
                                                                 desc_pointer,
-                                                                InitialResourceState,
+                                                                modified_initial_resource_state,
                                                                 clear_value_pointer,
                                                                 *riid.decoded_value,
                                                                 resource->GetHandlePointer());
@@ -1249,6 +1260,12 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
         {
             dummy_resource->Release();
         }
+    }
+    if (SUCCEEDED(replay_result))
+    {
+        auto extra_info           = std::make_unique<D3D12ResourceInfo>();
+        extra_info->current_state = modified_initial_resource_state;
+        SetExtraInfo(resource, std::move(extra_info));
     }
 
     return replay_result;
@@ -2128,7 +2145,10 @@ HRESULT Dx12ReplayConsumerBase::OverrideGetBuffer(DxObjectInfo*                r
             GFXRECON_ASSERT(buffer < swapchain_info->image_ids.size());
             if (swapchain_info->image_ids[buffer] == format::kNullHandleId)
             {
-                auto object_info = static_cast<DxObjectInfo*>(surface->GetConsumerData(0));
+                auto object_info          = static_cast<DxObjectInfo*>(surface->GetConsumerData(0));
+                auto extra_info           = std::make_unique<D3D12ResourceInfo>();
+                extra_info->current_state = D3D12_RESOURCE_STATE_PRESENT;
+                SetExtraInfo(surface, std::move(extra_info));
 
                 // Increment the replay reference to prevent the swapchain image info entry from being removed from the
                 // object info table while the swapchain is active.
@@ -3781,6 +3801,112 @@ std::wstring Dx12ReplayConsumerBase::ConstructObjectName(format::HandleId captur
     return constructed_name;
 }
 
+void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_ResourceBarrier(
+    const ApiCallInfo&                                    call_info,
+    DxObjectInfo*                                         object_info,
+    UINT                                                  NumBarriers,
+    StructPointerDecoder<Decoded_D3D12_RESOURCE_BARRIER>* pBarriers)
+{
+    auto barriers = pBarriers->GetMetaStructPointer();
+    for (uint32_t i = 0; i < NumBarriers; ++i)
+    {
+        auto resource_id          = barriers[i].Transition->pResource;
+        auto resource_object_info = GetObjectInfo(resource_id);
+        auto resource_extra_info  = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
+
+        if (options_.dump_resources_type != DumpResourcesType::kNone)
+        {
+            // This should be in the override functionsince it modifies the parameters. But here is ok.
+            barriers[i].Transition->decoded_value->StateBefore = resource_extra_info->current_state;
+            if (barriers[i].Transition->decoded_value->StateAfter & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE)
+            {
+                // shader resources can't change state after SetGraphicsRootDescriptorTable.
+                // Adding a COPY_SOURCE state here, so it doesn't need to change state for copy resources.
+                barriers[i].Transition->decoded_value->StateAfter |= D3D12_RESOURCE_STATE_COPY_SOURCE;
+            }
+        }
+        resource_extra_info->current_state = barriers[i].Transition->decoded_value->StateAfter;
+    }
+}
+
+void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateConstantBufferView(
+    const ApiCallInfo&                                             call_info,
+    DxObjectInfo*                                                  object_info,
+    StructPointerDecoder<Decoded_D3D12_CONSTANT_BUFFER_VIEW_DESC>* pDesc,
+    Decoded_D3D12_CPU_DESCRIPTOR_HANDLE                            DestDescriptor)
+{
+    auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
+    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+    auto desc             = pDesc->GetMetaStructPointer();
+    heap_extra_info->captured_constant_buffer_view_desc_gvas.emplace_back(desc->decoded_value->BufferLocation);
+}
+
+void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateShaderResourceView(
+    const ApiCallInfo&                                             call_info,
+    DxObjectInfo*                                                  object_info,
+    format::HandleId                                               pResource,
+    StructPointerDecoder<Decoded_D3D12_SHADER_RESOURCE_VIEW_DESC>* pDesc,
+    Decoded_D3D12_CPU_DESCRIPTOR_HANDLE                            DestDescriptor)
+{
+    auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
+    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+    heap_extra_info->shader_resource_ids.emplace_back(pResource);
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
+    const ApiCallInfo&                                           call_info,
+    DxObjectInfo*                                                object_info,
+    format::HandleId                                             pResource,
+    StructPointerDecoder<Decoded_D3D12_RENDER_TARGET_VIEW_DESC>* pDesc,
+    Decoded_D3D12_CPU_DESCRIPTOR_HANDLE                          DestDescriptor)
+{
+    auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
+    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+    heap_extra_info->replay_render_target_handles.emplace_back(*DestDescriptor.decoded_value);
+    heap_extra_info->render_target_resource_ids.emplace_back(pResource);
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
+    const ApiCallInfo&                                           call_info,
+    DxObjectInfo*                                                object_info,
+    format::HandleId                                             pResource,
+    StructPointerDecoder<Decoded_D3D12_DEPTH_STENCIL_VIEW_DESC>* pDesc,
+    Decoded_D3D12_CPU_DESCRIPTOR_HANDLE                          DestDescriptor)
+{
+    auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
+    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+    heap_extra_info->replay_depth_stencil_handles.emplace_back(*DestDescriptor.decoded_value);
+    heap_extra_info->depth_stencil_resource_ids.emplace_back(pResource);
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_OMSetRenderTargets(
+    const ApiCallInfo&                                         call_info,
+    DxObjectInfo*                                              object_info,
+    UINT                                                       NumRenderTargetDescriptors,
+    StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pRenderTargetDescriptors,
+    BOOL                                                       RTsSingleHandleToDescriptorRange,
+    StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
+{
+    if (options_.dump_resources_type != DumpResourcesType::kNone &&
+        track_dump_resources_.target.set_render_targets_code_index == call_info.index)
+    {
+        auto rt_handles = pRenderTargetDescriptors->GetMetaStructPointer();
+        track_dump_resources_.render_target_heap_ids.resize(NumRenderTargetDescriptors);
+        track_dump_resources_.replay_render_target_handles.resize(NumRenderTargetDescriptors);
+        for (uint32_t i = 0; i < NumRenderTargetDescriptors; ++i)
+        {
+            track_dump_resources_.render_target_heap_ids[i]       = rt_handles[i].heap_id;
+            track_dump_resources_.replay_render_target_handles[i] = *rt_handles[i].decoded_value;
+        }
+        auto ds_handle = pDepthStencilDescriptor->GetMetaStructPointer();
+        if (ds_handle)
+        {
+            track_dump_resources_.depth_stencil_heap_id       = ds_handle->heap_id;
+            track_dump_resources_.replay_depth_stencil_handle = *ds_handle->decoded_value;
+        }
+    }
+}
+
 void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
                                                                              DxObjectInfo*      object_info,
                                                                              UINT               VertexCountPerInstance,
@@ -3851,6 +3977,39 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12Grap
     AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(copy_command_list,
                                                      track_dump_resources_.target.captured_vertex_buffer_view_gvas,
                                                      track_dump_resources_.copy_vertex_resources);
+    // index
+    AddCopyResourceCommandForBeforeDrawcallByGPUVA(copy_command_list,
+                                                   track_dump_resources_.target.captured_index_buffer_view_gva,
+                                                   track_dump_resources_.copy_index_resource);
+    // descriptor
+    auto size = track_dump_resources_.target.descriptor_heap_ids.size();
+    track_dump_resources_.descriptor_heap_datas.resize(size);
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        auto heap_object_info = GetObjectInfo(track_dump_resources_.target.descriptor_heap_ids[i]);
+        auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+
+        // constant buffer
+        AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
+            copy_command_list,
+            heap_extra_info->captured_constant_buffer_view_desc_gvas,
+            track_dump_resources_.descriptor_heap_datas[i].copy_constant_buffer_resources);
+
+        // shader resource
+        AddCopyResourceCommandsForBeforeDrawcall(copy_command_list,
+                                                 heap_extra_info->shader_resource_ids,
+                                                 track_dump_resources_.descriptor_heap_datas[i].copy_shader_resources);
+    }
+
+    // render target
+    AddCopyRenderTargetCommandsForBeforeDrawcall(copy_command_list,
+                                                 track_dump_resources_.render_target_heap_ids,
+                                                 track_dump_resources_.replay_render_target_handles,
+                                                 track_dump_resources_.copy_render_target_resources);
+    AddCopyDepthStencilCommandForBeforeDrawcall(copy_command_list,
+                                                track_dump_resources_.depth_stencil_heap_id,
+                                                track_dump_resources_.replay_depth_stencil_handle,
+                                                track_dump_resources_.copy_depth_stencil_resource);
 }
 
 void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
@@ -3883,6 +4042,20 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcallByGPUVA(
         copy_command_list, copy_resource_data.source_resource_id, copy_resource_data);
 }
 
+void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(
+    ID3D12GraphicsCommandList*               copy_command_list,
+    const std::vector<format::HandleId>&     source_resource_ids,
+    std::vector<graphics::CopyResourceData>& copy_resource_datas)
+{
+    auto size = source_resource_ids.size();
+    copy_resource_datas.resize(size);
+
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        AddCopyResourceCommandForBeforeDrawcall(copy_command_list, source_resource_ids[i], copy_resource_datas[i]);
+    }
+}
+
 void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
                                                                      format::HandleId            source_resource_id,
                                                                      graphics::CopyResourceData& copy_resource_data)
@@ -3909,10 +4082,79 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(ID3D12Graph
     AddCopyResourceCommand(copy_command_list, copy_resource_data, copy_resource_data.before_resource);
 }
 
+void Dx12ReplayConsumerBase::AddCopyRenderTargetCommandsForBeforeDrawcall(
+    ID3D12GraphicsCommandList*                      copy_command_list,
+    const std::vector<format::HandleId>&            heap_ids,
+    const std::vector<D3D12_CPU_DESCRIPTOR_HANDLE>& replay_render_target_handles,
+    std::vector<graphics::CopyResourceData>&        copy_resource_datas)
+{
+    auto rt_size = replay_render_target_handles.size();
+    copy_resource_datas.resize(rt_size);
+
+    for (uint32_t i = 0; i < rt_size; ++i)
+    {
+        auto heap_object_info = GetObjectInfo(heap_ids[i]);
+        auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+
+        auto record_size = heap_extra_info->replay_render_target_handles.size();
+        for (uint32_t j = 0; j < record_size; ++j)
+        {
+            if (heap_extra_info->replay_render_target_handles[j].ptr == replay_render_target_handles[i].ptr)
+            {
+                AddCopyResourceCommandForBeforeDrawcall(
+                    copy_command_list, heap_extra_info->render_target_resource_ids[j], copy_resource_datas[i]);
+                break;
+            }
+        }
+    }
+}
+
+void Dx12ReplayConsumerBase::AddCopyDepthStencilCommandForBeforeDrawcall(
+    ID3D12GraphicsCommandList*  copy_command_list,
+    format::HandleId            heap_id,
+    D3D12_CPU_DESCRIPTOR_HANDLE replay_depth_stencil_handle,
+    graphics::CopyResourceData& copy_resource_data)
+{
+    if (replay_depth_stencil_handle.ptr == decode::kNullCpuAddress)
+    {
+        return;
+    }
+    auto heap_object_info = GetObjectInfo(heap_id);
+    auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
+
+    auto size = heap_extra_info->replay_depth_stencil_handles.size();
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        if (heap_extra_info->replay_depth_stencil_handles[i].ptr == replay_depth_stencil_handle.ptr)
+        {
+            AddCopyResourceCommandForBeforeDrawcall(
+                copy_command_list, heap_extra_info->depth_stencil_resource_ids[i], copy_resource_data);
+            break;
+        }
+    }
+}
+
 void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList* copy_command_list)
 {
     // vertex
     AddCopyResourceCommandsForAfterDrawcall(copy_command_list, track_dump_resources_.copy_vertex_resources);
+
+    // index
+    AddCopyResourceCommandForAfterDrawcall(copy_command_list, track_dump_resources_.copy_index_resource);
+
+    // descriptor
+    for (auto& heap_data : track_dump_resources_.descriptor_heap_datas)
+    {
+        // constant buffer
+        AddCopyResourceCommandsForAfterDrawcall(copy_command_list, heap_data.copy_constant_buffer_resources);
+
+        // shader resource
+        AddCopyResourceCommandsForAfterDrawcall(copy_command_list, heap_data.copy_shader_resources);
+    }
+
+    // render target
+    AddCopyResourceCommandsForAfterDrawcall(copy_command_list, track_dump_resources_.copy_render_target_resources);
+    AddCopyResourceCommandForAfterDrawcall(copy_command_list, track_dump_resources_.copy_depth_stencil_resource);
 }
 
 void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(
@@ -3938,10 +4180,12 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*  
                                                     graphics::CopyResourceData&           copy_resource_data,
                                                     graphics::dx12::ID3D12ResourceComPtr& copy_resource)
 {
-    auto source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
-    auto source_resource             = reinterpret_cast<ID3D12Resource*>(source_resource_object_info->object);
-    auto device                      = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(source_resource);
-    copy_resource                    = graphics::dx12::CreateBufferResource(device,
+    auto        source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
+    auto        source_resource             = reinterpret_cast<ID3D12Resource*>(source_resource_object_info->object);
+    auto        device                      = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(source_resource);
+    const auto& source_desc                 = copy_resource_data.desc;
+
+    copy_resource = graphics::dx12::CreateBufferResource(device,
                                                          copy_resource_data.size,
                                                          D3D12_HEAP_TYPE_READBACK,
                                                          D3D12_RESOURCE_STATE_COPY_DEST,
@@ -3949,7 +4193,54 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*  
 
     auto source_resource_extra_info = GetExtraInfo<D3D12ResourceInfo>(source_resource_object_info);
 
-    copy_command_list->CopyResource(copy_resource, source_resource);
+    if (!(source_resource_extra_info->current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
+    {
+        // shader resources can't change state after SetGraphicsRootDescriptorTable.
+        D3D12_RESOURCE_BARRIER barrier{};
+        barrier.Type                   = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Flags                  = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+        barrier.Transition.pResource   = source_resource;
+        barrier.Transition.StateBefore = source_resource_extra_info->current_state;
+        barrier.Transition.StateAfter  = D3D12_RESOURCE_STATE_COPY_SOURCE;
+        barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+        copy_command_list->ResourceBarrier(1, &barrier);
+    }
+
+    if (source_desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+    {
+        copy_command_list->CopyResource(copy_resource, source_resource);
+    }
+    else
+    {
+        D3D12_TEXTURE_COPY_LOCATION dst_location        = {};
+        dst_location.pResource                          = copy_resource;
+        dst_location.Type                               = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+        dst_location.PlacedFootprint.Footprint.Width    = source_desc.Width;
+        dst_location.PlacedFootprint.Footprint.Height   = source_desc.Height;
+        dst_location.PlacedFootprint.Footprint.Depth    = source_desc.DepthOrArraySize;
+        dst_location.PlacedFootprint.Footprint.Format   = source_desc.Format;
+        dst_location.PlacedFootprint.Footprint.RowPitch = graphics::dx12::GetTexturePitch(source_desc.Width);
+        dst_location.PlacedFootprint.Offset             = 0;
+
+        D3D12_TEXTURE_COPY_LOCATION src_location = {};
+        src_location.pResource                   = source_resource;
+        src_location.Type                        = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+        src_location.SubresourceIndex            = 0;
+        copy_command_list->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
+    }
+
+    if (!(source_resource_extra_info->current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
+    {
+        // shader resources can't change state after SetGraphicsRootDescriptorTable.
+        D3D12_RESOURCE_BARRIER barrier{};
+        barrier.Type                   = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Flags                  = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+        barrier.Transition.pResource   = source_resource;
+        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+        barrier.Transition.StateAfter  = source_resource_extra_info->current_state;
+        barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+        copy_command_list->ResourceBarrier(1, &barrier);
+    }
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -47,6 +47,8 @@ constexpr uint32_t kDefaultWaitTimeout     = INFINITE;
 
 constexpr uint64_t kInternalEventId = static_cast<uint64_t>(~0);
 
+constexpr bool TEST_SHADER_RES = true;
+
 template <typename T, typename U>
 void SetExtraInfo(HandlePointerDecoder<T>* decoder, std::unique_ptr<U>&& extra_info)
 {
@@ -4262,33 +4264,36 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(format::Ha
             }
         }
 
-        // shader resource
-        for (const auto& info : heap_extra_info->shader_resource_infos)
+        if (TEST_SHADER_RES)
         {
-            if (MatchDescriptorCPUGPUHandle(heap_extra_info->replay_cpu_addr_begin,
-                                            info.replay_handle.ptr,
-                                            heap_extra_info->capture_gpu_addr_begin,
-                                            track_dump_resources_.target.captured_descriptor_gpu_handles))
+            // shader resource
+            for (const auto& info : heap_extra_info->shader_resource_infos)
             {
-                uint64_t offset = 0;
-                uint64_t size   = 0;
-                switch (info.view.ViewDimension)
+                if (MatchDescriptorCPUGPUHandle(heap_extra_info->replay_cpu_addr_begin,
+                                                info.replay_handle.ptr,
+                                                heap_extra_info->capture_gpu_addr_begin,
+                                                track_dump_resources_.target.captured_descriptor_gpu_handles))
                 {
-                    case D3D12_SRV_DIMENSION_BUFFER:
-                        offset = info.view.Buffer.FirstElement * info.view.Buffer.StructureByteStride;
-                        size   = info.view.Buffer.NumElements * info.view.Buffer.StructureByteStride;
-                        break;
-                    // TODO: Set offset and size fot texture.
-                    default:
-                        break;
+                    uint64_t offset = 0;
+                    uint64_t size   = 0;
+                    switch (info.view.ViewDimension)
+                    {
+                        case D3D12_SRV_DIMENSION_BUFFER:
+                            offset = info.view.Buffer.FirstElement * info.view.Buffer.StructureByteStride;
+                            size   = info.view.Buffer.NumElements * info.view.Buffer.StructureByteStride;
+                            break;
+                        // TODO: Set offset and size fot texture.
+                        default:
+                            break;
+                    }
+
+                    graphics::CopyResourceData copy_resource_data;
+                    AddCopyResourceCommandForBeforeDrawcall(
+                        command_list_id, info.resource_id, offset, size, copy_resource_data);
+
+                    track_dump_resources_.descriptor_heap_datas[heap_index].copy_shader_resources.emplace_back(
+                        std::move(copy_resource_data));
                 }
-
-                graphics::CopyResourceData copy_resource_data;
-                AddCopyResourceCommandForBeforeDrawcall(
-                    command_list_id, info.resource_id, offset, size, copy_resource_data);
-
-                track_dump_resources_.descriptor_heap_datas[heap_index].copy_shader_resources.emplace_back(
-                    std::move(copy_resource_data));
             }
         }
     }
@@ -4482,8 +4487,11 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(format::Han
         // constant buffer
         AddCopyResourceCommandsForAfterDrawcall(command_list_id, heap_data.copy_constant_buffer_resources);
 
-        // shader resource
-        AddCopyResourceCommandsForAfterDrawcall(command_list_id, heap_data.copy_shader_resources);
+        if (TEST_SHADER_RES)
+        {
+            // shader resource
+            AddCopyResourceCommandsForAfterDrawcall(command_list_id, heap_data.copy_shader_resources);
+        }
     }
 
     // render target

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -448,7 +448,7 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
                                                  temp_subresource_layouts,
                                                  required_data_size);
 
-        resource_init_info.staging_resource  = resource_data_util_->CreateStagingBuffer(
+        resource_init_info.staging_resource = resource_data_util_->CreateStagingBuffer(
             graphics::Dx12ResourceDataUtil::CopyType::kCopyTypeWrite, required_data_size);
         SetResourceInitInfoState(resource_init_info, command_header, data);
 
@@ -3279,6 +3279,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCommandListReset(DxObjectInfo* command_l
 
     auto command_list_extra_info                         = GetExtraInfo<D3D12CommandListInfo>(command_list_object_info);
     command_list_extra_info->requires_sync_after_execute = false;
+    command_list_extra_info->track_resource_barriers.clear();
 
     if (resource_value_mapper_ != nullptr)
     {
@@ -3805,25 +3806,37 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_ResourceBarrier(
     UINT                                                  NumBarriers,
     StructPointerDecoder<Decoded_D3D12_RESOURCE_BARRIER>* pBarriers)
 {
+    const auto command_list_id = object_info->capture_id;
+    auto       extra_info      = GetExtraInfo<D3D12CommandListInfo>(GetObjectInfo(command_list_id));
+
     auto barriers = pBarriers->GetMetaStructPointer();
     for (uint32_t i = 0; i < NumBarriers; ++i)
     {
-        auto resource_id          = barriers[i].Transition->pResource;
-        auto resource_object_info = GetObjectInfo(resource_id);
-        auto resource_extra_info  = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
-
-        if (options_.enable_dump_resources)
+        if (barriers[i].decoded_value->Type == D3D12_RESOURCE_BARRIER_TYPE_TRANSITION)
         {
-            // This should be in the override functionsince it modifies the parameters. But here is ok.
-            barriers[i].Transition->decoded_value->StateBefore = resource_extra_info->current_state;
-            if (barriers[i].Transition->decoded_value->StateAfter & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE)
+            // It shouldn't change the state here. It should save the AfterState until ExecuteCommandList to change it.
+            auto resource_id = barriers[i].Transition->pResource;
+            extra_info->track_resource_barriers.insert(resource_id);
+            auto resource_object_info = GetObjectInfo(resource_id);
+            auto resource_extra_info  = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
+
+            if (options_.enable_dump_resources)
             {
-                // shader resources can't change state after SetGraphicsRootDescriptorTable.
-                // Adding a COPY_SOURCE state here, so it doesn't need to change state for copy resources.
-                barriers[i].Transition->decoded_value->StateAfter |= D3D12_RESOURCE_STATE_COPY_SOURCE;
+                // This should be in the override functionsince it modifies the parameters. But here is ok.
+                if (barriers[i].Transition->decoded_value->StateBefore & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE)
+                {
+                    barriers[i].Transition->decoded_value->StateBefore |= D3D12_RESOURCE_STATE_COPY_SOURCE;
+                }
+                if (barriers[i].Transition->decoded_value->StateAfter & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE)
+                {
+                    // shader resources can't change state after SetGraphicsRootDescriptorTable.
+                    // Adding a COPY_SOURCE state here, so it doesn't need to change state for copy resources.
+                    barriers[i].Transition->decoded_value->StateAfter |= D3D12_RESOURCE_STATE_COPY_SOURCE;
+                }
             }
+            resource_extra_info->track_resource_barrier_state_after[command_list_id] =
+                barriers[i].Transition->decoded_value->StateAfter;
         }
-        resource_extra_info->current_state = barriers[i].Transition->decoded_value->StateAfter;
     }
 }
 
@@ -4112,6 +4125,35 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12CommandQueue_ExecuteCommandLists(
     UINT                                      NumCommandLists,
     HandlePointerDecoder<ID3D12CommandList*>* ppCommandLists)
 {
+    for (uint32_t i = 0; i < NumCommandLists; ++i)
+    {
+        auto commandlist_id          = ppCommandLists->GetPointer()[i];
+        auto command_list_extra_info = GetExtraInfo<D3D12CommandListInfo>(GetObjectInfo(commandlist_id));
+
+        for (auto resource_id : command_list_extra_info->track_resource_barriers)
+        {
+            auto resource_object_info = GetObjectInfo(resource_id);
+            if (resource_object_info == nullptr)
+            {
+                GFXRECON_LOG_WARNING("resource id %" PRIu64
+                                     " can't found for update state in ExecuteCommandLists. It could be released",
+                                     resource_id);
+            }
+            else
+            {
+                auto resource_extra_info = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
+
+                auto it = resource_extra_info->track_resource_barrier_state_after.find(commandlist_id);
+                if (it != resource_extra_info->track_resource_barrier_state_after.end())
+                {
+                    resource_extra_info->current_state = it->second;
+                    resource_extra_info->track_resource_barrier_state_after.erase(it);
+                }
+            }
+        }
+        command_list_extra_info->track_resource_barriers.clear();
+    }
+
     if (track_dump_resources_.target.execute_code_index == call_info.index)
     {
         auto                              queue  = reinterpret_cast<ID3D12CommandQueue*>(object_info->object);
@@ -4132,20 +4174,20 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(const ApiC
 {
     if (track_dump_resources_.target.drawcall_code_index == call_info.index)
     {
-        auto commandlist = reinterpret_cast<ID3D12GraphicsCommandList*>(object_info->object);
         if (track_dump_resources_.target.begin_renderpass_code_index == 0)
         {
             // The program doesn't use renderpass.
-            AddCopyResourceCommandsForBeforeDrawcall(commandlist);
+            AddCopyResourceCommandsForBeforeDrawcall(object_info->capture_id);
         }
         else
         {
             // Insert renderpass
+            auto commandlist = reinterpret_cast<ID3D12GraphicsCommandList*>(object_info->object);
             graphics::dx12::ID3D12GraphicsCommandList4ComPtr commandlist4;
             commandlist->QueryInterface(IID_PPV_ARGS(&commandlist4));
             commandlist4->EndRenderPass();
 
-            AddCopyResourceCommandsForBeforeDrawcall(commandlist);
+            AddCopyResourceCommandsForBeforeDrawcall(object_info->capture_id);
 
             std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs;
             auto rt_descs_size = track_dump_resources_.replay_render_target_handles.size();
@@ -4174,21 +4216,21 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(const ApiC
     }
 }
 
-void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList* copy_command_list)
+void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(format::HandleId command_list_id)
 {
     // vertex
     for (const auto& view : track_dump_resources_.target.captured_vertex_buffer_views)
     {
         graphics::CopyResourceData copy_resource_data;
         AddCopyResourceCommandForBeforeDrawcallByGPUVA(
-            copy_command_list, view.BufferLocation, view.SizeInBytes, copy_resource_data);
+            command_list_id, view.BufferLocation, view.SizeInBytes, copy_resource_data);
 
         track_dump_resources_.copy_vertex_resources.emplace_back(std::move(copy_resource_data));
     }
 
     // index
     AddCopyResourceCommandForBeforeDrawcallByGPUVA(
-        copy_command_list,
+        command_list_id,
         track_dump_resources_.target.captured_index_buffer_view.BufferLocation,
         track_dump_resources_.target.captured_index_buffer_view.SizeInBytes,
         track_dump_resources_.copy_index_resource);
@@ -4210,7 +4252,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12Grap
                                             track_dump_resources_.target.captured_descriptor_gpu_handles))
             {
                 graphics::CopyResourceData copy_resource_data;
-                AddCopyResourceCommandForBeforeDrawcallByGPUVA(copy_command_list,
+                AddCopyResourceCommandForBeforeDrawcallByGPUVA(command_list_id,
                                                                info.captured_view.BufferLocation,
                                                                info.captured_view.SizeInBytes,
                                                                copy_resource_data);
@@ -4228,7 +4270,6 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12Grap
                                             heap_extra_info->capture_gpu_addr_begin,
                                             track_dump_resources_.target.captured_descriptor_gpu_handles))
             {
-
                 uint64_t offset = 0;
                 uint64_t size   = 0;
                 switch (info.view.ViewDimension)
@@ -4244,7 +4285,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12Grap
 
                 graphics::CopyResourceData copy_resource_data;
                 AddCopyResourceCommandForBeforeDrawcall(
-                    copy_command_list, info.resource_id, offset, size, copy_resource_data);
+                    command_list_id, info.resource_id, offset, size, copy_resource_data);
 
                 track_dump_resources_.descriptor_heap_datas[heap_index].copy_shader_resources.emplace_back(
                     std::move(copy_resource_data));
@@ -4267,7 +4308,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12Grap
             {
                 // TODO: Set offset and size by info.view.ViewDimension.
                 AddCopyResourceCommandForBeforeDrawcall(
-                    copy_command_list, info.resource_id, 0, 0, track_dump_resources_.copy_render_target_resources[i]);
+                    command_list_id, info.resource_id, 0, 0, track_dump_resources_.copy_render_target_resources[i]);
                 break;
             }
         }
@@ -4285,19 +4326,19 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12Grap
             {
                 // TODO: Set offset and size by info.view.ViewDimension.
                 AddCopyResourceCommandForBeforeDrawcall(
-                    copy_command_list, info.resource_id, 0, 0, track_dump_resources_.copy_depth_stencil_resource);
+                    command_list_id, info.resource_id, 0, 0, track_dump_resources_.copy_depth_stencil_resource);
                 break;
             }
         }
     }
 
     // ExecuteIndirect
-    AddCopyResourceCommandForBeforeDrawcall(copy_command_list,
+    AddCopyResourceCommandForBeforeDrawcall(command_list_id,
                                             track_dump_resources_.target.exe_indirect_argument_id,
                                             track_dump_resources_.target.exe_indirect_argument_offset,
                                             0,
                                             track_dump_resources_.copy_exe_indirect_argument);
-    AddCopyResourceCommandForBeforeDrawcall(copy_command_list,
+    AddCopyResourceCommandForBeforeDrawcall(command_list_id,
                                             track_dump_resources_.target.exe_indirect_count_id,
                                             track_dump_resources_.target.exe_indirect_count_offset,
                                             0,
@@ -4321,7 +4362,7 @@ bool Dx12ReplayConsumerBase::MatchDescriptorCPUGPUHandle(size_t   replay_cpu_add
 }
 
 void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcallByGPUVA(
-    ID3D12GraphicsCommandList*  copy_command_list,
+    format::HandleId            command_list_id,
     D3D12_GPU_VIRTUAL_ADDRESS   captured_source_gpu_va,
     uint64_t                    source_size,
     graphics::CopyResourceData& copy_resource_data)
@@ -4335,7 +4376,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcallByGPUVA(
     auto source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
     auto source_resource_extra_info  = GetExtraInfo<D3D12ResourceInfo>(source_resource_object_info);
 
-    AddCopyResourceCommandForBeforeDrawcall(copy_command_list,
+    AddCopyResourceCommandForBeforeDrawcall(command_list_id,
                                             copy_resource_data.source_resource_id,
                                             (captured_source_gpu_va - source_resource_extra_info->capture_address_),
                                             source_size,
@@ -4343,7 +4384,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcallByGPUVA(
 }
 
 // If source_size = 0, the meaning is the whole after offset.
-void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(format::HandleId            command_list_id,
                                                                      format::HandleId            source_resource_id,
                                                                      uint64_t                    source_offset,
                                                                      uint64_t                    source_size,
@@ -4374,7 +4415,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(ID3D12Graph
         copy_resource_data.source_size = total_bytes - copy_resource_data.source_offset;
     }
 
-    AddCopyResourceCommand(copy_command_list, copy_resource_data, copy_resource_data.before_resource);
+    AddCopyResourceCommand(command_list_id, copy_resource_data, copy_resource_data.before_resource);
 }
 
 void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(const ApiCallInfo& call_info,
@@ -4382,20 +4423,20 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(const ApiCa
 {
     if (track_dump_resources_.target.drawcall_code_index == call_info.index)
     {
-        auto commandlist = reinterpret_cast<ID3D12GraphicsCommandList*>(object_info->object);
         if (track_dump_resources_.target.begin_renderpass_code_index == 0)
         {
             // The program doesn't use renderpass.
-            AddCopyResourceCommandsForAfterDrawcall(commandlist);
+            AddCopyResourceCommandsForAfterDrawcall(object_info->capture_id);
         }
         else
         {
             // Insert renderpass
+            auto commandlist = reinterpret_cast<ID3D12GraphicsCommandList*>(object_info->object);
             graphics::dx12::ID3D12GraphicsCommandList4ComPtr commandlist4;
             commandlist->QueryInterface(IID_PPV_ARGS(&commandlist4));
             commandlist4->EndRenderPass();
 
-            AddCopyResourceCommandsForAfterDrawcall(commandlist);
+            AddCopyResourceCommandsForAfterDrawcall(object_info->capture_id);
 
             std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs;
             auto rt_descs_size = track_dump_resources_.replay_render_target_handles.size();
@@ -4427,56 +4468,57 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(const ApiCa
     }
 }
 
-void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList* copy_command_list)
+void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(format::HandleId command_list_id)
 {
     // vertex
-    AddCopyResourceCommandsForAfterDrawcall(copy_command_list, track_dump_resources_.copy_vertex_resources);
+    AddCopyResourceCommandsForAfterDrawcall(command_list_id, track_dump_resources_.copy_vertex_resources);
 
     // index
-    AddCopyResourceCommandForAfterDrawcall(copy_command_list, track_dump_resources_.copy_index_resource);
+    AddCopyResourceCommandForAfterDrawcall(command_list_id, track_dump_resources_.copy_index_resource);
 
     // descriptor
     for (auto& heap_data : track_dump_resources_.descriptor_heap_datas)
     {
         // constant buffer
-        AddCopyResourceCommandsForAfterDrawcall(copy_command_list, heap_data.copy_constant_buffer_resources);
+        AddCopyResourceCommandsForAfterDrawcall(command_list_id, heap_data.copy_constant_buffer_resources);
 
         // shader resource
-        AddCopyResourceCommandsForAfterDrawcall(copy_command_list, heap_data.copy_shader_resources);
+        AddCopyResourceCommandsForAfterDrawcall(command_list_id, heap_data.copy_shader_resources);
     }
 
     // render target
-    AddCopyResourceCommandsForAfterDrawcall(copy_command_list, track_dump_resources_.copy_render_target_resources);
-    AddCopyResourceCommandForAfterDrawcall(copy_command_list, track_dump_resources_.copy_depth_stencil_resource);
+    AddCopyResourceCommandsForAfterDrawcall(command_list_id, track_dump_resources_.copy_render_target_resources);
+    AddCopyResourceCommandForAfterDrawcall(command_list_id, track_dump_resources_.copy_depth_stencil_resource);
 
     // ExecuteIndirect
-    AddCopyResourceCommandForAfterDrawcall(copy_command_list, track_dump_resources_.copy_exe_indirect_argument);
-    AddCopyResourceCommandForAfterDrawcall(copy_command_list, track_dump_resources_.copy_exe_indirect_count);
+    AddCopyResourceCommandForAfterDrawcall(command_list_id, track_dump_resources_.copy_exe_indirect_argument);
+    AddCopyResourceCommandForAfterDrawcall(command_list_id, track_dump_resources_.copy_exe_indirect_count);
 }
 
 void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(
-    ID3D12GraphicsCommandList* copy_command_list, std::vector<graphics::CopyResourceData>& copy_resource_datas)
+    format::HandleId command_list_id, std::vector<graphics::CopyResourceData>& copy_resource_datas)
 {
     for (auto& copy_resource : copy_resource_datas)
     {
-        AddCopyResourceCommandForAfterDrawcall(copy_command_list, copy_resource);
+        AddCopyResourceCommandForAfterDrawcall(command_list_id, copy_resource);
     }
 }
 
-void Dx12ReplayConsumerBase::AddCopyResourceCommandForAfterDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+void Dx12ReplayConsumerBase::AddCopyResourceCommandForAfterDrawcall(format::HandleId            command_list_id,
                                                                     graphics::CopyResourceData& copy_resource_data)
 {
     if (copy_resource_data.source_resource_id == 0)
     {
         return;
     }
-    AddCopyResourceCommand(copy_command_list, copy_resource_data, copy_resource_data.after_resource);
+    AddCopyResourceCommand(command_list_id, copy_resource_data, copy_resource_data.after_resource);
 }
 
-void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*            copy_command_list,
+void Dx12ReplayConsumerBase::AddCopyResourceCommand(format::HandleId                      command_list_id,
                                                     graphics::CopyResourceData&           copy_resource_data,
                                                     graphics::dx12::ID3D12ResourceComPtr& copy_resource)
 {
+    auto        commandlist                 = MapObject<ID3D12GraphicsCommandList>(command_list_id);
     auto        source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
     auto        source_resource             = reinterpret_cast<ID3D12Resource*>(source_resource_object_info->object);
     auto        device                      = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(source_resource);
@@ -4490,22 +4532,31 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*  
 
     auto source_resource_extra_info = GetExtraInfo<D3D12ResourceInfo>(source_resource_object_info);
 
-    if (!(source_resource_extra_info->current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
+    // TODO: current_state could be wrong.
+    //       If the state is changed in another commandlist, and the commandlist is executed
+    //       after the target drawcall, we couldn't know the correct state.
+    D3D12_RESOURCE_STATES current_state = source_resource_extra_info->current_state;
+    auto                  it = source_resource_extra_info->track_resource_barrier_state_after.find(command_list_id);
+    if (it != source_resource_extra_info->track_resource_barrier_state_after.end())
+    {
+        current_state = it->second;
+    }
+    if (!(current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
     {
         // shader resources can't change state after SetGraphicsRootDescriptorTable.
         D3D12_RESOURCE_BARRIER barrier{};
         barrier.Type                   = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         barrier.Flags                  = D3D12_RESOURCE_BARRIER_FLAG_NONE;
         barrier.Transition.pResource   = source_resource;
-        barrier.Transition.StateBefore = source_resource_extra_info->current_state;
+        barrier.Transition.StateBefore = current_state;
         barrier.Transition.StateAfter  = D3D12_RESOURCE_STATE_COPY_SOURCE;
         barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-        copy_command_list->ResourceBarrier(1, &barrier);
+        commandlist->ResourceBarrier(1, &barrier);
     }
 
     if (source_desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
     {
-        copy_command_list->CopyBufferRegion(
+        commandlist->CopyBufferRegion(
             copy_resource, 0, source_resource, copy_resource_data.source_offset, copy_resource_data.source_size);
     }
     else
@@ -4520,10 +4571,10 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*  
         src_location.pResource                   = source_resource;
         src_location.Type                        = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
         src_location.SubresourceIndex            = 0;
-        copy_command_list->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
+        commandlist->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
     }
 
-    if (!(source_resource_extra_info->current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
+    if (!(current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
     {
         // shader resources can't change state after SetGraphicsRootDescriptorTable.
         D3D12_RESOURCE_BARRIER barrier{};
@@ -4531,9 +4582,9 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*  
         barrier.Flags                  = D3D12_RESOURCE_BARRIER_FLAG_NONE;
         barrier.Transition.pResource   = source_resource;
         barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
-        barrier.Transition.StateAfter  = source_resource_extra_info->current_state;
+        barrier.Transition.StateAfter  = current_state;
         barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-        copy_command_list->ResourceBarrier(1, &barrier);
+        commandlist->ResourceBarrier(1, &barrier);
     }
 }
 

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -3826,7 +3826,7 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12Device_CreateConstantBufferView(
     ConstantBufferInfo info;
     info.captured_view = *(desc->decoded_value);
 
-    heap_extra_info->constant_buffer_infos.emplace_back(std::move(info));
+    heap_extra_info->constant_buffer_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateConstantBufferView(
@@ -3838,7 +3838,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateConstantBufferView(
     auto heap_object_info = GetObjectInfo(DestDescriptor.heap_id);
     auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-    heap_extra_info->constant_buffer_infos.back().replay_handle = (*DestDescriptor.decoded_value);
+    heap_extra_info->constant_buffer_infos[DestDescriptor.index].replay_handle = (*DestDescriptor.decoded_value);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
@@ -3864,7 +3864,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
         info.is_view_null = false;
     }
 
-    heap_extra_info->shader_resource_infos.emplace_back(std::move(info));
+    heap_extra_info->shader_resource_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
@@ -3890,7 +3890,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
         info.is_view_null = false;
     }
 
-    heap_extra_info->render_target_infos.emplace_back(std::move(info));
+    heap_extra_info->render_target_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
@@ -3915,7 +3915,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
         info.view         = *(pDesc->GetMetaStructPointer()->decoded_value);
         info.is_view_null = false;
     }
-    heap_extra_info->depth_stencil_infos.emplace_back(std::move(info));
+    heap_extra_info->depth_stencil_infos[DestDescriptor.index] = std::move(info);
 }
 
 void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_OMSetRenderTargets(
@@ -4236,8 +4236,9 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(format::Ha
         auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
         // constant buffer
-        for (const auto& info : heap_extra_info->constant_buffer_infos)
+        for (const auto& info_pair : heap_extra_info->constant_buffer_infos)
         {
+            const auto& info = info_pair.second;
             if (MatchDescriptorCPUGPUHandle(heap_extra_info->replay_cpu_addr_begin,
                                             info.replay_handle.ptr,
                                             heap_extra_info->capture_gpu_addr_begin,
@@ -4257,8 +4258,9 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(format::Ha
         if (TEST_SHADER_RES)
         {
             // shader resource
-            for (const auto& info : heap_extra_info->shader_resource_infos)
+            for (const auto& info_pair : heap_extra_info->shader_resource_infos)
             {
+                const auto& info = info_pair.second;
                 if (MatchDescriptorCPUGPUHandle(heap_extra_info->replay_cpu_addr_begin,
                                                 info.replay_handle.ptr,
                                                 heap_extra_info->capture_gpu_addr_begin,
@@ -4297,8 +4299,9 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(format::Ha
         auto heap_object_info = GetObjectInfo(track_dump_resources_.render_target_heap_ids[i]);
         auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-        for (const auto& info : heap_extra_info->render_target_infos)
+        for (const auto& info_pair : heap_extra_info->render_target_infos)
         {
+            const auto& info = info_pair.second;
             if (info.replay_handle.ptr == track_dump_resources_.replay_render_target_handles[i].ptr)
             {
                 // TODO: Set offset and size by info.view.ViewDimension.
@@ -4315,8 +4318,9 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(format::Ha
         auto heap_object_info = GetObjectInfo(track_dump_resources_.depth_stencil_heap_id);
         auto heap_extra_info  = GetExtraInfo<D3D12DescriptorHeapInfo>(heap_object_info);
 
-        for (const auto& info : heap_extra_info->depth_stencil_infos)
+        for (const auto& info_pair : heap_extra_info->depth_stencil_infos)
         {
+            const auto& info = info_pair.second;
             if (info.replay_handle.ptr == track_dump_resources_.replay_depth_stencil_handle.ptr)
             {
                 // TODO: Set offset and size by info.view.ViewDimension.

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -3957,13 +3957,39 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_OMSetRenderTarge
 {
     if (call_info.index == track_dump_resources_.target.set_render_targets_code_index)
     {
+        auto descriptor_increment = 0;
+        if (RTsSingleHandleToDescriptorRange)
+        {
+            // Determine descriptor increment for contiguous render target descriptors.
+            auto cmd_list = reinterpret_cast<ID3D12GraphicsCommandList*>(object_info->object);
+            auto device   = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(cmd_list);
+            if (device != nullptr)
+            {
+                descriptor_increment = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR("Failed to get Device for GetDescriptorHandleIncrementSize in OMSetRenderTargets.");
+            }
+        }
+
         auto rt_handles = pRenderTargetDescriptors->GetMetaStructPointer();
         track_dump_resources_.render_target_heap_ids.resize(NumRenderTargetDescriptors);
         track_dump_resources_.replay_render_target_handles.resize(NumRenderTargetDescriptors);
         for (uint32_t i = 0; i < NumRenderTargetDescriptors; ++i)
         {
-            track_dump_resources_.render_target_heap_ids[i]       = rt_handles[i].heap_id;
-            track_dump_resources_.replay_render_target_handles[i] = *rt_handles[i].decoded_value;
+            if (RTsSingleHandleToDescriptorRange)
+            {
+                // All render target descriptors are contiguous in the same descriptor heap.
+                track_dump_resources_.render_target_heap_ids[i] = rt_handles[0].heap_id;
+                track_dump_resources_.replay_render_target_handles[i] =
+                    D3D12_CPU_DESCRIPTOR_HANDLE{ (*rt_handles[0].decoded_value).ptr + descriptor_increment * i };
+            }
+            else
+            {
+                track_dump_resources_.render_target_heap_ids[i]       = rt_handles[i].heap_id;
+                track_dump_resources_.replay_render_target_handles[i] = *rt_handles[i].decoded_value;
+            }
         }
         auto ds_handle = pDepthStencilDescriptor->GetMetaStructPointer();
         if (ds_handle)

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -24,6 +24,7 @@
 #include "decode/dx12_replay_consumer_base.h"
 
 #include "decode/dx12_enum_util.h"
+#include "decode/custom_dx12_struct_object_mappers.h"
 #include "generated/generated_dx12_call_id_to_string.h"
 #include "graphics/dx12_util.h"
 #include "graphics/dx12_image_renderer.h"
@@ -98,6 +99,15 @@ Dx12ReplayConsumerBase::Dx12ReplayConsumerBase(std::shared_ptr<application::Appl
     if (!options.screenshot_ranges.empty())
     {
         InitializeScreenshotHandler();
+    }
+
+    if (options.dump_resources_type != DumpResourcesType::kNone)
+    {
+        gfxrecon::graphics::Dx12DumpResourcesConfig config;
+        config.captured_file_name = options.filename;
+        config.type               = options.dump_resources_type;
+        config.argument           = options.dump_resources_argument;
+        dump_resources_           = gfxrecon::graphics::Dx12DumpResources::Create(config);
     }
 
     DetectAdapters();
@@ -3769,6 +3779,177 @@ std::wstring Dx12ReplayConsumerBase::ConstructObjectName(format::HandleId captur
     constructed_name.append(L" (" + object_creator + L")");
 
     return constructed_name;
+}
+
+void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
+                                                                             DxObjectInfo*      object_info,
+                                                                             UINT               VertexCountPerInstance,
+                                                                             UINT               InstanceCount,
+                                                                             UINT               StartVertexLocation,
+                                                                             UINT               StartInstanceLocation)
+{
+    if (options_.dump_resources_type != DumpResourcesType::kNone &&
+        track_dump_resources_.target.drawcall_code_index == call_info.index)
+    {
+        auto commandlist = reinterpret_cast<ID3D12GraphicsCommandList*>(object_info->object);
+        if (track_dump_resources_.target.begin_renderpass_code_index == 0)
+        {
+            // The program doesn't use renderpass.
+            AddCopyResourceCommandsForBeforeDrawcall(commandlist);
+        }
+    }
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
+                                                                              DxObjectInfo*      object_info,
+                                                                              UINT               VertexCountPerInstance,
+                                                                              UINT               InstanceCount,
+                                                                              UINT               StartVertexLocation,
+                                                                              UINT               StartInstanceLocation)
+{
+    if (options_.dump_resources_type != DumpResourcesType::kNone &&
+        track_dump_resources_.target.drawcall_code_index == call_info.index)
+    {
+        auto commandlist = reinterpret_cast<ID3D12GraphicsCommandList*>(object_info->object);
+        if (track_dump_resources_.target.begin_renderpass_code_index == 0)
+        {
+            // The program doesn't use renderpass.
+            AddCopyResourceCommandsForAfterDrawcall(commandlist);
+        }
+
+        // It has to run the original ExecuteCommandLists, not a new ExecuteCommandLists.
+        // Because some FIllMemoryCommand runs before the original ExecuteCommandLists.
+        // If it runs a new ExecuteCommandLists, it might miss FIllMemoryCommand.
+    }
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12CommandQueue_ExecuteCommandLists(
+    const ApiCallInfo&                        call_info,
+    DxObjectInfo*                             object_info,
+    UINT                                      NumCommandLists,
+    HandlePointerDecoder<ID3D12CommandList*>* ppCommandLists)
+{
+    if (options_.dump_resources_type != DumpResourcesType::kNone &&
+        track_dump_resources_.target.execute_code_index == call_info.index)
+    {
+        auto                              queue  = reinterpret_cast<ID3D12CommandQueue*>(object_info->object);
+        auto                              device = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(queue);
+        graphics::dx12::ID3D12FenceComPtr fence;
+        auto                              hr = device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence));
+        GFXRECON_ASSERT(SUCCEEDED(hr));
+
+        hr = graphics::dx12::WaitForQueue(queue, fence, UINT64_MAX);
+        GFXRECON_ASSERT(SUCCEEDED(hr));
+
+        dump_resources_->WriteResources(track_dump_resources_);
+    }
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList* copy_command_list)
+{
+    // vertex
+    AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(copy_command_list,
+                                                     track_dump_resources_.target.captured_vertex_buffer_view_gvas,
+                                                     track_dump_resources_.copy_vertex_resources);
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
+    ID3D12GraphicsCommandList*                    copy_command_list,
+    const std::vector<D3D12_GPU_VIRTUAL_ADDRESS>& captured_source_gpu_vas,
+    std::vector<graphics::CopyResourceData>&      copy_resource_datas)
+{
+    auto size = captured_source_gpu_vas.size();
+    copy_resource_datas.resize(size);
+
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        AddCopyResourceCommandForBeforeDrawcallByGPUVA(
+            copy_command_list, captured_source_gpu_vas[i], copy_resource_datas[i]);
+    }
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcallByGPUVA(
+    ID3D12GraphicsCommandList*  copy_command_list,
+    D3D12_GPU_VIRTUAL_ADDRESS   captured_source_gpu_va,
+    graphics::CopyResourceData& copy_resource_data)
+{
+    if (captured_source_gpu_va == 0)
+    {
+        return;
+    }
+    copy_resource_data.source_resource_id = object_mapping::FindResourceIDbyGpuVA(captured_source_gpu_va, gpu_va_map_);
+
+    AddCopyResourceCommandForBeforeDrawcall(
+        copy_command_list, copy_resource_data.source_resource_id, copy_resource_data);
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+                                                                     format::HandleId            source_resource_id,
+                                                                     graphics::CopyResourceData& copy_resource_data)
+{
+    if (source_resource_id == 0)
+    {
+        return;
+    }
+    copy_resource_data.source_resource_id = source_resource_id;
+
+    auto source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
+    auto source_resource             = reinterpret_cast<ID3D12Resource*>(source_resource_object_info->object);
+    auto device                      = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(source_resource);
+    auto source_desc                 = source_resource->GetDesc();
+    copy_resource_data.desc          = source_desc;
+
+    D3D12_PLACED_SUBRESOURCE_FOOTPRINT layout            = {};
+    UINT                               num_row           = 0;
+    UINT64                             row_size_in_bytes = 0;
+    UINT64                             total_bytes       = 0;
+    device->GetCopyableFootprints(&source_desc, 0, 1, 0, &layout, &num_row, &row_size_in_bytes, &total_bytes);
+    copy_resource_data.size = total_bytes;
+
+    AddCopyResourceCommand(copy_command_list, copy_resource_data, copy_resource_data.before_resource);
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList* copy_command_list)
+{
+    // vertex
+    AddCopyResourceCommandsForAfterDrawcall(copy_command_list, track_dump_resources_.copy_vertex_resources);
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommandsForAfterDrawcall(
+    ID3D12GraphicsCommandList* copy_command_list, std::vector<graphics::CopyResourceData>& copy_resource_datas)
+{
+    for (auto& copy_resource : copy_resource_datas)
+    {
+        AddCopyResourceCommandForAfterDrawcall(copy_command_list, copy_resource);
+    }
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommandForAfterDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+                                                                    graphics::CopyResourceData& copy_resource_data)
+{
+    if (copy_resource_data.source_resource_id == 0)
+    {
+        return;
+    }
+    AddCopyResourceCommand(copy_command_list, copy_resource_data, copy_resource_data.after_resource);
+}
+
+void Dx12ReplayConsumerBase::AddCopyResourceCommand(ID3D12GraphicsCommandList*            copy_command_list,
+                                                    graphics::CopyResourceData&           copy_resource_data,
+                                                    graphics::dx12::ID3D12ResourceComPtr& copy_resource)
+{
+    auto source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
+    auto source_resource             = reinterpret_cast<ID3D12Resource*>(source_resource_object_info->object);
+    auto device                      = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(source_resource);
+    copy_resource                    = graphics::dx12::CreateBufferResource(device,
+                                                         copy_resource_data.size,
+                                                         D3D12_HEAP_TYPE_READBACK,
+                                                         D3D12_RESOURCE_STATE_COPY_DEST,
+                                                         D3D12_RESOURCE_FLAG_NONE);
+
+    auto source_resource_extra_info = GetExtraInfo<D3D12ResourceInfo>(source_resource_object_info);
+
+    copy_command_list->CopyResource(copy_resource, source_resource);
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -1215,16 +1215,6 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
 
     auto clear_value_pointer = pOptimizedClearValue->GetPointer();
 
-    D3D12_RESOURCE_STATES modified_initial_resource_state = InitialResourceState;
-    if (options_.enable_dump_resources && (modified_initial_resource_state & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE))
-    {
-        // shader resources can't change state after SetGraphicsRootDescriptorTable.
-        // But even if it changes state and copy resources before SetGraphicsRootDescriptorTable,
-        // it can't solve it, because it also has to copy resources after drawcall.
-        // In this case, adding a COPY_SOURCE state here, so it doesn't need to change state for copy resources.
-        modified_initial_resource_state |= D3D12_RESOURCE_STATE_COPY_SOURCE;
-    }
-
     // Create an equivalent but temporary dummy resource
     // This allows us to further validate GFXR, since playback will now use a resource located at a different address
     HRESULT         dummy_result   = E_FAIL;
@@ -1234,7 +1224,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
         dummy_result = replay_object->CreateCommittedResource(heap_properties_pointer,
                                                               HeapFlags,
                                                               desc_pointer,
-                                                              modified_initial_resource_state,
+                                                              InitialResourceState,
                                                               clear_value_pointer,
                                                               IID_PPV_ARGS(&dummy_resource));
 
@@ -1248,7 +1238,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
     auto replay_result = replay_object->CreateCommittedResource(heap_properties_pointer,
                                                                 HeapFlags,
                                                                 desc_pointer,
-                                                                modified_initial_resource_state,
+                                                                InitialResourceState,
                                                                 clear_value_pointer,
                                                                 *riid.decoded_value,
                                                                 resource->GetHandlePointer());
@@ -1264,7 +1254,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCreateCommittedResource(
     if (SUCCEEDED(replay_result))
     {
         auto extra_info           = std::make_unique<D3D12ResourceInfo>();
-        extra_info->current_state = modified_initial_resource_state;
+        extra_info->current_state = InitialResourceState;
         SetExtraInfo(resource, std::move(extra_info));
     }
 
@@ -3822,20 +3812,6 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_ResourceBarrier(
             auto resource_object_info = GetObjectInfo(resource_id);
             auto resource_extra_info  = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
 
-            if (options_.enable_dump_resources)
-            {
-                // This should be in the override functionsince it modifies the parameters. But here is ok.
-                if (barriers[i].Transition->decoded_value->StateBefore & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE)
-                {
-                    barriers[i].Transition->decoded_value->StateBefore |= D3D12_RESOURCE_STATE_COPY_SOURCE;
-                }
-                if (barriers[i].Transition->decoded_value->StateAfter & D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE)
-                {
-                    // shader resources can't change state after SetGraphicsRootDescriptorTable.
-                    // Adding a COPY_SOURCE state here, so it doesn't need to change state for copy resources.
-                    barriers[i].Transition->decoded_value->StateAfter |= D3D12_RESOURCE_STATE_COPY_SOURCE;
-                }
-            }
             resource_extra_info->track_resource_barrier_state_after[command_list_id] =
                 barriers[i].Transition->decoded_value->StateAfter;
         }
@@ -4577,7 +4553,8 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(format::HandleId            
     }
     if (!(current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
     {
-        // shader resources can't change state after SetGraphicsRootDescriptorTable.
+        // shader resources that use D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC can't change state after
+        // SetGraphicsRootDescriptorTable.
         D3D12_RESOURCE_BARRIER barrier{};
         barrier.Type                   = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         barrier.Flags                  = D3D12_RESOURCE_BARRIER_FLAG_NONE;
@@ -4610,7 +4587,8 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(format::HandleId            
 
     if (!(current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
     {
-        // shader resources can't change state after SetGraphicsRootDescriptorTable.
+        // shader resources that use D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC can't change state after
+        // SetGraphicsRootDescriptorTable.
         D3D12_RESOURCE_BARRIER barrier{};
         barrier.Type                   = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
         barrier.Flags                  = D3D12_RESOURCE_BARRIER_FLAG_NONE;

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -3907,6 +3907,71 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_OMSetRenderTarge
     }
 }
 
+void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList4_BeginRenderPass(
+    const ApiCallInfo&                                                  call_info,
+    DxObjectInfo*                                                       object_info,
+    UINT                                                                NumRenderTargets,
+    StructPointerDecoder<Decoded_D3D12_RENDER_PASS_RENDER_TARGET_DESC>* pRenderTargets,
+    StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
+    D3D12_RENDER_PASS_FLAGS                                             Flags)
+{
+    if (options_.dump_resources_type != DumpResourcesType::kNone &&
+        call_info.index == track_dump_resources_.target.begin_renderpass_code_index)
+    {
+        // This should be in the override function since it modifies the parameters. But the override function
+        // doesn't have call_info, so stay here.
+
+        // Since it will insert renderpass, this EndingAccess has to be PRESERVE.
+        // And then the inserted renderpass's BeginningAccess has to be PRESERVE.
+        auto rt_descs = pRenderTargets->GetMetaStructPointer();
+        for (uint32_t i = 0; i < NumRenderTargets; ++i)
+        {
+            rt_descs[i].EndingAccess->decoded_value->Type = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;
+        }
+
+        auto ds_desc = pDepthStencil->GetMetaStructPointer();
+        if (ds_desc)
+        {
+            ds_desc->DepthEndingAccess->decoded_value->Type   = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;
+            ds_desc->StencilEndingAccess->decoded_value->Type = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;
+        }
+    }
+}
+
+void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList4_BeginRenderPass(
+    const ApiCallInfo&                                                  call_info,
+    DxObjectInfo*                                                       object_info,
+    UINT                                                                NumRenderTargets,
+    StructPointerDecoder<Decoded_D3D12_RENDER_PASS_RENDER_TARGET_DESC>* pRenderTargets,
+    StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
+    D3D12_RENDER_PASS_FLAGS                                             Flags)
+{
+    if (options_.dump_resources_type != DumpResourcesType::kNone &&
+        call_info.index == track_dump_resources_.target.begin_renderpass_code_index)
+    {
+        // Record ending accesses and flags for the inserted BeginRenderPass in after drawcall.
+        auto rt_descs = pRenderTargets->GetMetaStructPointer();
+        track_dump_resources_.render_target_heap_ids.resize(NumRenderTargets);
+        track_dump_resources_.replay_render_target_handles.resize(NumRenderTargets);
+        track_dump_resources_.record_render_target_ending_accesses.resize(NumRenderTargets);
+        for (uint32_t i = 0; i < NumRenderTargets; ++i)
+        {
+            track_dump_resources_.render_target_heap_ids[i]               = rt_descs[i].cpuDescriptor->heap_id;
+            track_dump_resources_.replay_render_target_handles[i]         = *rt_descs[i].cpuDescriptor->decoded_value;
+            track_dump_resources_.record_render_target_ending_accesses[i] = *rt_descs[i].EndingAccess->decoded_value;
+        }
+        auto ds_desc = pDepthStencil->GetMetaStructPointer();
+        if (ds_desc)
+        {
+            track_dump_resources_.depth_stencil_heap_id        = ds_desc->cpuDescriptor->heap_id;
+            track_dump_resources_.replay_depth_stencil_handle  = *ds_desc->cpuDescriptor->decoded_value;
+            track_dump_resources_.record_depth_ending_access   = *ds_desc->DepthEndingAccess->decoded_value;
+            track_dump_resources_.record_stencil_ending_access = *ds_desc->StencilEndingAccess->decoded_value;
+        }
+        track_dump_resources_.record_render_pass_flags = Flags;
+    }
+}
+
 void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
                                                                              DxObjectInfo*      object_info,
                                                                              UINT               VertexCountPerInstance,
@@ -3922,6 +3987,39 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_DrawInstanced(con
         {
             // The program doesn't use renderpass.
             AddCopyResourceCommandsForBeforeDrawcall(commandlist);
+        }
+        else
+        {
+            // Insert renderpass
+            graphics::dx12::ID3D12GraphicsCommandList4ComPtr commandlist4;
+            commandlist->QueryInterface(IID_PPV_ARGS(&commandlist4));
+            commandlist4->EndRenderPass();
+
+            AddCopyResourceCommandsForBeforeDrawcall(commandlist);
+
+            std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs;
+            auto rt_descs_size = track_dump_resources_.replay_render_target_handles.size();
+            rt_descs.resize(rt_descs_size);
+            for (uint32_t i = 0; i < rt_descs_size; ++i)
+            {
+                rt_descs[i].cpuDescriptor        = track_dump_resources_.replay_render_target_handles[i];
+                rt_descs[i].BeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE;
+                rt_descs[i].EndingAccess.Type    = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;
+            }
+
+            D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* p_ds_desc = nullptr;
+            D3D12_RENDER_PASS_DEPTH_STENCIL_DESC  ds_desc{};
+            if (track_dump_resources_.depth_stencil_heap_id != 0)
+            {
+                p_ds_desc                           = &ds_desc;
+                ds_desc.cpuDescriptor               = track_dump_resources_.replay_depth_stencil_handle;
+                ds_desc.DepthBeginningAccess.Type   = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE;
+                ds_desc.StencilBeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE;
+                ds_desc.DepthEndingAccess.Type      = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;
+                ds_desc.StencilEndingAccess.Type    = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE;
+            }
+            commandlist4->BeginRenderPass(
+                rt_descs_size, rt_descs.data(), p_ds_desc, track_dump_resources_.record_render_pass_flags);
         }
     }
 }
@@ -3942,7 +4040,39 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12GraphicsCommandList_DrawInstanced(co
             // The program doesn't use renderpass.
             AddCopyResourceCommandsForAfterDrawcall(commandlist);
         }
+        else
+        {
+            // Insert renderpass
+            graphics::dx12::ID3D12GraphicsCommandList4ComPtr commandlist4;
+            commandlist->QueryInterface(IID_PPV_ARGS(&commandlist4));
+            commandlist4->EndRenderPass();
 
+            AddCopyResourceCommandsForAfterDrawcall(commandlist);
+
+            std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs;
+            auto rt_descs_size = track_dump_resources_.replay_render_target_handles.size();
+            rt_descs.resize(rt_descs_size);
+            for (uint32_t i = 0; i < rt_descs_size; ++i)
+            {
+                rt_descs[i].cpuDescriptor        = track_dump_resources_.replay_render_target_handles[i];
+                rt_descs[i].BeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE;
+                rt_descs[i].EndingAccess         = track_dump_resources_.record_render_target_ending_accesses[i];
+            }
+
+            D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* p_ds_desc = nullptr;
+            D3D12_RENDER_PASS_DEPTH_STENCIL_DESC  ds_desc{};
+            if (track_dump_resources_.depth_stencil_heap_id != 0)
+            {
+                p_ds_desc                           = &ds_desc;
+                ds_desc.cpuDescriptor               = track_dump_resources_.replay_depth_stencil_handle;
+                ds_desc.DepthBeginningAccess.Type   = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE;
+                ds_desc.StencilBeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE;
+                ds_desc.DepthEndingAccess           = track_dump_resources_.record_depth_ending_access;
+                ds_desc.StencilEndingAccess         = track_dump_resources_.record_stencil_ending_access;
+            }
+            commandlist4->BeginRenderPass(
+                rt_descs_size, rt_descs.data(), p_ds_desc, track_dump_resources_.record_render_pass_flags);
+        }
         // It has to run the original ExecuteCommandLists, not a new ExecuteCommandLists.
         // Because some FIllMemoryCommand runs before the original ExecuteCommandLists.
         // If it runs a new ExecuteCommandLists, it might miss FIllMemoryCommand.

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -3271,7 +3271,7 @@ HRESULT Dx12ReplayConsumerBase::OverrideCommandListReset(DxObjectInfo* command_l
 
     auto command_list_extra_info                         = GetExtraInfo<D3D12CommandListInfo>(command_list_object_info);
     command_list_extra_info->requires_sync_after_execute = false;
-    command_list_extra_info->track_resource_barriers.clear();
+    command_list_extra_info->pending_resource_states.clear();
 
     if (resource_value_mapper_ != nullptr)
     {
@@ -3807,12 +3807,7 @@ void Dx12ReplayConsumerBase::PreCall_ID3D12GraphicsCommandList_ResourceBarrier(
         if (barriers[i].decoded_value->Type == D3D12_RESOURCE_BARRIER_TYPE_TRANSITION)
         {
             // It shouldn't change the state here. It should save the AfterState until ExecuteCommandList to change it.
-            auto resource_id = barriers[i].Transition->pResource;
-            extra_info->track_resource_barriers.insert(resource_id);
-            auto resource_object_info = GetObjectInfo(resource_id);
-            auto resource_extra_info  = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
-
-            resource_extra_info->track_resource_barrier_state_after[command_list_id] =
+            extra_info->pending_resource_states[barriers[i].Transition->pResource] =
                 barriers[i].Transition->decoded_value->StateAfter;
         }
     }
@@ -4134,28 +4129,21 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12CommandQueue_ExecuteCommandLists(
         auto commandlist_id          = ppCommandLists->GetPointer()[i];
         auto command_list_extra_info = GetExtraInfo<D3D12CommandListInfo>(GetObjectInfo(commandlist_id));
 
-        for (auto resource_id : command_list_extra_info->track_resource_barriers)
+        for (const auto& pair : command_list_extra_info->pending_resource_states)
         {
-            auto resource_object_info = GetObjectInfo(resource_id);
+            auto resource_object_info = GetObjectInfo(pair.first);
             if (resource_object_info == nullptr)
             {
                 GFXRECON_LOG_WARNING("resource id %" PRIu64
                                      " can't found for update state in ExecuteCommandLists. It could be released",
-                                     resource_id);
+                                     pair.first);
             }
             else
             {
-                auto resource_extra_info = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
-
-                auto it = resource_extra_info->track_resource_barrier_state_after.find(commandlist_id);
-                if (it != resource_extra_info->track_resource_barrier_state_after.end())
-                {
-                    resource_extra_info->current_state = it->second;
-                    resource_extra_info->track_resource_barrier_state_after.erase(it);
-                }
+                auto resource_extra_info           = GetExtraInfo<D3D12ResourceInfo>(resource_object_info);
+                resource_extra_info->current_state = pair.second;
             }
         }
-        command_list_extra_info->track_resource_barriers.clear();
     }
 
     if (track_dump_resources_.target.execute_code_index == call_info.index)
@@ -4529,6 +4517,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(format::HandleId            
                                                     graphics::dx12::ID3D12ResourceComPtr& copy_resource)
 {
     auto        commandlist                 = MapObject<ID3D12GraphicsCommandList>(command_list_id);
+    auto        cmd_list_extra_info         = GetExtraInfo<D3D12CommandListInfo>(GetObjectInfo(command_list_id));
     auto        source_resource_object_info = GetObjectInfo(copy_resource_data.source_resource_id);
     auto        source_resource             = reinterpret_cast<ID3D12Resource*>(source_resource_object_info->object);
     auto        device                      = graphics::dx12::GetDeviceComPtrFromChild<ID3D12Device>(source_resource);
@@ -4546,12 +4535,14 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(format::HandleId            
     //       If the state is changed in another commandlist, and the commandlist is executed
     //       after the target drawcall, we couldn't know the correct state.
     D3D12_RESOURCE_STATES current_state = source_resource_extra_info->current_state;
-    auto                  it = source_resource_extra_info->track_resource_barrier_state_after.find(command_list_id);
-    if (it != source_resource_extra_info->track_resource_barrier_state_after.end())
+    auto                  pending_state_iter =
+        cmd_list_extra_info->pending_resource_states.find(source_resource_object_info->capture_id);
+    if (pending_state_iter != cmd_list_extra_info->pending_resource_states.end())
     {
-        current_state = it->second;
+        current_state = pending_state_iter->second;
     }
-    if (!(current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
+    bool changed_state = false;
+    if (!(current_state & D3D12_RESOURCE_STATE_COPY_SOURCE) && (current_state != D3D12_RESOURCE_STATE_COMMON))
     {
         // shader resources that use D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC can't change state after
         // SetGraphicsRootDescriptorTable.
@@ -4560,9 +4551,10 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(format::HandleId            
         barrier.Flags                  = D3D12_RESOURCE_BARRIER_FLAG_NONE;
         barrier.Transition.pResource   = source_resource;
         barrier.Transition.StateBefore = current_state;
-        barrier.Transition.StateAfter  = D3D12_RESOURCE_STATE_COPY_SOURCE;
+        barrier.Transition.StateAfter  = D3D12_RESOURCE_STATE_COMMON;
         barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
         commandlist->ResourceBarrier(1, &barrier);
+        changed_state = true;
     }
 
     if (source_desc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
@@ -4585,7 +4577,7 @@ void Dx12ReplayConsumerBase::AddCopyResourceCommand(format::HandleId            
         commandlist->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
     }
 
-    if (!(current_state & D3D12_RESOURCE_STATE_COPY_SOURCE))
+    if (changed_state)
     {
         // shader resources that use D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC can't change state after
         // SetGraphicsRootDescriptorTable.

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -266,10 +266,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void RemoveObject(DxObjectInfo* info);
 
-    void SetDumpTarget(TrackDumpCommandList& track_dump_commandlist)
-    {
-        track_dump_resources_.target = track_dump_commandlist;
-    }
+    void SetDumpTarget(TrackDumpDrawcall& track_dump_target) { track_dump_resources_.target = track_dump_target; }
 
     IDXGIAdapter* GetAdapter();
 

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -166,6 +166,22 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
         BOOL                                                       RTsSingleHandleToDescriptorRange,
         StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor);
 
+    void PreCall_ID3D12GraphicsCommandList4_BeginRenderPass(
+        const ApiCallInfo&                                                  call_info,
+        DxObjectInfo*                                                       object_info,
+        UINT                                                                NumRenderTargets,
+        StructPointerDecoder<Decoded_D3D12_RENDER_PASS_RENDER_TARGET_DESC>* pRenderTargets,
+        StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
+        D3D12_RENDER_PASS_FLAGS                                             Flags);
+
+    void PostCall_ID3D12GraphicsCommandList4_BeginRenderPass(
+        const ApiCallInfo&                                                  call_info,
+        DxObjectInfo*                                                       object_info,
+        UINT                                                                NumRenderTargets,
+        StructPointerDecoder<Decoded_D3D12_RENDER_PASS_RENDER_TARGET_DESC>* pRenderTargets,
+        StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
+        D3D12_RENDER_PASS_FLAGS                                             Flags);
+
     void PreCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
                                                          DxObjectInfo*      object_info,
                                                          UINT               VertexCountPerInstance,

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -125,6 +125,47 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                            UINT                                     src_row_pitch,
                                                            UINT src_depth_pitch) override;
 
+    void
+    PreCall_ID3D12GraphicsCommandList_ResourceBarrier(const ApiCallInfo&                                    call_info,
+                                                      DxObjectInfo*                                         object_info,
+                                                      UINT                                                  NumBarriers,
+                                                      StructPointerDecoder<Decoded_D3D12_RESOURCE_BARRIER>* pBarriers);
+
+    void
+    PreCall_ID3D12Device_CreateConstantBufferView(const ApiCallInfo& call_info,
+                                                  DxObjectInfo*      object_info,
+                                                  StructPointerDecoder<Decoded_D3D12_CONSTANT_BUFFER_VIEW_DESC>* pDesc,
+                                                  Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+
+    void
+    PreCall_ID3D12Device_CreateShaderResourceView(const ApiCallInfo& call_info,
+                                                  DxObjectInfo*      object_info,
+                                                  format::HandleId   pResource,
+                                                  StructPointerDecoder<Decoded_D3D12_SHADER_RESOURCE_VIEW_DESC>* pDesc,
+                                                  Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+
+    void
+    PostCall_ID3D12Device_CreateRenderTargetView(const ApiCallInfo& call_info,
+                                                 DxObjectInfo*      object_info,
+                                                 format::HandleId   pResource,
+                                                 StructPointerDecoder<Decoded_D3D12_RENDER_TARGET_VIEW_DESC>* pDesc,
+                                                 Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+
+    void
+    PostCall_ID3D12Device_CreateDepthStencilView(const ApiCallInfo& call_info,
+                                                 DxObjectInfo*      object_info,
+                                                 format::HandleId   pResource,
+                                                 StructPointerDecoder<Decoded_D3D12_DEPTH_STENCIL_VIEW_DESC>* pDesc,
+                                                 Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+
+    void PostCall_ID3D12GraphicsCommandList_OMSetRenderTargets(
+        const ApiCallInfo&                                         call_info,
+        DxObjectInfo*                                              object_info,
+        UINT                                                       NumRenderTargetDescriptors,
+        StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pRenderTargetDescriptors,
+        BOOL                                                       RTsSingleHandleToDescriptorRange,
+        StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor);
+
     void PreCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
                                                          DxObjectInfo*      object_info,
                                                          UINT               VertexCountPerInstance,
@@ -886,9 +927,24 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                         D3D12_GPU_VIRTUAL_ADDRESS   capture_source_gpu_va,
                                                         graphics::CopyResourceData& copy_resource_data);
 
+    void AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList*               copy_command_list,
+                                                  const std::vector<format::HandleId>&     source_resource_ids,
+                                                  std::vector<graphics::CopyResourceData>& copy_resource_datas);
+
     void AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
                                                  format::HandleId            source_resource_id,
                                                  graphics::CopyResourceData& copy_resource_data);
+
+    void AddCopyRenderTargetCommandsForBeforeDrawcall(
+        ID3D12GraphicsCommandList*                      copy_command_list,
+        const std::vector<format::HandleId>&            heap_ids,
+        const std::vector<D3D12_CPU_DESCRIPTOR_HANDLE>& replay_render_target_handles,
+        std::vector<graphics::CopyResourceData>&        copy_resource_datas);
+
+    void AddCopyDepthStencilCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+                                                     format::HandleId            heap_id,
+                                                     D3D12_CPU_DESCRIPTOR_HANDLE replay_depth_stencil_handle,
+                                                     graphics::CopyResourceData& copy_resource_data);
 
     void AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList* copy_command_list);
 

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -983,19 +983,19 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void AddCopyResourceCommandsForBeforeDrawcall(const ApiCallInfo& call_info, DxObjectInfo* object_info);
 
-    void AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList* copy_command_list);
+    void AddCopyResourceCommandsForBeforeDrawcall(format::HandleId copy_command_list_id);
 
     bool MatchDescriptorCPUGPUHandle(size_t                                      replay_cpu_addr_begin,
                                      size_t                                      replay_target_cpu_addr,
                                      uint64_t                                    capture_gpu_addr_begin,
                                      std::map<UINT, D3D12_GPU_DESCRIPTOR_HANDLE> captured_gpu_addrs);
 
-    void AddCopyResourceCommandForBeforeDrawcallByGPUVA(ID3D12GraphicsCommandList*  copy_command_list,
+    void AddCopyResourceCommandForBeforeDrawcallByGPUVA(format::HandleId            command_list_id,
                                                         D3D12_GPU_VIRTUAL_ADDRESS   capture_source_gpu_va,
                                                         uint64_t                    source_size,
                                                         graphics::CopyResourceData& copy_resource_data);
 
-    void AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+    void AddCopyResourceCommandForBeforeDrawcall(format::HandleId            command_list_id,
                                                  format::HandleId            source_resource_id,
                                                  uint64_t                    source_offset,
                                                  uint64_t                    source_size,
@@ -1003,16 +1003,16 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void AddCopyResourceCommandsForAfterDrawcall(const ApiCallInfo& call_info, DxObjectInfo* object_info);
 
-    void AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList* copy_command_list);
+    void AddCopyResourceCommandsForAfterDrawcall(format::HandleId command_list_id);
 
     // source_resource_id have been saved in CopyResourceData in AddCopyResourceCommandForBeforeDrawcall.
-    void AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList*               copy_command_list,
+    void AddCopyResourceCommandsForAfterDrawcall(format::HandleId                         command_list_id,
                                                  std::vector<graphics::CopyResourceData>& copy_resource_datas);
 
-    void AddCopyResourceCommandForAfterDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+    void AddCopyResourceCommandForAfterDrawcall(format::HandleId            command_list_id,
                                                 graphics::CopyResourceData& copy_resource_data);
 
-    void AddCopyResourceCommand(ID3D12GraphicsCommandList*            copy_command_list,
+    void AddCopyResourceCommand(format::HandleId                      command_list_id,
                                 graphics::CopyResourceData&           copy_resource_data,
                                 graphics::dx12::ID3D12ResourceComPtr& copy_resource);
 

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -39,6 +39,7 @@
 #include "decode/screenshot_handler_base.h"
 #include "graphics/fps_info.h"
 #include "graphics/dx12_util.h"
+#include "graphics/dx12_dump_resources.h"
 #include "application/application.h"
 
 #include <functional>
@@ -124,6 +125,25 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                            UINT                                     src_row_pitch,
                                                            UINT src_depth_pitch) override;
 
+    void PreCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
+                                                         DxObjectInfo*      object_info,
+                                                         UINT               VertexCountPerInstance,
+                                                         UINT               InstanceCount,
+                                                         UINT               StartVertexLocation,
+                                                         UINT               StartInstanceLocation);
+
+    void PostCall_ID3D12GraphicsCommandList_DrawInstanced(const ApiCallInfo& call_info,
+                                                          DxObjectInfo*      object_info,
+                                                          UINT               VertexCountPerInstance,
+                                                          UINT               InstanceCount,
+                                                          UINT               StartVertexLocation,
+                                                          UINT               StartInstanceLocation);
+
+    void PostCall_ID3D12CommandQueue_ExecuteCommandLists(const ApiCallInfo&                        call_info,
+                                                         DxObjectInfo*                             object_info,
+                                                         UINT                                      NumCommandLists,
+                                                         HandlePointerDecoder<ID3D12CommandList*>* ppCommandLists);
+
     template <typename T>
     T* MapObject(const format::HandleId id)
     {
@@ -143,9 +163,14 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void RemoveObject(DxObjectInfo* info);
 
+    void SetDumpTarget(TrackDumpCommandList& track_dump_commandlist)
+    {
+        track_dump_resources_.target = track_dump_commandlist;
+    }
+
     IDXGIAdapter* GetAdapter();
 
-  protected:    
+  protected:
     void MapGpuDescriptorHandle(D3D12_GPU_DESCRIPTOR_HANDLE& handle);
 
     void MapGpuDescriptorHandle(uint8_t* dst_handle_ptr, const uint8_t* src_handle_ptr);
@@ -850,6 +875,34 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     std::wstring ConstructObjectName(format::HandleId capture_id, format::ApiCallId call_id);
 
+    void AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList* copy_command_list);
+
+    void AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
+        ID3D12GraphicsCommandList*                    copy_command_list,
+        const std::vector<D3D12_GPU_VIRTUAL_ADDRESS>& capture_source_gpu_vas,
+        std::vector<graphics::CopyResourceData>&      copy_resource_datas);
+
+    void AddCopyResourceCommandForBeforeDrawcallByGPUVA(ID3D12GraphicsCommandList*  copy_command_list,
+                                                        D3D12_GPU_VIRTUAL_ADDRESS   capture_source_gpu_va,
+                                                        graphics::CopyResourceData& copy_resource_data);
+
+    void AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+                                                 format::HandleId            source_resource_id,
+                                                 graphics::CopyResourceData& copy_resource_data);
+
+    void AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList* copy_command_list);
+
+    // source_resource_id have been saved in CopyResourceData in AddCopyResourceCommandForBeforeDrawcall.
+    void AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList*               copy_command_list,
+                                                 std::vector<graphics::CopyResourceData>& copy_resource_datas);
+
+    void AddCopyResourceCommandForAfterDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
+                                                graphics::CopyResourceData& copy_resource_data);
+
+    void AddCopyResourceCommand(ID3D12GraphicsCommandList*            copy_command_list,
+                                graphics::CopyResourceData&           copy_resource_data,
+                                graphics::dx12::ID3D12ResourceComPtr& copy_resource);
+
     std::unique_ptr<graphics::DX12ImageRenderer>          frame_buffer_renderer_;
     Dx12ObjectInfoTable                                   object_info_table_;
     std::shared_ptr<application::Application>             application_;
@@ -882,6 +935,8 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     util::ScreenshotFormat                                screenshot_format_;
     std::unique_ptr<ScreenshotHandlerBase>                screenshot_handler_;
     std::unordered_map<ID3D12Resource*, ResourceInitInfo> resource_init_infos_;
+    std::unique_ptr<graphics::Dx12DumpResources>          dump_resources_;
+    graphics::TrackDumpResources                          track_dump_resources_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -138,11 +138,17 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                   Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
 
     void
-    PreCall_ID3D12Device_CreateShaderResourceView(const ApiCallInfo& call_info,
-                                                  DxObjectInfo*      object_info,
-                                                  format::HandleId   pResource,
-                                                  StructPointerDecoder<Decoded_D3D12_SHADER_RESOURCE_VIEW_DESC>* pDesc,
-                                                  Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+    PostCall_ID3D12Device_CreateConstantBufferView(const ApiCallInfo& call_info,
+                                                   DxObjectInfo*      object_info,
+                                                   StructPointerDecoder<Decoded_D3D12_CONSTANT_BUFFER_VIEW_DESC>* pDesc,
+                                                   Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
+
+    void
+    PostCall_ID3D12Device_CreateShaderResourceView(const ApiCallInfo& call_info,
+                                                   DxObjectInfo*      object_info,
+                                                   format::HandleId   pResource,
+                                                   StructPointerDecoder<Decoded_D3D12_SHADER_RESOURCE_VIEW_DESC>* pDesc,
+                                                   Decoded_D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor);
 
     void
     PostCall_ID3D12Device_CreateRenderTargetView(const ApiCallInfo& call_info,
@@ -979,33 +985,21 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList* copy_command_list);
 
-    void AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
-        ID3D12GraphicsCommandList*                    copy_command_list,
-        const std::vector<D3D12_GPU_VIRTUAL_ADDRESS>& capture_source_gpu_vas,
-        std::vector<graphics::CopyResourceData>&      copy_resource_datas);
+    bool MatchDescriptorCPUGPUHandle(size_t                                      replay_cpu_addr_begin,
+                                     size_t                                      replay_target_cpu_addr,
+                                     uint64_t                                    capture_gpu_addr_begin,
+                                     std::map<UINT, D3D12_GPU_DESCRIPTOR_HANDLE> captured_gpu_addrs);
 
     void AddCopyResourceCommandForBeforeDrawcallByGPUVA(ID3D12GraphicsCommandList*  copy_command_list,
                                                         D3D12_GPU_VIRTUAL_ADDRESS   capture_source_gpu_va,
+                                                        uint64_t                    source_size,
                                                         graphics::CopyResourceData& copy_resource_data);
-
-    void AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList*               copy_command_list,
-                                                  const std::vector<format::HandleId>&     source_resource_ids,
-                                                  std::vector<graphics::CopyResourceData>& copy_resource_datas);
 
     void AddCopyResourceCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
                                                  format::HandleId            source_resource_id,
+                                                 uint64_t                    source_offset,
+                                                 uint64_t                    source_size,
                                                  graphics::CopyResourceData& copy_resource_data);
-
-    void AddCopyRenderTargetCommandsForBeforeDrawcall(
-        ID3D12GraphicsCommandList*                      copy_command_list,
-        const std::vector<format::HandleId>&            heap_ids,
-        const std::vector<D3D12_CPU_DESCRIPTOR_HANDLE>& replay_render_target_handles,
-        std::vector<graphics::CopyResourceData>&        copy_resource_datas);
-
-    void AddCopyDepthStencilCommandForBeforeDrawcall(ID3D12GraphicsCommandList*  copy_command_list,
-                                                     format::HandleId            heap_id,
-                                                     D3D12_CPU_DESCRIPTOR_HANDLE replay_depth_stencil_handle,
-                                                     graphics::CopyResourceData& copy_resource_data);
 
     void AddCopyResourceCommandsForAfterDrawcall(const ApiCallInfo& call_info, DxObjectInfo* object_info);
 

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -196,6 +196,52 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                           UINT               StartVertexLocation,
                                                           UINT               StartInstanceLocation);
 
+    void PreCall_ID3D12GraphicsCommandList_DrawIndexedInstanced(const ApiCallInfo& call_info,
+                                                                DxObjectInfo*      object_info,
+                                                                UINT               IndexCountPerInstance,
+                                                                UINT               InstanceCount,
+                                                                UINT               StartIndexLocation,
+                                                                INT                BaseVertexLocation,
+                                                                UINT               StartInstanceLocation);
+
+    void PostCall_ID3D12GraphicsCommandList_DrawIndexedInstanced(const ApiCallInfo& call_info,
+                                                                 DxObjectInfo*      object_info,
+                                                                 UINT               IndexCountPerInstance,
+                                                                 UINT               InstanceCount,
+                                                                 UINT               StartIndexLocation,
+                                                                 INT                BaseVertexLocation,
+                                                                 UINT               StartInstanceLocation);
+
+    void PreCall_ID3D12GraphicsCommandList_Dispatch(const ApiCallInfo& call_info,
+                                                    DxObjectInfo*      object_info,
+                                                    UINT               ThreadGroupCountX,
+                                                    UINT               ThreadGroupCountY,
+                                                    UINT               ThreadGroupCountZ);
+
+    void PostCall_ID3D12GraphicsCommandList_Dispatch(const ApiCallInfo& call_info,
+                                                     DxObjectInfo*      object_info,
+                                                     UINT               ThreadGroupCountX,
+                                                     UINT               ThreadGroupCountY,
+                                                     UINT               ThreadGroupCountZ);
+
+    void PreCall_ID3D12GraphicsCommandList_ExecuteIndirect(const ApiCallInfo& call_info,
+                                                           DxObjectInfo*      object_info,
+                                                           format::HandleId   pCommandSignature,
+                                                           UINT               MaxCommandCount,
+                                                           format::HandleId   pArgumentBuffer,
+                                                           UINT64             ArgumentBufferOffset,
+                                                           format::HandleId   pCountBuffer,
+                                                           UINT64             CountBufferOffset);
+
+    void PostCall_ID3D12GraphicsCommandList_ExecuteIndirect(const ApiCallInfo& call_info,
+                                                            DxObjectInfo*      object_info,
+                                                            format::HandleId   pCommandSignature,
+                                                            UINT               MaxCommandCount,
+                                                            format::HandleId   pArgumentBuffer,
+                                                            UINT64             ArgumentBufferOffset,
+                                                            format::HandleId   pCountBuffer,
+                                                            UINT64             CountBufferOffset);
+
     void PostCall_ID3D12CommandQueue_ExecuteCommandLists(const ApiCallInfo&                        call_info,
                                                          DxObjectInfo*                             object_info,
                                                          UINT                                      NumCommandLists,
@@ -932,6 +978,8 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     std::wstring ConstructObjectName(format::HandleId capture_id, format::ApiCallId call_id);
 
+    void AddCopyResourceCommandsForBeforeDrawcall(const ApiCallInfo& call_info, DxObjectInfo* object_info);
+
     void AddCopyResourceCommandsForBeforeDrawcall(ID3D12GraphicsCommandList* copy_command_list);
 
     void AddCopyResourceCommandsForBeforeDrawcallByGPUVAs(
@@ -961,6 +1009,8 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                      format::HandleId            heap_id,
                                                      D3D12_CPU_DESCRIPTOR_HANDLE replay_depth_stencil_handle,
                                                      graphics::CopyResourceData& copy_resource_data);
+
+    void AddCopyResourceCommandsForAfterDrawcall(const ApiCallInfo& call_info, DxObjectInfo* object_info);
 
     void AddCopyResourceCommandsForAfterDrawcall(ID3D12GraphicsCommandList* copy_command_list);
 

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -39,24 +39,12 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 static constexpr uint32_t kDefaultBatchingMemoryUsage = 80;
 
-enum class DumpResourcesType
+struct DumpResourcesTarget
 {
-    kNone     = 0,
-    kDrawCall = 1,
+    uint32_t submit_index{ 0 };
+    uint32_t command_index{ 0 };
+    uint32_t drawcall_index{ 0 };
 };
-
-inline std::string GetDumpResourcesType(DumpResourcesType type)
-{
-    switch (type)
-    {
-        case DumpResourcesType::kDrawCall:
-            return "drawcall";
-        default:
-            break;
-    }
-    GFXRECON_LOG_WARNING("Unrecognized DumpResourcesType %d. Return \"none \".", static_cast<int>(type));
-    return "none";
-}
 
 struct DxReplayOptions : public ReplayOptions
 {
@@ -66,8 +54,8 @@ struct DxReplayOptions : public ReplayOptions
     std::vector<int32_t> AllowedDebugMessages;
     std::vector<int32_t> DeniedDebugMessages;
     bool                 override_object_names{ false };
-    DumpResourcesType    dump_resources_type{ DumpResourcesType::kNone };
-    uint64_t             dump_resources_argument{ 0 };
+    bool                 enable_dump_resources{ false };
+    DumpResourcesTarget  dump_resources_target{};
 
     util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
     std::vector<ScreenshotRange> screenshot_ranges;

--- a/framework/decode/dx_replay_options.h
+++ b/framework/decode/dx_replay_options.h
@@ -29,6 +29,7 @@
 
 #include "util/defines.h"
 #include "util/options.h"
+#include "util/logging.h"
 
 #include <vector>
 #include <string>
@@ -38,6 +39,25 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 static constexpr uint32_t kDefaultBatchingMemoryUsage = 80;
 
+enum class DumpResourcesType
+{
+    kNone     = 0,
+    kDrawCall = 1,
+};
+
+inline std::string GetDumpResourcesType(DumpResourcesType type)
+{
+    switch (type)
+    {
+        case DumpResourcesType::kDrawCall:
+            return "drawcall";
+        default:
+            break;
+    }
+    GFXRECON_LOG_WARNING("Unrecognized DumpResourcesType %d. Return \"none \".", static_cast<int>(type));
+    return "none";
+}
+
 struct DxReplayOptions : public ReplayOptions
 {
     bool                 enable_d3d12{ true };
@@ -46,6 +66,8 @@ struct DxReplayOptions : public ReplayOptions
     std::vector<int32_t> AllowedDebugMessages;
     std::vector<int32_t> DeniedDebugMessages;
     bool                 override_object_names{ false };
+    DumpResourcesType    dump_resources_type{ DumpResourcesType::kNone };
+    uint64_t             dump_resources_argument{ 0 };
 
     util::ScreenshotFormat       screenshot_format{ util::ScreenshotFormat::kBmp };
     std::vector<ScreenshotRange> screenshot_ranges;

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -40,17 +40,18 @@ struct ScreenshotRange
 
 struct ReplayOptions
 {
-    bool     enable_validation_layer{ false };
-    bool     sync_queue_submissions{ false };
-    bool     enable_debug_device_lost{ false };
-    bool     create_dummy_allocations{ false };
-    bool     omit_null_hardware_buffers{ false };
-    bool     quit_after_measurement_frame_range{ false };
-    bool     flush_measurement_frame_range{ false };
-    bool     force_windowed{ false };
-    uint32_t windowed_width{ 0 };
-    uint32_t windowed_height{ 0 };
-    int32_t  override_gpu_index{ -1 };
+    bool        enable_validation_layer{ false };
+    bool        sync_queue_submissions{ false };
+    bool        enable_debug_device_lost{ false };
+    bool        create_dummy_allocations{ false };
+    bool        omit_null_hardware_buffers{ false };
+    bool        quit_after_measurement_frame_range{ false };
+    bool        flush_measurement_frame_range{ false };
+    bool        force_windowed{ false };
+    uint32_t    windowed_width{ 0 };
+    uint32_t    windowed_height{ 0 };
+    int32_t     override_gpu_index{ -1 };
+    std::string filename;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -28,7 +28,9 @@
 #include "generated/generated_dx12_replay_consumer.h"
 
 #include "decode/custom_dx12_struct_object_mappers.h"
+#include "decode/custom_dx12_replay_commands.h"
 #include "generated/generated_dx12_struct_object_mappers.h"
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
@@ -38,6 +40,11 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppFactory)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_CreateDXGIFactory>::Dispatch(
+        this,
+        call_info,
+        riid,
+        ppFactory);
     if(!ppFactory->IsNull()) ppFactory->SetHandleLength(1);
     auto out_p_ppFactory    = ppFactory->GetPointer();
     auto out_hp_ppFactory   = ppFactory->GetHandlePointer();
@@ -48,6 +55,11 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory(
         AddObject(out_p_ppFactory, out_hp_ppFactory, format::ApiCall_CreateDXGIFactory);
     }
     CheckReplayResult("CreateDXGIFactory", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_CreateDXGIFactory>::Dispatch(
+        this,
+        call_info,
+        riid,
+        ppFactory);
 }
 
 void Dx12ReplayConsumer::Process_CreateDXGIFactory1(
@@ -56,6 +68,11 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory1(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppFactory)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_CreateDXGIFactory1>::Dispatch(
+        this,
+        call_info,
+        riid,
+        ppFactory);
     if(!ppFactory->IsNull()) ppFactory->SetHandleLength(1);
     auto out_p_ppFactory    = ppFactory->GetPointer();
     auto out_hp_ppFactory   = ppFactory->GetHandlePointer();
@@ -66,6 +83,11 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory1(
         AddObject(out_p_ppFactory, out_hp_ppFactory, format::ApiCall_CreateDXGIFactory1);
     }
     CheckReplayResult("CreateDXGIFactory1", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_CreateDXGIFactory1>::Dispatch(
+        this,
+        call_info,
+        riid,
+        ppFactory);
 }
 
 void Dx12ReplayConsumer::Process_CreateDXGIFactory2(
@@ -75,6 +97,12 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory2(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppFactory)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_CreateDXGIFactory2>::Dispatch(
+        this,
+        call_info,
+        Flags,
+        riid,
+        ppFactory);
     if(!ppFactory->IsNull()) ppFactory->SetHandleLength(1);
     DxObjectInfo object_info{};
     ppFactory->SetConsumerData(0, &object_info);
@@ -87,6 +115,12 @@ void Dx12ReplayConsumer::Process_CreateDXGIFactory2(
         AddObject(ppFactory->GetPointer(), ppFactory->GetHandlePointer(), std::move(object_info), format::ApiCall_CreateDXGIFactory2);
     }
     CheckReplayResult("CreateDXGIFactory2", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_CreateDXGIFactory2>::Dispatch(
+        this,
+        call_info,
+        Flags,
+        riid,
+        ppFactory);
 }
 
 void Dx12ReplayConsumer::Process_DXGIGetDebugInterface1(
@@ -96,6 +130,12 @@ void Dx12ReplayConsumer::Process_DXGIGetDebugInterface1(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                pDebug)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_DXGIGetDebugInterface1>::Dispatch(
+        this,
+        call_info,
+        Flags,
+        riid,
+        pDebug);
     if(!pDebug->IsNull()) pDebug->SetHandleLength(1);
     auto out_p_pDebug    = pDebug->GetPointer();
     auto out_hp_pDebug   = pDebug->GetHandlePointer();
@@ -107,14 +147,26 @@ void Dx12ReplayConsumer::Process_DXGIGetDebugInterface1(
         AddObject(out_p_pDebug, out_hp_pDebug, format::ApiCall_DXGIGetDebugInterface1);
     }
     CheckReplayResult("DXGIGetDebugInterface1", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_DXGIGetDebugInterface1>::Dispatch(
+        this,
+        call_info,
+        Flags,
+        riid,
+        pDebug);
 }
 
 void Dx12ReplayConsumer::Process_DXGIDeclareAdapterRemovalSupport(
     const ApiCallInfo&                          call_info,
     HRESULT                                     return_value)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_DXGIDeclareAdapterRemovalSupport>::Dispatch(
+        this,
+        call_info);
     auto replay_result = DXGIDeclareAdapterRemovalSupport();
     CheckReplayResult("DXGIDeclareAdapterRemovalSupport", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_DXGIDeclareAdapterRemovalSupport>::Dispatch(
+        this,
+        call_info);
 }
 
 void Dx12ReplayConsumer::Process_D3D12SerializeRootSignature(
@@ -125,6 +177,13 @@ void Dx12ReplayConsumer::Process_D3D12SerializeRootSignature(
     HandlePointerDecoder<ID3D10Blob*>*          ppBlob,
     HandlePointerDecoder<ID3D10Blob*>*          ppErrorBlob)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12SerializeRootSignature>::Dispatch(
+        this,
+        call_info,
+        pRootSignature,
+        Version,
+        ppBlob,
+        ppErrorBlob);
     if(!ppBlob->IsNull()) ppBlob->SetHandleLength(1);
     auto out_p_ppBlob    = ppBlob->GetPointer();
     auto out_hp_ppBlob   = ppBlob->GetHandlePointer();
@@ -141,6 +200,13 @@ void Dx12ReplayConsumer::Process_D3D12SerializeRootSignature(
         AddObject(out_p_ppErrorBlob, out_hp_ppErrorBlob, format::ApiCall_D3D12SerializeRootSignature);
     }
     CheckReplayResult("D3D12SerializeRootSignature", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12SerializeRootSignature>::Dispatch(
+        this,
+        call_info,
+        pRootSignature,
+        Version,
+        ppBlob,
+        ppErrorBlob);
 }
 
 void Dx12ReplayConsumer::Process_D3D12CreateRootSignatureDeserializer(
@@ -151,6 +217,13 @@ void Dx12ReplayConsumer::Process_D3D12CreateRootSignatureDeserializer(
     Decoded_GUID                                pRootSignatureDeserializerInterface,
     HandlePointerDecoder<void*>*                ppRootSignatureDeserializer)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12CreateRootSignatureDeserializer>::Dispatch(
+        this,
+        call_info,
+        pSrcData,
+        SrcDataSizeInBytes,
+        pRootSignatureDeserializerInterface,
+        ppRootSignatureDeserializer);
     if(!ppRootSignatureDeserializer->IsNull()) ppRootSignatureDeserializer->SetHandleLength(1);
     auto out_p_ppRootSignatureDeserializer    = ppRootSignatureDeserializer->GetPointer();
     auto out_hp_ppRootSignatureDeserializer   = ppRootSignatureDeserializer->GetHandlePointer();
@@ -163,6 +236,13 @@ void Dx12ReplayConsumer::Process_D3D12CreateRootSignatureDeserializer(
         AddObject(out_p_ppRootSignatureDeserializer, out_hp_ppRootSignatureDeserializer, format::ApiCall_D3D12CreateRootSignatureDeserializer);
     }
     CheckReplayResult("D3D12CreateRootSignatureDeserializer", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12CreateRootSignatureDeserializer>::Dispatch(
+        this,
+        call_info,
+        pSrcData,
+        SrcDataSizeInBytes,
+        pRootSignatureDeserializerInterface,
+        ppRootSignatureDeserializer);
 }
 
 void Dx12ReplayConsumer::Process_D3D12SerializeVersionedRootSignature(
@@ -172,6 +252,12 @@ void Dx12ReplayConsumer::Process_D3D12SerializeVersionedRootSignature(
     HandlePointerDecoder<ID3D10Blob*>*          ppBlob,
     HandlePointerDecoder<ID3D10Blob*>*          ppErrorBlob)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12SerializeVersionedRootSignature>::Dispatch(
+        this,
+        call_info,
+        pRootSignature,
+        ppBlob,
+        ppErrorBlob);
     if(!ppBlob->IsNull()) ppBlob->SetHandleLength(1);
     auto out_p_ppBlob    = ppBlob->GetPointer();
     auto out_hp_ppBlob   = ppBlob->GetHandlePointer();
@@ -187,6 +273,12 @@ void Dx12ReplayConsumer::Process_D3D12SerializeVersionedRootSignature(
         AddObject(out_p_ppErrorBlob, out_hp_ppErrorBlob, format::ApiCall_D3D12SerializeVersionedRootSignature);
     }
     CheckReplayResult("D3D12SerializeVersionedRootSignature", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12SerializeVersionedRootSignature>::Dispatch(
+        this,
+        call_info,
+        pRootSignature,
+        ppBlob,
+        ppErrorBlob);
 }
 
 void Dx12ReplayConsumer::Process_D3D12CreateVersionedRootSignatureDeserializer(
@@ -197,6 +289,13 @@ void Dx12ReplayConsumer::Process_D3D12CreateVersionedRootSignatureDeserializer(
     Decoded_GUID                                pRootSignatureDeserializerInterface,
     HandlePointerDecoder<void*>*                ppRootSignatureDeserializer)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12CreateVersionedRootSignatureDeserializer>::Dispatch(
+        this,
+        call_info,
+        pSrcData,
+        SrcDataSizeInBytes,
+        pRootSignatureDeserializerInterface,
+        ppRootSignatureDeserializer);
     if(!ppRootSignatureDeserializer->IsNull()) ppRootSignatureDeserializer->SetHandleLength(1);
     auto out_p_ppRootSignatureDeserializer    = ppRootSignatureDeserializer->GetPointer();
     auto out_hp_ppRootSignatureDeserializer   = ppRootSignatureDeserializer->GetHandlePointer();
@@ -209,6 +308,13 @@ void Dx12ReplayConsumer::Process_D3D12CreateVersionedRootSignatureDeserializer(
         AddObject(out_p_ppRootSignatureDeserializer, out_hp_ppRootSignatureDeserializer, format::ApiCall_D3D12CreateVersionedRootSignatureDeserializer);
     }
     CheckReplayResult("D3D12CreateVersionedRootSignatureDeserializer", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12CreateVersionedRootSignatureDeserializer>::Dispatch(
+        this,
+        call_info,
+        pSrcData,
+        SrcDataSizeInBytes,
+        pRootSignatureDeserializerInterface,
+        ppRootSignatureDeserializer);
 }
 
 void Dx12ReplayConsumer::Process_D3D12CreateDevice(
@@ -219,6 +325,13 @@ void Dx12ReplayConsumer::Process_D3D12CreateDevice(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppDevice)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12CreateDevice>::Dispatch(
+        this,
+        call_info,
+        pAdapter,
+        MinimumFeatureLevel,
+        riid,
+        ppDevice);
     auto in_pAdapter = GetObjectInfo(pAdapter);
     if(!ppDevice->IsNull()) ppDevice->SetHandleLength(1);
     DxObjectInfo object_info{};
@@ -233,6 +346,13 @@ void Dx12ReplayConsumer::Process_D3D12CreateDevice(
         AddObject(ppDevice->GetPointer(), ppDevice->GetHandlePointer(), std::move(object_info), format::ApiCall_D3D12CreateDevice);
     }
     CheckReplayResult("D3D12CreateDevice", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12CreateDevice>::Dispatch(
+        this,
+        call_info,
+        pAdapter,
+        MinimumFeatureLevel,
+        riid,
+        ppDevice);
 }
 
 void Dx12ReplayConsumer::Process_D3D12GetDebugInterface(
@@ -241,6 +361,11 @@ void Dx12ReplayConsumer::Process_D3D12GetDebugInterface(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvDebug)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12GetDebugInterface>::Dispatch(
+        this,
+        call_info,
+        riid,
+        ppvDebug);
     if(!ppvDebug->IsNull()) ppvDebug->SetHandleLength(1);
     auto out_p_ppvDebug    = ppvDebug->GetPointer();
     auto out_hp_ppvDebug   = ppvDebug->GetHandlePointer();
@@ -251,6 +376,11 @@ void Dx12ReplayConsumer::Process_D3D12GetDebugInterface(
         AddObject(out_p_ppvDebug, out_hp_ppvDebug, format::ApiCall_D3D12GetDebugInterface);
     }
     CheckReplayResult("D3D12GetDebugInterface", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12GetDebugInterface>::Dispatch(
+        this,
+        call_info,
+        riid,
+        ppvDebug);
 }
 
 void Dx12ReplayConsumer::Process_D3D12EnableExperimentalFeatures(
@@ -261,11 +391,25 @@ void Dx12ReplayConsumer::Process_D3D12EnableExperimentalFeatures(
     PointerDecoder<uint8_t>*                    pConfigurationStructs,
     PointerDecoder<UINT>*                       pConfigurationStructSizes)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12EnableExperimentalFeatures>::Dispatch(
+        this,
+        call_info,
+        NumFeatures,
+        pIIDs,
+        pConfigurationStructs,
+        pConfigurationStructSizes);
     auto replay_result = D3D12EnableExperimentalFeatures(NumFeatures,
                                                          pIIDs->GetPointer(),
                                                          pConfigurationStructs->GetPointer(),
                                                          pConfigurationStructSizes->GetPointer());
     CheckReplayResult("D3D12EnableExperimentalFeatures", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12EnableExperimentalFeatures>::Dispatch(
+        this,
+        call_info,
+        NumFeatures,
+        pIIDs,
+        pConfigurationStructs,
+        pConfigurationStructSizes);
 }
 
 void Dx12ReplayConsumer::Process_D3D12GetInterface(
@@ -275,6 +419,12 @@ void Dx12ReplayConsumer::Process_D3D12GetInterface(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvDebug)
 {
+    CustomReplayPreCall<format::ApiCallId::ApiCall_D3D12GetInterface>::Dispatch(
+        this,
+        call_info,
+        rclsid,
+        riid,
+        ppvDebug);
     if(!ppvDebug->IsNull()) ppvDebug->SetHandleLength(1);
     auto out_p_ppvDebug    = ppvDebug->GetPointer();
     auto out_hp_ppvDebug   = ppvDebug->GetHandlePointer();
@@ -286,6 +436,12 @@ void Dx12ReplayConsumer::Process_D3D12GetInterface(
         AddObject(out_p_ppvDebug, out_hp_ppvDebug, format::ApiCall_D3D12GetInterface);
     }
     CheckReplayResult("D3D12GetInterface", return_value, replay_result);
+    CustomReplayPostCall<format::ApiCallId::ApiCall_D3D12GetInterface>::Dispatch(
+        this,
+        call_info,
+        rclsid,
+        riid,
+        ppvDebug);
 }
 void Dx12ReplayConsumer::Process_IDXGIObject_SetPrivateData(
     const ApiCallInfo&                          call_info,
@@ -295,13 +451,27 @@ void Dx12ReplayConsumer::Process_IDXGIObject_SetPrivateData(
     UINT                                        DataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    auto replay_object = MapObject<IDXGIObject>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetPrivateData(*Name.decoded_value,
-                                                           DataSize,
-                                                           pData->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIObject_SetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            DataSize,
+            pData);
+        auto replay_result = reinterpret_cast<IDXGIObject*>(replay_object->object)->SetPrivateData(*Name.decoded_value,
+                                                                                                   DataSize,
+                                                                                                   pData->GetPointer());
         CheckReplayResult("IDXGIObject_SetPrivateData", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIObject_SetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            DataSize,
+            pData);
     }
 }
 
@@ -312,13 +482,25 @@ void Dx12ReplayConsumer::Process_IDXGIObject_SetPrivateDataInterface(
     Decoded_GUID                                Name,
     format::HandleId                            pUnknown)
 {
-    auto replay_object = MapObject<IDXGIObject>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIObject_SetPrivateDataInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            pUnknown);
         auto in_pUnknown = MapObject<IUnknown>(pUnknown);
-        auto replay_result = replay_object->SetPrivateDataInterface(*Name.decoded_value,
-                                                                    in_pUnknown);
+        auto replay_result = reinterpret_cast<IDXGIObject*>(replay_object->object)->SetPrivateDataInterface(*Name.decoded_value,
+                                                                                                            in_pUnknown);
         CheckReplayResult("IDXGIObject_SetPrivateDataInterface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIObject_SetPrivateDataInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            pUnknown);
     }
 }
 
@@ -330,13 +512,27 @@ void Dx12ReplayConsumer::Process_IDXGIObject_GetPrivateData(
     PointerDecoder<UINT>*                       pDataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    auto replay_object = MapObject<IDXGIObject>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetPrivateData(*Name.decoded_value,
-                                                           pDataSize->GetPointer(),
-                                                           pData->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIObject_GetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            pDataSize,
+            pData);
+        auto replay_result = reinterpret_cast<IDXGIObject*>(replay_object->object)->GetPrivateData(*Name.decoded_value,
+                                                                                                   pDataSize->GetPointer(),
+                                                                                                   pData->GetPointer());
         CheckReplayResult("IDXGIObject_GetPrivateData", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIObject_GetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            pDataSize,
+            pData);
     }
 }
 
@@ -347,19 +543,31 @@ void Dx12ReplayConsumer::Process_IDXGIObject_GetParent(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppParent)
 {
-    auto replay_object = MapObject<IDXGIObject>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIObject_GetParent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppParent);
         if(!ppParent->IsNull()) ppParent->SetHandleLength(1);
         auto out_p_ppParent    = ppParent->GetPointer();
         auto out_hp_ppParent   = ppParent->GetHandlePointer();
-        auto replay_result = replay_object->GetParent(*riid.decoded_value,
-                                                      out_hp_ppParent);
+        auto replay_result = reinterpret_cast<IDXGIObject*>(replay_object->object)->GetParent(*riid.decoded_value,
+                                                                                              out_hp_ppParent);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppParent, out_hp_ppParent, format::ApiCall_IDXGIObject_GetParent);
         }
         CheckReplayResult("IDXGIObject_GetParent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIObject_GetParent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppParent);
     }
 }
 
@@ -370,19 +578,31 @@ void Dx12ReplayConsumer::Process_IDXGIDeviceSubObject_GetDevice(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppDevice)
 {
-    auto replay_object = MapObject<IDXGIDeviceSubObject>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDeviceSubObject_GetDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppDevice);
         if(!ppDevice->IsNull()) ppDevice->SetHandleLength(1);
         auto out_p_ppDevice    = ppDevice->GetPointer();
         auto out_hp_ppDevice   = ppDevice->GetHandlePointer();
-        auto replay_result = replay_object->GetDevice(*riid.decoded_value,
-                                                      out_hp_ppDevice);
+        auto replay_result = reinterpret_cast<IDXGIDeviceSubObject*>(replay_object->object)->GetDevice(*riid.decoded_value,
+                                                                                                       out_hp_ppDevice);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppDevice, out_hp_ppDevice, format::ApiCall_IDXGIDeviceSubObject_GetDevice);
         }
         CheckReplayResult("IDXGIDeviceSubObject_GetDevice", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDeviceSubObject_GetDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppDevice);
     }
 }
 
@@ -392,17 +612,27 @@ void Dx12ReplayConsumer::Process_IDXGIResource_GetSharedHandle(
     HRESULT                                     return_value,
     PointerDecoder<uint64_t, void*>*            pSharedHandle)
 {
-    auto replay_object = MapObject<IDXGIResource>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIResource_GetSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pSharedHandle);
         if(!pSharedHandle->IsNull())
         {
             pSharedHandle->AllocateOutputData(1);
         }
         auto out_p_pSharedHandle    = pSharedHandle->GetPointer();
         auto out_op_pSharedHandle   = reinterpret_cast<HANDLE*>(pSharedHandle->GetOutputPointer());
-        auto replay_result = replay_object->GetSharedHandle(out_op_pSharedHandle);
+        auto replay_result = reinterpret_cast<IDXGIResource*>(replay_object->object)->GetSharedHandle(out_op_pSharedHandle);
         CheckReplayResult("IDXGIResource_GetSharedHandle", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIResource_GetSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pSharedHandle);
         PostProcessExternalObject(replay_result, out_op_pSharedHandle, out_p_pSharedHandle, format::ApiCallId::ApiCall_IDXGIResource_GetSharedHandle, "IDXGIResource_GetSharedHandle");
     }
 }
@@ -413,11 +643,21 @@ void Dx12ReplayConsumer::Process_IDXGIResource_GetUsage(
     HRESULT                                     return_value,
     PointerDecoder<DXGI_USAGE>*                 pUsage)
 {
-    auto replay_object = MapObject<IDXGIResource>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetUsage(pUsage->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIResource_GetUsage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pUsage);
+        auto replay_result = reinterpret_cast<IDXGIResource*>(replay_object->object)->GetUsage(pUsage->GetPointer());
         CheckReplayResult("IDXGIResource_GetUsage", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIResource_GetUsage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pUsage);
     }
 }
 
@@ -427,11 +667,21 @@ void Dx12ReplayConsumer::Process_IDXGIResource_SetEvictionPriority(
     HRESULT                                     return_value,
     UINT                                        EvictionPriority)
 {
-    auto replay_object = MapObject<IDXGIResource>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetEvictionPriority(EvictionPriority);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIResource_SetEvictionPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EvictionPriority);
+        auto replay_result = reinterpret_cast<IDXGIResource*>(replay_object->object)->SetEvictionPriority(EvictionPriority);
         CheckReplayResult("IDXGIResource_SetEvictionPriority", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIResource_SetEvictionPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EvictionPriority);
     }
 }
 
@@ -441,11 +691,21 @@ void Dx12ReplayConsumer::Process_IDXGIResource_GetEvictionPriority(
     HRESULT                                     return_value,
     PointerDecoder<UINT>*                       pEvictionPriority)
 {
-    auto replay_object = MapObject<IDXGIResource>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetEvictionPriority(pEvictionPriority->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIResource_GetEvictionPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pEvictionPriority);
+        auto replay_result = reinterpret_cast<IDXGIResource*>(replay_object->object)->GetEvictionPriority(pEvictionPriority->GetPointer());
         CheckReplayResult("IDXGIResource_GetEvictionPriority", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIResource_GetEvictionPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pEvictionPriority);
     }
 }
 
@@ -456,12 +716,24 @@ void Dx12ReplayConsumer::Process_IDXGIKeyedMutex_AcquireSync(
     UINT64                                      Key,
     DWORD                                       dwMilliseconds)
 {
-    auto replay_object = MapObject<IDXGIKeyedMutex>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->AcquireSync(Key,
-                                                        dwMilliseconds);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIKeyedMutex_AcquireSync>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Key,
+            dwMilliseconds);
+        auto replay_result = reinterpret_cast<IDXGIKeyedMutex*>(replay_object->object)->AcquireSync(Key,
+                                                                                                    dwMilliseconds);
         CheckReplayResult("IDXGIKeyedMutex_AcquireSync", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIKeyedMutex_AcquireSync>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Key,
+            dwMilliseconds);
     }
 }
 
@@ -471,11 +743,21 @@ void Dx12ReplayConsumer::Process_IDXGIKeyedMutex_ReleaseSync(
     HRESULT                                     return_value,
     UINT64                                      Key)
 {
-    auto replay_object = MapObject<IDXGIKeyedMutex>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ReleaseSync(Key);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIKeyedMutex_ReleaseSync>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Key);
+        auto replay_result = reinterpret_cast<IDXGIKeyedMutex*>(replay_object->object)->ReleaseSync(Key);
         CheckReplayResult("IDXGIKeyedMutex_ReleaseSync", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIKeyedMutex_ReleaseSync>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Key);
     }
 }
 
@@ -485,11 +767,21 @@ void Dx12ReplayConsumer::Process_IDXGISurface_GetDesc(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_SURFACE_DESC>* pDesc)
 {
-    auto replay_object = MapObject<IDXGISurface>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISurface_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGISurface*>(replay_object->object)->GetDesc(pDesc->GetPointer());
         CheckReplayResult("IDXGISurface_GetDesc", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -500,12 +792,24 @@ void Dx12ReplayConsumer::Process_IDXGISurface_Map(
     StructPointerDecoder<Decoded_DXGI_MAPPED_RECT>* pLockedRect,
     UINT                                        MapFlags)
 {
-    auto replay_object = MapObject<IDXGISurface>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->Map(pLockedRect->GetPointer(),
-                                                MapFlags);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISurface_Map>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLockedRect,
+            MapFlags);
+        auto replay_result = reinterpret_cast<IDXGISurface*>(replay_object->object)->Map(pLockedRect->GetPointer(),
+                                                                                         MapFlags);
         CheckReplayResult("IDXGISurface_Map", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface_Map>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLockedRect,
+            MapFlags);
     }
 }
 
@@ -514,11 +818,19 @@ void Dx12ReplayConsumer::Process_IDXGISurface_Unmap(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<IDXGISurface>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->Unmap();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISurface_Unmap>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGISurface*>(replay_object->object)->Unmap();
         CheckReplayResult("IDXGISurface_Unmap", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface_Unmap>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -529,18 +841,30 @@ void Dx12ReplayConsumer::Process_IDXGISurface1_GetDC(
     BOOL                                        Discard,
     PointerDecoder<uint64_t, void*>*            phdc)
 {
-    auto replay_object = MapObject<IDXGISurface1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISurface1_GetDC>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Discard,
+            phdc);
         if(!phdc->IsNull())
         {
             phdc->AllocateOutputData(1);
         }
         auto out_p_phdc    = phdc->GetPointer();
         auto out_op_phdc   = reinterpret_cast<HDC*>(phdc->GetOutputPointer());
-        auto replay_result = replay_object->GetDC(Discard,
-                                                  out_op_phdc);
+        auto replay_result = reinterpret_cast<IDXGISurface1*>(replay_object->object)->GetDC(Discard,
+                                                                                            out_op_phdc);
         CheckReplayResult("IDXGISurface1_GetDC", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface1_GetDC>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Discard,
+            phdc);
         PostProcessExternalObject(replay_result, out_op_phdc, out_p_phdc, format::ApiCallId::ApiCall_IDXGISurface1_GetDC, "IDXGISurface1_GetDC");
     }
 }
@@ -551,11 +875,21 @@ void Dx12ReplayConsumer::Process_IDXGISurface1_ReleaseDC(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_tagRECT>*      pDirtyRect)
 {
-    auto replay_object = MapObject<IDXGISurface1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ReleaseDC(pDirtyRect->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISurface1_ReleaseDC>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDirtyRect);
+        auto replay_result = reinterpret_cast<IDXGISurface1*>(replay_object->object)->ReleaseDC(pDirtyRect->GetPointer());
         CheckReplayResult("IDXGISurface1_ReleaseDC", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface1_ReleaseDC>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDirtyRect);
     }
 }
 
@@ -566,19 +900,31 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter_EnumOutputs(
     UINT                                        Output,
     HandlePointerDecoder<IDXGIOutput*>*         ppOutput)
 {
-    auto replay_object = MapObject<IDXGIAdapter>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter_EnumOutputs>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Output,
+            ppOutput);
         if(!ppOutput->IsNull()) ppOutput->SetHandleLength(1);
         auto out_p_ppOutput    = ppOutput->GetPointer();
         auto out_hp_ppOutput   = ppOutput->GetHandlePointer();
-        auto replay_result = replay_object->EnumOutputs(Output,
-                                                        out_hp_ppOutput);
+        auto replay_result = reinterpret_cast<IDXGIAdapter*>(replay_object->object)->EnumOutputs(Output,
+                                                                                                 out_hp_ppOutput);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppOutput, out_hp_ppOutput, format::ApiCall_IDXGIAdapter_EnumOutputs);
         }
         CheckReplayResult("IDXGIAdapter_EnumOutputs", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter_EnumOutputs>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Output,
+            ppOutput);
     }
 }
 
@@ -588,11 +934,21 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter_GetDesc(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIAdapter>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIAdapter*>(replay_object->object)->GetDesc(pDesc->GetPointer());
         CheckReplayResult("IDXGIAdapter_GetDesc", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -603,12 +959,24 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter_CheckInterfaceSupport(
     Decoded_GUID                                InterfaceName,
     StructPointerDecoder<Decoded_LARGE_INTEGER>* pUMDVersion)
 {
-    auto replay_object = MapObject<IDXGIAdapter>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->CheckInterfaceSupport(*InterfaceName.decoded_value,
-                                                                  pUMDVersion->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter_CheckInterfaceSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            InterfaceName,
+            pUMDVersion);
+        auto replay_result = reinterpret_cast<IDXGIAdapter*>(replay_object->object)->CheckInterfaceSupport(*InterfaceName.decoded_value,
+                                                                                                           pUMDVersion->GetPointer());
         CheckReplayResult("IDXGIAdapter_CheckInterfaceSupport", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter_CheckInterfaceSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            InterfaceName,
+            pUMDVersion);
     }
 }
 
@@ -618,11 +986,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetDesc(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_OUTPUT_DESC>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDesc(pDesc->GetPointer());
         CheckReplayResult("IDXGIOutput_GetDesc", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -635,14 +1013,30 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetDisplayModeList(
     PointerDecoder<UINT>*                       pNumModes,
     StructPointerDecoder<Decoded_DXGI_MODE_DESC>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDisplayModeList(EnumFormat,
-                                                               Flags,
-                                                               pNumModes->GetPointer(),
-                                                               pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDisplayModeList>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EnumFormat,
+            Flags,
+            pNumModes,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDisplayModeList(EnumFormat,
+                                                                                                       Flags,
+                                                                                                       pNumModes->GetPointer(),
+                                                                                                       pDesc->GetPointer());
         CheckReplayResult("IDXGIOutput_GetDisplayModeList", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDisplayModeList>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EnumFormat,
+            Flags,
+            pNumModes,
+            pDesc);
     }
 }
 
@@ -654,14 +1048,28 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_FindClosestMatchingMode(
     StructPointerDecoder<Decoded_DXGI_MODE_DESC>* pClosestMatch,
     format::HandleId                            pConcernedDevice)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_FindClosestMatchingMode>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pModeToMatch,
+            pClosestMatch,
+            pConcernedDevice);
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
-        auto replay_result = replay_object->FindClosestMatchingMode(pModeToMatch->GetPointer(),
-                                                                    pClosestMatch->GetPointer(),
-                                                                    in_pConcernedDevice);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->FindClosestMatchingMode(pModeToMatch->GetPointer(),
+                                                                                                            pClosestMatch->GetPointer(),
+                                                                                                            in_pConcernedDevice);
         CheckReplayResult("IDXGIOutput_FindClosestMatchingMode", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_FindClosestMatchingMode>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pModeToMatch,
+            pClosestMatch,
+            pConcernedDevice);
     }
 }
 
@@ -670,11 +1078,19 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_WaitForVBlank(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->WaitForVBlank();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_WaitForVBlank>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->WaitForVBlank();
         CheckReplayResult("IDXGIOutput_WaitForVBlank", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_WaitForVBlank>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -685,13 +1101,25 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_TakeOwnership(
     format::HandleId                            pDevice,
     BOOL                                        Exclusive)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_TakeOwnership>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            Exclusive);
         auto in_pDevice = MapObject<IUnknown>(pDevice);
-        auto replay_result = replay_object->TakeOwnership(in_pDevice,
-                                                          Exclusive);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->TakeOwnership(in_pDevice,
+                                                                                                  Exclusive);
         CheckReplayResult("IDXGIOutput_TakeOwnership", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_TakeOwnership>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            Exclusive);
     }
 }
 
@@ -699,10 +1127,18 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_ReleaseOwnership(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->ReleaseOwnership();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_ReleaseOwnership>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<IDXGIOutput*>(replay_object->object)->ReleaseOwnership();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_ReleaseOwnership>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -712,11 +1148,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetGammaControlCapabilities(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_GAMMA_CONTROL_CAPABILITIES>* pGammaCaps)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetGammaControlCapabilities(pGammaCaps->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControlCapabilities>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pGammaCaps);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetGammaControlCapabilities(pGammaCaps->GetPointer());
         CheckReplayResult("IDXGIOutput_GetGammaControlCapabilities", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControlCapabilities>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pGammaCaps);
     }
 }
 
@@ -726,11 +1172,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_SetGammaControl(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_GAMMA_CONTROL>* pArray)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetGammaControl(pArray->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_SetGammaControl>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pArray);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->SetGammaControl(pArray->GetPointer());
         CheckReplayResult("IDXGIOutput_SetGammaControl", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_SetGammaControl>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pArray);
     }
 }
 
@@ -740,11 +1196,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetGammaControl(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_GAMMA_CONTROL>* pArray)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetGammaControl(pArray->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControl>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pArray);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetGammaControl(pArray->GetPointer());
         CheckReplayResult("IDXGIOutput_GetGammaControl", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetGammaControl>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pArray);
     }
 }
 
@@ -754,12 +1220,22 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_SetDisplaySurface(
     HRESULT                                     return_value,
     format::HandleId                            pScanoutSurface)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_SetDisplaySurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pScanoutSurface);
         auto in_pScanoutSurface = MapObject<IDXGISurface>(pScanoutSurface);
-        auto replay_result = replay_object->SetDisplaySurface(in_pScanoutSurface);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->SetDisplaySurface(in_pScanoutSurface);
         CheckReplayResult("IDXGIOutput_SetDisplaySurface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_SetDisplaySurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pScanoutSurface);
     }
 }
 
@@ -769,12 +1245,22 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetDisplaySurfaceData(
     HRESULT                                     return_value,
     format::HandleId                            pDestination)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDisplaySurfaceData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDestination);
         auto in_pDestination = MapObject<IDXGISurface>(pDestination);
-        auto replay_result = replay_object->GetDisplaySurfaceData(in_pDestination);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetDisplaySurfaceData(in_pDestination);
         CheckReplayResult("IDXGIOutput_GetDisplaySurfaceData", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetDisplaySurfaceData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDestination);
     }
 }
 
@@ -784,11 +1270,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutput_GetFrameStatistics(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_FRAME_STATISTICS>* pStats)
 {
-    auto replay_object = MapObject<IDXGIOutput>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFrameStatistics(pStats->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput_GetFrameStatistics>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStats);
+        auto replay_result = reinterpret_cast<IDXGIOutput*>(replay_object->object)->GetFrameStatistics(pStats->GetPointer());
         CheckReplayResult("IDXGIOutput_GetFrameStatistics", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput_GetFrameStatistics>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStats);
     }
 }
 
@@ -802,11 +1298,23 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_Present(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_Present>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SyncInterval,
+            Flags);
         auto replay_result = OverridePresent(replay_object,
                                              return_value,
                                              SyncInterval,
                                              Flags);
         CheckReplayResult("IDXGISwapChain_Present", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_Present>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SyncInterval,
+            Flags);
     }
 }
 
@@ -821,6 +1329,13 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetBuffer(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetBuffer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Buffer,
+            riid,
+            ppSurface);
         if(!ppSurface->IsNull()) ppSurface->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppSurface->SetConsumerData(0, &object_info);
@@ -834,6 +1349,13 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetBuffer(
             AddObject(ppSurface->GetPointer(), ppSurface->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGISwapChain_GetBuffer);
         }
         CheckReplayResult("IDXGISwapChain_GetBuffer", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetBuffer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Buffer,
+            riid,
+            ppSurface);
     }
 }
 
@@ -847,12 +1369,24 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_SetFullscreenState(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_SetFullscreenState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Fullscreen,
+            pTarget);
         auto in_pTarget = GetObjectInfo(pTarget);
         auto replay_result = OverrideSetFullscreenState(replay_object,
                                                         return_value,
                                                         Fullscreen,
                                                         in_pTarget);
         CheckReplayResult("IDXGISwapChain_SetFullscreenState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_SetFullscreenState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Fullscreen,
+            pTarget);
     }
 }
 
@@ -863,19 +1397,31 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetFullscreenState(
     PointerDecoder<BOOL>*                       pFullscreen,
     HandlePointerDecoder<IDXGIOutput*>*         ppTarget)
 {
-    auto replay_object = MapObject<IDXGISwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetFullscreenState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFullscreen,
+            ppTarget);
         if(!ppTarget->IsNull()) ppTarget->SetHandleLength(1);
         auto out_p_ppTarget    = ppTarget->GetPointer();
         auto out_hp_ppTarget   = ppTarget->GetHandlePointer();
-        auto replay_result = replay_object->GetFullscreenState(pFullscreen->GetPointer(),
-                                                               out_hp_ppTarget);
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetFullscreenState(pFullscreen->GetPointer(),
+                                                                                                          out_hp_ppTarget);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppTarget, out_hp_ppTarget, format::ApiCall_IDXGISwapChain_GetFullscreenState);
         }
         CheckReplayResult("IDXGISwapChain_GetFullscreenState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetFullscreenState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFullscreen,
+            ppTarget);
     }
 }
 
@@ -885,11 +1431,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetDesc(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_SWAP_CHAIN_DESC>* pDesc)
 {
-    auto replay_object = MapObject<IDXGISwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetDesc(pDesc->GetPointer());
         CheckReplayResult("IDXGISwapChain_GetDesc", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -906,6 +1462,15 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_ResizeBuffers(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_ResizeBuffers>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BufferCount,
+            Width,
+            Height,
+            NewFormat,
+            SwapChainFlags);
         auto replay_result = OverrideResizeBuffers(replay_object,
                                                    return_value,
                                                    BufferCount,
@@ -914,6 +1479,15 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_ResizeBuffers(
                                                    NewFormat,
                                                    SwapChainFlags);
         CheckReplayResult("IDXGISwapChain_ResizeBuffers", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_ResizeBuffers>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BufferCount,
+            Width,
+            Height,
+            NewFormat,
+            SwapChainFlags);
     }
 }
 
@@ -923,11 +1497,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_ResizeTarget(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_MODE_DESC>* pNewTargetParameters)
 {
-    auto replay_object = MapObject<IDXGISwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ResizeTarget(pNewTargetParameters->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_ResizeTarget>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pNewTargetParameters);
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->ResizeTarget(pNewTargetParameters->GetPointer());
         CheckReplayResult("IDXGISwapChain_ResizeTarget", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_ResizeTarget>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pNewTargetParameters);
     }
 }
 
@@ -937,18 +1521,28 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetContainingOutput(
     HRESULT                                     return_value,
     HandlePointerDecoder<IDXGIOutput*>*         ppOutput)
 {
-    auto replay_object = MapObject<IDXGISwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetContainingOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppOutput);
         if(!ppOutput->IsNull()) ppOutput->SetHandleLength(1);
         auto out_p_ppOutput    = ppOutput->GetPointer();
         auto out_hp_ppOutput   = ppOutput->GetHandlePointer();
-        auto replay_result = replay_object->GetContainingOutput(out_hp_ppOutput);
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetContainingOutput(out_hp_ppOutput);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppOutput, out_hp_ppOutput, format::ApiCall_IDXGISwapChain_GetContainingOutput);
         }
         CheckReplayResult("IDXGISwapChain_GetContainingOutput", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetContainingOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppOutput);
     }
 }
 
@@ -958,11 +1552,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetFrameStatistics(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_FRAME_STATISTICS>* pStats)
 {
-    auto replay_object = MapObject<IDXGISwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFrameStatistics(pStats->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetFrameStatistics>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStats);
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetFrameStatistics(pStats->GetPointer());
         CheckReplayResult("IDXGISwapChain_GetFrameStatistics", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetFrameStatistics>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStats);
     }
 }
 
@@ -972,11 +1576,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain_GetLastPresentCount(
     HRESULT                                     return_value,
     PointerDecoder<UINT>*                       pLastPresentCount)
 {
-    auto replay_object = MapObject<IDXGISwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetLastPresentCount(pLastPresentCount->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetLastPresentCount>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLastPresentCount);
+        auto replay_result = reinterpret_cast<IDXGISwapChain*>(replay_object->object)->GetLastPresentCount(pLastPresentCount->GetPointer());
         CheckReplayResult("IDXGISwapChain_GetLastPresentCount", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain_GetLastPresentCount>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLastPresentCount);
     }
 }
 
@@ -987,19 +1601,31 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_EnumAdapters(
     UINT                                        Adapter,
     HandlePointerDecoder<IDXGIAdapter*>*        ppAdapter)
 {
-    auto replay_object = MapObject<IDXGIFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory_EnumAdapters>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Adapter,
+            ppAdapter);
         if(!ppAdapter->IsNull()) ppAdapter->SetHandleLength(1);
         auto out_p_ppAdapter    = ppAdapter->GetPointer();
         auto out_hp_ppAdapter   = ppAdapter->GetHandlePointer();
-        auto replay_result = replay_object->EnumAdapters(Adapter,
-                                                         out_hp_ppAdapter);
+        auto replay_result = reinterpret_cast<IDXGIFactory*>(replay_object->object)->EnumAdapters(Adapter,
+                                                                                                  out_hp_ppAdapter);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppAdapter, out_hp_ppAdapter, format::ApiCall_IDXGIFactory_EnumAdapters);
         }
         CheckReplayResult("IDXGIFactory_EnumAdapters", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory_EnumAdapters>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Adapter,
+            ppAdapter);
     }
 }
 
@@ -1010,13 +1636,25 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_MakeWindowAssociation(
     uint64_t                                    WindowHandle,
     UINT                                        Flags)
 {
-    auto replay_object = MapObject<IDXGIFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory_MakeWindowAssociation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            WindowHandle,
+            Flags);
         auto in_WindowHandle = static_cast<HWND>(PreProcessExternalObject(WindowHandle, format::ApiCallId::ApiCall_IDXGIFactory_MakeWindowAssociation, "IDXGIFactory_MakeWindowAssociation"));
-        auto replay_result = replay_object->MakeWindowAssociation(in_WindowHandle,
-                                                                  Flags);
+        auto replay_result = reinterpret_cast<IDXGIFactory*>(replay_object->object)->MakeWindowAssociation(in_WindowHandle,
+                                                                                                           Flags);
         CheckReplayResult("IDXGIFactory_MakeWindowAssociation", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory_MakeWindowAssociation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            WindowHandle,
+            Flags);
     }
 }
 
@@ -1026,17 +1664,27 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_GetWindowAssociation(
     HRESULT                                     return_value,
     PointerDecoder<uint64_t, void*>*            pWindowHandle)
 {
-    auto replay_object = MapObject<IDXGIFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory_GetWindowAssociation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pWindowHandle);
         if(!pWindowHandle->IsNull())
         {
             pWindowHandle->AllocateOutputData(1);
         }
         auto out_p_pWindowHandle    = pWindowHandle->GetPointer();
         auto out_op_pWindowHandle   = reinterpret_cast<HWND*>(pWindowHandle->GetOutputPointer());
-        auto replay_result = replay_object->GetWindowAssociation(out_op_pWindowHandle);
+        auto replay_result = reinterpret_cast<IDXGIFactory*>(replay_object->object)->GetWindowAssociation(out_op_pWindowHandle);
         CheckReplayResult("IDXGIFactory_GetWindowAssociation", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory_GetWindowAssociation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pWindowHandle);
         PostProcessExternalObject(replay_result, out_op_pWindowHandle, out_p_pWindowHandle, format::ApiCallId::ApiCall_IDXGIFactory_GetWindowAssociation, "IDXGIFactory_GetWindowAssociation");
     }
 }
@@ -1052,6 +1700,13 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_CreateSwapChain(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory_CreateSwapChain>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            pDesc,
+            ppSwapChain);
         auto in_pDevice = GetObjectInfo(pDevice);
         if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -1066,6 +1721,13 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_CreateSwapChain(
             AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory_CreateSwapChain);
         }
         CheckReplayResult("IDXGIFactory_CreateSwapChain", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory_CreateSwapChain>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            pDesc,
+            ppSwapChain);
     }
 }
 
@@ -1076,20 +1738,32 @@ void Dx12ReplayConsumer::Process_IDXGIFactory_CreateSoftwareAdapter(
     uint64_t                                    Module,
     HandlePointerDecoder<IDXGIAdapter*>*        ppAdapter)
 {
-    auto replay_object = MapObject<IDXGIFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory_CreateSoftwareAdapter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Module,
+            ppAdapter);
         auto in_Module = static_cast<HMODULE>(PreProcessExternalObject(Module, format::ApiCallId::ApiCall_IDXGIFactory_CreateSoftwareAdapter, "IDXGIFactory_CreateSoftwareAdapter"));
         if(!ppAdapter->IsNull()) ppAdapter->SetHandleLength(1);
         auto out_p_ppAdapter    = ppAdapter->GetPointer();
         auto out_hp_ppAdapter   = ppAdapter->GetHandlePointer();
-        auto replay_result = replay_object->CreateSoftwareAdapter(in_Module,
-                                                                  out_hp_ppAdapter);
+        auto replay_result = reinterpret_cast<IDXGIFactory*>(replay_object->object)->CreateSoftwareAdapter(in_Module,
+                                                                                                           out_hp_ppAdapter);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppAdapter, out_hp_ppAdapter, format::ApiCall_IDXGIFactory_CreateSoftwareAdapter);
         }
         CheckReplayResult("IDXGIFactory_CreateSoftwareAdapter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory_CreateSoftwareAdapter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Module,
+            ppAdapter);
     }
 }
 
@@ -1099,18 +1773,28 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_GetAdapter(
     HRESULT                                     return_value,
     HandlePointerDecoder<IDXGIAdapter*>*        pAdapter)
 {
-    auto replay_object = MapObject<IDXGIDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice_GetAdapter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAdapter);
         if(!pAdapter->IsNull()) pAdapter->SetHandleLength(1);
         auto out_p_pAdapter    = pAdapter->GetPointer();
         auto out_hp_pAdapter   = pAdapter->GetHandlePointer();
-        auto replay_result = replay_object->GetAdapter(out_hp_pAdapter);
+        auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->GetAdapter(out_hp_pAdapter);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_pAdapter, out_hp_pAdapter, format::ApiCall_IDXGIDevice_GetAdapter);
         }
         CheckReplayResult("IDXGIDevice_GetAdapter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_GetAdapter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAdapter);
     }
 }
 
@@ -1124,22 +1808,40 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_CreateSurface(
     StructPointerDecoder<Decoded_DXGI_SHARED_RESOURCE>* pSharedResource,
     HandlePointerDecoder<IDXGISurface*>*        ppSurface)
 {
-    auto replay_object = MapObject<IDXGIDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice_CreateSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            NumSurfaces,
+            Usage,
+            pSharedResource,
+            ppSurface);
         if(!ppSurface->IsNull()) ppSurface->SetHandleLength(1);
         auto out_p_ppSurface    = ppSurface->GetPointer();
         auto out_hp_ppSurface   = ppSurface->GetHandlePointer();
-        auto replay_result = replay_object->CreateSurface(pDesc->GetPointer(),
-                                                          NumSurfaces,
-                                                          Usage,
-                                                          pSharedResource->GetPointer(),
-                                                          out_hp_ppSurface);
+        auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->CreateSurface(pDesc->GetPointer(),
+                                                                                                  NumSurfaces,
+                                                                                                  Usage,
+                                                                                                  pSharedResource->GetPointer(),
+                                                                                                  out_hp_ppSurface);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppSurface, out_hp_ppSurface, format::ApiCall_IDXGIDevice_CreateSurface);
         }
         CheckReplayResult("IDXGIDevice_CreateSurface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_CreateSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            NumSurfaces,
+            Usage,
+            pSharedResource,
+            ppSurface);
     }
 }
 
@@ -1151,14 +1853,28 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_QueryResourceResidency(
     PointerDecoder<DXGI_RESIDENCY>*             pResidencyStatus,
     UINT                                        NumResources)
 {
-    auto replay_object = MapObject<IDXGIDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice_QueryResourceResidency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppResources,
+            pResidencyStatus,
+            NumResources);
         auto in_ppResources = MapObjects<IUnknown>(ppResources, NumResources);
-        auto replay_result = replay_object->QueryResourceResidency(in_ppResources,
-                                                                   pResidencyStatus->GetPointer(),
-                                                                   NumResources);
+        auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->QueryResourceResidency(in_ppResources,
+                                                                                                           pResidencyStatus->GetPointer(),
+                                                                                                           NumResources);
         CheckReplayResult("IDXGIDevice_QueryResourceResidency", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_QueryResourceResidency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppResources,
+            pResidencyStatus,
+            NumResources);
     }
 }
 
@@ -1168,11 +1884,21 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_SetGPUThreadPriority(
     HRESULT                                     return_value,
     INT                                         Priority)
 {
-    auto replay_object = MapObject<IDXGIDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetGPUThreadPriority(Priority);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice_SetGPUThreadPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Priority);
+        auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->SetGPUThreadPriority(Priority);
         CheckReplayResult("IDXGIDevice_SetGPUThreadPriority", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_SetGPUThreadPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Priority);
     }
 }
 
@@ -1182,11 +1908,21 @@ void Dx12ReplayConsumer::Process_IDXGIDevice_GetGPUThreadPriority(
     HRESULT                                     return_value,
     PointerDecoder<INT>*                        pPriority)
 {
-    auto replay_object = MapObject<IDXGIDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetGPUThreadPriority(pPriority->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice_GetGPUThreadPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pPriority);
+        auto replay_result = reinterpret_cast<IDXGIDevice*>(replay_object->object)->GetGPUThreadPriority(pPriority->GetPointer());
         CheckReplayResult("IDXGIDevice_GetGPUThreadPriority", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice_GetGPUThreadPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pPriority);
     }
 }
 
@@ -1197,19 +1933,31 @@ void Dx12ReplayConsumer::Process_IDXGIFactory1_EnumAdapters1(
     UINT                                        Adapter,
     HandlePointerDecoder<IDXGIAdapter1*>*       ppAdapter)
 {
-    auto replay_object = MapObject<IDXGIFactory1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory1_EnumAdapters1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Adapter,
+            ppAdapter);
         if(!ppAdapter->IsNull()) ppAdapter->SetHandleLength(1);
         auto out_p_ppAdapter    = ppAdapter->GetPointer();
         auto out_hp_ppAdapter   = ppAdapter->GetHandlePointer();
-        auto replay_result = replay_object->EnumAdapters1(Adapter,
-                                                          out_hp_ppAdapter);
+        auto replay_result = reinterpret_cast<IDXGIFactory1*>(replay_object->object)->EnumAdapters1(Adapter,
+                                                                                                    out_hp_ppAdapter);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppAdapter, out_hp_ppAdapter, format::ApiCall_IDXGIFactory1_EnumAdapters1);
         }
         CheckReplayResult("IDXGIFactory1_EnumAdapters1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory1_EnumAdapters1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Adapter,
+            ppAdapter);
     }
 }
 
@@ -1218,10 +1966,18 @@ void Dx12ReplayConsumer::Process_IDXGIFactory1_IsCurrent(
     format::HandleId                            object_id,
     BOOL                                        return_value)
 {
-    auto replay_object = MapObject<IDXGIFactory1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->IsCurrent();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory1_IsCurrent>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIFactory1*>(replay_object->object)->IsCurrent();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory1_IsCurrent>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -1231,11 +1987,21 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter1_GetDesc1(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC1>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIAdapter1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc1(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter1_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIAdapter1*>(replay_object->object)->GetDesc1(pDesc->GetPointer());
         CheckReplayResult("IDXGIAdapter1_GetDesc1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter1_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -1245,11 +2011,21 @@ void Dx12ReplayConsumer::Process_IDXGIDevice1_SetMaximumFrameLatency(
     HRESULT                                     return_value,
     UINT                                        MaxLatency)
 {
-    auto replay_object = MapObject<IDXGIDevice1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetMaximumFrameLatency(MaxLatency);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice1_SetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MaxLatency);
+        auto replay_result = reinterpret_cast<IDXGIDevice1*>(replay_object->object)->SetMaximumFrameLatency(MaxLatency);
         CheckReplayResult("IDXGIDevice1_SetMaximumFrameLatency", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice1_SetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MaxLatency);
     }
 }
 
@@ -1259,11 +2035,21 @@ void Dx12ReplayConsumer::Process_IDXGIDevice1_GetMaximumFrameLatency(
     HRESULT                                     return_value,
     PointerDecoder<UINT>*                       pMaxLatency)
 {
-    auto replay_object = MapObject<IDXGIDevice1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetMaximumFrameLatency(pMaxLatency->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice1_GetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMaxLatency);
+        auto replay_result = reinterpret_cast<IDXGIDevice1*>(replay_object->object)->GetMaximumFrameLatency(pMaxLatency->GetPointer());
         CheckReplayResult("IDXGIDevice1_GetMaximumFrameLatency", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice1_GetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMaxLatency);
     }
 }
 
@@ -1272,10 +2058,18 @@ void Dx12ReplayConsumer::Process_IDXGIDisplayControl_IsStereoEnabled(
     format::HandleId                            object_id,
     BOOL                                        return_value)
 {
-    auto replay_object = MapObject<IDXGIDisplayControl>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->IsStereoEnabled();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDisplayControl_IsStereoEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIDisplayControl*>(replay_object->object)->IsStereoEnabled();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDisplayControl_IsStereoEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -1284,10 +2078,20 @@ void Dx12ReplayConsumer::Process_IDXGIDisplayControl_SetStereoEnabled(
     format::HandleId                            object_id,
     BOOL                                        enabled)
 {
-    auto replay_object = MapObject<IDXGIDisplayControl>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetStereoEnabled(enabled);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDisplayControl_SetStereoEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            enabled);
+        reinterpret_cast<IDXGIDisplayControl*>(replay_object->object)->SetStereoEnabled(enabled);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDisplayControl_SetStereoEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            enabled);
     }
 }
 
@@ -1296,10 +2100,20 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetDesc(
     format::HandleId                            object_id,
     StructPointerDecoder<Decoded_DXGI_OUTDUPL_DESC>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->GetDesc(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetDesc(pDesc->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -1311,20 +2125,34 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_AcquireNextFrame(
     StructPointerDecoder<Decoded_DXGI_OUTDUPL_FRAME_INFO>* pFrameInfo,
     HandlePointerDecoder<IDXGIResource*>*       ppDesktopResource)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_AcquireNextFrame>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            TimeoutInMilliseconds,
+            pFrameInfo,
+            ppDesktopResource);
         if(!ppDesktopResource->IsNull()) ppDesktopResource->SetHandleLength(1);
         auto out_p_ppDesktopResource    = ppDesktopResource->GetPointer();
         auto out_hp_ppDesktopResource   = ppDesktopResource->GetHandlePointer();
-        auto replay_result = replay_object->AcquireNextFrame(TimeoutInMilliseconds,
-                                                             pFrameInfo->GetPointer(),
-                                                             out_hp_ppDesktopResource);
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->AcquireNextFrame(TimeoutInMilliseconds,
+                                                                                                                pFrameInfo->GetPointer(),
+                                                                                                                out_hp_ppDesktopResource);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppDesktopResource, out_hp_ppDesktopResource, format::ApiCall_IDXGIOutputDuplication_AcquireNextFrame);
         }
         CheckReplayResult("IDXGIOutputDuplication_AcquireNextFrame", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_AcquireNextFrame>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            TimeoutInMilliseconds,
+            pFrameInfo,
+            ppDesktopResource);
     }
 }
 
@@ -1336,13 +2164,27 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetFrameDirtyRects(
     StructPointerDecoder<Decoded_tagRECT>*      pDirtyRectsBuffer,
     PointerDecoder<UINT>*                       pDirtyRectsBufferSizeRequired)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFrameDirtyRects(DirtyRectsBufferSize,
-                                                               pDirtyRectsBuffer->GetPointer(),
-                                                               pDirtyRectsBufferSizeRequired->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameDirtyRects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DirtyRectsBufferSize,
+            pDirtyRectsBuffer,
+            pDirtyRectsBufferSizeRequired);
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetFrameDirtyRects(DirtyRectsBufferSize,
+                                                                                                                  pDirtyRectsBuffer->GetPointer(),
+                                                                                                                  pDirtyRectsBufferSizeRequired->GetPointer());
         CheckReplayResult("IDXGIOutputDuplication_GetFrameDirtyRects", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameDirtyRects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DirtyRectsBufferSize,
+            pDirtyRectsBuffer,
+            pDirtyRectsBufferSizeRequired);
     }
 }
 
@@ -1354,13 +2196,27 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetFrameMoveRects(
     StructPointerDecoder<Decoded_DXGI_OUTDUPL_MOVE_RECT>* pMoveRectBuffer,
     PointerDecoder<UINT>*                       pMoveRectsBufferSizeRequired)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFrameMoveRects(MoveRectsBufferSize,
-                                                              pMoveRectBuffer->GetPointer(),
-                                                              pMoveRectsBufferSizeRequired->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameMoveRects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MoveRectsBufferSize,
+            pMoveRectBuffer,
+            pMoveRectsBufferSizeRequired);
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetFrameMoveRects(MoveRectsBufferSize,
+                                                                                                                 pMoveRectBuffer->GetPointer(),
+                                                                                                                 pMoveRectsBufferSizeRequired->GetPointer());
         CheckReplayResult("IDXGIOutputDuplication_GetFrameMoveRects", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFrameMoveRects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MoveRectsBufferSize,
+            pMoveRectBuffer,
+            pMoveRectsBufferSizeRequired);
     }
 }
 
@@ -1373,14 +2229,30 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_GetFramePointerShape(
     PointerDecoder<UINT>*                       pPointerShapeBufferSizeRequired,
     StructPointerDecoder<Decoded_DXGI_OUTDUPL_POINTER_SHAPE_INFO>* pPointerShapeInfo)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFramePointerShape(PointerShapeBufferSize,
-                                                                 pPointerShapeBuffer->GetPointer(),
-                                                                 pPointerShapeBufferSizeRequired->GetPointer(),
-                                                                 pPointerShapeInfo->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFramePointerShape>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            PointerShapeBufferSize,
+            pPointerShapeBuffer,
+            pPointerShapeBufferSizeRequired,
+            pPointerShapeInfo);
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->GetFramePointerShape(PointerShapeBufferSize,
+                                                                                                                    pPointerShapeBuffer->GetPointer(),
+                                                                                                                    pPointerShapeBufferSizeRequired->GetPointer(),
+                                                                                                                    pPointerShapeInfo->GetPointer());
         CheckReplayResult("IDXGIOutputDuplication_GetFramePointerShape", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_GetFramePointerShape>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            PointerShapeBufferSize,
+            pPointerShapeBuffer,
+            pPointerShapeBufferSizeRequired,
+            pPointerShapeInfo);
     }
 }
 
@@ -1390,11 +2262,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_MapDesktopSurface(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_MAPPED_RECT>* pLockedRect)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->MapDesktopSurface(pLockedRect->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_MapDesktopSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLockedRect);
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->MapDesktopSurface(pLockedRect->GetPointer());
         CheckReplayResult("IDXGIOutputDuplication_MapDesktopSurface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_MapDesktopSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLockedRect);
     }
 }
 
@@ -1403,11 +2285,19 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_UnMapDesktopSurface(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->UnMapDesktopSurface();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_UnMapDesktopSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->UnMapDesktopSurface();
         CheckReplayResult("IDXGIOutputDuplication_UnMapDesktopSurface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_UnMapDesktopSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -1416,11 +2306,19 @@ void Dx12ReplayConsumer::Process_IDXGIOutputDuplication_ReleaseFrame(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<IDXGIOutputDuplication>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ReleaseFrame();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_ReleaseFrame>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIOutputDuplication*>(replay_object->object)->ReleaseFrame();
         CheckReplayResult("IDXGIOutputDuplication_ReleaseFrame", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutputDuplication_ReleaseFrame>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -1432,20 +2330,34 @@ void Dx12ReplayConsumer::Process_IDXGISurface2_GetResource(
     HandlePointerDecoder<void*>*                ppParentResource,
     PointerDecoder<UINT>*                       pSubresourceIndex)
 {
-    auto replay_object = MapObject<IDXGISurface2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISurface2_GetResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppParentResource,
+            pSubresourceIndex);
         if(!ppParentResource->IsNull()) ppParentResource->SetHandleLength(1);
         auto out_p_ppParentResource    = ppParentResource->GetPointer();
         auto out_hp_ppParentResource   = ppParentResource->GetHandlePointer();
-        auto replay_result = replay_object->GetResource(*riid.decoded_value,
-                                                        out_hp_ppParentResource,
-                                                        pSubresourceIndex->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGISurface2*>(replay_object->object)->GetResource(*riid.decoded_value,
+                                                                                                  out_hp_ppParentResource,
+                                                                                                  pSubresourceIndex->GetPointer());
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppParentResource, out_hp_ppParentResource, format::ApiCall_IDXGISurface2_GetResource);
         }
         CheckReplayResult("IDXGISurface2_GetResource", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISurface2_GetResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppParentResource,
+            pSubresourceIndex);
     }
 }
 
@@ -1456,19 +2368,31 @@ void Dx12ReplayConsumer::Process_IDXGIResource1_CreateSubresourceSurface(
     UINT                                        index,
     HandlePointerDecoder<IDXGISurface2*>*       ppSurface)
 {
-    auto replay_object = MapObject<IDXGIResource1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIResource1_CreateSubresourceSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            index,
+            ppSurface);
         if(!ppSurface->IsNull()) ppSurface->SetHandleLength(1);
         auto out_p_ppSurface    = ppSurface->GetPointer();
         auto out_hp_ppSurface   = ppSurface->GetHandlePointer();
-        auto replay_result = replay_object->CreateSubresourceSurface(index,
-                                                                     out_hp_ppSurface);
+        auto replay_result = reinterpret_cast<IDXGIResource1*>(replay_object->object)->CreateSubresourceSurface(index,
+                                                                                                                out_hp_ppSurface);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppSurface, out_hp_ppSurface, format::ApiCall_IDXGIResource1_CreateSubresourceSurface);
         }
         CheckReplayResult("IDXGIResource1_CreateSubresourceSurface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIResource1_CreateSubresourceSurface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            index,
+            ppSurface);
     }
 }
 
@@ -1481,20 +2405,36 @@ void Dx12ReplayConsumer::Process_IDXGIResource1_CreateSharedHandle(
     WStringDecoder*                             lpName,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
-    auto replay_object = MapObject<IDXGIResource1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIResource1_CreateSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAttributes,
+            dwAccess,
+            lpName,
+            pHandle);
         if(!pHandle->IsNull())
         {
             pHandle->AllocateOutputData(1);
         }
         auto out_p_pHandle    = pHandle->GetPointer();
         auto out_op_pHandle   = reinterpret_cast<HANDLE*>(pHandle->GetOutputPointer());
-        auto replay_result = replay_object->CreateSharedHandle(pAttributes->GetPointer(),
-                                                               dwAccess,
-                                                               lpName->GetPointer(),
-                                                               out_op_pHandle);
+        auto replay_result = reinterpret_cast<IDXGIResource1*>(replay_object->object)->CreateSharedHandle(pAttributes->GetPointer(),
+                                                                                                          dwAccess,
+                                                                                                          lpName->GetPointer(),
+                                                                                                          out_op_pHandle);
         CheckReplayResult("IDXGIResource1_CreateSharedHandle", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIResource1_CreateSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAttributes,
+            dwAccess,
+            lpName,
+            pHandle);
         PostProcessExternalObject(replay_result, out_op_pHandle, out_p_pHandle, format::ApiCallId::ApiCall_IDXGIResource1_CreateSharedHandle, "IDXGIResource1_CreateSharedHandle");
     }
 }
@@ -1507,14 +2447,28 @@ void Dx12ReplayConsumer::Process_IDXGIDevice2_OfferResources(
     HandlePointerDecoder<IDXGIResource*>*       ppResources,
     DXGI_OFFER_RESOURCE_PRIORITY                Priority)
 {
-    auto replay_object = MapObject<IDXGIDevice2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice2_OfferResources>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            Priority);
         auto in_ppResources = MapObjects<IDXGIResource>(ppResources, NumResources);
-        auto replay_result = replay_object->OfferResources(NumResources,
-                                                           in_ppResources,
-                                                           Priority);
+        auto replay_result = reinterpret_cast<IDXGIDevice2*>(replay_object->object)->OfferResources(NumResources,
+                                                                                                    in_ppResources,
+                                                                                                    Priority);
         CheckReplayResult("IDXGIDevice2_OfferResources", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice2_OfferResources>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            Priority);
     }
 }
 
@@ -1526,14 +2480,28 @@ void Dx12ReplayConsumer::Process_IDXGIDevice2_ReclaimResources(
     HandlePointerDecoder<IDXGIResource*>*       ppResources,
     PointerDecoder<BOOL>*                       pDiscarded)
 {
-    auto replay_object = MapObject<IDXGIDevice2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice2_ReclaimResources>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            pDiscarded);
         auto in_ppResources = MapObjects<IDXGIResource>(ppResources, NumResources);
-        auto replay_result = replay_object->ReclaimResources(NumResources,
-                                                             in_ppResources,
-                                                             pDiscarded->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIDevice2*>(replay_object->object)->ReclaimResources(NumResources,
+                                                                                                      in_ppResources,
+                                                                                                      pDiscarded->GetPointer());
         CheckReplayResult("IDXGIDevice2_ReclaimResources", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice2_ReclaimResources>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            pDiscarded);
     }
 }
 
@@ -1543,12 +2511,22 @@ void Dx12ReplayConsumer::Process_IDXGIDevice2_EnqueueSetEvent(
     HRESULT                                     return_value,
     uint64_t                                    hEvent)
 {
-    auto replay_object = MapObject<IDXGIDevice2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice2_EnqueueSetEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIDevice2_EnqueueSetEvent, "IDXGIDevice2_EnqueueSetEvent"));
-        auto replay_result = replay_object->EnqueueSetEvent(in_hEvent);
+        auto replay_result = reinterpret_cast<IDXGIDevice2*>(replay_object->object)->EnqueueSetEvent(in_hEvent);
         CheckReplayResult("IDXGIDevice2_EnqueueSetEvent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice2_EnqueueSetEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent);
     }
 }
 
@@ -1558,11 +2536,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetDesc1(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_SWAP_CHAIN_DESC1>* pDesc)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc1(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetDesc1(pDesc->GetPointer());
         CheckReplayResult("IDXGISwapChain1_GetDesc1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -1572,11 +2560,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetFullscreenDesc(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_SWAP_CHAIN_FULLSCREEN_DESC>* pDesc)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFullscreenDesc(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetFullscreenDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetFullscreenDesc(pDesc->GetPointer());
         CheckReplayResult("IDXGISwapChain1_GetFullscreenDesc", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetFullscreenDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -1586,17 +2584,27 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetHwnd(
     HRESULT                                     return_value,
     PointerDecoder<uint64_t, void*>*            pHwnd)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetHwnd>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHwnd);
         if(!pHwnd->IsNull())
         {
             pHwnd->AllocateOutputData(1);
         }
         auto out_p_pHwnd    = pHwnd->GetPointer();
         auto out_op_pHwnd   = reinterpret_cast<HWND*>(pHwnd->GetOutputPointer());
-        auto replay_result = replay_object->GetHwnd(out_op_pHwnd);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetHwnd(out_op_pHwnd);
         CheckReplayResult("IDXGISwapChain1_GetHwnd", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetHwnd>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHwnd);
         PostProcessExternalObject(replay_result, out_op_pHwnd, out_p_pHwnd, format::ApiCallId::ApiCall_IDXGISwapChain1_GetHwnd, "IDXGISwapChain1_GetHwnd");
     }
 }
@@ -1608,19 +2616,31 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetCoreWindow(
     Decoded_GUID                                refiid,
     HandlePointerDecoder<void*>*                ppUnk)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetCoreWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            refiid,
+            ppUnk);
         if(!ppUnk->IsNull()) ppUnk->SetHandleLength(1);
         auto out_p_ppUnk    = ppUnk->GetPointer();
         auto out_hp_ppUnk   = ppUnk->GetHandlePointer();
-        auto replay_result = replay_object->GetCoreWindow(*refiid.decoded_value,
-                                                          out_hp_ppUnk);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetCoreWindow(*refiid.decoded_value,
+                                                                                                      out_hp_ppUnk);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppUnk, out_hp_ppUnk, format::ApiCall_IDXGISwapChain1_GetCoreWindow);
         }
         CheckReplayResult("IDXGISwapChain1_GetCoreWindow", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetCoreWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            refiid,
+            ppUnk);
     }
 }
 
@@ -1635,12 +2655,26 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_Present1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_Present1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SyncInterval,
+            PresentFlags,
+            pPresentParameters);
         auto replay_result = OverridePresent1(replay_object,
                                               return_value,
                                               SyncInterval,
                                               PresentFlags,
                                               pPresentParameters);
         CheckReplayResult("IDXGISwapChain1_Present1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_Present1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SyncInterval,
+            PresentFlags,
+            pPresentParameters);
     }
 }
 
@@ -1649,10 +2683,18 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_IsTemporaryMonoSupported(
     format::HandleId                            object_id,
     BOOL                                        return_value)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->IsTemporaryMonoSupported();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_IsTemporaryMonoSupported>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->IsTemporaryMonoSupported();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_IsTemporaryMonoSupported>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -1662,18 +2704,28 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetRestrictToOutput(
     HRESULT                                     return_value,
     HandlePointerDecoder<IDXGIOutput*>*         ppRestrictToOutput)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetRestrictToOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppRestrictToOutput);
         if(!ppRestrictToOutput->IsNull()) ppRestrictToOutput->SetHandleLength(1);
         auto out_p_ppRestrictToOutput    = ppRestrictToOutput->GetPointer();
         auto out_hp_ppRestrictToOutput   = ppRestrictToOutput->GetHandlePointer();
-        auto replay_result = replay_object->GetRestrictToOutput(out_hp_ppRestrictToOutput);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetRestrictToOutput(out_hp_ppRestrictToOutput);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppRestrictToOutput, out_hp_ppRestrictToOutput, format::ApiCall_IDXGISwapChain1_GetRestrictToOutput);
         }
         CheckReplayResult("IDXGISwapChain1_GetRestrictToOutput", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetRestrictToOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppRestrictToOutput);
     }
 }
 
@@ -1683,11 +2735,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_SetBackgroundColor(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3DCOLORVALUE>* pColor)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetBackgroundColor(pColor->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_SetBackgroundColor>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pColor);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->SetBackgroundColor(pColor->GetPointer());
         CheckReplayResult("IDXGISwapChain1_SetBackgroundColor", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_SetBackgroundColor>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pColor);
     }
 }
 
@@ -1697,11 +2759,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetBackgroundColor(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3DCOLORVALUE>* pColor)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetBackgroundColor(pColor->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetBackgroundColor>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pColor);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetBackgroundColor(pColor->GetPointer());
         CheckReplayResult("IDXGISwapChain1_GetBackgroundColor", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetBackgroundColor>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pColor);
     }
 }
 
@@ -1711,11 +2783,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_SetRotation(
     HRESULT                                     return_value,
     DXGI_MODE_ROTATION                          Rotation)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetRotation(Rotation);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_SetRotation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Rotation);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->SetRotation(Rotation);
         CheckReplayResult("IDXGISwapChain1_SetRotation", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_SetRotation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Rotation);
     }
 }
 
@@ -1725,11 +2807,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain1_GetRotation(
     HRESULT                                     return_value,
     PointerDecoder<DXGI_MODE_ROTATION>*         pRotation)
 {
-    auto replay_object = MapObject<IDXGISwapChain1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetRotation(pRotation->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetRotation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRotation);
+        auto replay_result = reinterpret_cast<IDXGISwapChain1*>(replay_object->object)->GetRotation(pRotation->GetPointer());
         CheckReplayResult("IDXGISwapChain1_GetRotation", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain1_GetRotation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRotation);
     }
 }
 
@@ -1738,10 +2830,18 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_IsWindowedStereoEnabled(
     format::HandleId                            object_id,
     BOOL                                        return_value)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->IsWindowedStereoEnabled();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_IsWindowedStereoEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->IsWindowedStereoEnabled();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_IsWindowedStereoEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -1759,6 +2859,16 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForHwnd(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForHwnd>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            hWnd,
+            pDesc,
+            pFullscreenDesc,
+            pRestrictToOutput,
+            ppSwapChain);
         auto in_pDevice = GetObjectInfo(pDevice);
         auto in_pRestrictToOutput = GetObjectInfo(pRestrictToOutput);
         if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
@@ -1777,6 +2887,16 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForHwnd(
             AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory2_CreateSwapChainForHwnd);
         }
         CheckReplayResult("IDXGIFactory2_CreateSwapChainForHwnd", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForHwnd>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            hWnd,
+            pDesc,
+            pFullscreenDesc,
+            pRestrictToOutput,
+            ppSwapChain);
     }
 }
 
@@ -1793,6 +2913,15 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForCoreWindow(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForCoreWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            pWindow,
+            pDesc,
+            pRestrictToOutput,
+            ppSwapChain);
         auto in_pDevice = GetObjectInfo(pDevice);
         auto in_pWindow = GetObjectInfo(pWindow);
         auto in_pRestrictToOutput = GetObjectInfo(pRestrictToOutput);
@@ -1811,6 +2940,15 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForCoreWindow(
             AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory2_CreateSwapChainForCoreWindow);
         }
         CheckReplayResult("IDXGIFactory2_CreateSwapChainForCoreWindow", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForCoreWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            pWindow,
+            pDesc,
+            pRestrictToOutput,
+            ppSwapChain);
     }
 }
 
@@ -1821,13 +2959,25 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_GetSharedResourceAdapterLuid(
     uint64_t                                    hResource,
     StructPointerDecoder<Decoded_LUID>*         pLuid)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_GetSharedResourceAdapterLuid>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hResource,
+            pLuid);
         auto in_hResource = static_cast<HANDLE>(PreProcessExternalObject(hResource, format::ApiCallId::ApiCall_IDXGIFactory2_GetSharedResourceAdapterLuid, "IDXGIFactory2_GetSharedResourceAdapterLuid"));
-        auto replay_result = replay_object->GetSharedResourceAdapterLuid(in_hResource,
-                                                                         pLuid->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->GetSharedResourceAdapterLuid(in_hResource,
+                                                                                                                   pLuid->GetPointer());
         CheckReplayResult("IDXGIFactory2_GetSharedResourceAdapterLuid", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_GetSharedResourceAdapterLuid>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hResource,
+            pLuid);
     }
 }
 
@@ -1839,14 +2989,28 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterStereoStatusWindow(
     UINT                                        wMsg,
     PointerDecoder<DWORD>*                      pdwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            WindowHandle,
+            wMsg,
+            pdwCookie);
         auto in_WindowHandle = static_cast<HWND>(PreProcessExternalObject(WindowHandle, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusWindow, "IDXGIFactory2_RegisterStereoStatusWindow"));
-        auto replay_result = replay_object->RegisterStereoStatusWindow(in_WindowHandle,
-                                                                       wMsg,
-                                                                       pdwCookie->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterStereoStatusWindow(in_WindowHandle,
+                                                                                                                 wMsg,
+                                                                                                                 pdwCookie->GetPointer());
         CheckReplayResult("IDXGIFactory2_RegisterStereoStatusWindow", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            WindowHandle,
+            wMsg,
+            pdwCookie);
     }
 }
 
@@ -1857,13 +3021,25 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterStereoStatusEvent(
     uint64_t                                    hEvent,
     PointerDecoder<DWORD>*                      pdwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusEvent, "IDXGIFactory2_RegisterStereoStatusEvent"));
-        auto replay_result = replay_object->RegisterStereoStatusEvent(in_hEvent,
-                                                                      pdwCookie->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterStereoStatusEvent(in_hEvent,
+                                                                                                                pdwCookie->GetPointer());
         CheckReplayResult("IDXGIFactory2_RegisterStereoStatusEvent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterStereoStatusEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
     }
 }
 
@@ -1872,10 +3048,20 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_UnregisterStereoStatus(
     format::HandleId                            object_id,
     DWORD                                       dwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->UnregisterStereoStatus(dwCookie);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_UnregisterStereoStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
+        reinterpret_cast<IDXGIFactory2*>(replay_object->object)->UnregisterStereoStatus(dwCookie);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_UnregisterStereoStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
     }
 }
 
@@ -1887,14 +3073,28 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterOcclusionStatusWindow(
     UINT                                        wMsg,
     PointerDecoder<DWORD>*                      pdwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            WindowHandle,
+            wMsg,
+            pdwCookie);
         auto in_WindowHandle = static_cast<HWND>(PreProcessExternalObject(WindowHandle, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusWindow, "IDXGIFactory2_RegisterOcclusionStatusWindow"));
-        auto replay_result = replay_object->RegisterOcclusionStatusWindow(in_WindowHandle,
-                                                                          wMsg,
-                                                                          pdwCookie->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterOcclusionStatusWindow(in_WindowHandle,
+                                                                                                                    wMsg,
+                                                                                                                    pdwCookie->GetPointer());
         CheckReplayResult("IDXGIFactory2_RegisterOcclusionStatusWindow", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusWindow>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            WindowHandle,
+            wMsg,
+            pdwCookie);
     }
 }
 
@@ -1905,13 +3105,25 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_RegisterOcclusionStatusEvent(
     uint64_t                                    hEvent,
     PointerDecoder<DWORD>*                      pdwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusEvent, "IDXGIFactory2_RegisterOcclusionStatusEvent"));
-        auto replay_result = replay_object->RegisterOcclusionStatusEvent(in_hEvent,
-                                                                         pdwCookie->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIFactory2*>(replay_object->object)->RegisterOcclusionStatusEvent(in_hEvent,
+                                                                                                                   pdwCookie->GetPointer());
         CheckReplayResult("IDXGIFactory2_RegisterOcclusionStatusEvent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_RegisterOcclusionStatusEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
     }
 }
 
@@ -1920,10 +3132,20 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_UnregisterOcclusionStatus(
     format::HandleId                            object_id,
     DWORD                                       dwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->UnregisterOcclusionStatus(dwCookie);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_UnregisterOcclusionStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
+        reinterpret_cast<IDXGIFactory2*>(replay_object->object)->UnregisterOcclusionStatus(dwCookie);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_UnregisterOcclusionStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
     }
 }
 
@@ -1939,6 +3161,14 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForComposition(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForComposition>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            pDesc,
+            pRestrictToOutput,
+            ppSwapChain);
         auto in_pDevice = GetObjectInfo(pDevice);
         auto in_pRestrictToOutput = GetObjectInfo(pRestrictToOutput);
         if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
@@ -1955,6 +3185,14 @@ void Dx12ReplayConsumer::Process_IDXGIFactory2_CreateSwapChainForComposition(
             AddObject(ppSwapChain->GetPointer(), ppSwapChain->GetHandlePointer(), std::move(object_info), format::ApiCall_IDXGIFactory2_CreateSwapChainForComposition);
         }
         CheckReplayResult("IDXGIFactory2_CreateSwapChainForComposition", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory2_CreateSwapChainForComposition>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            pDesc,
+            pRestrictToOutput,
+            ppSwapChain);
     }
 }
 
@@ -1964,11 +3202,21 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter2_GetDesc2(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC2>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIAdapter2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc2(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter2_GetDesc2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIAdapter2*>(replay_object->object)->GetDesc2(pDesc->GetPointer());
         CheckReplayResult("IDXGIAdapter2_GetDesc2", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter2_GetDesc2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -1981,14 +3229,30 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_GetDisplayModeList1(
     PointerDecoder<UINT>*                       pNumModes,
     StructPointerDecoder<Decoded_DXGI_MODE_DESC1>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIOutput1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDisplayModeList1(EnumFormat,
-                                                                Flags,
-                                                                pNumModes->GetPointer(),
-                                                                pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplayModeList1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EnumFormat,
+            Flags,
+            pNumModes,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->GetDisplayModeList1(EnumFormat,
+                                                                                                         Flags,
+                                                                                                         pNumModes->GetPointer(),
+                                                                                                         pDesc->GetPointer());
         CheckReplayResult("IDXGIOutput1_GetDisplayModeList1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplayModeList1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EnumFormat,
+            Flags,
+            pNumModes,
+            pDesc);
     }
 }
 
@@ -2000,14 +3264,28 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_FindClosestMatchingMode1(
     StructPointerDecoder<Decoded_DXGI_MODE_DESC1>* pClosestMatch,
     format::HandleId                            pConcernedDevice)
 {
-    auto replay_object = MapObject<IDXGIOutput1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput1_FindClosestMatchingMode1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pModeToMatch,
+            pClosestMatch,
+            pConcernedDevice);
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
-        auto replay_result = replay_object->FindClosestMatchingMode1(pModeToMatch->GetPointer(),
-                                                                     pClosestMatch->GetPointer(),
-                                                                     in_pConcernedDevice);
+        auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->FindClosestMatchingMode1(pModeToMatch->GetPointer(),
+                                                                                                              pClosestMatch->GetPointer(),
+                                                                                                              in_pConcernedDevice);
         CheckReplayResult("IDXGIOutput1_FindClosestMatchingMode1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_FindClosestMatchingMode1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pModeToMatch,
+            pClosestMatch,
+            pConcernedDevice);
     }
 }
 
@@ -2017,12 +3295,22 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_GetDisplaySurfaceData1(
     HRESULT                                     return_value,
     format::HandleId                            pDestination)
 {
-    auto replay_object = MapObject<IDXGIOutput1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplaySurfaceData1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDestination);
         auto in_pDestination = MapObject<IDXGIResource>(pDestination);
-        auto replay_result = replay_object->GetDisplaySurfaceData1(in_pDestination);
+        auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->GetDisplaySurfaceData1(in_pDestination);
         CheckReplayResult("IDXGIOutput1_GetDisplaySurfaceData1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_GetDisplaySurfaceData1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDestination);
     }
 }
 
@@ -2033,20 +3321,32 @@ void Dx12ReplayConsumer::Process_IDXGIOutput1_DuplicateOutput(
     format::HandleId                            pDevice,
     HandlePointerDecoder<IDXGIOutputDuplication*>* ppOutputDuplication)
 {
-    auto replay_object = MapObject<IDXGIOutput1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput1_DuplicateOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            ppOutputDuplication);
         auto in_pDevice = MapObject<IUnknown>(pDevice);
         if(!ppOutputDuplication->IsNull()) ppOutputDuplication->SetHandleLength(1);
         auto out_p_ppOutputDuplication    = ppOutputDuplication->GetPointer();
         auto out_hp_ppOutputDuplication   = ppOutputDuplication->GetHandlePointer();
-        auto replay_result = replay_object->DuplicateOutput(in_pDevice,
-                                                            out_hp_ppOutputDuplication);
+        auto replay_result = reinterpret_cast<IDXGIOutput1*>(replay_object->object)->DuplicateOutput(in_pDevice,
+                                                                                                     out_hp_ppOutputDuplication);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppOutputDuplication, out_hp_ppOutputDuplication, format::ApiCall_IDXGIOutput1_DuplicateOutput);
         }
         CheckReplayResult("IDXGIOutput1_DuplicateOutput", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput1_DuplicateOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            ppOutputDuplication);
     }
 }
 
@@ -2054,10 +3354,18 @@ void Dx12ReplayConsumer::Process_IDXGIDevice3_Trim(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<IDXGIDevice3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->Trim();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice3_Trim>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<IDXGIDevice3*>(replay_object->object)->Trim();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice3_Trim>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -2068,12 +3376,24 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_SetSourceSize(
     UINT                                        Width,
     UINT                                        Height)
 {
-    auto replay_object = MapObject<IDXGISwapChain2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetSourceSize(Width,
-                                                          Height);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain2_SetSourceSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Width,
+            Height);
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->SetSourceSize(Width,
+                                                                                                      Height);
         CheckReplayResult("IDXGISwapChain2_SetSourceSize", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_SetSourceSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Width,
+            Height);
     }
 }
 
@@ -2084,12 +3404,24 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_GetSourceSize(
     PointerDecoder<UINT>*                       pWidth,
     PointerDecoder<UINT>*                       pHeight)
 {
-    auto replay_object = MapObject<IDXGISwapChain2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetSourceSize(pWidth->GetPointer(),
-                                                          pHeight->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetSourceSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pWidth,
+            pHeight);
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetSourceSize(pWidth->GetPointer(),
+                                                                                                      pHeight->GetPointer());
         CheckReplayResult("IDXGISwapChain2_GetSourceSize", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetSourceSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pWidth,
+            pHeight);
     }
 }
 
@@ -2099,11 +3431,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_SetMaximumFrameLatency(
     HRESULT                                     return_value,
     UINT                                        MaxLatency)
 {
-    auto replay_object = MapObject<IDXGISwapChain2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetMaximumFrameLatency(MaxLatency);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain2_SetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MaxLatency);
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->SetMaximumFrameLatency(MaxLatency);
         CheckReplayResult("IDXGISwapChain2_SetMaximumFrameLatency", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_SetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MaxLatency);
     }
 }
 
@@ -2113,11 +3455,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_GetMaximumFrameLatency(
     HRESULT                                     return_value,
     PointerDecoder<UINT>*                       pMaxLatency)
 {
-    auto replay_object = MapObject<IDXGISwapChain2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetMaximumFrameLatency(pMaxLatency->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMaxLatency);
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetMaximumFrameLatency(pMaxLatency->GetPointer());
         CheckReplayResult("IDXGISwapChain2_GetMaximumFrameLatency", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetMaximumFrameLatency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMaxLatency);
     }
 }
 
@@ -2126,10 +3478,18 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_GetFrameLatencyWaitableObject(
     format::HandleId                            object_id,
     uint64_t                                    return_value)
 {
-    auto replay_object = MapObject<IDXGISwapChain2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFrameLatencyWaitableObject();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetFrameLatencyWaitableObject>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetFrameLatencyWaitableObject();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetFrameLatencyWaitableObject>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -2139,11 +3499,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_SetMatrixTransform(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_MATRIX_3X2_F>* pMatrix)
 {
-    auto replay_object = MapObject<IDXGISwapChain2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetMatrixTransform(pMatrix->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain2_SetMatrixTransform>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMatrix);
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->SetMatrixTransform(pMatrix->GetPointer());
         CheckReplayResult("IDXGISwapChain2_SetMatrixTransform", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_SetMatrixTransform>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMatrix);
     }
 }
 
@@ -2153,11 +3523,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain2_GetMatrixTransform(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_MATRIX_3X2_F>* pMatrix)
 {
-    auto replay_object = MapObject<IDXGISwapChain2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetMatrixTransform(pMatrix->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetMatrixTransform>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMatrix);
+        auto replay_result = reinterpret_cast<IDXGISwapChain2*>(replay_object->object)->GetMatrixTransform(pMatrix->GetPointer());
         CheckReplayResult("IDXGISwapChain2_GetMatrixTransform", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain2_GetMatrixTransform>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMatrix);
     }
 }
 
@@ -2166,10 +3546,18 @@ void Dx12ReplayConsumer::Process_IDXGIOutput2_SupportsOverlays(
     format::HandleId                            object_id,
     BOOL                                        return_value)
 {
-    auto replay_object = MapObject<IDXGIOutput2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SupportsOverlays();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput2_SupportsOverlays>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIOutput2*>(replay_object->object)->SupportsOverlays();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput2_SupportsOverlays>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -2178,10 +3566,18 @@ void Dx12ReplayConsumer::Process_IDXGIFactory3_GetCreationFlags(
     format::HandleId                            object_id,
     UINT                                        return_value)
 {
-    auto replay_object = MapObject<IDXGIFactory3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetCreationFlags();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory3_GetCreationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIFactory3*>(replay_object->object)->GetCreationFlags();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory3_GetCreationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -2193,13 +3589,27 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_PresentBuffer(
     UINT                                        SyncInterval,
     UINT                                        Flags)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->PresentBuffer(BufferToPresent,
-                                                          SyncInterval,
-                                                          Flags);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_PresentBuffer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BufferToPresent,
+            SyncInterval,
+            Flags);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->PresentBuffer(BufferToPresent,
+                                                                                                           SyncInterval,
+                                                                                                           Flags);
         CheckReplayResult("IDXGIDecodeSwapChain_PresentBuffer", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_PresentBuffer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BufferToPresent,
+            SyncInterval,
+            Flags);
     }
 }
 
@@ -2209,11 +3619,21 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_SetSourceRect(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_tagRECT>*      pRect)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetSourceRect(pRect->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetSourceRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->SetSourceRect(pRect->GetPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_SetSourceRect", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetSourceRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
     }
 }
 
@@ -2223,11 +3643,21 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_SetTargetRect(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_tagRECT>*      pRect)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetTargetRect(pRect->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetTargetRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->SetTargetRect(pRect->GetPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_SetTargetRect", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetTargetRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
     }
 }
 
@@ -2238,12 +3668,24 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_SetDestSize(
     UINT                                        Width,
     UINT                                        Height)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetDestSize(Width,
-                                                        Height);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetDestSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Width,
+            Height);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->SetDestSize(Width,
+                                                                                                         Height);
         CheckReplayResult("IDXGIDecodeSwapChain_SetDestSize", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetDestSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Width,
+            Height);
     }
 }
 
@@ -2253,11 +3695,21 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_GetSourceRect(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_tagRECT>*      pRect)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetSourceRect(pRect->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetSourceRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetSourceRect(pRect->GetPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_GetSourceRect", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetSourceRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
     }
 }
 
@@ -2267,11 +3719,21 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_GetTargetRect(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_tagRECT>*      pRect)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetTargetRect(pRect->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetTargetRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetTargetRect(pRect->GetPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_GetTargetRect", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetTargetRect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRect);
     }
 }
 
@@ -2282,12 +3744,24 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_GetDestSize(
     PointerDecoder<UINT>*                       pWidth,
     PointerDecoder<UINT>*                       pHeight)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDestSize(pWidth->GetPointer(),
-                                                        pHeight->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetDestSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pWidth,
+            pHeight);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetDestSize(pWidth->GetPointer(),
+                                                                                                         pHeight->GetPointer());
         CheckReplayResult("IDXGIDecodeSwapChain_GetDestSize", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetDestSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pWidth,
+            pHeight);
     }
 }
 
@@ -2297,11 +3771,21 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_SetColorSpace(
     HRESULT                                     return_value,
     DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS         ColorSpace)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetColorSpace(ColorSpace);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetColorSpace>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ColorSpace);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->SetColorSpace(ColorSpace);
         CheckReplayResult("IDXGIDecodeSwapChain_SetColorSpace", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_SetColorSpace>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ColorSpace);
     }
 }
 
@@ -2310,10 +3794,18 @@ void Dx12ReplayConsumer::Process_IDXGIDecodeSwapChain_GetColorSpace(
     format::HandleId                            object_id,
     DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS         return_value)
 {
-    auto replay_object = MapObject<IDXGIDecodeSwapChain>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetColorSpace();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetColorSpace>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGIDecodeSwapChain*>(replay_object->object)->GetColorSpace();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDecodeSwapChain_GetColorSpace>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -2327,25 +3819,43 @@ void Dx12ReplayConsumer::Process_IDXGIFactoryMedia_CreateSwapChainForComposition
     format::HandleId                            pRestrictToOutput,
     HandlePointerDecoder<IDXGISwapChain1*>*     ppSwapChain)
 {
-    auto replay_object = MapObject<IDXGIFactoryMedia>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            hSurface,
+            pDesc,
+            pRestrictToOutput,
+            ppSwapChain);
         auto in_pDevice = MapObject<IUnknown>(pDevice);
         auto in_hSurface = static_cast<HANDLE>(PreProcessExternalObject(hSurface, format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle, "IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle"));
         auto in_pRestrictToOutput = MapObject<IDXGIOutput>(pRestrictToOutput);
         if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
         auto out_p_ppSwapChain    = ppSwapChain->GetPointer();
         auto out_hp_ppSwapChain   = ppSwapChain->GetHandlePointer();
-        auto replay_result = replay_object->CreateSwapChainForCompositionSurfaceHandle(in_pDevice,
-                                                                                       in_hSurface,
-                                                                                       pDesc->GetPointer(),
-                                                                                       in_pRestrictToOutput,
-                                                                                       out_hp_ppSwapChain);
+        auto replay_result = reinterpret_cast<IDXGIFactoryMedia*>(replay_object->object)->CreateSwapChainForCompositionSurfaceHandle(in_pDevice,
+                                                                                                                                     in_hSurface,
+                                                                                                                                     pDesc->GetPointer(),
+                                                                                                                                     in_pRestrictToOutput,
+                                                                                                                                     out_hp_ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppSwapChain, out_hp_ppSwapChain, format::ApiCall_IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle);
         }
         CheckReplayResult("IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateSwapChainForCompositionSurfaceHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            hSurface,
+            pDesc,
+            pRestrictToOutput,
+            ppSwapChain);
     }
 }
 
@@ -2360,9 +3870,19 @@ void Dx12ReplayConsumer::Process_IDXGIFactoryMedia_CreateDecodeSwapChainForCompo
     format::HandleId                            pRestrictToOutput,
     HandlePointerDecoder<IDXGIDecodeSwapChain*>* ppSwapChain)
 {
-    auto replay_object = MapObject<IDXGIFactoryMedia>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            hSurface,
+            pDesc,
+            pYuvDecodeBuffers,
+            pRestrictToOutput,
+            ppSwapChain);
         auto in_pDevice = MapObject<IUnknown>(pDevice);
         auto in_hSurface = static_cast<HANDLE>(PreProcessExternalObject(hSurface, format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle, "IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle"));
         auto in_pYuvDecodeBuffers = MapObject<IDXGIResource>(pYuvDecodeBuffers);
@@ -2370,17 +3890,27 @@ void Dx12ReplayConsumer::Process_IDXGIFactoryMedia_CreateDecodeSwapChainForCompo
         if(!ppSwapChain->IsNull()) ppSwapChain->SetHandleLength(1);
         auto out_p_ppSwapChain    = ppSwapChain->GetPointer();
         auto out_hp_ppSwapChain   = ppSwapChain->GetHandlePointer();
-        auto replay_result = replay_object->CreateDecodeSwapChainForCompositionSurfaceHandle(in_pDevice,
-                                                                                             in_hSurface,
-                                                                                             pDesc->GetPointer(),
-                                                                                             in_pYuvDecodeBuffers,
-                                                                                             in_pRestrictToOutput,
-                                                                                             out_hp_ppSwapChain);
+        auto replay_result = reinterpret_cast<IDXGIFactoryMedia*>(replay_object->object)->CreateDecodeSwapChainForCompositionSurfaceHandle(in_pDevice,
+                                                                                                                                           in_hSurface,
+                                                                                                                                           pDesc->GetPointer(),
+                                                                                                                                           in_pYuvDecodeBuffers,
+                                                                                                                                           in_pRestrictToOutput,
+                                                                                                                                           out_hp_ppSwapChain);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppSwapChain, out_hp_ppSwapChain, format::ApiCall_IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle);
         }
         CheckReplayResult("IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactoryMedia_CreateDecodeSwapChainForCompositionSurfaceHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            hSurface,
+            pDesc,
+            pYuvDecodeBuffers,
+            pRestrictToOutput,
+            ppSwapChain);
     }
 }
 
@@ -2390,11 +3920,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChainMedia_GetFrameStatisticsMedia(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_FRAME_STATISTICS_MEDIA>* pStats)
 {
-    auto replay_object = MapObject<IDXGISwapChainMedia>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFrameStatisticsMedia(pStats->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_GetFrameStatisticsMedia>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStats);
+        auto replay_result = reinterpret_cast<IDXGISwapChainMedia*>(replay_object->object)->GetFrameStatisticsMedia(pStats->GetPointer());
         CheckReplayResult("IDXGISwapChainMedia_GetFrameStatisticsMedia", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_GetFrameStatisticsMedia>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStats);
     }
 }
 
@@ -2404,11 +3944,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChainMedia_SetPresentDuration(
     HRESULT                                     return_value,
     UINT                                        Duration)
 {
-    auto replay_object = MapObject<IDXGISwapChainMedia>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetPresentDuration(Duration);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_SetPresentDuration>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Duration);
+        auto replay_result = reinterpret_cast<IDXGISwapChainMedia*>(replay_object->object)->SetPresentDuration(Duration);
         CheckReplayResult("IDXGISwapChainMedia_SetPresentDuration", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_SetPresentDuration>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Duration);
     }
 }
 
@@ -2420,13 +3970,27 @@ void Dx12ReplayConsumer::Process_IDXGISwapChainMedia_CheckPresentDurationSupport
     PointerDecoder<UINT>*                       pClosestSmallerPresentDuration,
     PointerDecoder<UINT>*                       pClosestLargerPresentDuration)
 {
-    auto replay_object = MapObject<IDXGISwapChainMedia>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->CheckPresentDurationSupport(DesiredPresentDuration,
-                                                                        pClosestSmallerPresentDuration->GetPointer(),
-                                                                        pClosestLargerPresentDuration->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_CheckPresentDurationSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DesiredPresentDuration,
+            pClosestSmallerPresentDuration,
+            pClosestLargerPresentDuration);
+        auto replay_result = reinterpret_cast<IDXGISwapChainMedia*>(replay_object->object)->CheckPresentDurationSupport(DesiredPresentDuration,
+                                                                                                                        pClosestSmallerPresentDuration->GetPointer(),
+                                                                                                                        pClosestLargerPresentDuration->GetPointer());
         CheckReplayResult("IDXGISwapChainMedia_CheckPresentDurationSupport", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChainMedia_CheckPresentDurationSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DesiredPresentDuration,
+            pClosestSmallerPresentDuration,
+            pClosestLargerPresentDuration);
     }
 }
 
@@ -2438,14 +4002,28 @@ void Dx12ReplayConsumer::Process_IDXGIOutput3_CheckOverlaySupport(
     format::HandleId                            pConcernedDevice,
     PointerDecoder<UINT>*                       pFlags)
 {
-    auto replay_object = MapObject<IDXGIOutput3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput3_CheckOverlaySupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EnumFormat,
+            pConcernedDevice,
+            pFlags);
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
-        auto replay_result = replay_object->CheckOverlaySupport(EnumFormat,
-                                                                in_pConcernedDevice,
-                                                                pFlags->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIOutput3*>(replay_object->object)->CheckOverlaySupport(EnumFormat,
+                                                                                                         in_pConcernedDevice,
+                                                                                                         pFlags->GetPointer());
         CheckReplayResult("IDXGIOutput3_CheckOverlaySupport", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput3_CheckOverlaySupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            EnumFormat,
+            pConcernedDevice,
+            pFlags);
     }
 }
 
@@ -2454,10 +4032,18 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain3_GetCurrentBackBufferIndex(
     format::HandleId                            object_id,
     UINT                                        return_value)
 {
-    auto replay_object = MapObject<IDXGISwapChain3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetCurrentBackBufferIndex();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain3_GetCurrentBackBufferIndex>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<IDXGISwapChain3*>(replay_object->object)->GetCurrentBackBufferIndex();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain3_GetCurrentBackBufferIndex>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -2468,12 +4054,24 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain3_CheckColorSpaceSupport(
     DXGI_COLOR_SPACE_TYPE                       ColorSpace,
     PointerDecoder<UINT>*                       pColorSpaceSupport)
 {
-    auto replay_object = MapObject<IDXGISwapChain3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->CheckColorSpaceSupport(ColorSpace,
-                                                                   pColorSpaceSupport->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain3_CheckColorSpaceSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ColorSpace,
+            pColorSpaceSupport);
+        auto replay_result = reinterpret_cast<IDXGISwapChain3*>(replay_object->object)->CheckColorSpaceSupport(ColorSpace,
+                                                                                                               pColorSpaceSupport->GetPointer());
         CheckReplayResult("IDXGISwapChain3_CheckColorSpaceSupport", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain3_CheckColorSpaceSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ColorSpace,
+            pColorSpaceSupport);
     }
 }
 
@@ -2483,11 +4081,21 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain3_SetColorSpace1(
     HRESULT                                     return_value,
     DXGI_COLOR_SPACE_TYPE                       ColorSpace)
 {
-    auto replay_object = MapObject<IDXGISwapChain3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetColorSpace1(ColorSpace);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain3_SetColorSpace1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ColorSpace);
+        auto replay_result = reinterpret_cast<IDXGISwapChain3*>(replay_object->object)->SetColorSpace1(ColorSpace);
         CheckReplayResult("IDXGISwapChain3_SetColorSpace1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain3_SetColorSpace1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ColorSpace);
     }
 }
 
@@ -2506,6 +4114,17 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain3_ResizeBuffers1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain3_ResizeBuffers1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BufferCount,
+            Width,
+            Height,
+            Format,
+            SwapChainFlags,
+            pCreationNodeMask,
+            ppPresentQueue);
         MapObjects<IUnknown>(ppPresentQueue, BufferCount);
         auto replay_result = OverrideResizeBuffers1(replay_object,
                                                     return_value,
@@ -2517,6 +4136,17 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain3_ResizeBuffers1(
                                                     pCreationNodeMask,
                                                     ppPresentQueue);
         CheckReplayResult("IDXGISwapChain3_ResizeBuffers1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain3_ResizeBuffers1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BufferCount,
+            Width,
+            Height,
+            Format,
+            SwapChainFlags,
+            pCreationNodeMask,
+            ppPresentQueue);
     }
 }
 
@@ -2529,15 +4159,31 @@ void Dx12ReplayConsumer::Process_IDXGIOutput4_CheckOverlayColorSpaceSupport(
     format::HandleId                            pConcernedDevice,
     PointerDecoder<UINT>*                       pFlags)
 {
-    auto replay_object = MapObject<IDXGIOutput4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput4_CheckOverlayColorSpaceSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Format,
+            ColorSpace,
+            pConcernedDevice,
+            pFlags);
         auto in_pConcernedDevice = MapObject<IUnknown>(pConcernedDevice);
-        auto replay_result = replay_object->CheckOverlayColorSpaceSupport(Format,
-                                                                          ColorSpace,
-                                                                          in_pConcernedDevice,
-                                                                          pFlags->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIOutput4*>(replay_object->object)->CheckOverlayColorSpaceSupport(Format,
+                                                                                                                   ColorSpace,
+                                                                                                                   in_pConcernedDevice,
+                                                                                                                   pFlags->GetPointer());
         CheckReplayResult("IDXGIOutput4_CheckOverlayColorSpaceSupport", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput4_CheckOverlayColorSpaceSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Format,
+            ColorSpace,
+            pConcernedDevice,
+            pFlags);
     }
 }
 
@@ -2549,20 +4195,34 @@ void Dx12ReplayConsumer::Process_IDXGIFactory4_EnumAdapterByLuid(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvAdapter)
 {
-    auto replay_object = MapObject<IDXGIFactory4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory4_EnumAdapterByLuid>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            AdapterLuid,
+            riid,
+            ppvAdapter);
         if(!ppvAdapter->IsNull()) ppvAdapter->SetHandleLength(1);
         auto out_p_ppvAdapter    = ppvAdapter->GetPointer();
         auto out_hp_ppvAdapter   = ppvAdapter->GetHandlePointer();
-        auto replay_result = replay_object->EnumAdapterByLuid(*AdapterLuid.decoded_value,
-                                                              *riid.decoded_value,
-                                                              out_hp_ppvAdapter);
+        auto replay_result = reinterpret_cast<IDXGIFactory4*>(replay_object->object)->EnumAdapterByLuid(*AdapterLuid.decoded_value,
+                                                                                                        *riid.decoded_value,
+                                                                                                        out_hp_ppvAdapter);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvAdapter, out_hp_ppvAdapter, format::ApiCall_IDXGIFactory4_EnumAdapterByLuid);
         }
         CheckReplayResult("IDXGIFactory4_EnumAdapterByLuid", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory4_EnumAdapterByLuid>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            AdapterLuid,
+            riid,
+            ppvAdapter);
     }
 }
 
@@ -2573,19 +4233,31 @@ void Dx12ReplayConsumer::Process_IDXGIFactory4_EnumWarpAdapter(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvAdapter)
 {
-    auto replay_object = MapObject<IDXGIFactory4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory4_EnumWarpAdapter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppvAdapter);
         if(!ppvAdapter->IsNull()) ppvAdapter->SetHandleLength(1);
         auto out_p_ppvAdapter    = ppvAdapter->GetPointer();
         auto out_hp_ppvAdapter   = ppvAdapter->GetHandlePointer();
-        auto replay_result = replay_object->EnumWarpAdapter(*riid.decoded_value,
-                                                            out_hp_ppvAdapter);
+        auto replay_result = reinterpret_cast<IDXGIFactory4*>(replay_object->object)->EnumWarpAdapter(*riid.decoded_value,
+                                                                                                      out_hp_ppvAdapter);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvAdapter, out_hp_ppvAdapter, format::ApiCall_IDXGIFactory4_EnumWarpAdapter);
         }
         CheckReplayResult("IDXGIFactory4_EnumWarpAdapter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory4_EnumWarpAdapter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppvAdapter);
     }
 }
 
@@ -2596,13 +4268,25 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_RegisterHardwareContentProtection
     uint64_t                                    hEvent,
     PointerDecoder<DWORD>*                      pdwCookie)
 {
-    auto replay_object = MapObject<IDXGIAdapter3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent, "IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent"));
-        auto replay_result = replay_object->RegisterHardwareContentProtectionTeardownStatusEvent(in_hEvent,
-                                                                                                 pdwCookie->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->RegisterHardwareContentProtectionTeardownStatusEvent(in_hEvent,
+                                                                                                                                           pdwCookie->GetPointer());
         CheckReplayResult("IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterHardwareContentProtectionTeardownStatusEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
     }
 }
 
@@ -2611,10 +4295,20 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_UnregisterHardwareContentProtecti
     format::HandleId                            object_id,
     DWORD                                       dwCookie)
 {
-    auto replay_object = MapObject<IDXGIAdapter3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->UnregisterHardwareContentProtectionTeardownStatus(dwCookie);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter3_UnregisterHardwareContentProtectionTeardownStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
+        reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->UnregisterHardwareContentProtectionTeardownStatus(dwCookie);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_UnregisterHardwareContentProtectionTeardownStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
     }
 }
 
@@ -2626,13 +4320,27 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_QueryVideoMemoryInfo(
     DXGI_MEMORY_SEGMENT_GROUP                   MemorySegmentGroup,
     StructPointerDecoder<Decoded_DXGI_QUERY_VIDEO_MEMORY_INFO>* pVideoMemoryInfo)
 {
-    auto replay_object = MapObject<IDXGIAdapter3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->QueryVideoMemoryInfo(NodeIndex,
-                                                                 MemorySegmentGroup,
-                                                                 pVideoMemoryInfo->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter3_QueryVideoMemoryInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NodeIndex,
+            MemorySegmentGroup,
+            pVideoMemoryInfo);
+        auto replay_result = reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->QueryVideoMemoryInfo(NodeIndex,
+                                                                                                           MemorySegmentGroup,
+                                                                                                           pVideoMemoryInfo->GetPointer());
         CheckReplayResult("IDXGIAdapter3_QueryVideoMemoryInfo", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_QueryVideoMemoryInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NodeIndex,
+            MemorySegmentGroup,
+            pVideoMemoryInfo);
     }
 }
 
@@ -2644,13 +4352,27 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_SetVideoMemoryReservation(
     DXGI_MEMORY_SEGMENT_GROUP                   MemorySegmentGroup,
     UINT64                                      Reservation)
 {
-    auto replay_object = MapObject<IDXGIAdapter3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetVideoMemoryReservation(NodeIndex,
-                                                                      MemorySegmentGroup,
-                                                                      Reservation);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter3_SetVideoMemoryReservation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NodeIndex,
+            MemorySegmentGroup,
+            Reservation);
+        auto replay_result = reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->SetVideoMemoryReservation(NodeIndex,
+                                                                                                                MemorySegmentGroup,
+                                                                                                                Reservation);
         CheckReplayResult("IDXGIAdapter3_SetVideoMemoryReservation", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_SetVideoMemoryReservation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NodeIndex,
+            MemorySegmentGroup,
+            Reservation);
     }
 }
 
@@ -2661,13 +4383,25 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNo
     uint64_t                                    hEvent,
     PointerDecoder<DWORD>*                      pdwCookie)
 {
-    auto replay_object = MapObject<IDXGIAdapter3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent, "IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent"));
-        auto replay_result = replay_object->RegisterVideoMemoryBudgetChangeNotificationEvent(in_hEvent,
-                                                                                             pdwCookie->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->RegisterVideoMemoryBudgetChangeNotificationEvent(in_hEvent,
+                                                                                                                                       pdwCookie->GetPointer());
         CheckReplayResult("IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_RegisterVideoMemoryBudgetChangeNotificationEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
     }
 }
 
@@ -2676,10 +4410,20 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter3_UnregisterVideoMemoryBudgetChange
     format::HandleId                            object_id,
     DWORD                                       dwCookie)
 {
-    auto replay_object = MapObject<IDXGIAdapter3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->UnregisterVideoMemoryBudgetChangeNotification(dwCookie);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter3_UnregisterVideoMemoryBudgetChangeNotification>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
+        reinterpret_cast<IDXGIAdapter3*>(replay_object->object)->UnregisterVideoMemoryBudgetChangeNotification(dwCookie);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter3_UnregisterVideoMemoryBudgetChangeNotification>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
     }
 }
 
@@ -2693,23 +4437,41 @@ void Dx12ReplayConsumer::Process_IDXGIOutput5_DuplicateOutput1(
     PointerDecoder<DXGI_FORMAT>*                pSupportedFormats,
     HandlePointerDecoder<IDXGIOutputDuplication*>* ppOutputDuplication)
 {
-    auto replay_object = MapObject<IDXGIOutput5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput5_DuplicateOutput1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            Flags,
+            SupportedFormatsCount,
+            pSupportedFormats,
+            ppOutputDuplication);
         auto in_pDevice = MapObject<IUnknown>(pDevice);
         if(!ppOutputDuplication->IsNull()) ppOutputDuplication->SetHandleLength(1);
         auto out_p_ppOutputDuplication    = ppOutputDuplication->GetPointer();
         auto out_hp_ppOutputDuplication   = ppOutputDuplication->GetHandlePointer();
-        auto replay_result = replay_object->DuplicateOutput1(in_pDevice,
-                                                             Flags,
-                                                             SupportedFormatsCount,
-                                                             pSupportedFormats->GetPointer(),
-                                                             out_hp_ppOutputDuplication);
+        auto replay_result = reinterpret_cast<IDXGIOutput5*>(replay_object->object)->DuplicateOutput1(in_pDevice,
+                                                                                                      Flags,
+                                                                                                      SupportedFormatsCount,
+                                                                                                      pSupportedFormats->GetPointer(),
+                                                                                                      out_hp_ppOutputDuplication);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppOutputDuplication, out_hp_ppOutputDuplication, format::ApiCall_IDXGIOutput5_DuplicateOutput1);
         }
         CheckReplayResult("IDXGIOutput5_DuplicateOutput1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput5_DuplicateOutput1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDevice,
+            Flags,
+            SupportedFormatsCount,
+            pSupportedFormats,
+            ppOutputDuplication);
     }
 }
 
@@ -2721,13 +4483,27 @@ void Dx12ReplayConsumer::Process_IDXGISwapChain4_SetHDRMetaData(
     UINT                                        Size,
     PointerDecoder<uint8_t>*                    pMetaData)
 {
-    auto replay_object = MapObject<IDXGISwapChain4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetHDRMetaData(Type,
-                                                           Size,
-                                                           pMetaData->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMetaData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            Size,
+            pMetaData);
+        auto replay_result = reinterpret_cast<IDXGISwapChain4*>(replay_object->object)->SetHDRMetaData(Type,
+                                                                                                       Size,
+                                                                                                       pMetaData->GetPointer());
         CheckReplayResult("IDXGISwapChain4_SetHDRMetaData", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGISwapChain4_SetHDRMetaData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            Size,
+            pMetaData);
     }
 }
 
@@ -2740,15 +4516,31 @@ void Dx12ReplayConsumer::Process_IDXGIDevice4_OfferResources1(
     DXGI_OFFER_RESOURCE_PRIORITY                Priority,
     UINT                                        Flags)
 {
-    auto replay_object = MapObject<IDXGIDevice4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice4_OfferResources1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            Priority,
+            Flags);
         auto in_ppResources = MapObjects<IDXGIResource>(ppResources, NumResources);
-        auto replay_result = replay_object->OfferResources1(NumResources,
-                                                            in_ppResources,
-                                                            Priority,
-                                                            Flags);
+        auto replay_result = reinterpret_cast<IDXGIDevice4*>(replay_object->object)->OfferResources1(NumResources,
+                                                                                                     in_ppResources,
+                                                                                                     Priority,
+                                                                                                     Flags);
         CheckReplayResult("IDXGIDevice4_OfferResources1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice4_OfferResources1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            Priority,
+            Flags);
     }
 }
 
@@ -2760,14 +4552,28 @@ void Dx12ReplayConsumer::Process_IDXGIDevice4_ReclaimResources1(
     HandlePointerDecoder<IDXGIResource*>*       ppResources,
     PointerDecoder<DXGI_RECLAIM_RESOURCE_RESULTS>* pResults)
 {
-    auto replay_object = MapObject<IDXGIDevice4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIDevice4_ReclaimResources1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            pResults);
         auto in_ppResources = MapObjects<IDXGIResource>(ppResources, NumResources);
-        auto replay_result = replay_object->ReclaimResources1(NumResources,
-                                                              in_ppResources,
-                                                              pResults->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIDevice4*>(replay_object->object)->ReclaimResources1(NumResources,
+                                                                                                       in_ppResources,
+                                                                                                       pResults->GetPointer());
         CheckReplayResult("IDXGIDevice4_ReclaimResources1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIDevice4_ReclaimResources1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumResources,
+            ppResources,
+            pResults);
     }
 }
 
@@ -2777,11 +4583,21 @@ void Dx12ReplayConsumer::Process_IDXGIAdapter4_GetDesc3(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_ADAPTER_DESC3>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIAdapter4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc3(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIAdapter4_GetDesc3>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIAdapter4*>(replay_object->object)->GetDesc3(pDesc->GetPointer());
         CheckReplayResult("IDXGIAdapter4_GetDesc3", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIAdapter4_GetDesc3>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -2791,11 +4607,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutput6_GetDesc1(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_DXGI_OUTPUT_DESC1>* pDesc)
 {
-    auto replay_object = MapObject<IDXGIOutput6>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc1(pDesc->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput6_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
+        auto replay_result = reinterpret_cast<IDXGIOutput6*>(replay_object->object)->GetDesc1(pDesc->GetPointer());
         CheckReplayResult("IDXGIOutput6_GetDesc1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput6_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -2805,11 +4631,21 @@ void Dx12ReplayConsumer::Process_IDXGIOutput6_CheckHardwareCompositionSupport(
     HRESULT                                     return_value,
     PointerDecoder<UINT>*                       pFlags)
 {
-    auto replay_object = MapObject<IDXGIOutput6>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->CheckHardwareCompositionSupport(pFlags->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIOutput6_CheckHardwareCompositionSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFlags);
+        auto replay_result = reinterpret_cast<IDXGIOutput6*>(replay_object->object)->CheckHardwareCompositionSupport(pFlags->GetPointer());
         CheckReplayResult("IDXGIOutput6_CheckHardwareCompositionSupport", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIOutput6_CheckHardwareCompositionSupport>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFlags);
     }
 }
 
@@ -2822,21 +4658,37 @@ void Dx12ReplayConsumer::Process_IDXGIFactory6_EnumAdapterByGpuPreference(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvAdapter)
 {
-    auto replay_object = MapObject<IDXGIFactory6>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory6_EnumAdapterByGpuPreference>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Adapter,
+            GpuPreference,
+            riid,
+            ppvAdapter);
         if(!ppvAdapter->IsNull()) ppvAdapter->SetHandleLength(1);
         auto out_p_ppvAdapter    = ppvAdapter->GetPointer();
         auto out_hp_ppvAdapter   = ppvAdapter->GetHandlePointer();
-        auto replay_result = replay_object->EnumAdapterByGpuPreference(Adapter,
-                                                                       GpuPreference,
-                                                                       *riid.decoded_value,
-                                                                       out_hp_ppvAdapter);
+        auto replay_result = reinterpret_cast<IDXGIFactory6*>(replay_object->object)->EnumAdapterByGpuPreference(Adapter,
+                                                                                                                 GpuPreference,
+                                                                                                                 *riid.decoded_value,
+                                                                                                                 out_hp_ppvAdapter);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvAdapter, out_hp_ppvAdapter, format::ApiCall_IDXGIFactory6_EnumAdapterByGpuPreference);
         }
         CheckReplayResult("IDXGIFactory6_EnumAdapterByGpuPreference", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory6_EnumAdapterByGpuPreference>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Adapter,
+            GpuPreference,
+            riid,
+            ppvAdapter);
     }
 }
 
@@ -2847,13 +4699,25 @@ void Dx12ReplayConsumer::Process_IDXGIFactory7_RegisterAdaptersChangedEvent(
     uint64_t                                    hEvent,
     PointerDecoder<DWORD>*                      pdwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory7>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory7_RegisterAdaptersChangedEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_IDXGIFactory7_RegisterAdaptersChangedEvent, "IDXGIFactory7_RegisterAdaptersChangedEvent"));
-        auto replay_result = replay_object->RegisterAdaptersChangedEvent(in_hEvent,
-                                                                         pdwCookie->GetPointer());
+        auto replay_result = reinterpret_cast<IDXGIFactory7*>(replay_object->object)->RegisterAdaptersChangedEvent(in_hEvent,
+                                                                                                                   pdwCookie->GetPointer());
         CheckReplayResult("IDXGIFactory7_RegisterAdaptersChangedEvent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory7_RegisterAdaptersChangedEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hEvent,
+            pdwCookie);
     }
 }
 
@@ -2863,11 +4727,21 @@ void Dx12ReplayConsumer::Process_IDXGIFactory7_UnregisterAdaptersChangedEvent(
     HRESULT                                     return_value,
     DWORD                                       dwCookie)
 {
-    auto replay_object = MapObject<IDXGIFactory7>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->UnregisterAdaptersChangedEvent(dwCookie);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IDXGIFactory7_UnregisterAdaptersChangedEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
+        auto replay_result = reinterpret_cast<IDXGIFactory7*>(replay_object->object)->UnregisterAdaptersChangedEvent(dwCookie);
         CheckReplayResult("IDXGIFactory7_UnregisterAdaptersChangedEvent", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IDXGIFactory7_UnregisterAdaptersChangedEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            dwCookie);
     }
 }
 
@@ -2879,13 +4753,27 @@ void Dx12ReplayConsumer::Process_ID3D12Object_GetPrivateData(
     PointerDecoder<UINT>*                       pDataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    auto replay_object = MapObject<ID3D12Object>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetPrivateData(*guid.decoded_value,
-                                                           pDataSize->GetPointer(),
-                                                           pData->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Object_GetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid,
+            pDataSize,
+            pData);
+        auto replay_result = reinterpret_cast<ID3D12Object*>(replay_object->object)->GetPrivateData(*guid.decoded_value,
+                                                                                                    pDataSize->GetPointer(),
+                                                                                                    pData->GetPointer());
         CheckReplayResult("ID3D12Object_GetPrivateData", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Object_GetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid,
+            pDataSize,
+            pData);
     }
 }
 
@@ -2897,13 +4785,27 @@ void Dx12ReplayConsumer::Process_ID3D12Object_SetPrivateData(
     UINT                                        DataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    auto replay_object = MapObject<ID3D12Object>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetPrivateData(*guid.decoded_value,
-                                                           DataSize,
-                                                           pData->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Object_SetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid,
+            DataSize,
+            pData);
+        auto replay_result = reinterpret_cast<ID3D12Object*>(replay_object->object)->SetPrivateData(*guid.decoded_value,
+                                                                                                    DataSize,
+                                                                                                    pData->GetPointer());
         CheckReplayResult("ID3D12Object_SetPrivateData", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Object_SetPrivateData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid,
+            DataSize,
+            pData);
     }
 }
 
@@ -2914,13 +4816,25 @@ void Dx12ReplayConsumer::Process_ID3D12Object_SetPrivateDataInterface(
     Decoded_GUID                                guid,
     format::HandleId                            pData)
 {
-    auto replay_object = MapObject<ID3D12Object>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Object_SetPrivateDataInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid,
+            pData);
         auto in_pData = MapObject<IUnknown>(pData);
-        auto replay_result = replay_object->SetPrivateDataInterface(*guid.decoded_value,
-                                                                    in_pData);
+        auto replay_result = reinterpret_cast<ID3D12Object*>(replay_object->object)->SetPrivateDataInterface(*guid.decoded_value,
+                                                                                                             in_pData);
         CheckReplayResult("ID3D12Object_SetPrivateDataInterface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Object_SetPrivateDataInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid,
+            pData);
     }
 }
 
@@ -2933,10 +4847,20 @@ void Dx12ReplayConsumer::Process_ID3D12Object_SetName(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Object_SetName>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name);
         auto replay_result = OverrideSetName(replay_object,
                                              return_value,
                                              Name);
         CheckReplayResult("ID3D12Object_SetName", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Object_SetName>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name);
     }
 }
 
@@ -2947,19 +4871,31 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceChild_GetDevice(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvDevice)
 {
-    auto replay_object = MapObject<ID3D12DeviceChild>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceChild_GetDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppvDevice);
         if(!ppvDevice->IsNull()) ppvDevice->SetHandleLength(1);
         auto out_p_ppvDevice    = ppvDevice->GetPointer();
         auto out_hp_ppvDevice   = ppvDevice->GetHandlePointer();
-        auto replay_result = replay_object->GetDevice(*riid.decoded_value,
-                                                      out_hp_ppvDevice);
+        auto replay_result = reinterpret_cast<ID3D12DeviceChild*>(replay_object->object)->GetDevice(*riid.decoded_value,
+                                                                                                    out_hp_ppvDevice);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvDevice, out_hp_ppvDevice, format::ApiCall_ID3D12DeviceChild_GetDevice);
         }
         CheckReplayResult("ID3D12DeviceChild_GetDevice", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceChild_GetDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppvDevice);
     }
 }
 
@@ -2968,10 +4904,18 @@ void Dx12ReplayConsumer::Process_ID3D12RootSignatureDeserializer_GetRootSignatur
     format::HandleId                            object_id,
     StructPointerDecoder<Decoded_D3D12_ROOT_SIGNATURE_DESC>* return_value)
 {
-    auto replay_object = MapObject<ID3D12RootSignatureDeserializer>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetRootSignatureDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12RootSignatureDeserializer_GetRootSignatureDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12RootSignatureDeserializer*>(replay_object->object)->GetRootSignatureDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12RootSignatureDeserializer_GetRootSignatureDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -2982,13 +4926,25 @@ void Dx12ReplayConsumer::Process_ID3D12VersionedRootSignatureDeserializer_GetRoo
     D3D_ROOT_SIGNATURE_VERSION                  convertToVersion,
     StructPointerDecoder<Decoded_D3D12_VERSIONED_ROOT_SIGNATURE_DESC>* ppDesc)
 {
-    auto replay_object = MapObject<ID3D12VersionedRootSignatureDeserializer>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            convertToVersion,
+            ppDesc);
         auto in_ppDesc    = ppDesc->GetPointer();
-        auto replay_result = replay_object->GetRootSignatureDescAtVersion(convertToVersion,
-                                                                          const_cast<const D3D12_VERSIONED_ROOT_SIGNATURE_DESC**>(&in_ppDesc));
+        auto replay_result = reinterpret_cast<ID3D12VersionedRootSignatureDeserializer*>(replay_object->object)->GetRootSignatureDescAtVersion(convertToVersion,
+                                                                                                                                               const_cast<const D3D12_VERSIONED_ROOT_SIGNATURE_DESC**>(&in_ppDesc));
         CheckReplayResult("ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12VersionedRootSignatureDeserializer_GetRootSignatureDescAtVersion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            convertToVersion,
+            ppDesc);
     }
 }
 
@@ -2997,10 +4953,18 @@ void Dx12ReplayConsumer::Process_ID3D12VersionedRootSignatureDeserializer_GetUnc
     format::HandleId                            object_id,
     StructPointerDecoder<Decoded_D3D12_VERSIONED_ROOT_SIGNATURE_DESC>* return_value)
 {
-    auto replay_object = MapObject<ID3D12VersionedRootSignatureDeserializer>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetUnconvertedRootSignatureDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12VersionedRootSignatureDeserializer_GetUnconvertedRootSignatureDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12VersionedRootSignatureDeserializer*>(replay_object->object)->GetUnconvertedRootSignatureDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12VersionedRootSignatureDeserializer_GetUnconvertedRootSignatureDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3009,10 +4973,18 @@ void Dx12ReplayConsumer::Process_ID3D12Heap_GetDesc(
     format::HandleId                            object_id,
     Decoded_D3D12_HEAP_DESC                     return_value)
 {
-    auto replay_object = MapObject<ID3D12Heap>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Heap_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Heap*>(replay_object->object)->GetDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Heap_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3027,6 +4999,13 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_Map(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource_Map>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Subresource,
+            pReadRange,
+            ppData);
         if(!ppData->IsNull())
         {
             ppData->AllocateOutputData(1);
@@ -3037,6 +5016,13 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_Map(
                                                  pReadRange,
                                                  ppData);
         CheckReplayResult("ID3D12Resource_Map", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource_Map>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Subresource,
+            pReadRange,
+            ppData);
     }
 }
 
@@ -3049,9 +5035,21 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_Unmap(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource_Unmap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Subresource,
+            pWrittenRange);
         OverrideResourceUnmap(replay_object,
                               Subresource,
                               pWrittenRange);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource_Unmap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Subresource,
+            pWrittenRange);
     }
 }
 
@@ -3060,10 +5058,18 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_GetDesc(
     format::HandleId                            object_id,
     Decoded_D3D12_RESOURCE_DESC                 return_value)
 {
-    auto replay_object = MapObject<ID3D12Resource>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Resource*>(replay_object->object)->GetDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3075,8 +5081,16 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_GetGPUVirtualAddress(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource_GetGPUVirtualAddress>::Dispatch(
+            this,
+            call_info,
+            replay_object);
         auto replay_result = OverrideGetGpuVirtualAddress(replay_object,
                                                           return_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource_GetGPUVirtualAddress>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3093,6 +5107,15 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_ReadFromSubresource(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource_ReadFromSubresource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstData,
+            DstRowPitch,
+            DstDepthPitch,
+            SrcSubresource,
+            pSrcBox);
         auto replay_result = OverrideReadFromSubresource(replay_object,
                                                          return_value,
                                                          pDstData,
@@ -3101,6 +5124,15 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_ReadFromSubresource(
                                                          SrcSubresource,
                                                          pSrcBox);
         CheckReplayResult("ID3D12Resource_ReadFromSubresource", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource_ReadFromSubresource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstData,
+            DstRowPitch,
+            DstDepthPitch,
+            SrcSubresource,
+            pSrcBox);
     }
 }
 
@@ -3111,12 +5143,24 @@ void Dx12ReplayConsumer::Process_ID3D12Resource_GetHeapProperties(
     StructPointerDecoder<Decoded_D3D12_HEAP_PROPERTIES>* pHeapProperties,
     PointerDecoder<D3D12_HEAP_FLAGS>*           pHeapFlags)
 {
-    auto replay_object = MapObject<ID3D12Resource>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetHeapProperties(pHeapProperties->GetPointer(),
-                                                              pHeapFlags->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource_GetHeapProperties>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            pHeapFlags);
+        auto replay_result = reinterpret_cast<ID3D12Resource*>(replay_object->object)->GetHeapProperties(pHeapProperties->GetPointer(),
+                                                                                                         pHeapFlags->GetPointer());
         CheckReplayResult("ID3D12Resource_GetHeapProperties", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource_GetHeapProperties>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            pHeapFlags);
     }
 }
 
@@ -3125,11 +5169,19 @@ void Dx12ReplayConsumer::Process_ID3D12CommandAllocator_Reset(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12CommandAllocator>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->Reset();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandAllocator_Reset>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12CommandAllocator*>(replay_object->object)->Reset();
         CheckReplayResult("ID3D12CommandAllocator_Reset", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandAllocator_Reset>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3141,8 +5193,16 @@ void Dx12ReplayConsumer::Process_ID3D12Fence_GetCompletedValue(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Fence_GetCompletedValue>::Dispatch(
+            this,
+            call_info,
+            replay_object);
         auto replay_result = OverrideGetCompletedValue(replay_object,
                                                        return_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Fence_GetCompletedValue>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3156,11 +5216,23 @@ void Dx12ReplayConsumer::Process_ID3D12Fence_SetEventOnCompletion(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Fence_SetEventOnCompletion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Value,
+            hEvent);
         auto replay_result = OverrideSetEventOnCompletion(replay_object,
                                                           return_value,
                                                           Value,
                                                           hEvent);
         CheckReplayResult("ID3D12Fence_SetEventOnCompletion", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Fence_SetEventOnCompletion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Value,
+            hEvent);
     }
 }
 
@@ -3173,10 +5245,20 @@ void Dx12ReplayConsumer::Process_ID3D12Fence_Signal(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Fence_Signal>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Value);
         auto replay_result = OverrideFenceSignal(replay_object,
                                                  return_value,
                                                  Value);
         CheckReplayResult("ID3D12Fence_Signal", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Fence_Signal>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Value);
     }
 }
 
@@ -3185,10 +5267,18 @@ void Dx12ReplayConsumer::Process_ID3D12Fence1_GetCreationFlags(
     format::HandleId                            object_id,
     D3D12_FENCE_FLAGS                           return_value)
 {
-    auto replay_object = MapObject<ID3D12Fence1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetCreationFlags();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Fence1_GetCreationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Fence1*>(replay_object->object)->GetCreationFlags();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Fence1_GetCreationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3198,18 +5288,28 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineState_GetCachedBlob(
     HRESULT                                     return_value,
     HandlePointerDecoder<ID3D10Blob*>*          ppBlob)
 {
-    auto replay_object = MapObject<ID3D12PipelineState>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12PipelineState_GetCachedBlob>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppBlob);
         if(!ppBlob->IsNull()) ppBlob->SetHandleLength(1);
         auto out_p_ppBlob    = ppBlob->GetPointer();
         auto out_hp_ppBlob   = ppBlob->GetHandlePointer();
-        auto replay_result = replay_object->GetCachedBlob(out_hp_ppBlob);
+        auto replay_result = reinterpret_cast<ID3D12PipelineState*>(replay_object->object)->GetCachedBlob(out_hp_ppBlob);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppBlob, out_hp_ppBlob, format::ApiCall_ID3D12PipelineState_GetCachedBlob);
         }
         CheckReplayResult("ID3D12PipelineState_GetCachedBlob", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineState_GetCachedBlob>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppBlob);
     }
 }
 
@@ -3218,10 +5318,18 @@ void Dx12ReplayConsumer::Process_ID3D12DescriptorHeap_GetDesc(
     format::HandleId                            object_id,
     Decoded_D3D12_DESCRIPTOR_HEAP_DESC          return_value)
 {
-    auto replay_object = MapObject<ID3D12DescriptorHeap>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DescriptorHeap*>(replay_object->object)->GetDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3233,8 +5341,16 @@ void Dx12ReplayConsumer::Process_ID3D12DescriptorHeap_GetCPUDescriptorHandleForH
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart>::Dispatch(
+            this,
+            call_info,
+            replay_object);
         auto replay_result = OverrideGetCPUDescriptorHandleForHeapStart(replay_object,
                                                                         return_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3246,8 +5362,16 @@ void Dx12ReplayConsumer::Process_ID3D12DescriptorHeap_GetGPUDescriptorHandleForH
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart>::Dispatch(
+            this,
+            call_info,
+            replay_object);
         auto replay_result = OverrideGetGPUDescriptorHandleForHeapStart(replay_object,
                                                                         return_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3256,10 +5380,18 @@ void Dx12ReplayConsumer::Process_ID3D12CommandList_GetType(
     format::HandleId                            object_id,
     D3D12_COMMAND_LIST_TYPE                     return_value)
 {
-    auto replay_object = MapObject<ID3D12CommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetType();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandList_GetType>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12CommandList*>(replay_object->object)->GetType();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandList_GetType>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3268,11 +5400,19 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_Close(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->Close();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Close>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->Close();
         CheckReplayResult("ID3D12GraphicsCommandList_Close", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Close>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -3286,6 +5426,12 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_Reset(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Reset>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAllocator,
+            pInitialState);
         auto in_pAllocator = GetObjectInfo(pAllocator);
         auto in_pInitialState = GetObjectInfo(pInitialState);
         auto replay_result = OverrideCommandListReset(replay_object,
@@ -3293,6 +5439,12 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_Reset(
                                                       in_pAllocator,
                                                       in_pInitialState);
         CheckReplayResult("ID3D12GraphicsCommandList_Reset", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Reset>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAllocator,
+            pInitialState);
     }
 }
 
@@ -3301,11 +5453,21 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ClearState(
     format::HandleId                            object_id,
     format::HandleId                            pPipelineState)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pPipelineState);
         auto in_pPipelineState = MapObject<ID3D12PipelineState>(pPipelineState);
-        replay_object->ClearState(in_pPipelineState);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ClearState(in_pPipelineState);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pPipelineState);
     }
 }
 
@@ -3317,13 +5479,29 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_DrawInstanced(
     UINT                                        StartVertexLocation,
     UINT                                        StartInstanceLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->DrawInstanced(VertexCountPerInstance,
-                                     InstanceCount,
-                                     StartVertexLocation,
-                                     StartInstanceLocation);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawInstanced>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            VertexCountPerInstance,
+            InstanceCount,
+            StartVertexLocation,
+            StartInstanceLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->DrawInstanced(VertexCountPerInstance,
+                                                                                           InstanceCount,
+                                                                                           StartVertexLocation,
+                                                                                           StartInstanceLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawInstanced>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            VertexCountPerInstance,
+            InstanceCount,
+            StartVertexLocation,
+            StartInstanceLocation);
     }
 }
 
@@ -3336,14 +5514,32 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_DrawIndexedInstanced(
     INT                                         BaseVertexLocation,
     UINT                                        StartInstanceLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->DrawIndexedInstanced(IndexCountPerInstance,
-                                            InstanceCount,
-                                            StartIndexLocation,
-                                            BaseVertexLocation,
-                                            StartInstanceLocation);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawIndexedInstanced>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            IndexCountPerInstance,
+            InstanceCount,
+            StartIndexLocation,
+            BaseVertexLocation,
+            StartInstanceLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->DrawIndexedInstanced(IndexCountPerInstance,
+                                                                                                  InstanceCount,
+                                                                                                  StartIndexLocation,
+                                                                                                  BaseVertexLocation,
+                                                                                                  StartInstanceLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DrawIndexedInstanced>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            IndexCountPerInstance,
+            InstanceCount,
+            StartIndexLocation,
+            BaseVertexLocation,
+            StartInstanceLocation);
     }
 }
 
@@ -3354,12 +5550,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_Dispatch(
     UINT                                        ThreadGroupCountY,
     UINT                                        ThreadGroupCountZ)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->Dispatch(ThreadGroupCountX,
-                                ThreadGroupCountY,
-                                ThreadGroupCountZ);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Dispatch>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ThreadGroupCountX,
+            ThreadGroupCountY,
+            ThreadGroupCountZ);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->Dispatch(ThreadGroupCountX,
+                                                                                      ThreadGroupCountY,
+                                                                                      ThreadGroupCountZ);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Dispatch>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ThreadGroupCountX,
+            ThreadGroupCountY,
+            ThreadGroupCountZ);
     }
 }
 
@@ -3375,6 +5585,15 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_CopyBufferRegion(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyBufferRegion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstBuffer,
+            DstOffset,
+            pSrcBuffer,
+            SrcOffset,
+            NumBytes);
         auto in_pDstBuffer = GetObjectInfo(pDstBuffer);
         auto in_pSrcBuffer = GetObjectInfo(pSrcBuffer);
         OverrideCopyBufferRegion(replay_object,
@@ -3383,6 +5602,15 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_CopyBufferRegion(
                                  in_pSrcBuffer,
                                  SrcOffset,
                                  NumBytes);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyBufferRegion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstBuffer,
+            DstOffset,
+            pSrcBuffer,
+            SrcOffset,
+            NumBytes);
     }
 }
 
@@ -3399,6 +5627,16 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_CopyTextureRegion(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyTextureRegion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDst,
+            DstX,
+            DstY,
+            DstZ,
+            pSrc,
+            pSrcBox);
         MapStructObjects(pDst->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         MapStructObjects(pSrc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         OverrideCopyTextureRegion(replay_object,
@@ -3408,6 +5646,16 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_CopyTextureRegion(
                                   DstZ,
                                   pSrc,
                                   pSrcBox);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyTextureRegion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDst,
+            DstX,
+            DstY,
+            DstZ,
+            pSrc,
+            pSrcBox);
     }
 }
 
@@ -3420,11 +5668,23 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_CopyResource(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            pSrcResource);
         auto in_pDstResource = GetObjectInfo(pDstResource);
         auto in_pSrcResource = GetObjectInfo(pSrcResource);
         OverrideCopyResource(replay_object,
                              in_pDstResource,
                              in_pSrcResource);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            pSrcResource);
     }
 }
 
@@ -3438,17 +5698,37 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_CopyTiles(
     UINT64                                      BufferStartOffsetInBytes,
     D3D12_TILE_COPY_FLAGS                       Flags)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyTiles>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pTiledResource,
+            pTileRegionStartCoordinate,
+            pTileRegionSize,
+            pBuffer,
+            BufferStartOffsetInBytes,
+            Flags);
         auto in_pTiledResource = MapObject<ID3D12Resource>(pTiledResource);
         auto in_pBuffer = MapObject<ID3D12Resource>(pBuffer);
-        replay_object->CopyTiles(in_pTiledResource,
-                                 pTileRegionStartCoordinate->GetPointer(),
-                                 pTileRegionSize->GetPointer(),
-                                 in_pBuffer,
-                                 BufferStartOffsetInBytes,
-                                 Flags);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->CopyTiles(in_pTiledResource,
+                                                                                       pTileRegionStartCoordinate->GetPointer(),
+                                                                                       pTileRegionSize->GetPointer(),
+                                                                                       in_pBuffer,
+                                                                                       BufferStartOffsetInBytes,
+                                                                                       Flags);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_CopyTiles>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pTiledResource,
+            pTileRegionStartCoordinate,
+            pTileRegionSize,
+            pBuffer,
+            BufferStartOffsetInBytes,
+            Flags);
     }
 }
 
@@ -3461,16 +5741,34 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ResolveSubresource(
     UINT                                        SrcSubresource,
     DXGI_FORMAT                                 Format)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResolveSubresource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            DstSubresource,
+            pSrcResource,
+            SrcSubresource,
+            Format);
         auto in_pDstResource = MapObject<ID3D12Resource>(pDstResource);
         auto in_pSrcResource = MapObject<ID3D12Resource>(pSrcResource);
-        replay_object->ResolveSubresource(in_pDstResource,
-                                          DstSubresource,
-                                          in_pSrcResource,
-                                          SrcSubresource,
-                                          Format);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ResolveSubresource(in_pDstResource,
+                                                                                                DstSubresource,
+                                                                                                in_pSrcResource,
+                                                                                                SrcSubresource,
+                                                                                                Format);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResolveSubresource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            DstSubresource,
+            pSrcResource,
+            SrcSubresource,
+            Format);
     }
 }
 
@@ -3479,10 +5777,20 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_IASetPrimitiveTopolog
     format::HandleId                            object_id,
     D3D_PRIMITIVE_TOPOLOGY                      PrimitiveTopology)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->IASetPrimitiveTopology(PrimitiveTopology);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetPrimitiveTopology>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            PrimitiveTopology);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->IASetPrimitiveTopology(PrimitiveTopology);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetPrimitiveTopology>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            PrimitiveTopology);
     }
 }
 
@@ -3492,11 +5800,23 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_RSSetViewports(
     UINT                                        NumViewports,
     StructPointerDecoder<Decoded_D3D12_VIEWPORT>* pViewports)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->RSSetViewports(NumViewports,
-                                      pViewports->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_RSSetViewports>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumViewports,
+            pViewports);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->RSSetViewports(NumViewports,
+                                                                                            pViewports->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_RSSetViewports>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumViewports,
+            pViewports);
     }
 }
 
@@ -3506,11 +5826,23 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_RSSetScissorRects(
     UINT                                        NumRects,
     StructPointerDecoder<Decoded_tagRECT>*      pRects)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->RSSetScissorRects(NumRects,
-                                         pRects->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_RSSetScissorRects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumRects,
+            pRects);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->RSSetScissorRects(NumRects,
+                                                                                               pRects->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_RSSetScissorRects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumRects,
+            pRects);
     }
 }
 
@@ -3519,10 +5851,20 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_OMSetBlendFactor(
     format::HandleId                            object_id,
     PointerDecoder<FLOAT>*                      BlendFactor)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->OMSetBlendFactor(BlendFactor->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetBlendFactor>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BlendFactor);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->OMSetBlendFactor(BlendFactor->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetBlendFactor>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            BlendFactor);
     }
 }
 
@@ -3531,10 +5873,20 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_OMSetStencilRef(
     format::HandleId                            object_id,
     UINT                                        StencilRef)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->OMSetStencilRef(StencilRef);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetStencilRef>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            StencilRef);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->OMSetStencilRef(StencilRef);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetStencilRef>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            StencilRef);
     }
 }
 
@@ -3543,11 +5895,21 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetPipelineState(
     format::HandleId                            object_id,
     format::HandleId                            pPipelineState)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetPipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pPipelineState);
         auto in_pPipelineState = MapObject<ID3D12PipelineState>(pPipelineState);
-        replay_object->SetPipelineState(in_pPipelineState);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetPipelineState(in_pPipelineState);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetPipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pPipelineState);
     }
 }
 
@@ -3557,12 +5919,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ResourceBarrier(
     UINT                                        NumBarriers,
     StructPointerDecoder<Decoded_D3D12_RESOURCE_BARRIER>* pBarriers)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResourceBarrier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumBarriers,
+            pBarriers);
         MapStructArrayObjects(pBarriers->GetMetaStructPointer(), pBarriers->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->ResourceBarrier(NumBarriers,
-                                       pBarriers->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ResourceBarrier(NumBarriers,
+                                                                                             pBarriers->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResourceBarrier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumBarriers,
+            pBarriers);
     }
 }
 
@@ -3571,11 +5945,21 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ExecuteBundle(
     format::HandleId                            object_id,
     format::HandleId                            pCommandList)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteBundle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pCommandList);
         auto in_pCommandList = MapObject<ID3D12GraphicsCommandList>(pCommandList);
-        replay_object->ExecuteBundle(in_pCommandList);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ExecuteBundle(in_pCommandList);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteBundle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pCommandList);
     }
 }
 
@@ -3585,12 +5969,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetDescriptorHeaps(
     UINT                                        NumDescriptorHeaps,
     HandlePointerDecoder<ID3D12DescriptorHeap*>* ppDescriptorHeaps)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetDescriptorHeaps>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumDescriptorHeaps,
+            ppDescriptorHeaps);
         auto in_ppDescriptorHeaps = MapObjects<ID3D12DescriptorHeap>(ppDescriptorHeaps, NumDescriptorHeaps);
-        replay_object->SetDescriptorHeaps(NumDescriptorHeaps,
-                                          in_ppDescriptorHeaps);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetDescriptorHeaps(NumDescriptorHeaps,
+                                                                                                in_ppDescriptorHeaps);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetDescriptorHeaps>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumDescriptorHeaps,
+            ppDescriptorHeaps);
     }
 }
 
@@ -3599,11 +5995,21 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootSignatu
     format::HandleId                            object_id,
     format::HandleId                            pRootSignature)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRootSignature);
         auto in_pRootSignature = MapObject<ID3D12RootSignature>(pRootSignature);
-        replay_object->SetComputeRootSignature(in_pRootSignature);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetComputeRootSignature(in_pRootSignature);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRootSignature);
     }
 }
 
@@ -3612,11 +6018,21 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootSignat
     format::HandleId                            object_id,
     format::HandleId                            pRootSignature)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRootSignature);
         auto in_pRootSignature = MapObject<ID3D12RootSignature>(pRootSignature);
-        replay_object->SetGraphicsRootSignature(in_pRootSignature);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetGraphicsRootSignature(in_pRootSignature);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pRootSignature);
     }
 }
 
@@ -3626,12 +6042,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootDescrip
     UINT                                        RootParameterIndex,
     Decoded_D3D12_GPU_DESCRIPTOR_HANDLE         BaseDescriptor)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootDescriptorTable>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BaseDescriptor);
         MapGpuDescriptorHandle(*BaseDescriptor.decoded_value);
-        replay_object->SetComputeRootDescriptorTable(RootParameterIndex,
-                                                     *BaseDescriptor.decoded_value);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetComputeRootDescriptorTable(RootParameterIndex,
+                                                                                                           *BaseDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootDescriptorTable>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BaseDescriptor);
     }
 }
 
@@ -3641,12 +6069,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootDescri
     UINT                                        RootParameterIndex,
     Decoded_D3D12_GPU_DESCRIPTOR_HANDLE         BaseDescriptor)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BaseDescriptor);
         MapGpuDescriptorHandle(*BaseDescriptor.decoded_value);
-        replay_object->SetGraphicsRootDescriptorTable(RootParameterIndex,
-                                                      *BaseDescriptor.decoded_value);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetGraphicsRootDescriptorTable(RootParameterIndex,
+                                                                                                            *BaseDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BaseDescriptor);
     }
 }
 
@@ -3657,12 +6097,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetComputeRoot32BitCo
     UINT                                        SrcData,
     UINT                                        DestOffsetIn32BitValues)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetComputeRoot32BitConstant(RootParameterIndex,
-                                                   SrcData,
-                                                   DestOffsetIn32BitValues);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstant>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            SrcData,
+            DestOffsetIn32BitValues);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetComputeRoot32BitConstant(RootParameterIndex,
+                                                                                                         SrcData,
+                                                                                                         DestOffsetIn32BitValues);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstant>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            SrcData,
+            DestOffsetIn32BitValues);
     }
 }
 
@@ -3673,12 +6127,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRoot32BitC
     UINT                                        SrcData,
     UINT                                        DestOffsetIn32BitValues)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetGraphicsRoot32BitConstant(RootParameterIndex,
-                                                    SrcData,
-                                                    DestOffsetIn32BitValues);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstant>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            SrcData,
+            DestOffsetIn32BitValues);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetGraphicsRoot32BitConstant(RootParameterIndex,
+                                                                                                          SrcData,
+                                                                                                          DestOffsetIn32BitValues);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstant>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            SrcData,
+            DestOffsetIn32BitValues);
     }
 }
 
@@ -3690,13 +6158,29 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetComputeRoot32BitCo
     PointerDecoder<uint8_t>*                    pSrcData,
     UINT                                        DestOffsetIn32BitValues)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetComputeRoot32BitConstants(RootParameterIndex,
-                                                    Num32BitValuesToSet,
-                                                    pSrcData->GetPointer(),
-                                                    DestOffsetIn32BitValues);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstants>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            Num32BitValuesToSet,
+            pSrcData,
+            DestOffsetIn32BitValues);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetComputeRoot32BitConstants(RootParameterIndex,
+                                                                                                          Num32BitValuesToSet,
+                                                                                                          pSrcData->GetPointer(),
+                                                                                                          DestOffsetIn32BitValues);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRoot32BitConstants>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            Num32BitValuesToSet,
+            pSrcData,
+            DestOffsetIn32BitValues);
     }
 }
 
@@ -3708,13 +6192,29 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRoot32BitC
     PointerDecoder<uint8_t>*                    pSrcData,
     UINT                                        DestOffsetIn32BitValues)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetGraphicsRoot32BitConstants(RootParameterIndex,
-                                                     Num32BitValuesToSet,
-                                                     pSrcData->GetPointer(),
-                                                     DestOffsetIn32BitValues);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstants>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            Num32BitValuesToSet,
+            pSrcData,
+            DestOffsetIn32BitValues);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetGraphicsRoot32BitConstants(RootParameterIndex,
+                                                                                                           Num32BitValuesToSet,
+                                                                                                           pSrcData->GetPointer(),
+                                                                                                           DestOffsetIn32BitValues);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRoot32BitConstants>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            Num32BitValuesToSet,
+            pSrcData,
+            DestOffsetIn32BitValues);
     }
 }
 
@@ -3724,12 +6224,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootConstan
     UINT                                        RootParameterIndex,
     D3D12_GPU_VIRTUAL_ADDRESS                   BufferLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootConstantBufferView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
         MapGpuVirtualAddress(BufferLocation);
-        replay_object->SetComputeRootConstantBufferView(RootParameterIndex,
-                                                        BufferLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetComputeRootConstantBufferView(RootParameterIndex,
+                                                                                                              BufferLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootConstantBufferView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
     }
 }
 
@@ -3739,12 +6251,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootConsta
     UINT                                        RootParameterIndex,
     D3D12_GPU_VIRTUAL_ADDRESS                   BufferLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
         MapGpuVirtualAddress(BufferLocation);
-        replay_object->SetGraphicsRootConstantBufferView(RootParameterIndex,
-                                                         BufferLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetGraphicsRootConstantBufferView(RootParameterIndex,
+                                                                                                               BufferLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
     }
 }
 
@@ -3754,12 +6278,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootShaderR
     UINT                                        RootParameterIndex,
     D3D12_GPU_VIRTUAL_ADDRESS                   BufferLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootShaderResourceView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
         MapGpuVirtualAddress(BufferLocation);
-        replay_object->SetComputeRootShaderResourceView(RootParameterIndex,
-                                                        BufferLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetComputeRootShaderResourceView(RootParameterIndex,
+                                                                                                              BufferLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootShaderResourceView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
     }
 }
 
@@ -3769,12 +6305,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootShader
     UINT                                        RootParameterIndex,
     D3D12_GPU_VIRTUAL_ADDRESS                   BufferLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootShaderResourceView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
         MapGpuVirtualAddress(BufferLocation);
-        replay_object->SetGraphicsRootShaderResourceView(RootParameterIndex,
-                                                         BufferLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetGraphicsRootShaderResourceView(RootParameterIndex,
+                                                                                                               BufferLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootShaderResourceView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
     }
 }
 
@@ -3784,12 +6332,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetComputeRootUnorder
     UINT                                        RootParameterIndex,
     D3D12_GPU_VIRTUAL_ADDRESS                   BufferLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
         MapGpuVirtualAddress(BufferLocation);
-        replay_object->SetComputeRootUnorderedAccessView(RootParameterIndex,
-                                                         BufferLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetComputeRootUnorderedAccessView(RootParameterIndex,
+                                                                                                               BufferLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetComputeRootUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
     }
 }
 
@@ -3799,12 +6359,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetGraphicsRootUnorde
     UINT                                        RootParameterIndex,
     D3D12_GPU_VIRTUAL_ADDRESS                   BufferLocation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
         MapGpuVirtualAddress(BufferLocation);
-        replay_object->SetGraphicsRootUnorderedAccessView(RootParameterIndex,
-                                                          BufferLocation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetGraphicsRootUnorderedAccessView(RootParameterIndex,
+                                                                                                                BufferLocation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetGraphicsRootUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RootParameterIndex,
+            BufferLocation);
     }
 }
 
@@ -3816,9 +6388,19 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_IASetIndexBuffer(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetIndexBuffer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pView);
         MapStructObjects(pView->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         OverrideIASetIndexBuffer(replay_object,
                                  pView);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetIndexBuffer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pView);
     }
 }
 
@@ -3832,11 +6414,25 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_IASetVertexBuffers(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetVertexBuffers>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            StartSlot,
+            NumViews,
+            pViews);
         MapStructArrayObjects(pViews->GetMetaStructPointer(), pViews->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
         OverrideIASetVertexBuffers(replay_object,
                                    StartSlot,
                                    NumViews,
                                    pViews);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_IASetVertexBuffers>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            StartSlot,
+            NumViews,
+            pViews);
     }
 }
 
@@ -3847,13 +6443,27 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SOSetTargets(
     UINT                                        NumViews,
     StructPointerDecoder<Decoded_D3D12_STREAM_OUTPUT_BUFFER_VIEW>* pViews)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SOSetTargets>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            StartSlot,
+            NumViews,
+            pViews);
         MapStructArrayObjects(pViews->GetMetaStructPointer(), pViews->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->SOSetTargets(StartSlot,
-                                    NumViews,
-                                    pViews->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SOSetTargets(StartSlot,
+                                                                                          NumViews,
+                                                                                          pViews->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SOSetTargets>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            StartSlot,
+            NumViews,
+            pViews);
     }
 }
 
@@ -3865,15 +6475,31 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_OMSetRenderTargets(
     BOOL                                        RTsSingleHandleToDescriptorRange,
     StructPointerDecoder<Decoded_D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetRenderTargets>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumRenderTargetDescriptors,
+            pRenderTargetDescriptors,
+            RTsSingleHandleToDescriptorRange,
+            pDepthStencilDescriptor);
         MapStructArrayObjects(pRenderTargetDescriptors->GetMetaStructPointer(), pRenderTargetDescriptors->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
         MapStructObjects(pDepthStencilDescriptor->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->OMSetRenderTargets(NumRenderTargetDescriptors,
-                                          pRenderTargetDescriptors->GetPointer(),
-                                          RTsSingleHandleToDescriptorRange,
-                                          pDepthStencilDescriptor->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->OMSetRenderTargets(NumRenderTargetDescriptors,
+                                                                                                pRenderTargetDescriptors->GetPointer(),
+                                                                                                RTsSingleHandleToDescriptorRange,
+                                                                                                pDepthStencilDescriptor->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_OMSetRenderTargets>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumRenderTargetDescriptors,
+            pRenderTargetDescriptors,
+            RTsSingleHandleToDescriptorRange,
+            pDepthStencilDescriptor);
     }
 }
 
@@ -3887,16 +6513,36 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ClearDepthStencilView
     UINT                                        NumRects,
     StructPointerDecoder<Decoded_tagRECT>*      pRects)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearDepthStencilView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DepthStencilView,
+            ClearFlags,
+            Depth,
+            Stencil,
+            NumRects,
+            pRects);
         MapStructObjects(&DepthStencilView, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->ClearDepthStencilView(*DepthStencilView.decoded_value,
-                                             ClearFlags,
-                                             Depth,
-                                             Stencil,
-                                             NumRects,
-                                             pRects->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ClearDepthStencilView(*DepthStencilView.decoded_value,
+                                                                                                   ClearFlags,
+                                                                                                   Depth,
+                                                                                                   Stencil,
+                                                                                                   NumRects,
+                                                                                                   pRects->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearDepthStencilView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DepthStencilView,
+            ClearFlags,
+            Depth,
+            Stencil,
+            NumRects,
+            pRects);
     }
 }
 
@@ -3908,14 +6554,30 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ClearRenderTargetView
     UINT                                        NumRects,
     StructPointerDecoder<Decoded_tagRECT>*      pRects)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearRenderTargetView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RenderTargetView,
+            ColorRGBA,
+            NumRects,
+            pRects);
         MapStructObjects(&RenderTargetView, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->ClearRenderTargetView(*RenderTargetView.decoded_value,
-                                             ColorRGBA->GetPointer(),
-                                             NumRects,
-                                             pRects->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ClearRenderTargetView(*RenderTargetView.decoded_value,
+                                                                                                   ColorRGBA->GetPointer(),
+                                                                                                   NumRects,
+                                                                                                   pRects->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearRenderTargetView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            RenderTargetView,
+            ColorRGBA,
+            NumRects,
+            pRects);
     }
 }
 
@@ -3929,18 +6591,38 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ClearUnorderedAccessV
     UINT                                        NumRects,
     StructPointerDecoder<Decoded_tagRECT>*      pRects)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewUint>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ViewGPUHandleInCurrentHeap,
+            ViewCPUHandle,
+            pResource,
+            Values,
+            NumRects,
+            pRects);
         MapGpuDescriptorHandle(*ViewGPUHandleInCurrentHeap.decoded_value);
         MapStructObjects(&ViewCPUHandle, GetObjectInfoTable(), GetGpuVaTable());
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        replay_object->ClearUnorderedAccessViewUint(*ViewGPUHandleInCurrentHeap.decoded_value,
-                                                    *ViewCPUHandle.decoded_value,
-                                                    in_pResource,
-                                                    Values->GetPointer(),
-                                                    NumRects,
-                                                    pRects->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ClearUnorderedAccessViewUint(*ViewGPUHandleInCurrentHeap.decoded_value,
+                                                                                                          *ViewCPUHandle.decoded_value,
+                                                                                                          in_pResource,
+                                                                                                          Values->GetPointer(),
+                                                                                                          NumRects,
+                                                                                                          pRects->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewUint>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ViewGPUHandleInCurrentHeap,
+            ViewCPUHandle,
+            pResource,
+            Values,
+            NumRects,
+            pRects);
     }
 }
 
@@ -3954,18 +6636,38 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ClearUnorderedAccessV
     UINT                                        NumRects,
     StructPointerDecoder<Decoded_tagRECT>*      pRects)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewFloat>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ViewGPUHandleInCurrentHeap,
+            ViewCPUHandle,
+            pResource,
+            Values,
+            NumRects,
+            pRects);
         MapGpuDescriptorHandle(*ViewGPUHandleInCurrentHeap.decoded_value);
         MapStructObjects(&ViewCPUHandle, GetObjectInfoTable(), GetGpuVaTable());
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        replay_object->ClearUnorderedAccessViewFloat(*ViewGPUHandleInCurrentHeap.decoded_value,
-                                                     *ViewCPUHandle.decoded_value,
-                                                     in_pResource,
-                                                     Values->GetPointer(),
-                                                     NumRects,
-                                                     pRects->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ClearUnorderedAccessViewFloat(*ViewGPUHandleInCurrentHeap.decoded_value,
+                                                                                                           *ViewCPUHandle.decoded_value,
+                                                                                                           in_pResource,
+                                                                                                           Values->GetPointer(),
+                                                                                                           NumRects,
+                                                                                                           pRects->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ClearUnorderedAccessViewFloat>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ViewGPUHandleInCurrentHeap,
+            ViewCPUHandle,
+            pResource,
+            Values,
+            NumRects,
+            pRects);
     }
 }
 
@@ -3975,12 +6677,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_DiscardResource(
     format::HandleId                            pResource,
     StructPointerDecoder<Decoded_D3D12_DISCARD_REGION>* pRegion)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DiscardResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pRegion);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        replay_object->DiscardResource(in_pResource,
-                                       pRegion->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->DiscardResource(in_pResource,
+                                                                                             pRegion->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_DiscardResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pRegion);
     }
 }
 
@@ -3991,13 +6705,27 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_BeginQuery(
     D3D12_QUERY_TYPE                            Type,
     UINT                                        Index)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_BeginQuery>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pQueryHeap,
+            Type,
+            Index);
         auto in_pQueryHeap = MapObject<ID3D12QueryHeap>(pQueryHeap);
-        replay_object->BeginQuery(in_pQueryHeap,
-                                  Type,
-                                  Index);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->BeginQuery(in_pQueryHeap,
+                                                                                        Type,
+                                                                                        Index);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_BeginQuery>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pQueryHeap,
+            Type,
+            Index);
     }
 }
 
@@ -4008,13 +6736,27 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_EndQuery(
     D3D12_QUERY_TYPE                            Type,
     UINT                                        Index)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_EndQuery>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pQueryHeap,
+            Type,
+            Index);
         auto in_pQueryHeap = MapObject<ID3D12QueryHeap>(pQueryHeap);
-        replay_object->EndQuery(in_pQueryHeap,
-                                Type,
-                                Index);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->EndQuery(in_pQueryHeap,
+                                                                                      Type,
+                                                                                      Index);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_EndQuery>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pQueryHeap,
+            Type,
+            Index);
     }
 }
 
@@ -4028,17 +6770,37 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ResolveQueryData(
     format::HandleId                            pDestinationBuffer,
     UINT64                                      AlignedDestinationBufferOffset)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResolveQueryData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pQueryHeap,
+            Type,
+            StartIndex,
+            NumQueries,
+            pDestinationBuffer,
+            AlignedDestinationBufferOffset);
         auto in_pQueryHeap = MapObject<ID3D12QueryHeap>(pQueryHeap);
         auto in_pDestinationBuffer = MapObject<ID3D12Resource>(pDestinationBuffer);
-        replay_object->ResolveQueryData(in_pQueryHeap,
-                                        Type,
-                                        StartIndex,
-                                        NumQueries,
-                                        in_pDestinationBuffer,
-                                        AlignedDestinationBufferOffset);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->ResolveQueryData(in_pQueryHeap,
+                                                                                              Type,
+                                                                                              StartIndex,
+                                                                                              NumQueries,
+                                                                                              in_pDestinationBuffer,
+                                                                                              AlignedDestinationBufferOffset);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ResolveQueryData>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pQueryHeap,
+            Type,
+            StartIndex,
+            NumQueries,
+            pDestinationBuffer,
+            AlignedDestinationBufferOffset);
     }
 }
 
@@ -4049,13 +6811,27 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetPredication(
     UINT64                                      AlignedBufferOffset,
     D3D12_PREDICATION_OP                        Operation)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetPredication>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pBuffer,
+            AlignedBufferOffset,
+            Operation);
         auto in_pBuffer = MapObject<ID3D12Resource>(pBuffer);
-        replay_object->SetPredication(in_pBuffer,
-                                      AlignedBufferOffset,
-                                      Operation);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetPredication(in_pBuffer,
+                                                                                            AlignedBufferOffset,
+                                                                                            Operation);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetPredication>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pBuffer,
+            AlignedBufferOffset,
+            Operation);
     }
 }
 
@@ -4066,12 +6842,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_SetMarker(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        Size)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetMarker(Metadata,
-                                 pData->GetPointer(),
-                                 Size);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetMarker>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->SetMarker(Metadata,
+                                                                                       pData->GetPointer(),
+                                                                                       Size);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_SetMarker>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
     }
 }
 
@@ -4082,12 +6872,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_BeginEvent(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        Size)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->BeginEvent(Metadata,
-                                  pData->GetPointer(),
-                                  Size);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_BeginEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->BeginEvent(Metadata,
+                                                                                        pData->GetPointer(),
+                                                                                        Size);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_BeginEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
     }
 }
 
@@ -4095,10 +6899,18 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_EndEvent(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->EndEvent();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_EndEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12GraphicsCommandList*>(replay_object->object)->EndEvent();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_EndEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -4115,6 +6927,16 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ExecuteIndirect(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteIndirect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pCommandSignature,
+            MaxCommandCount,
+            pArgumentBuffer,
+            ArgumentBufferOffset,
+            pCountBuffer,
+            CountBufferOffset);
         auto in_pCommandSignature = GetObjectInfo(pCommandSignature);
         auto in_pArgumentBuffer = GetObjectInfo(pArgumentBuffer);
         auto in_pCountBuffer = GetObjectInfo(pCountBuffer);
@@ -4125,6 +6947,16 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList_ExecuteIndirect(
                                 ArgumentBufferOffset,
                                 in_pCountBuffer,
                                 CountBufferOffset);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_ExecuteIndirect>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pCommandSignature,
+            MaxCommandCount,
+            pArgumentBuffer,
+            ArgumentBufferOffset,
+            pCountBuffer,
+            CountBufferOffset);
     }
 }
 
@@ -4139,19 +6971,41 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT
     HandlePointerDecoder<ID3D12Resource*>*      ppDependentResources,
     StructPointerDecoder<Decoded_D3D12_SUBRESOURCE_RANGE_UINT64>* pDependentSubresourceRanges)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstBuffer,
+            DstOffset,
+            pSrcBuffer,
+            SrcOffset,
+            Dependencies,
+            ppDependentResources,
+            pDependentSubresourceRanges);
         auto in_pDstBuffer = MapObject<ID3D12Resource>(pDstBuffer);
         auto in_pSrcBuffer = MapObject<ID3D12Resource>(pSrcBuffer);
         auto in_ppDependentResources = MapObjects<ID3D12Resource>(ppDependentResources, Dependencies);
-        replay_object->AtomicCopyBufferUINT(in_pDstBuffer,
-                                            DstOffset,
-                                            in_pSrcBuffer,
-                                            SrcOffset,
-                                            Dependencies,
-                                            in_ppDependentResources,
-                                            pDependentSubresourceRanges->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList1*>(replay_object->object)->AtomicCopyBufferUINT(in_pDstBuffer,
+                                                                                                   DstOffset,
+                                                                                                   in_pSrcBuffer,
+                                                                                                   SrcOffset,
+                                                                                                   Dependencies,
+                                                                                                   in_ppDependentResources,
+                                                                                                   pDependentSubresourceRanges->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstBuffer,
+            DstOffset,
+            pSrcBuffer,
+            SrcOffset,
+            Dependencies,
+            ppDependentResources,
+            pDependentSubresourceRanges);
     }
 }
 
@@ -4166,19 +7020,41 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT
     HandlePointerDecoder<ID3D12Resource*>*      ppDependentResources,
     StructPointerDecoder<Decoded_D3D12_SUBRESOURCE_RANGE_UINT64>* pDependentSubresourceRanges)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT64>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstBuffer,
+            DstOffset,
+            pSrcBuffer,
+            SrcOffset,
+            Dependencies,
+            ppDependentResources,
+            pDependentSubresourceRanges);
         auto in_pDstBuffer = MapObject<ID3D12Resource>(pDstBuffer);
         auto in_pSrcBuffer = MapObject<ID3D12Resource>(pSrcBuffer);
         auto in_ppDependentResources = MapObjects<ID3D12Resource>(ppDependentResources, Dependencies);
-        replay_object->AtomicCopyBufferUINT64(in_pDstBuffer,
-                                              DstOffset,
-                                              in_pSrcBuffer,
-                                              SrcOffset,
-                                              Dependencies,
-                                              in_ppDependentResources,
-                                              pDependentSubresourceRanges->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList1*>(replay_object->object)->AtomicCopyBufferUINT64(in_pDstBuffer,
+                                                                                                     DstOffset,
+                                                                                                     in_pSrcBuffer,
+                                                                                                     SrcOffset,
+                                                                                                     Dependencies,
+                                                                                                     in_ppDependentResources,
+                                                                                                     pDependentSubresourceRanges->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_AtomicCopyBufferUINT64>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstBuffer,
+            DstOffset,
+            pSrcBuffer,
+            SrcOffset,
+            Dependencies,
+            ppDependentResources,
+            pDependentSubresourceRanges);
     }
 }
 
@@ -4188,11 +7064,23 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList1_OMSetDepthBounds(
     FLOAT                                       Min,
     FLOAT                                       Max)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->OMSetDepthBounds(Min,
-                                        Max);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_OMSetDepthBounds>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Min,
+            Max);
+        reinterpret_cast<ID3D12GraphicsCommandList1*>(replay_object->object)->OMSetDepthBounds(Min,
+                                                                                               Max);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_OMSetDepthBounds>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Min,
+            Max);
     }
 }
 
@@ -4203,12 +7091,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList1_SetSamplePositions(
     UINT                                        NumPixels,
     StructPointerDecoder<Decoded_D3D12_SAMPLE_POSITION>* pSamplePositions)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetSamplePositions(NumSamplesPerPixel,
-                                          NumPixels,
-                                          pSamplePositions->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_SetSamplePositions>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumSamplesPerPixel,
+            NumPixels,
+            pSamplePositions);
+        reinterpret_cast<ID3D12GraphicsCommandList1*>(replay_object->object)->SetSamplePositions(NumSamplesPerPixel,
+                                                                                                 NumPixels,
+                                                                                                 pSamplePositions->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_SetSamplePositions>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumSamplesPerPixel,
+            NumPixels,
+            pSamplePositions);
     }
 }
 
@@ -4225,20 +7127,46 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList1_ResolveSubresourceRe
     DXGI_FORMAT                                 Format,
     D3D12_RESOLVE_MODE                          ResolveMode)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_ResolveSubresourceRegion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            DstSubresource,
+            DstX,
+            DstY,
+            pSrcResource,
+            SrcSubresource,
+            pSrcRect,
+            Format,
+            ResolveMode);
         auto in_pDstResource = MapObject<ID3D12Resource>(pDstResource);
         auto in_pSrcResource = MapObject<ID3D12Resource>(pSrcResource);
-        replay_object->ResolveSubresourceRegion(in_pDstResource,
-                                                DstSubresource,
-                                                DstX,
-                                                DstY,
-                                                in_pSrcResource,
-                                                SrcSubresource,
-                                                pSrcRect->GetPointer(),
-                                                Format,
-                                                ResolveMode);
+        reinterpret_cast<ID3D12GraphicsCommandList1*>(replay_object->object)->ResolveSubresourceRegion(in_pDstResource,
+                                                                                                       DstSubresource,
+                                                                                                       DstX,
+                                                                                                       DstY,
+                                                                                                       in_pSrcResource,
+                                                                                                       SrcSubresource,
+                                                                                                       pSrcRect->GetPointer(),
+                                                                                                       Format,
+                                                                                                       ResolveMode);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_ResolveSubresourceRegion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            DstSubresource,
+            DstX,
+            DstY,
+            pSrcResource,
+            SrcSubresource,
+            pSrcRect,
+            Format,
+            ResolveMode);
     }
 }
 
@@ -4247,10 +7175,20 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList1_SetViewInstanceMask(
     format::HandleId                            object_id,
     UINT                                        Mask)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetViewInstanceMask(Mask);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_SetViewInstanceMask>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mask);
+        reinterpret_cast<ID3D12GraphicsCommandList1*>(replay_object->object)->SetViewInstanceMask(Mask);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList1_SetViewInstanceMask>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mask);
     }
 }
 
@@ -4261,13 +7199,27 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList2_WriteBufferImmediate
     StructPointerDecoder<Decoded_D3D12_WRITEBUFFERIMMEDIATE_PARAMETER>* pParams,
     PointerDecoder<D3D12_WRITEBUFFERIMMEDIATE_MODE>* pModes)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList2_WriteBufferImmediate>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Count,
+            pParams,
+            pModes);
         MapStructArrayObjects(pParams->GetMetaStructPointer(), pParams->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->WriteBufferImmediate(Count,
-                                            pParams->GetPointer(),
-                                            pModes->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList2*>(replay_object->object)->WriteBufferImmediate(Count,
+                                                                                                   pParams->GetPointer(),
+                                                                                                   pModes->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList2_WriteBufferImmediate>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Count,
+            pParams,
+            pModes);
     }
 }
 
@@ -4285,21 +7237,49 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_UpdateTileMappings(
     PointerDecoder<UINT>*                       pRangeTileCounts,
     D3D12_TILE_MAPPING_FLAGS                    Flags)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_UpdateTileMappings>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            NumResourceRegions,
+            pResourceRegionStartCoordinates,
+            pResourceRegionSizes,
+            pHeap,
+            NumRanges,
+            pRangeFlags,
+            pHeapRangeStartOffsets,
+            pRangeTileCounts,
+            Flags);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
         auto in_pHeap = MapObject<ID3D12Heap>(pHeap);
-        replay_object->UpdateTileMappings(in_pResource,
-                                          NumResourceRegions,
-                                          pResourceRegionStartCoordinates->GetPointer(),
-                                          pResourceRegionSizes->GetPointer(),
-                                          in_pHeap,
-                                          NumRanges,
-                                          pRangeFlags->GetPointer(),
-                                          pHeapRangeStartOffsets->GetPointer(),
-                                          pRangeTileCounts->GetPointer(),
-                                          Flags);
+        reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->UpdateTileMappings(in_pResource,
+                                                                                         NumResourceRegions,
+                                                                                         pResourceRegionStartCoordinates->GetPointer(),
+                                                                                         pResourceRegionSizes->GetPointer(),
+                                                                                         in_pHeap,
+                                                                                         NumRanges,
+                                                                                         pRangeFlags->GetPointer(),
+                                                                                         pHeapRangeStartOffsets->GetPointer(),
+                                                                                         pRangeTileCounts->GetPointer(),
+                                                                                         Flags);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_UpdateTileMappings>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            NumResourceRegions,
+            pResourceRegionStartCoordinates,
+            pResourceRegionSizes,
+            pHeap,
+            NumRanges,
+            pRangeFlags,
+            pHeapRangeStartOffsets,
+            pRangeTileCounts,
+            Flags);
     }
 }
 
@@ -4313,17 +7293,37 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_CopyTileMappings(
     StructPointerDecoder<Decoded_D3D12_TILE_REGION_SIZE>* pRegionSize,
     D3D12_TILE_MAPPING_FLAGS                    Flags)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_CopyTileMappings>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            pDstRegionStartCoordinate,
+            pSrcResource,
+            pSrcRegionStartCoordinate,
+            pRegionSize,
+            Flags);
         auto in_pDstResource = MapObject<ID3D12Resource>(pDstResource);
         auto in_pSrcResource = MapObject<ID3D12Resource>(pSrcResource);
-        replay_object->CopyTileMappings(in_pDstResource,
-                                        pDstRegionStartCoordinate->GetPointer(),
-                                        in_pSrcResource,
-                                        pSrcRegionStartCoordinate->GetPointer(),
-                                        pRegionSize->GetPointer(),
-                                        Flags);
+        reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->CopyTileMappings(in_pDstResource,
+                                                                                       pDstRegionStartCoordinate->GetPointer(),
+                                                                                       in_pSrcResource,
+                                                                                       pSrcRegionStartCoordinate->GetPointer(),
+                                                                                       pRegionSize->GetPointer(),
+                                                                                       Flags);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_CopyTileMappings>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDstResource,
+            pDstRegionStartCoordinate,
+            pSrcResource,
+            pSrcRegionStartCoordinate,
+            pRegionSize,
+            Flags);
     }
 }
 
@@ -4336,10 +7336,22 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_ExecuteCommandLists(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumCommandLists,
+            ppCommandLists);
         MapObjects<ID3D12CommandList>(ppCommandLists, NumCommandLists);
         OverrideExecuteCommandLists(replay_object,
                                     NumCommandLists,
                                     ppCommandLists);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_ExecuteCommandLists>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumCommandLists,
+            ppCommandLists);
     }
 }
 
@@ -4350,12 +7362,26 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_SetMarker(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        Size)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetMarker(Metadata,
-                                 pData->GetPointer(),
-                                 Size);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_SetMarker>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
+        reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->SetMarker(Metadata,
+                                                                                pData->GetPointer(),
+                                                                                Size);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_SetMarker>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
     }
 }
 
@@ -4366,12 +7392,26 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_BeginEvent(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        Size)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->BeginEvent(Metadata,
-                                  pData->GetPointer(),
-                                  Size);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_BeginEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
+        reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->BeginEvent(Metadata,
+                                                                                 pData->GetPointer(),
+                                                                                 Size);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_BeginEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Metadata,
+            pData,
+            Size);
     }
 }
 
@@ -4379,10 +7419,18 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_EndEvent(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->EndEvent();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_EndEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->EndEvent();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_EndEvent>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -4396,12 +7444,24 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_Signal(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_Signal>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            Value);
         auto in_pFence = GetObjectInfo(pFence);
         auto replay_result = OverrideCommandQueueSignal(replay_object,
                                                         return_value,
                                                         in_pFence,
                                                         Value);
         CheckReplayResult("ID3D12CommandQueue_Signal", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_Signal>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            Value);
     }
 }
 
@@ -4415,12 +7475,24 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_Wait(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_Wait>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            Value);
         auto in_pFence = GetObjectInfo(pFence);
         auto replay_result = OverrideCommandQueueWait(replay_object,
                                                       return_value,
                                                       in_pFence,
                                                       Value);
         CheckReplayResult("ID3D12CommandQueue_Wait", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_Wait>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            Value);
     }
 }
 
@@ -4430,11 +7502,21 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_GetTimestampFrequency(
     HRESULT                                     return_value,
     PointerDecoder<UINT64>*                     pFrequency)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetTimestampFrequency(pFrequency->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetTimestampFrequency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFrequency);
+        auto replay_result = reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->GetTimestampFrequency(pFrequency->GetPointer());
         CheckReplayResult("ID3D12CommandQueue_GetTimestampFrequency", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetTimestampFrequency>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFrequency);
     }
 }
 
@@ -4445,12 +7527,24 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_GetClockCalibration(
     PointerDecoder<UINT64>*                     pGpuTimestamp,
     PointerDecoder<UINT64>*                     pCpuTimestamp)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetClockCalibration(pGpuTimestamp->GetPointer(),
-                                                                pCpuTimestamp->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetClockCalibration>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pGpuTimestamp,
+            pCpuTimestamp);
+        auto replay_result = reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->GetClockCalibration(pGpuTimestamp->GetPointer(),
+                                                                                                               pCpuTimestamp->GetPointer());
         CheckReplayResult("ID3D12CommandQueue_GetClockCalibration", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetClockCalibration>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pGpuTimestamp,
+            pCpuTimestamp);
     }
 }
 
@@ -4459,10 +7553,18 @@ void Dx12ReplayConsumer::Process_ID3D12CommandQueue_GetDesc(
     format::HandleId                            object_id,
     Decoded_D3D12_COMMAND_QUEUE_DESC            return_value)
 {
-    auto replay_object = MapObject<ID3D12CommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12CommandQueue*>(replay_object->object)->GetDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12CommandQueue_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -4471,10 +7573,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetNodeCount(
     format::HandleId                            object_id,
     UINT                                        return_value)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetNodeCount();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetNodeCount>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->GetNodeCount();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetNodeCount>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -4489,6 +7599,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandQueue(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandQueue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppCommandQueue);
         if(!ppCommandQueue->IsNull()) ppCommandQueue->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppCommandQueue->SetConsumerData(0, &object_info);
@@ -4502,6 +7619,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandQueue(
             AddObject(ppCommandQueue->GetPointer(), ppCommandQueue->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateCommandQueue);
         }
         CheckReplayResult("ID3D12Device_CreateCommandQueue", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandQueue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppCommandQueue);
     }
 }
 
@@ -4513,20 +7637,34 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandAllocator(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppCommandAllocator)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandAllocator>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            type,
+            riid,
+            ppCommandAllocator);
         if(!ppCommandAllocator->IsNull()) ppCommandAllocator->SetHandleLength(1);
         auto out_p_ppCommandAllocator    = ppCommandAllocator->GetPointer();
         auto out_hp_ppCommandAllocator   = ppCommandAllocator->GetHandlePointer();
-        auto replay_result = replay_object->CreateCommandAllocator(type,
-                                                                   *riid.decoded_value,
-                                                                   out_hp_ppCommandAllocator);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateCommandAllocator(type,
+                                                                                                            *riid.decoded_value,
+                                                                                                            out_hp_ppCommandAllocator);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppCommandAllocator, out_hp_ppCommandAllocator, format::ApiCall_ID3D12Device_CreateCommandAllocator);
         }
         CheckReplayResult("ID3D12Device_CreateCommandAllocator", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandAllocator>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            type,
+            riid,
+            ppCommandAllocator);
     }
 }
 
@@ -4541,6 +7679,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateGraphicsPipelineState(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateGraphicsPipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -4555,6 +7700,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateGraphicsPipelineState(
             AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateGraphicsPipelineState);
         }
         CheckReplayResult("ID3D12Device_CreateGraphicsPipelineState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateGraphicsPipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppPipelineState);
     }
 }
 
@@ -4569,6 +7721,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateComputePipelineState(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateComputePipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -4583,6 +7742,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateComputePipelineState(
             AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateComputePipelineState);
         }
         CheckReplayResult("ID3D12Device_CreateComputePipelineState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateComputePipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppPipelineState);
     }
 }
 
@@ -4600,6 +7766,16 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandList(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandList>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            type,
+            pCommandAllocator,
+            pInitialState,
+            riid,
+            ppCommandList);
         auto in_pCommandAllocator = GetObjectInfo(pCommandAllocator);
         auto in_pInitialState = GetObjectInfo(pInitialState);
         if(!ppCommandList->IsNull()) ppCommandList->SetHandleLength(1);
@@ -4618,6 +7794,16 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandList(
             AddObject(ppCommandList->GetPointer(), ppCommandList->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateCommandList);
         }
         CheckReplayResult("ID3D12Device_CreateCommandList", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandList>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            type,
+            pCommandAllocator,
+            pInitialState,
+            riid,
+            ppCommandList);
     }
 }
 
@@ -4632,6 +7818,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateDescriptorHeap(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateDescriptorHeap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDescriptorHeapDesc,
+            riid,
+            ppvHeap);
         if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppvHeap->SetConsumerData(0, &object_info);
@@ -4645,6 +7838,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateDescriptorHeap(
             AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateDescriptorHeap);
         }
         CheckReplayResult("ID3D12Device_CreateDescriptorHeap", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateDescriptorHeap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDescriptorHeapDesc,
+            riid,
+            ppvHeap);
     }
 }
 
@@ -4657,9 +7857,19 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetDescriptorHandleIncrementSize(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetDescriptorHandleIncrementSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DescriptorHeapType);
         auto replay_result = OverrideGetDescriptorHandleIncrementSize(replay_object,
                                                                       return_value,
                                                                       DescriptorHeapType);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetDescriptorHandleIncrementSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DescriptorHeapType);
     }
 }
 
@@ -4676,6 +7886,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateRootSignature(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            pBlobWithRootSignature,
+            blobLengthInBytes,
+            riid,
+            ppvRootSignature);
         if(!ppvRootSignature->IsNull()) ppvRootSignature->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppvRootSignature->SetConsumerData(0, &object_info);
@@ -4691,6 +7910,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateRootSignature(
             AddObject(ppvRootSignature->GetPointer(), ppvRootSignature->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateRootSignature);
         }
         CheckReplayResult("ID3D12Device_CreateRootSignature", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            pBlobWithRootSignature,
+            blobLengthInBytes,
+            riid,
+            ppvRootSignature);
     }
 }
 
@@ -4700,13 +7928,25 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateConstantBufferView(
     StructPointerDecoder<Decoded_D3D12_CONSTANT_BUFFER_VIEW_DESC>* pDesc,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateConstantBufferView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            DestDescriptor);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateConstantBufferView(pDesc->GetPointer(),
-                                                *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateConstantBufferView(pDesc->GetPointer(),
+                                                                                         *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateConstantBufferView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            DestDescriptor);
     }
 }
 
@@ -4717,15 +7957,29 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateShaderResourceView(
     StructPointerDecoder<Decoded_D3D12_SHADER_RESOURCE_VIEW_DESC>* pDesc,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateShaderResourceView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pDesc,
+            DestDescriptor);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateShaderResourceView(in_pResource,
-                                                pDesc->GetPointer(),
-                                                *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateShaderResourceView(in_pResource,
+                                                                                         pDesc->GetPointer(),
+                                                                                         *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateShaderResourceView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pDesc,
+            DestDescriptor);
     }
 }
 
@@ -4737,16 +7991,32 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateUnorderedAccessView(
     StructPointerDecoder<Decoded_D3D12_UNORDERED_ACCESS_VIEW_DESC>* pDesc,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pCounterResource,
+            pDesc,
+            DestDescriptor);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
         auto in_pCounterResource = MapObject<ID3D12Resource>(pCounterResource);
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateUnorderedAccessView(in_pResource,
-                                                 in_pCounterResource,
-                                                 pDesc->GetPointer(),
-                                                 *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateUnorderedAccessView(in_pResource,
+                                                                                          in_pCounterResource,
+                                                                                          pDesc->GetPointer(),
+                                                                                          *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pCounterResource,
+            pDesc,
+            DestDescriptor);
     }
 }
 
@@ -4757,14 +8027,28 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateRenderTargetView(
     StructPointerDecoder<Decoded_D3D12_RENDER_TARGET_VIEW_DESC>* pDesc,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateRenderTargetView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pDesc,
+            DestDescriptor);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateRenderTargetView(in_pResource,
-                                              pDesc->GetPointer(),
-                                              *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateRenderTargetView(in_pResource,
+                                                                                       pDesc->GetPointer(),
+                                                                                       *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateRenderTargetView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pDesc,
+            DestDescriptor);
     }
 }
 
@@ -4775,14 +8059,28 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateDepthStencilView(
     StructPointerDecoder<Decoded_D3D12_DEPTH_STENCIL_VIEW_DESC>* pDesc,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateDepthStencilView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pDesc,
+            DestDescriptor);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateDepthStencilView(in_pResource,
-                                              pDesc->GetPointer(),
-                                              *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateDepthStencilView(in_pResource,
+                                                                                       pDesc->GetPointer(),
+                                                                                       *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateDepthStencilView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            pDesc,
+            DestDescriptor);
     }
 }
 
@@ -4792,12 +8090,24 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateSampler(
     StructPointerDecoder<Decoded_D3D12_SAMPLER_DESC>* pDesc,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateSampler>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            DestDescriptor);
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateSampler(pDesc->GetPointer(),
-                                     *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateSampler(pDesc->GetPointer(),
+                                                                              *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateSampler>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            DestDescriptor);
     }
 }
 
@@ -4812,18 +8122,40 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CopyDescriptors(
     PointerDecoder<UINT>*                       pSrcDescriptorRangeSizes,
     D3D12_DESCRIPTOR_HEAP_TYPE                  DescriptorHeapsType)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CopyDescriptors>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumDestDescriptorRanges,
+            pDestDescriptorRangeStarts,
+            pDestDescriptorRangeSizes,
+            NumSrcDescriptorRanges,
+            pSrcDescriptorRangeStarts,
+            pSrcDescriptorRangeSizes,
+            DescriptorHeapsType);
         MapStructArrayObjects(pDestDescriptorRangeStarts->GetMetaStructPointer(), pDestDescriptorRangeStarts->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
         MapStructArrayObjects(pSrcDescriptorRangeStarts->GetMetaStructPointer(), pSrcDescriptorRangeStarts->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CopyDescriptors(NumDestDescriptorRanges,
-                                       pDestDescriptorRangeStarts->GetPointer(),
-                                       pDestDescriptorRangeSizes->GetPointer(),
-                                       NumSrcDescriptorRanges,
-                                       pSrcDescriptorRangeStarts->GetPointer(),
-                                       pSrcDescriptorRangeSizes->GetPointer(),
-                                       DescriptorHeapsType);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CopyDescriptors(NumDestDescriptorRanges,
+                                                                                pDestDescriptorRangeStarts->GetPointer(),
+                                                                                pDestDescriptorRangeSizes->GetPointer(),
+                                                                                NumSrcDescriptorRanges,
+                                                                                pSrcDescriptorRangeStarts->GetPointer(),
+                                                                                pSrcDescriptorRangeSizes->GetPointer(),
+                                                                                DescriptorHeapsType);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CopyDescriptors>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumDestDescriptorRanges,
+            pDestDescriptorRangeStarts,
+            pDestDescriptorRangeSizes,
+            NumSrcDescriptorRanges,
+            pSrcDescriptorRangeStarts,
+            pSrcDescriptorRangeSizes,
+            DescriptorHeapsType);
     }
 }
 
@@ -4835,15 +8167,31 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CopyDescriptorsSimple(
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         SrcDescriptorRangeStart,
     D3D12_DESCRIPTOR_HEAP_TYPE                  DescriptorHeapsType)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CopyDescriptorsSimple>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumDescriptors,
+            DestDescriptorRangeStart,
+            SrcDescriptorRangeStart,
+            DescriptorHeapsType);
         MapStructObjects(&DestDescriptorRangeStart, GetObjectInfoTable(), GetGpuVaTable());
         MapStructObjects(&SrcDescriptorRangeStart, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CopyDescriptorsSimple(NumDescriptors,
-                                             *DestDescriptorRangeStart.decoded_value,
-                                             *SrcDescriptorRangeStart.decoded_value,
-                                             DescriptorHeapsType);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->CopyDescriptorsSimple(NumDescriptors,
+                                                                                      *DestDescriptorRangeStart.decoded_value,
+                                                                                      *SrcDescriptorRangeStart.decoded_value,
+                                                                                      DescriptorHeapsType);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CopyDescriptorsSimple>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumDescriptors,
+            DestDescriptorRangeStart,
+            SrcDescriptorRangeStart,
+            DescriptorHeapsType);
     }
 }
 
@@ -4855,12 +8203,26 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetResourceAllocationInfo(
     UINT                                        numResourceDescs,
     StructPointerDecoder<Decoded_D3D12_RESOURCE_DESC>* pResourceDescs)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetResourceAllocationInfo(visibleMask,
-                                                                      numResourceDescs,
-                                                                      pResourceDescs->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetResourceAllocationInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->GetResourceAllocationInfo(visibleMask,
+                                                                                                               numResourceDescs,
+                                                                                                               pResourceDescs->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetResourceAllocationInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs);
     }
 }
 
@@ -4871,11 +8233,23 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetCustomHeapProperties(
     UINT                                        nodeMask,
     D3D12_HEAP_TYPE                             heapType)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetCustomHeapProperties(nodeMask,
-                                                                    heapType);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetCustomHeapProperties>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            heapType);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->GetCustomHeapProperties(nodeMask,
+                                                                                                             heapType);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetCustomHeapProperties>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            heapType);
     }
 }
 
@@ -4894,6 +8268,17 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommittedResource(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommittedResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialResourceState,
+            pOptimizedClearValue,
+            riidResource,
+            ppvResource);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppvResource->SetConsumerData(0, &object_info);
@@ -4912,6 +8297,17 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommittedResource(
             SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreateCommittedResource", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommittedResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialResourceState,
+            pOptimizedClearValue,
+            riidResource,
+            ppvResource);
     }
 }
 
@@ -4926,6 +8322,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateHeap(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateHeap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppvHeap);
         if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppvHeap->SetConsumerData(0, &object_info);
@@ -4939,6 +8342,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateHeap(
             AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateHeap);
         }
         CheckReplayResult("ID3D12Device_CreateHeap", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateHeap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppvHeap);
     }
 }
 
@@ -4954,26 +8364,48 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreatePlacedResource(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvResource)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreatePlacedResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeap,
+            HeapOffset,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            riid,
+            ppvResource);
         auto in_pHeap = MapObject<ID3D12Heap>(pHeap);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         auto out_p_ppvResource    = ppvResource->GetPointer();
         auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
-        auto replay_result = replay_object->CreatePlacedResource(in_pHeap,
-                                                                 HeapOffset,
-                                                                 pDesc->GetPointer(),
-                                                                 InitialState,
-                                                                 pOptimizedClearValue->GetPointer(),
-                                                                 *riid.decoded_value,
-                                                                 out_hp_ppvResource);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->CreatePlacedResource(in_pHeap,
+                                                                                                          HeapOffset,
+                                                                                                          pDesc->GetPointer(),
+                                                                                                          InitialState,
+                                                                                                          pOptimizedClearValue->GetPointer(),
+                                                                                                          *riid.decoded_value,
+                                                                                                          out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device_CreatePlacedResource);
             SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreatePlacedResource", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreatePlacedResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeap,
+            HeapOffset,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            riid,
+            ppvResource);
     }
 }
 
@@ -4990,6 +8422,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateReservedResource(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateReservedResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            riid,
+            ppvResource);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppvResource->SetConsumerData(0, &object_info);
@@ -5006,6 +8447,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateReservedResource(
             SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device_CreateReservedResource", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateReservedResource>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            riid,
+            ppvResource);
     }
 }
 
@@ -5019,9 +8469,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateSharedHandle(
     WStringDecoder*                             Name,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pObject,
+            pAttributes,
+            Access,
+            Name,
+            pHandle);
         auto in_pObject = MapObject<ID3D12DeviceChild>(pObject);
         if(!pHandle->IsNull())
         {
@@ -5029,12 +8488,21 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateSharedHandle(
         }
         auto out_p_pHandle    = pHandle->GetPointer();
         auto out_op_pHandle   = reinterpret_cast<HANDLE*>(pHandle->GetOutputPointer());
-        auto replay_result = replay_object->CreateSharedHandle(in_pObject,
-                                                               pAttributes->GetPointer(),
-                                                               Access,
-                                                               Name->GetPointer(),
-                                                               out_op_pHandle);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateSharedHandle(in_pObject,
+                                                                                                        pAttributes->GetPointer(),
+                                                                                                        Access,
+                                                                                                        Name->GetPointer(),
+                                                                                                        out_op_pHandle);
         CheckReplayResult("ID3D12Device_CreateSharedHandle", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pObject,
+            pAttributes,
+            Access,
+            Name,
+            pHandle);
         PostProcessExternalObject(replay_result, out_op_pHandle, out_p_pHandle, format::ApiCallId::ApiCall_ID3D12Device_CreateSharedHandle, "ID3D12Device_CreateSharedHandle");
     }
 }
@@ -5047,21 +8515,35 @@ void Dx12ReplayConsumer::Process_ID3D12Device_OpenSharedHandle(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvObj)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NTHandle,
+            riid,
+            ppvObj);
         auto in_NTHandle = static_cast<HANDLE>(PreProcessExternalObject(NTHandle, format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle, "ID3D12Device_OpenSharedHandle"));
         if(!ppvObj->IsNull()) ppvObj->SetHandleLength(1);
         auto out_p_ppvObj    = ppvObj->GetPointer();
         auto out_hp_ppvObj   = ppvObj->GetHandlePointer();
-        auto replay_result = replay_object->OpenSharedHandle(in_NTHandle,
-                                                             *riid.decoded_value,
-                                                             out_hp_ppvObj);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->OpenSharedHandle(in_NTHandle,
+                                                                                                      *riid.decoded_value,
+                                                                                                      out_hp_ppvObj);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvObj, out_hp_ppvObj, format::ApiCall_ID3D12Device_OpenSharedHandle);
         }
         CheckReplayResult("ID3D12Device_OpenSharedHandle", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandle>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NTHandle,
+            riid,
+            ppvObj);
     }
 }
 
@@ -5073,19 +8555,33 @@ void Dx12ReplayConsumer::Process_ID3D12Device_OpenSharedHandleByName(
     DWORD                                       Access,
     PointerDecoder<uint64_t, void*>*            pNTHandle)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandleByName>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            Access,
+            pNTHandle);
         if(!pNTHandle->IsNull())
         {
             pNTHandle->AllocateOutputData(1);
         }
         auto out_p_pNTHandle    = pNTHandle->GetPointer();
         auto out_op_pNTHandle   = reinterpret_cast<HANDLE*>(pNTHandle->GetOutputPointer());
-        auto replay_result = replay_object->OpenSharedHandleByName(Name->GetPointer(),
-                                                                   Access,
-                                                                   out_op_pNTHandle);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->OpenSharedHandleByName(Name->GetPointer(),
+                                                                                                            Access,
+                                                                                                            out_op_pNTHandle);
         CheckReplayResult("ID3D12Device_OpenSharedHandleByName", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandleByName>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Name,
+            Access,
+            pNTHandle);
         PostProcessExternalObject(replay_result, out_op_pNTHandle, out_p_pNTHandle, format::ApiCallId::ApiCall_ID3D12Device_OpenSharedHandleByName, "ID3D12Device_OpenSharedHandleByName");
     }
 }
@@ -5097,13 +8593,25 @@ void Dx12ReplayConsumer::Process_ID3D12Device_MakeResident(
     UINT                                        NumObjects,
     HandlePointerDecoder<ID3D12Pageable*>*      ppObjects)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_MakeResident>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumObjects,
+            ppObjects);
         auto in_ppObjects = MapObjects<ID3D12Pageable>(ppObjects, NumObjects);
-        auto replay_result = replay_object->MakeResident(NumObjects,
-                                                         in_ppObjects);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->MakeResident(NumObjects,
+                                                                                                  in_ppObjects);
         CheckReplayResult("ID3D12Device_MakeResident", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_MakeResident>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumObjects,
+            ppObjects);
     }
 }
 
@@ -5114,13 +8622,25 @@ void Dx12ReplayConsumer::Process_ID3D12Device_Evict(
     UINT                                        NumObjects,
     HandlePointerDecoder<ID3D12Pageable*>*      ppObjects)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_Evict>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumObjects,
+            ppObjects);
         auto in_ppObjects = MapObjects<ID3D12Pageable>(ppObjects, NumObjects);
-        auto replay_result = replay_object->Evict(NumObjects,
-                                                  in_ppObjects);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->Evict(NumObjects,
+                                                                                           in_ppObjects);
         CheckReplayResult("ID3D12Device_Evict", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_Evict>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumObjects,
+            ppObjects);
     }
 }
 
@@ -5136,6 +8656,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateFence(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateFence>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            InitialValue,
+            Flags,
+            riid,
+            ppFence);
         if(!ppFence->IsNull()) ppFence->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppFence->SetConsumerData(0, &object_info);
@@ -5150,6 +8678,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateFence(
             AddObject(ppFence->GetPointer(), ppFence->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateFence);
         }
         CheckReplayResult("ID3D12Device_CreateFence", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateFence>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            InitialValue,
+            Flags,
+            riid,
+            ppFence);
     }
 }
 
@@ -5158,11 +8694,19 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetDeviceRemovedReason(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDeviceRemovedReason();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetDeviceRemovedReason>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->GetDeviceRemovedReason();
         CheckReplayResult("ID3D12Device_GetDeviceRemovedReason", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetDeviceRemovedReason>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5178,17 +8722,41 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetCopyableFootprints(
     PointerDecoder<UINT64>*                     pRowSizeInBytes,
     PointerDecoder<UINT64>*                     pTotalBytes)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->GetCopyableFootprints(pResourceDesc->GetPointer(),
-                                             FirstSubresource,
-                                             NumSubresources,
-                                             BaseOffset,
-                                             pLayouts->GetPointer(),
-                                             pNumRows->GetPointer(),
-                                             pRowSizeInBytes->GetPointer(),
-                                             pTotalBytes->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetCopyableFootprints>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResourceDesc,
+            FirstSubresource,
+            NumSubresources,
+            BaseOffset,
+            pLayouts,
+            pNumRows,
+            pRowSizeInBytes,
+            pTotalBytes);
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->GetCopyableFootprints(pResourceDesc->GetPointer(),
+                                                                                      FirstSubresource,
+                                                                                      NumSubresources,
+                                                                                      BaseOffset,
+                                                                                      pLayouts->GetPointer(),
+                                                                                      pNumRows->GetPointer(),
+                                                                                      pRowSizeInBytes->GetPointer(),
+                                                                                      pTotalBytes->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetCopyableFootprints>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResourceDesc,
+            FirstSubresource,
+            NumSubresources,
+            BaseOffset,
+            pLayouts,
+            pNumRows,
+            pRowSizeInBytes,
+            pTotalBytes);
     }
 }
 
@@ -5200,20 +8768,34 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateQueryHeap(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvHeap)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateQueryHeap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppvHeap);
         if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         auto out_p_ppvHeap    = ppvHeap->GetPointer();
         auto out_hp_ppvHeap   = ppvHeap->GetHandlePointer();
-        auto replay_result = replay_object->CreateQueryHeap(pDesc->GetPointer(),
-                                                            *riid.decoded_value,
-                                                            out_hp_ppvHeap);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->CreateQueryHeap(pDesc->GetPointer(),
+                                                                                                     *riid.decoded_value,
+                                                                                                     out_hp_ppvHeap);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvHeap, out_hp_ppvHeap, format::ApiCall_ID3D12Device_CreateQueryHeap);
         }
         CheckReplayResult("ID3D12Device_CreateQueryHeap", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateQueryHeap>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppvHeap);
     }
 }
 
@@ -5223,11 +8805,21 @@ void Dx12ReplayConsumer::Process_ID3D12Device_SetStablePowerState(
     HRESULT                                     return_value,
     BOOL                                        Enable)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetStablePowerState(Enable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_SetStablePowerState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->SetStablePowerState(Enable);
         CheckReplayResult("ID3D12Device_SetStablePowerState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_SetStablePowerState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
     }
 }
 
@@ -5243,6 +8835,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandSignature(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            pRootSignature,
+            riid,
+            ppvCommandSignature);
         auto in_pRootSignature = GetObjectInfo(pRootSignature);
         if(!ppvCommandSignature->IsNull()) ppvCommandSignature->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -5258,6 +8858,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device_CreateCommandSignature(
             AddObject(ppvCommandSignature->GetPointer(), ppvCommandSignature->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device_CreateCommandSignature);
         }
         CheckReplayResult("ID3D12Device_CreateCommandSignature", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_CreateCommandSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            pRootSignature,
+            riid,
+            ppvCommandSignature);
     }
 }
 
@@ -5272,17 +8880,39 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetResourceTiling(
     UINT                                        FirstSubresourceTilingToGet,
     StructPointerDecoder<Decoded_D3D12_SUBRESOURCE_TILING>* pSubresourceTilingsForNonPackedMips)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetResourceTiling>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pTiledResource,
+            pNumTilesForEntireResource,
+            pPackedMipDesc,
+            pStandardTileShapeForNonPackedMips,
+            pNumSubresourceTilings,
+            FirstSubresourceTilingToGet,
+            pSubresourceTilingsForNonPackedMips);
         auto in_pTiledResource = MapObject<ID3D12Resource>(pTiledResource);
-        replay_object->GetResourceTiling(in_pTiledResource,
-                                         pNumTilesForEntireResource->GetPointer(),
-                                         pPackedMipDesc->GetPointer(),
-                                         pStandardTileShapeForNonPackedMips->GetPointer(),
-                                         pNumSubresourceTilings->GetPointer(),
-                                         FirstSubresourceTilingToGet,
-                                         pSubresourceTilingsForNonPackedMips->GetPointer());
+        reinterpret_cast<ID3D12Device*>(replay_object->object)->GetResourceTiling(in_pTiledResource,
+                                                                                  pNumTilesForEntireResource->GetPointer(),
+                                                                                  pPackedMipDesc->GetPointer(),
+                                                                                  pStandardTileShapeForNonPackedMips->GetPointer(),
+                                                                                  pNumSubresourceTilings->GetPointer(),
+                                                                                  FirstSubresourceTilingToGet,
+                                                                                  pSubresourceTilingsForNonPackedMips->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetResourceTiling>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pTiledResource,
+            pNumTilesForEntireResource,
+            pPackedMipDesc,
+            pStandardTileShapeForNonPackedMips,
+            pNumSubresourceTilings,
+            FirstSubresourceTilingToGet,
+            pSubresourceTilingsForNonPackedMips);
     }
 }
 
@@ -5291,10 +8921,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device_GetAdapterLuid(
     format::HandleId                            object_id,
     Decoded_LUID                                return_value)
 {
-    auto replay_object = MapObject<ID3D12Device>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetAdapterLuid();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device_GetAdapterLuid>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Device*>(replay_object->object)->GetAdapterLuid();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device_GetAdapterLuid>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5305,13 +8943,25 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_StorePipeline(
     WStringDecoder*                             pName,
     format::HandleId                            pPipeline)
 {
-    auto replay_object = MapObject<ID3D12PipelineLibrary>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_StorePipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pPipeline);
         auto in_pPipeline = MapObject<ID3D12PipelineState>(pPipeline);
-        auto replay_result = replay_object->StorePipeline(pName->GetPointer(),
-                                                          in_pPipeline);
+        auto replay_result = reinterpret_cast<ID3D12PipelineLibrary*>(replay_object->object)->StorePipeline(pName->GetPointer(),
+                                                                                                            in_pPipeline);
         CheckReplayResult("ID3D12PipelineLibrary_StorePipeline", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_StorePipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pPipeline);
     }
 }
 
@@ -5327,6 +8977,14 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadGraphicsPipeline(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_LoadGraphicsPipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pDesc,
+            riid,
+            ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -5342,6 +9000,14 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadGraphicsPipeline(
             AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12PipelineLibrary_LoadGraphicsPipeline);
         }
         CheckReplayResult("ID3D12PipelineLibrary_LoadGraphicsPipeline", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_LoadGraphicsPipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pDesc,
+            riid,
+            ppPipelineState);
     }
 }
 
@@ -5357,6 +9023,14 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadComputePipeline(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_LoadComputePipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pDesc,
+            riid,
+            ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -5372,6 +9046,14 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_LoadComputePipeline(
             AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12PipelineLibrary_LoadComputePipeline);
         }
         CheckReplayResult("ID3D12PipelineLibrary_LoadComputePipeline", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_LoadComputePipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pDesc,
+            riid,
+            ppPipelineState);
     }
 }
 
@@ -5380,10 +9062,18 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_GetSerializedSize(
     format::HandleId                            object_id,
     SIZE_T                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12PipelineLibrary>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetSerializedSize();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_GetSerializedSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12PipelineLibrary*>(replay_object->object)->GetSerializedSize();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_GetSerializedSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5394,12 +9084,24 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary_Serialize(
     PointerDecoder<uint8_t>*                    pData,
     SIZE_T                                      DataSizeInBytes)
 {
-    auto replay_object = MapObject<ID3D12PipelineLibrary>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->Serialize(pData->GetPointer(),
-                                                      DataSizeInBytes);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_Serialize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pData,
+            DataSizeInBytes);
+        auto replay_result = reinterpret_cast<ID3D12PipelineLibrary*>(replay_object->object)->Serialize(pData->GetPointer(),
+                                                                                                        DataSizeInBytes);
         CheckReplayResult("ID3D12PipelineLibrary_Serialize", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary_Serialize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pData,
+            DataSizeInBytes);
     }
 }
 
@@ -5415,6 +9117,14 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary1_LoadPipeline(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary1_LoadPipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pDesc,
+            riid,
+            ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -5430,6 +9140,14 @@ void Dx12ReplayConsumer::Process_ID3D12PipelineLibrary1_LoadPipeline(
             AddObject(ppPipelineState->GetPointer(), ppPipelineState->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12PipelineLibrary1_LoadPipeline);
         }
         CheckReplayResult("ID3D12PipelineLibrary1_LoadPipeline", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12PipelineLibrary1_LoadPipeline>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pName,
+            pDesc,
+            riid,
+            ppPipelineState);
     }
 }
 
@@ -5445,6 +9163,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device1_CreatePipelineLibrary(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device1_CreatePipelineLibrary>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLibraryBlob,
+            BlobLength,
+            riid,
+            ppPipelineLibrary);
         if(!ppPipelineLibrary->IsNull()) ppPipelineLibrary->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppPipelineLibrary->SetConsumerData(0, &object_info);
@@ -5459,6 +9185,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device1_CreatePipelineLibrary(
             AddObject(ppPipelineLibrary->GetPointer(), ppPipelineLibrary->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device1_CreatePipelineLibrary);
         }
         CheckReplayResult("ID3D12Device1_CreatePipelineLibrary", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device1_CreatePipelineLibrary>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pLibraryBlob,
+            BlobLength,
+            riid,
+            ppPipelineLibrary);
     }
 }
 
@@ -5472,17 +9206,35 @@ void Dx12ReplayConsumer::Process_ID3D12Device1_SetEventOnMultipleFenceCompletion
     D3D12_MULTIPLE_FENCE_WAIT_FLAGS             Flags,
     uint64_t                                    hEvent)
 {
-    auto replay_object = MapObject<ID3D12Device1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device1_SetEventOnMultipleFenceCompletion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppFences,
+            pFenceValues,
+            NumFences,
+            Flags,
+            hEvent);
         auto in_ppFences = MapObjects<ID3D12Fence>(ppFences, NumFences);
         auto in_hEvent = static_cast<HANDLE>(PreProcessExternalObject(hEvent, format::ApiCallId::ApiCall_ID3D12Device1_SetEventOnMultipleFenceCompletion, "ID3D12Device1_SetEventOnMultipleFenceCompletion"));
-        auto replay_result = replay_object->SetEventOnMultipleFenceCompletion(in_ppFences,
-                                                                              pFenceValues->GetPointer(),
-                                                                              NumFences,
-                                                                              Flags,
-                                                                              in_hEvent);
+        auto replay_result = reinterpret_cast<ID3D12Device1*>(replay_object->object)->SetEventOnMultipleFenceCompletion(in_ppFences,
+                                                                                                                        pFenceValues->GetPointer(),
+                                                                                                                        NumFences,
+                                                                                                                        Flags,
+                                                                                                                        in_hEvent);
         CheckReplayResult("ID3D12Device1_SetEventOnMultipleFenceCompletion", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device1_SetEventOnMultipleFenceCompletion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ppFences,
+            pFenceValues,
+            NumFences,
+            Flags,
+            hEvent);
     }
 }
 
@@ -5494,14 +9246,28 @@ void Dx12ReplayConsumer::Process_ID3D12Device1_SetResidencyPriority(
     HandlePointerDecoder<ID3D12Pageable*>*      ppObjects,
     PointerDecoder<D3D12_RESIDENCY_PRIORITY>*   pPriorities)
 {
-    auto replay_object = MapObject<ID3D12Device1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device1_SetResidencyPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumObjects,
+            ppObjects,
+            pPriorities);
         auto in_ppObjects = MapObjects<ID3D12Pageable>(ppObjects, NumObjects);
-        auto replay_result = replay_object->SetResidencyPriority(NumObjects,
-                                                                 in_ppObjects,
-                                                                 pPriorities->GetPointer());
+        auto replay_result = reinterpret_cast<ID3D12Device1*>(replay_object->object)->SetResidencyPriority(NumObjects,
+                                                                                                           in_ppObjects,
+                                                                                                           pPriorities->GetPointer());
         CheckReplayResult("ID3D12Device1_SetResidencyPriority", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device1_SetResidencyPriority>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumObjects,
+            ppObjects,
+            pPriorities);
     }
 }
 
@@ -5513,21 +9279,35 @@ void Dx12ReplayConsumer::Process_ID3D12Device2_CreatePipelineState(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppPipelineState)
 {
-    auto replay_object = MapObject<ID3D12Device2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device2_CreatePipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppPipelineState);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppPipelineState->IsNull()) ppPipelineState->SetHandleLength(1);
         auto out_p_ppPipelineState    = ppPipelineState->GetPointer();
         auto out_hp_ppPipelineState   = ppPipelineState->GetHandlePointer();
-        auto replay_result = replay_object->CreatePipelineState(pDesc->GetPointer(),
-                                                                *riid.decoded_value,
-                                                                out_hp_ppPipelineState);
+        auto replay_result = reinterpret_cast<ID3D12Device2*>(replay_object->object)->CreatePipelineState(pDesc->GetPointer(),
+                                                                                                          *riid.decoded_value,
+                                                                                                          out_hp_ppPipelineState);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppPipelineState, out_hp_ppPipelineState, format::ApiCall_ID3D12Device2_CreatePipelineState);
         }
         CheckReplayResult("ID3D12Device2_CreatePipelineState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device2_CreatePipelineState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppPipelineState);
     }
 }
 
@@ -5542,6 +9322,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_OpenExistingHeapFromAddress(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device3_OpenExistingHeapFromAddress>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAddress,
+            riid,
+            ppvHeap);
         if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppvHeap->SetConsumerData(0, &object_info);
@@ -5555,6 +9342,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_OpenExistingHeapFromAddress(
             AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device3_OpenExistingHeapFromAddress);
         }
         CheckReplayResult("ID3D12Device3_OpenExistingHeapFromAddress", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device3_OpenExistingHeapFromAddress>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAddress,
+            riid,
+            ppvHeap);
     }
 }
 
@@ -5566,21 +9360,35 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_OpenExistingHeapFromFileMapping(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvHeap)
 {
-    auto replay_object = MapObject<ID3D12Device3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device3_OpenExistingHeapFromFileMapping>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hFileMapping,
+            riid,
+            ppvHeap);
         auto in_hFileMapping = static_cast<HANDLE>(PreProcessExternalObject(hFileMapping, format::ApiCallId::ApiCall_ID3D12Device3_OpenExistingHeapFromFileMapping, "ID3D12Device3_OpenExistingHeapFromFileMapping"));
         if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         auto out_p_ppvHeap    = ppvHeap->GetPointer();
         auto out_hp_ppvHeap   = ppvHeap->GetHandlePointer();
-        auto replay_result = replay_object->OpenExistingHeapFromFileMapping(in_hFileMapping,
-                                                                            *riid.decoded_value,
-                                                                            out_hp_ppvHeap);
+        auto replay_result = reinterpret_cast<ID3D12Device3*>(replay_object->object)->OpenExistingHeapFromFileMapping(in_hFileMapping,
+                                                                                                                      *riid.decoded_value,
+                                                                                                                      out_hp_ppvHeap);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvHeap, out_hp_ppvHeap, format::ApiCall_ID3D12Device3_OpenExistingHeapFromFileMapping);
         }
         CheckReplayResult("ID3D12Device3_OpenExistingHeapFromFileMapping", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device3_OpenExistingHeapFromFileMapping>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            hFileMapping,
+            riid,
+            ppvHeap);
     }
 }
 
@@ -5597,6 +9405,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_EnqueueMakeResident(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device3_EnqueueMakeResident>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags,
+            NumObjects,
+            ppObjects,
+            pFenceToSignal,
+            FenceValueToSignal);
         MapObjects<ID3D12Pageable>(ppObjects, NumObjects);
         auto in_pFenceToSignal = GetObjectInfo(pFenceToSignal);
         auto replay_result = OverrideEnqueueMakeResident(replay_object,
@@ -5607,6 +9424,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device3_EnqueueMakeResident(
                                                          in_pFenceToSignal,
                                                          FenceValueToSignal);
         CheckReplayResult("ID3D12Device3_EnqueueMakeResident", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device3_EnqueueMakeResident>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags,
+            NumObjects,
+            ppObjects,
+            pFenceToSignal,
+            FenceValueToSignal);
     }
 }
 
@@ -5617,19 +9443,31 @@ void Dx12ReplayConsumer::Process_ID3D12ProtectedSession_GetStatusFence(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppFence)
 {
-    auto replay_object = MapObject<ID3D12ProtectedSession>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ProtectedSession_GetStatusFence>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppFence);
         if(!ppFence->IsNull()) ppFence->SetHandleLength(1);
         auto out_p_ppFence    = ppFence->GetPointer();
         auto out_hp_ppFence   = ppFence->GetHandlePointer();
-        auto replay_result = replay_object->GetStatusFence(*riid.decoded_value,
-                                                           out_hp_ppFence);
+        auto replay_result = reinterpret_cast<ID3D12ProtectedSession*>(replay_object->object)->GetStatusFence(*riid.decoded_value,
+                                                                                                              out_hp_ppFence);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppFence, out_hp_ppFence, format::ApiCall_ID3D12ProtectedSession_GetStatusFence);
         }
         CheckReplayResult("ID3D12ProtectedSession_GetStatusFence", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ProtectedSession_GetStatusFence>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppFence);
     }
 }
 
@@ -5638,10 +9476,18 @@ void Dx12ReplayConsumer::Process_ID3D12ProtectedSession_GetSessionStatus(
     format::HandleId                            object_id,
     D3D12_PROTECTED_SESSION_STATUS              return_value)
 {
-    auto replay_object = MapObject<ID3D12ProtectedSession>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetSessionStatus();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ProtectedSession_GetSessionStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12ProtectedSession*>(replay_object->object)->GetSessionStatus();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ProtectedSession_GetSessionStatus>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5650,10 +9496,18 @@ void Dx12ReplayConsumer::Process_ID3D12ProtectedResourceSession_GetDesc(
     format::HandleId                            object_id,
     Decoded_D3D12_PROTECTED_RESOURCE_SESSION_DESC return_value)
 {
-    auto replay_object = MapObject<ID3D12ProtectedResourceSession>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ProtectedResourceSession_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12ProtectedResourceSession*>(replay_object->object)->GetDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ProtectedResourceSession_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5670,6 +9524,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommandList1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateCommandList1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            type,
+            flags,
+            riid,
+            ppCommandList);
         if(!ppCommandList->IsNull()) ppCommandList->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppCommandList->SetConsumerData(0, &object_info);
@@ -5685,6 +9548,15 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommandList1(
             AddObject(ppCommandList->GetPointer(), ppCommandList->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device4_CreateCommandList1);
         }
         CheckReplayResult("ID3D12Device4_CreateCommandList1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateCommandList1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            nodeMask,
+            type,
+            flags,
+            riid,
+            ppCommandList);
     }
 }
 
@@ -5696,20 +9568,34 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateProtectedResourceSession(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppSession)
 {
-    auto replay_object = MapObject<ID3D12Device4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppSession);
         if(!ppSession->IsNull()) ppSession->SetHandleLength(1);
         auto out_p_ppSession    = ppSession->GetPointer();
         auto out_hp_ppSession   = ppSession->GetHandlePointer();
-        auto replay_result = replay_object->CreateProtectedResourceSession(pDesc->GetPointer(),
-                                                                           *riid.decoded_value,
-                                                                           out_hp_ppSession);
+        auto replay_result = reinterpret_cast<ID3D12Device4*>(replay_object->object)->CreateProtectedResourceSession(pDesc->GetPointer(),
+                                                                                                                     *riid.decoded_value,
+                                                                                                                     out_hp_ppSession);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppSession, out_hp_ppSession, format::ApiCall_ID3D12Device4_CreateProtectedResourceSession);
         }
         CheckReplayResult("ID3D12Device4_CreateProtectedResourceSession", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppSession);
     }
 }
 
@@ -5729,6 +9615,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommittedResource1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateCommittedResource1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialResourceState,
+            pOptimizedClearValue,
+            pProtectedSession,
+            riidResource,
+            ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -5749,6 +9647,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateCommittedResource1(
             SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device4_CreateCommittedResource1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateCommittedResource1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialResourceState,
+            pOptimizedClearValue,
+            pProtectedSession,
+            riidResource,
+            ppvResource);
     }
 }
 
@@ -5764,6 +9674,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateHeap1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateHeap1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            pProtectedSession,
+            riid,
+            ppvHeap);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
         if(!ppvHeap->IsNull()) ppvHeap->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -5779,6 +9697,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateHeap1(
             AddObject(ppvHeap->GetPointer(), ppvHeap->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device4_CreateHeap1);
         }
         CheckReplayResult("ID3D12Device4_CreateHeap1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateHeap1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            pProtectedSession,
+            riid,
+            ppvHeap);
     }
 }
 
@@ -5796,6 +9722,16 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateReservedResource1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateReservedResource1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            pProtectedSession,
+            riid,
+            ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -5814,6 +9750,16 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_CreateReservedResource1(
             SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device4_CreateReservedResource1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateReservedResource1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            pProtectedSession,
+            riid,
+            ppvResource);
     }
 }
 
@@ -5826,13 +9772,29 @@ void Dx12ReplayConsumer::Process_ID3D12Device4_GetResourceAllocationInfo1(
     StructPointerDecoder<Decoded_D3D12_RESOURCE_DESC>* pResourceDescs,
     StructPointerDecoder<Decoded_D3D12_RESOURCE_ALLOCATION_INFO1>* pResourceAllocationInfo1)
 {
-    auto replay_object = MapObject<ID3D12Device4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetResourceAllocationInfo1(visibleMask,
-                                                                       numResourceDescs,
-                                                                       pResourceDescs->GetPointer(),
-                                                                       pResourceAllocationInfo1->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device4_GetResourceAllocationInfo1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs,
+            pResourceAllocationInfo1);
+        auto replay_result = reinterpret_cast<ID3D12Device4*>(replay_object->object)->GetResourceAllocationInfo1(visibleMask,
+                                                                                                                 numResourceDescs,
+                                                                                                                 pResourceDescs->GetPointer(),
+                                                                                                                 pResourceAllocationInfo1->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device4_GetResourceAllocationInfo1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs,
+            pResourceAllocationInfo1);
     }
 }
 
@@ -5841,10 +9803,20 @@ void Dx12ReplayConsumer::Process_ID3D12LifetimeOwner_LifetimeStateUpdated(
     format::HandleId                            object_id,
     D3D12_LIFETIME_STATE                        NewState)
 {
-    auto replay_object = MapObject<ID3D12LifetimeOwner>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->LifetimeStateUpdated(NewState);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12LifetimeOwner_LifetimeStateUpdated>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NewState);
+        reinterpret_cast<ID3D12LifetimeOwner*>(replay_object->object)->LifetimeStateUpdated(NewState);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12LifetimeOwner_LifetimeStateUpdated>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NewState);
     }
 }
 
@@ -5853,10 +9825,18 @@ void Dx12ReplayConsumer::Process_ID3D12SwapChainAssistant_GetLUID(
     format::HandleId                            object_id,
     Decoded_LUID                                return_value)
 {
-    auto replay_object = MapObject<ID3D12SwapChainAssistant>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetLUID();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetLUID>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12SwapChainAssistant*>(replay_object->object)->GetLUID();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetLUID>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5867,19 +9847,31 @@ void Dx12ReplayConsumer::Process_ID3D12SwapChainAssistant_GetSwapChainObject(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppv)
 {
-    auto replay_object = MapObject<ID3D12SwapChainAssistant>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetSwapChainObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppv);
         if(!ppv->IsNull()) ppv->SetHandleLength(1);
         auto out_p_ppv    = ppv->GetPointer();
         auto out_hp_ppv   = ppv->GetHandlePointer();
-        auto replay_result = replay_object->GetSwapChainObject(*riid.decoded_value,
-                                                               out_hp_ppv);
+        auto replay_result = reinterpret_cast<ID3D12SwapChainAssistant*>(replay_object->object)->GetSwapChainObject(*riid.decoded_value,
+                                                                                                                    out_hp_ppv);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppv, out_hp_ppv, format::ApiCall_ID3D12SwapChainAssistant_GetSwapChainObject);
         }
         CheckReplayResult("ID3D12SwapChainAssistant_GetSwapChainObject", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetSwapChainObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppv);
     }
 }
 
@@ -5892,25 +9884,41 @@ void Dx12ReplayConsumer::Process_ID3D12SwapChainAssistant_GetCurrentResourceAndC
     Decoded_GUID                                riidQueue,
     HandlePointerDecoder<void*>*                ppvQueue)
 {
-    auto replay_object = MapObject<ID3D12SwapChainAssistant>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riidResource,
+            ppvResource,
+            riidQueue,
+            ppvQueue);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         auto out_p_ppvResource    = ppvResource->GetPointer();
         auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
         if(!ppvQueue->IsNull()) ppvQueue->SetHandleLength(1);
         auto out_p_ppvQueue    = ppvQueue->GetPointer();
         auto out_hp_ppvQueue   = ppvQueue->GetHandlePointer();
-        auto replay_result = replay_object->GetCurrentResourceAndCommandQueue(*riidResource.decoded_value,
-                                                                              out_hp_ppvResource,
-                                                                              *riidQueue.decoded_value,
-                                                                              out_hp_ppvQueue);
+        auto replay_result = reinterpret_cast<ID3D12SwapChainAssistant*>(replay_object->object)->GetCurrentResourceAndCommandQueue(*riidResource.decoded_value,
+                                                                                                                                   out_hp_ppvResource,
+                                                                                                                                   *riidQueue.decoded_value,
+                                                                                                                                   out_hp_ppvQueue);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue);
             AddObject(out_p_ppvQueue, out_hp_ppvQueue, format::ApiCall_ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue);
         }
         CheckReplayResult("ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_GetCurrentResourceAndCommandQueue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riidResource,
+            ppvResource,
+            riidQueue,
+            ppvQueue);
     }
 }
 
@@ -5919,11 +9927,19 @@ void Dx12ReplayConsumer::Process_ID3D12SwapChainAssistant_InsertImplicitSync(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12SwapChainAssistant>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->InsertImplicitSync();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_InsertImplicitSync>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12SwapChainAssistant*>(replay_object->object)->InsertImplicitSync();
         CheckReplayResult("ID3D12SwapChainAssistant_InsertImplicitSync", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SwapChainAssistant_InsertImplicitSync>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5933,12 +9949,22 @@ void Dx12ReplayConsumer::Process_ID3D12LifetimeTracker_DestroyOwnedObject(
     HRESULT                                     return_value,
     format::HandleId                            pObject)
 {
-    auto replay_object = MapObject<ID3D12LifetimeTracker>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12LifetimeTracker_DestroyOwnedObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pObject);
         auto in_pObject = MapObject<ID3D12DeviceChild>(pObject);
-        auto replay_result = replay_object->DestroyOwnedObject(in_pObject);
+        auto replay_result = reinterpret_cast<ID3D12LifetimeTracker*>(replay_object->object)->DestroyOwnedObject(in_pObject);
         CheckReplayResult("ID3D12LifetimeTracker_DestroyOwnedObject", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12LifetimeTracker_DestroyOwnedObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pObject);
     }
 }
 
@@ -5951,9 +9977,19 @@ void Dx12ReplayConsumer::Process_ID3D12StateObjectProperties_GetShaderIdentifier
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetShaderIdentifier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pExportName);
         auto replay_result = OverrideGetShaderIdentifier(replay_object,
                                                          return_value,
                                                          pExportName);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetShaderIdentifier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pExportName);
     }
 }
 
@@ -5963,10 +9999,20 @@ void Dx12ReplayConsumer::Process_ID3D12StateObjectProperties_GetShaderStackSize(
     UINT64                                      return_value,
     WStringDecoder*                             pExportName)
 {
-    auto replay_object = MapObject<ID3D12StateObjectProperties>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetShaderStackSize(pExportName->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetShaderStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pExportName);
+        auto replay_result = reinterpret_cast<ID3D12StateObjectProperties*>(replay_object->object)->GetShaderStackSize(pExportName->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetShaderStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pExportName);
     }
 }
 
@@ -5975,10 +10021,18 @@ void Dx12ReplayConsumer::Process_ID3D12StateObjectProperties_GetPipelineStackSiz
     format::HandleId                            object_id,
     UINT64                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12StateObjectProperties>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetPipelineStackSize();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetPipelineStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12StateObjectProperties*>(replay_object->object)->GetPipelineStackSize();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_GetPipelineStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -5987,10 +10041,20 @@ void Dx12ReplayConsumer::Process_ID3D12StateObjectProperties_SetPipelineStackSiz
     format::HandleId                            object_id,
     UINT64                                      PipelineStackSizeInBytes)
 {
-    auto replay_object = MapObject<ID3D12StateObjectProperties>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetPipelineStackSize(PipelineStackSizeInBytes);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_SetPipelineStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            PipelineStackSizeInBytes);
+        reinterpret_cast<ID3D12StateObjectProperties*>(replay_object->object)->SetPipelineStackSize(PipelineStackSizeInBytes);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12StateObjectProperties_SetPipelineStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            PipelineStackSizeInBytes);
     }
 }
 
@@ -6002,21 +10066,35 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateLifetimeTracker(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvTracker)
 {
-    auto replay_object = MapObject<ID3D12Device5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_CreateLifetimeTracker>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOwner,
+            riid,
+            ppvTracker);
         auto in_pOwner = MapObject<ID3D12LifetimeOwner>(pOwner);
         if(!ppvTracker->IsNull()) ppvTracker->SetHandleLength(1);
         auto out_p_ppvTracker    = ppvTracker->GetPointer();
         auto out_hp_ppvTracker   = ppvTracker->GetHandlePointer();
-        auto replay_result = replay_object->CreateLifetimeTracker(in_pOwner,
-                                                                  *riid.decoded_value,
-                                                                  out_hp_ppvTracker);
+        auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->CreateLifetimeTracker(in_pOwner,
+                                                                                                            *riid.decoded_value,
+                                                                                                            out_hp_ppvTracker);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvTracker, out_hp_ppvTracker, format::ApiCall_ID3D12Device5_CreateLifetimeTracker);
         }
         CheckReplayResult("ID3D12Device5_CreateLifetimeTracker", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_CreateLifetimeTracker>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOwner,
+            riid,
+            ppvTracker);
     }
 }
 
@@ -6024,10 +10102,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_RemoveDevice(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12Device5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->RemoveDevice();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_RemoveDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12Device5*>(replay_object->object)->RemoveDevice();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_RemoveDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -6038,12 +10124,24 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommands(
     PointerDecoder<UINT>*                       pNumMetaCommands,
     StructPointerDecoder<Decoded_D3D12_META_COMMAND_DESC>* pDescs)
 {
-    auto replay_object = MapObject<ID3D12Device5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->EnumerateMetaCommands(pNumMetaCommands->GetPointer(),
-                                                                  pDescs->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommands>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pNumMetaCommands,
+            pDescs);
+        auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommands(pNumMetaCommands->GetPointer(),
+                                                                                                            pDescs->GetPointer());
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommands", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommands>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pNumMetaCommands,
+            pDescs);
     }
 }
 
@@ -6057,15 +10155,33 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_EnumerateMetaCommandParameters(
     PointerDecoder<UINT>*                       pParameterCount,
     StructPointerDecoder<Decoded_D3D12_META_COMMAND_PARAMETER_DESC>* pParameterDescs)
 {
-    auto replay_object = MapObject<ID3D12Device5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->EnumerateMetaCommandParameters(*CommandId.decoded_value,
-                                                                           Stage,
-                                                                           pTotalStructureSizeInBytes->GetPointer(),
-                                                                           pParameterCount->GetPointer(),
-                                                                           pParameterDescs->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommandParameters>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CommandId,
+            Stage,
+            pTotalStructureSizeInBytes,
+            pParameterCount,
+            pParameterDescs);
+        auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->EnumerateMetaCommandParameters(*CommandId.decoded_value,
+                                                                                                                     Stage,
+                                                                                                                     pTotalStructureSizeInBytes->GetPointer(),
+                                                                                                                     pParameterCount->GetPointer(),
+                                                                                                                     pParameterDescs->GetPointer());
         CheckReplayResult("ID3D12Device5_EnumerateMetaCommandParameters", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_EnumerateMetaCommandParameters>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CommandId,
+            Stage,
+            pTotalStructureSizeInBytes,
+            pParameterCount,
+            pParameterDescs);
     }
 }
 
@@ -6080,23 +10196,43 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateMetaCommand(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppMetaCommand)
 {
-    auto replay_object = MapObject<ID3D12Device5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_CreateMetaCommand>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CommandId,
+            NodeMask,
+            pCreationParametersData,
+            CreationParametersDataSizeInBytes,
+            riid,
+            ppMetaCommand);
         if(!ppMetaCommand->IsNull()) ppMetaCommand->SetHandleLength(1);
         auto out_p_ppMetaCommand    = ppMetaCommand->GetPointer();
         auto out_hp_ppMetaCommand   = ppMetaCommand->GetHandlePointer();
-        auto replay_result = replay_object->CreateMetaCommand(*CommandId.decoded_value,
-                                                              NodeMask,
-                                                              pCreationParametersData->GetPointer(),
-                                                              CreationParametersDataSizeInBytes,
-                                                              *riid.decoded_value,
-                                                              out_hp_ppMetaCommand);
+        auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->CreateMetaCommand(*CommandId.decoded_value,
+                                                                                                        NodeMask,
+                                                                                                        pCreationParametersData->GetPointer(),
+                                                                                                        CreationParametersDataSizeInBytes,
+                                                                                                        *riid.decoded_value,
+                                                                                                        out_hp_ppMetaCommand);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppMetaCommand, out_hp_ppMetaCommand, format::ApiCall_ID3D12Device5_CreateMetaCommand);
         }
         CheckReplayResult("ID3D12Device5_CreateMetaCommand", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_CreateMetaCommand>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CommandId,
+            NodeMask,
+            pCreationParametersData,
+            CreationParametersDataSizeInBytes,
+            riid,
+            ppMetaCommand);
     }
 }
 
@@ -6111,6 +10247,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateStateObject(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_CreateStateObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppStateObject);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if(!ppStateObject->IsNull()) ppStateObject->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -6125,6 +10268,13 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CreateStateObject(
             AddObject(ppStateObject->GetPointer(), ppStateObject->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device5_CreateStateObject);
         }
         CheckReplayResult("ID3D12Device5_CreateStateObject", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_CreateStateObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppStateObject);
     }
 }
 
@@ -6137,10 +10287,22 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_GetRaytracingAccelerationStructur
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_GetRaytracingAccelerationStructurePrebuildInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            pInfo);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         OverrideGetRaytracingAccelerationStructurePrebuildInfo(replay_object,
                                                                pDesc,
                                                                pInfo);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_GetRaytracingAccelerationStructurePrebuildInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            pInfo);
     }
 }
 
@@ -6151,11 +10313,23 @@ void Dx12ReplayConsumer::Process_ID3D12Device5_CheckDriverMatchingIdentifier(
     D3D12_SERIALIZED_DATA_TYPE                  SerializedDataType,
     StructPointerDecoder<Decoded_D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER>* pIdentifierToCheck)
 {
-    auto replay_object = MapObject<ID3D12Device5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->CheckDriverMatchingIdentifier(SerializedDataType,
-                                                                          pIdentifierToCheck->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device5_CheckDriverMatchingIdentifier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SerializedDataType,
+            pIdentifierToCheck);
+        auto replay_result = reinterpret_cast<ID3D12Device5*>(replay_object->object)->CheckDriverMatchingIdentifier(SerializedDataType,
+                                                                                                                    pIdentifierToCheck->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device5_CheckDriverMatchingIdentifier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SerializedDataType,
+            pIdentifierToCheck);
     }
 }
 
@@ -6167,8 +10341,18 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings_SetAuto
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetAutoBreadcrumbsEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
         OverrideSetAutoBreadcrumbsEnablement(replay_object,
                                              Enablement);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetAutoBreadcrumbsEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
     }
 }
 
@@ -6180,8 +10364,18 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings_SetPage
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetPageFaultEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
         OverrideSetPageFaultEnablement(replay_object,
                                        Enablement);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetPageFaultEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
     }
 }
 
@@ -6190,10 +10384,20 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings_SetWats
     format::HandleId                            object_id,
     D3D12_DRED_ENABLEMENT                       Enablement)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedDataSettings>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetWatsonDumpEnablement(Enablement);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetWatsonDumpEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
+        reinterpret_cast<ID3D12DeviceRemovedExtendedDataSettings*>(replay_object->object)->SetWatsonDumpEnablement(Enablement);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetWatsonDumpEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
     }
 }
 
@@ -6205,8 +10409,18 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings1_SetBre
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings1_SetBreadcrumbContextEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
         OverrideSetBreadcrumbContextEnablement(replay_object,
                                                Enablement);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings1_SetBreadcrumbContextEnablement>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enablement);
     }
 }
 
@@ -6215,10 +10429,20 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedDataSettings2_UseMar
     format::HandleId                            object_id,
     BOOL                                        MarkersOnly)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedDataSettings2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->UseMarkersOnlyAutoBreadcrumbs(MarkersOnly);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings2_UseMarkersOnlyAutoBreadcrumbs>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MarkersOnly);
+        reinterpret_cast<ID3D12DeviceRemovedExtendedDataSettings2*>(replay_object->object)->UseMarkersOnlyAutoBreadcrumbs(MarkersOnly);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings2_UseMarkersOnlyAutoBreadcrumbs>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MarkersOnly);
     }
 }
 
@@ -6228,15 +10452,25 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData_GetAutoBreadcru
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT>* pOutput)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedData>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetAutoBreadcrumbsOutput(pOutput->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData_GetAutoBreadcrumbsOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData*>(replay_object->object)->GetAutoBreadcrumbsOutput(pOutput->GetPointer());
         if (SUCCEEDED(replay_result))
         {
             AddStructObjects(pOutput, pOutput->GetPointer(), GetObjectInfoTable());
         }
         CheckReplayResult("ID3D12DeviceRemovedExtendedData_GetAutoBreadcrumbsOutput", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData_GetAutoBreadcrumbsOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
     }
 }
 
@@ -6246,12 +10480,22 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData_GetPageFaultAll
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_DRED_PAGE_FAULT_OUTPUT>* pOutput)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedData>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData_GetPageFaultAllocationOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
         MapStructObjects(pOutput->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        auto replay_result = replay_object->GetPageFaultAllocationOutput(pOutput->GetPointer());
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData*>(replay_object->object)->GetPageFaultAllocationOutput(pOutput->GetPointer());
         CheckReplayResult("ID3D12DeviceRemovedExtendedData_GetPageFaultAllocationOutput", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData_GetPageFaultAllocationOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
     }
 }
 
@@ -6261,15 +10505,25 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData1_GetAutoBreadcr
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1>* pOutput)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedData1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetAutoBreadcrumbsOutput1(pOutput->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData1_GetAutoBreadcrumbsOutput1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData1*>(replay_object->object)->GetAutoBreadcrumbsOutput1(pOutput->GetPointer());
         if (SUCCEEDED(replay_result))
         {
             AddStructObjects(pOutput, pOutput->GetPointer(), GetObjectInfoTable());
         }
         CheckReplayResult("ID3D12DeviceRemovedExtendedData1_GetAutoBreadcrumbsOutput1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData1_GetAutoBreadcrumbsOutput1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
     }
 }
 
@@ -6279,16 +10533,26 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData1_GetPageFaultAl
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_DRED_PAGE_FAULT_OUTPUT1>* pOutput)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedData1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData1_GetPageFaultAllocationOutput1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
         MapStructObjects(pOutput->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        auto replay_result = replay_object->GetPageFaultAllocationOutput1(pOutput->GetPointer());
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData1*>(replay_object->object)->GetPageFaultAllocationOutput1(pOutput->GetPointer());
         if (SUCCEEDED(replay_result))
         {
             AddStructObjects(pOutput, pOutput->GetPointer(), GetObjectInfoTable());
         }
         CheckReplayResult("ID3D12DeviceRemovedExtendedData1_GetPageFaultAllocationOutput1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData1_GetPageFaultAllocationOutput1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
     }
 }
 
@@ -6298,16 +10562,26 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData2_GetPageFaultAl
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_DRED_PAGE_FAULT_OUTPUT2>* pOutput)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedData2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
         MapStructObjects(pOutput->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        auto replay_result = replay_object->GetPageFaultAllocationOutput2(pOutput->GetPointer());
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData2*>(replay_object->object)->GetPageFaultAllocationOutput2(pOutput->GetPointer());
         if (SUCCEEDED(replay_result))
         {
             AddStructObjects(pOutput, pOutput->GetPointer(), GetObjectInfoTable());
         }
         CheckReplayResult("ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput2", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData2_GetPageFaultAllocationOutput2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pOutput);
     }
 }
 
@@ -6316,10 +10590,18 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceRemovedExtendedData2_GetDeviceState
     format::HandleId                            object_id,
     D3D12_DRED_DEVICE_STATE                     return_value)
 {
-    auto replay_object = MapObject<ID3D12DeviceRemovedExtendedData2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDeviceState();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData2_GetDeviceState>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DeviceRemovedExtendedData2*>(replay_object->object)->GetDeviceState();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedData2_GetDeviceState>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -6332,15 +10614,31 @@ void Dx12ReplayConsumer::Process_ID3D12Device6_SetBackgroundProcessingMode(
     uint64_t                                    hEventToSignalUponCompletion,
     PointerDecoder<BOOL>*                       pbFurtherMeasurementsDesired)
 {
-    auto replay_object = MapObject<ID3D12Device6>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device6_SetBackgroundProcessingMode>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mode,
+            MeasurementsAction,
+            hEventToSignalUponCompletion,
+            pbFurtherMeasurementsDesired);
         auto in_hEventToSignalUponCompletion = static_cast<HANDLE>(PreProcessExternalObject(hEventToSignalUponCompletion, format::ApiCallId::ApiCall_ID3D12Device6_SetBackgroundProcessingMode, "ID3D12Device6_SetBackgroundProcessingMode"));
-        auto replay_result = replay_object->SetBackgroundProcessingMode(Mode,
-                                                                        MeasurementsAction,
-                                                                        in_hEventToSignalUponCompletion,
-                                                                        pbFurtherMeasurementsDesired->GetPointer());
+        auto replay_result = reinterpret_cast<ID3D12Device6*>(replay_object->object)->SetBackgroundProcessingMode(Mode,
+                                                                                                                  MeasurementsAction,
+                                                                                                                  in_hEventToSignalUponCompletion,
+                                                                                                                  pbFurtherMeasurementsDesired->GetPointer());
         CheckReplayResult("ID3D12Device6_SetBackgroundProcessingMode", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device6_SetBackgroundProcessingMode>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mode,
+            MeasurementsAction,
+            hEventToSignalUponCompletion,
+            pbFurtherMeasurementsDesired);
     }
 }
 
@@ -6349,10 +10647,18 @@ void Dx12ReplayConsumer::Process_ID3D12ProtectedResourceSession1_GetDesc1(
     format::HandleId                            object_id,
     Decoded_D3D12_PROTECTED_RESOURCE_SESSION_DESC1 return_value)
 {
-    auto replay_object = MapObject<ID3D12ProtectedResourceSession1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc1();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ProtectedResourceSession1_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12ProtectedResourceSession1*>(replay_object->object)->GetDesc1();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ProtectedResourceSession1_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -6368,6 +10674,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device7_AddToStateObject(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device7_AddToStateObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAddition,
+            pStateObjectToGrowFrom,
+            riid,
+            ppNewStateObject);
         MapStructObjects(pAddition->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         auto in_pStateObjectToGrowFrom = GetObjectInfo(pStateObjectToGrowFrom);
         if(!ppNewStateObject->IsNull()) ppNewStateObject->SetHandleLength(1);
@@ -6384,6 +10698,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device7_AddToStateObject(
             AddObject(ppNewStateObject->GetPointer(), ppNewStateObject->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device7_AddToStateObject);
         }
         CheckReplayResult("ID3D12Device7_AddToStateObject", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device7_AddToStateObject>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pAddition,
+            pStateObjectToGrowFrom,
+            riid,
+            ppNewStateObject);
     }
 }
 
@@ -6395,20 +10717,34 @@ void Dx12ReplayConsumer::Process_ID3D12Device7_CreateProtectedResourceSession1(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppSession)
 {
-    auto replay_object = MapObject<ID3D12Device7>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device7_CreateProtectedResourceSession1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppSession);
         if(!ppSession->IsNull()) ppSession->SetHandleLength(1);
         auto out_p_ppSession    = ppSession->GetPointer();
         auto out_hp_ppSession   = ppSession->GetHandlePointer();
-        auto replay_result = replay_object->CreateProtectedResourceSession1(pDesc->GetPointer(),
-                                                                            *riid.decoded_value,
-                                                                            out_hp_ppSession);
+        auto replay_result = reinterpret_cast<ID3D12Device7*>(replay_object->object)->CreateProtectedResourceSession1(pDesc->GetPointer(),
+                                                                                                                      *riid.decoded_value,
+                                                                                                                      out_hp_ppSession);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppSession, out_hp_ppSession, format::ApiCall_ID3D12Device7_CreateProtectedResourceSession1);
         }
         CheckReplayResult("ID3D12Device7_CreateProtectedResourceSession1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device7_CreateProtectedResourceSession1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppSession);
     }
 }
 
@@ -6421,13 +10757,29 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_GetResourceAllocationInfo2(
     StructPointerDecoder<Decoded_D3D12_RESOURCE_DESC1>* pResourceDescs,
     StructPointerDecoder<Decoded_D3D12_RESOURCE_ALLOCATION_INFO1>* pResourceAllocationInfo1)
 {
-    auto replay_object = MapObject<ID3D12Device8>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetResourceAllocationInfo2(visibleMask,
-                                                                       numResourceDescs,
-                                                                       pResourceDescs->GetPointer(),
-                                                                       pResourceAllocationInfo1->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device8_GetResourceAllocationInfo2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs,
+            pResourceAllocationInfo1);
+        auto replay_result = reinterpret_cast<ID3D12Device8*>(replay_object->object)->GetResourceAllocationInfo2(visibleMask,
+                                                                                                                 numResourceDescs,
+                                                                                                                 pResourceDescs->GetPointer(),
+                                                                                                                 pResourceAllocationInfo1->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device8_GetResourceAllocationInfo2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs,
+            pResourceAllocationInfo1);
     }
 }
 
@@ -6447,6 +10799,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreateCommittedResource2(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device8_CreateCommittedResource2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialResourceState,
+            pOptimizedClearValue,
+            pProtectedSession,
+            riidResource,
+            ppvResource);
         auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         DxObjectInfo object_info{};
@@ -6467,6 +10831,18 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreateCommittedResource2(
             SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device8_CreateCommittedResource2", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device8_CreateCommittedResource2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialResourceState,
+            pOptimizedClearValue,
+            pProtectedSession,
+            riidResource,
+            ppvResource);
     }
 }
 
@@ -6482,26 +10858,48 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreatePlacedResource1(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvResource)
 {
-    auto replay_object = MapObject<ID3D12Device8>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device8_CreatePlacedResource1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeap,
+            HeapOffset,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            riid,
+            ppvResource);
         auto in_pHeap = MapObject<ID3D12Heap>(pHeap);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         auto out_p_ppvResource    = ppvResource->GetPointer();
         auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
-        auto replay_result = replay_object->CreatePlacedResource1(in_pHeap,
-                                                                  HeapOffset,
-                                                                  pDesc->GetPointer(),
-                                                                  InitialState,
-                                                                  pOptimizedClearValue->GetPointer(),
-                                                                  *riid.decoded_value,
-                                                                  out_hp_ppvResource);
+        auto replay_result = reinterpret_cast<ID3D12Device8*>(replay_object->object)->CreatePlacedResource1(in_pHeap,
+                                                                                                            HeapOffset,
+                                                                                                            pDesc->GetPointer(),
+                                                                                                            InitialState,
+                                                                                                            pOptimizedClearValue->GetPointer(),
+                                                                                                            *riid.decoded_value,
+                                                                                                            out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device8_CreatePlacedResource1);
             SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device8_CreatePlacedResource1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device8_CreatePlacedResource1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeap,
+            HeapOffset,
+            pDesc,
+            InitialState,
+            pOptimizedClearValue,
+            riid,
+            ppvResource);
     }
 }
 
@@ -6512,15 +10910,29 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_CreateSamplerFeedbackUnorderedAcc
     format::HandleId                            pFeedbackResource,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device8>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pTargetedResource,
+            pFeedbackResource,
+            DestDescriptor);
         auto in_pTargetedResource = MapObject<ID3D12Resource>(pTargetedResource);
         auto in_pFeedbackResource = MapObject<ID3D12Resource>(pFeedbackResource);
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateSamplerFeedbackUnorderedAccessView(in_pTargetedResource,
-                                                                in_pFeedbackResource,
-                                                                *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device8*>(replay_object->object)->CreateSamplerFeedbackUnorderedAccessView(in_pTargetedResource,
+                                                                                                          in_pFeedbackResource,
+                                                                                                          *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device8_CreateSamplerFeedbackUnorderedAccessView>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pTargetedResource,
+            pFeedbackResource,
+            DestDescriptor);
     }
 }
 
@@ -6536,17 +10948,41 @@ void Dx12ReplayConsumer::Process_ID3D12Device8_GetCopyableFootprints1(
     PointerDecoder<UINT64>*                     pRowSizeInBytes,
     PointerDecoder<UINT64>*                     pTotalBytes)
 {
-    auto replay_object = MapObject<ID3D12Device8>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->GetCopyableFootprints1(pResourceDesc->GetPointer(),
-                                              FirstSubresource,
-                                              NumSubresources,
-                                              BaseOffset,
-                                              pLayouts->GetPointer(),
-                                              pNumRows->GetPointer(),
-                                              pRowSizeInBytes->GetPointer(),
-                                              pTotalBytes->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device8_GetCopyableFootprints1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResourceDesc,
+            FirstSubresource,
+            NumSubresources,
+            BaseOffset,
+            pLayouts,
+            pNumRows,
+            pRowSizeInBytes,
+            pTotalBytes);
+        reinterpret_cast<ID3D12Device8*>(replay_object->object)->GetCopyableFootprints1(pResourceDesc->GetPointer(),
+                                                                                        FirstSubresource,
+                                                                                        NumSubresources,
+                                                                                        BaseOffset,
+                                                                                        pLayouts->GetPointer(),
+                                                                                        pNumRows->GetPointer(),
+                                                                                        pRowSizeInBytes->GetPointer(),
+                                                                                        pTotalBytes->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device8_GetCopyableFootprints1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResourceDesc,
+            FirstSubresource,
+            NumSubresources,
+            BaseOffset,
+            pLayouts,
+            pNumRows,
+            pRowSizeInBytes,
+            pTotalBytes);
     }
 }
 
@@ -6557,19 +10993,31 @@ void Dx12ReplayConsumer::Process_ID3D12Resource1_GetProtectedResourceSession(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppProtectedSession)
 {
-    auto replay_object = MapObject<ID3D12Resource1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource1_GetProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppProtectedSession);
         if(!ppProtectedSession->IsNull()) ppProtectedSession->SetHandleLength(1);
         auto out_p_ppProtectedSession    = ppProtectedSession->GetPointer();
         auto out_hp_ppProtectedSession   = ppProtectedSession->GetHandlePointer();
-        auto replay_result = replay_object->GetProtectedResourceSession(*riid.decoded_value,
-                                                                        out_hp_ppProtectedSession);
+        auto replay_result = reinterpret_cast<ID3D12Resource1*>(replay_object->object)->GetProtectedResourceSession(*riid.decoded_value,
+                                                                                                                    out_hp_ppProtectedSession);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppProtectedSession, out_hp_ppProtectedSession, format::ApiCall_ID3D12Resource1_GetProtectedResourceSession);
         }
         CheckReplayResult("ID3D12Resource1_GetProtectedResourceSession", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource1_GetProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppProtectedSession);
     }
 }
 
@@ -6578,10 +11026,18 @@ void Dx12ReplayConsumer::Process_ID3D12Resource2_GetDesc1(
     format::HandleId                            object_id,
     Decoded_D3D12_RESOURCE_DESC1                return_value)
 {
-    auto replay_object = MapObject<ID3D12Resource2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc1();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Resource2_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Resource2*>(replay_object->object)->GetDesc1();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Resource2_GetDesc1>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -6592,19 +11048,31 @@ void Dx12ReplayConsumer::Process_ID3D12Heap1_GetProtectedResourceSession(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppProtectedSession)
 {
-    auto replay_object = MapObject<ID3D12Heap1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Heap1_GetProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppProtectedSession);
         if(!ppProtectedSession->IsNull()) ppProtectedSession->SetHandleLength(1);
         auto out_p_ppProtectedSession    = ppProtectedSession->GetPointer();
         auto out_hp_ppProtectedSession   = ppProtectedSession->GetHandlePointer();
-        auto replay_result = replay_object->GetProtectedResourceSession(*riid.decoded_value,
-                                                                        out_hp_ppProtectedSession);
+        auto replay_result = reinterpret_cast<ID3D12Heap1*>(replay_object->object)->GetProtectedResourceSession(*riid.decoded_value,
+                                                                                                                out_hp_ppProtectedSession);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppProtectedSession, out_hp_ppProtectedSession, format::ApiCall_ID3D12Heap1_GetProtectedResourceSession);
         }
         CheckReplayResult("ID3D12Heap1_GetProtectedResourceSession", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Heap1_GetProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppProtectedSession);
     }
 }
 
@@ -6613,11 +11081,21 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList3_SetProtectedResource
     format::HandleId                            object_id,
     format::HandleId                            pProtectedResourceSession)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList3_SetProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pProtectedResourceSession);
         auto in_pProtectedResourceSession = MapObject<ID3D12ProtectedResourceSession>(pProtectedResourceSession);
-        replay_object->SetProtectedResourceSession(in_pProtectedResourceSession);
+        reinterpret_cast<ID3D12GraphicsCommandList3*>(replay_object->object)->SetProtectedResourceSession(in_pProtectedResourceSession);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList3_SetProtectedResourceSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pProtectedResourceSession);
     }
 }
 
@@ -6628,11 +11106,23 @@ void Dx12ReplayConsumer::Process_ID3D12MetaCommand_GetRequiredParameterResourceS
     D3D12_META_COMMAND_PARAMETER_STAGE          Stage,
     UINT                                        ParameterIndex)
 {
-    auto replay_object = MapObject<ID3D12MetaCommand>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetRequiredParameterResourceSize(Stage,
-                                                                             ParameterIndex);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12MetaCommand_GetRequiredParameterResourceSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Stage,
+            ParameterIndex);
+        auto replay_result = reinterpret_cast<ID3D12MetaCommand*>(replay_object->object)->GetRequiredParameterResourceSize(Stage,
+                                                                                                                           ParameterIndex);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12MetaCommand_GetRequiredParameterResourceSize>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Stage,
+            ParameterIndex);
     }
 }
 
@@ -6644,15 +11134,31 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_BeginRenderPass(
     StructPointerDecoder<Decoded_D3D12_RENDER_PASS_DEPTH_STENCIL_DESC>* pDepthStencil,
     D3D12_RENDER_PASS_FLAGS                     Flags)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BeginRenderPass>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumRenderTargets,
+            pRenderTargets,
+            pDepthStencil,
+            Flags);
         MapStructArrayObjects(pRenderTargets->GetMetaStructPointer(), pRenderTargets->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
         MapStructObjects(pDepthStencil->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->BeginRenderPass(NumRenderTargets,
-                                       pRenderTargets->GetPointer(),
-                                       pDepthStencil->GetPointer(),
-                                       Flags);
+        reinterpret_cast<ID3D12GraphicsCommandList4*>(replay_object->object)->BeginRenderPass(NumRenderTargets,
+                                                                                              pRenderTargets->GetPointer(),
+                                                                                              pDepthStencil->GetPointer(),
+                                                                                              Flags);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BeginRenderPass>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumRenderTargets,
+            pRenderTargets,
+            pDepthStencil,
+            Flags);
     }
 }
 
@@ -6660,10 +11166,18 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_EndRenderPass(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->EndRenderPass();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_EndRenderPass>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12GraphicsCommandList4*>(replay_object->object)->EndRenderPass();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_EndRenderPass>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -6674,13 +11188,27 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_InitializeMetaComman
     PointerDecoder<uint8_t>*                    pInitializationParametersData,
     SIZE_T                                      InitializationParametersDataSizeInBytes)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_InitializeMetaCommand>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMetaCommand,
+            pInitializationParametersData,
+            InitializationParametersDataSizeInBytes);
         auto in_pMetaCommand = MapObject<ID3D12MetaCommand>(pMetaCommand);
-        replay_object->InitializeMetaCommand(in_pMetaCommand,
-                                             pInitializationParametersData->GetPointer(),
-                                             InitializationParametersDataSizeInBytes);
+        reinterpret_cast<ID3D12GraphicsCommandList4*>(replay_object->object)->InitializeMetaCommand(in_pMetaCommand,
+                                                                                                    pInitializationParametersData->GetPointer(),
+                                                                                                    InitializationParametersDataSizeInBytes);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_InitializeMetaCommand>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMetaCommand,
+            pInitializationParametersData,
+            InitializationParametersDataSizeInBytes);
     }
 }
 
@@ -6691,13 +11219,27 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_ExecuteMetaCommand(
     PointerDecoder<uint8_t>*                    pExecutionParametersData,
     SIZE_T                                      ExecutionParametersDataSizeInBytes)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_ExecuteMetaCommand>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMetaCommand,
+            pExecutionParametersData,
+            ExecutionParametersDataSizeInBytes);
         auto in_pMetaCommand = MapObject<ID3D12MetaCommand>(pMetaCommand);
-        replay_object->ExecuteMetaCommand(in_pMetaCommand,
-                                          pExecutionParametersData->GetPointer(),
-                                          ExecutionParametersDataSizeInBytes);
+        reinterpret_cast<ID3D12GraphicsCommandList4*>(replay_object->object)->ExecuteMetaCommand(in_pMetaCommand,
+                                                                                                 pExecutionParametersData->GetPointer(),
+                                                                                                 ExecutionParametersDataSizeInBytes);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_ExecuteMetaCommand>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pMetaCommand,
+            pExecutionParametersData,
+            ExecutionParametersDataSizeInBytes);
     }
 }
 
@@ -6711,12 +11253,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_BuildRaytracingAccel
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BuildRaytracingAccelerationStructure>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            NumPostbuildInfoDescs,
+            pPostbuildInfoDescs);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         MapStructArrayObjects(pPostbuildInfoDescs->GetMetaStructPointer(), pPostbuildInfoDescs->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
         OverrideBuildRaytracingAccelerationStructure(replay_object,
                                                      pDesc,
                                                      NumPostbuildInfoDescs,
                                                      pPostbuildInfoDescs);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_BuildRaytracingAccelerationStructure>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            NumPostbuildInfoDescs,
+            pPostbuildInfoDescs);
     }
 }
 
@@ -6727,17 +11283,31 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_EmitRaytracingAccele
     UINT                                        NumSourceAccelerationStructures,
     PointerDecoder<D3D12_GPU_VIRTUAL_ADDRESS>*  pSourceAccelerationStructureData)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            NumSourceAccelerationStructures,
+            pSourceAccelerationStructureData);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         if (pSourceAccelerationStructureData && !pSourceAccelerationStructureData->IsNull())
         {
             MapGpuVirtualAddresses(pSourceAccelerationStructureData->GetPointer(), NumSourceAccelerationStructures);
         }
-        replay_object->EmitRaytracingAccelerationStructurePostbuildInfo(pDesc->GetPointer(),
-                                                                        NumSourceAccelerationStructures,
-                                                                        pSourceAccelerationStructureData->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList4*>(replay_object->object)->EmitRaytracingAccelerationStructurePostbuildInfo(pDesc->GetPointer(),
+                                                                                                                               NumSourceAccelerationStructures,
+                                                                                                                               pSourceAccelerationStructureData->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_EmitRaytracingAccelerationStructurePostbuildInfo>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            NumSourceAccelerationStructures,
+            pSourceAccelerationStructureData);
     }
 }
 
@@ -6748,14 +11318,28 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_CopyRaytracingAccele
     D3D12_GPU_VIRTUAL_ADDRESS                   SourceAccelerationStructureData,
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_CopyRaytracingAccelerationStructure>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DestAccelerationStructureData,
+            SourceAccelerationStructureData,
+            Mode);
         MapGpuVirtualAddress(DestAccelerationStructureData);
         MapGpuVirtualAddress(SourceAccelerationStructureData);
-        replay_object->CopyRaytracingAccelerationStructure(DestAccelerationStructureData,
-                                                           SourceAccelerationStructureData,
-                                                           Mode);
+        reinterpret_cast<ID3D12GraphicsCommandList4*>(replay_object->object)->CopyRaytracingAccelerationStructure(DestAccelerationStructureData,
+                                                                                                                  SourceAccelerationStructureData,
+                                                                                                                  Mode);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_CopyRaytracingAccelerationStructure>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DestAccelerationStructureData,
+            SourceAccelerationStructureData,
+            Mode);
     }
 }
 
@@ -6767,9 +11351,19 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_SetPipelineState1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_SetPipelineState1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStateObject);
         auto in_pStateObject = GetObjectInfo(pStateObject);
         OverrideSetPipelineState1(replay_object,
                                   in_pStateObject);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_SetPipelineState1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pStateObject);
     }
 }
 
@@ -6781,9 +11375,19 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList4_DispatchRays(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_DispatchRays>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
         MapStructObjects(pDesc->GetMetaStructPointer(), GetObjectInfoTable(), GetGpuVaTable());
         OverrideDispatchRays(replay_object,
                              pDesc);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList4_DispatchRays>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc);
     }
 }
 
@@ -6796,14 +11400,30 @@ void Dx12ReplayConsumer::Process_ID3D12ShaderCacheSession_FindValue(
     PointerDecoder<uint8_t>*                    pValue,
     PointerDecoder<UINT>*                       pValueSize)
 {
-    auto replay_object = MapObject<ID3D12ShaderCacheSession>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->FindValue(pKey->GetPointer(),
-                                                      KeySize,
-                                                      pValue->GetPointer(),
-                                                      pValueSize->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_FindValue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pKey,
+            KeySize,
+            pValue,
+            pValueSize);
+        auto replay_result = reinterpret_cast<ID3D12ShaderCacheSession*>(replay_object->object)->FindValue(pKey->GetPointer(),
+                                                                                                           KeySize,
+                                                                                                           pValue->GetPointer(),
+                                                                                                           pValueSize->GetPointer());
         CheckReplayResult("ID3D12ShaderCacheSession_FindValue", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_FindValue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pKey,
+            KeySize,
+            pValue,
+            pValueSize);
     }
 }
 
@@ -6816,14 +11436,30 @@ void Dx12ReplayConsumer::Process_ID3D12ShaderCacheSession_StoreValue(
     PointerDecoder<uint8_t>*                    pValue,
     UINT                                        ValueSize)
 {
-    auto replay_object = MapObject<ID3D12ShaderCacheSession>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->StoreValue(pKey->GetPointer(),
-                                                       KeySize,
-                                                       pValue->GetPointer(),
-                                                       ValueSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_StoreValue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pKey,
+            KeySize,
+            pValue,
+            ValueSize);
+        auto replay_result = reinterpret_cast<ID3D12ShaderCacheSession*>(replay_object->object)->StoreValue(pKey->GetPointer(),
+                                                                                                            KeySize,
+                                                                                                            pValue->GetPointer(),
+                                                                                                            ValueSize);
         CheckReplayResult("ID3D12ShaderCacheSession_StoreValue", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_StoreValue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pKey,
+            KeySize,
+            pValue,
+            ValueSize);
     }
 }
 
@@ -6831,10 +11467,18 @@ void Dx12ReplayConsumer::Process_ID3D12ShaderCacheSession_SetDeleteOnDestroy(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12ShaderCacheSession>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetDeleteOnDestroy();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_SetDeleteOnDestroy>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12ShaderCacheSession*>(replay_object->object)->SetDeleteOnDestroy();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_SetDeleteOnDestroy>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -6843,10 +11487,18 @@ void Dx12ReplayConsumer::Process_ID3D12ShaderCacheSession_GetDesc(
     format::HandleId                            object_id,
     Decoded_D3D12_SHADER_CACHE_SESSION_DESC     return_value)
 {
-    auto replay_object = MapObject<ID3D12ShaderCacheSession>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12ShaderCacheSession*>(replay_object->object)->GetDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ShaderCacheSession_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -6858,20 +11510,34 @@ void Dx12ReplayConsumer::Process_ID3D12Device9_CreateShaderCacheSession(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvSession)
 {
-    auto replay_object = MapObject<ID3D12Device9>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device9_CreateShaderCacheSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppvSession);
         if(!ppvSession->IsNull()) ppvSession->SetHandleLength(1);
         auto out_p_ppvSession    = ppvSession->GetPointer();
         auto out_hp_ppvSession   = ppvSession->GetHandlePointer();
-        auto replay_result = replay_object->CreateShaderCacheSession(pDesc->GetPointer(),
-                                                                     *riid.decoded_value,
-                                                                     out_hp_ppvSession);
+        auto replay_result = reinterpret_cast<ID3D12Device9*>(replay_object->object)->CreateShaderCacheSession(pDesc->GetPointer(),
+                                                                                                               *riid.decoded_value,
+                                                                                                               out_hp_ppvSession);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvSession, out_hp_ppvSession, format::ApiCall_ID3D12Device9_CreateShaderCacheSession);
         }
         CheckReplayResult("ID3D12Device9_CreateShaderCacheSession", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device9_CreateShaderCacheSession>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            riid,
+            ppvSession);
     }
 }
 
@@ -6882,12 +11548,24 @@ void Dx12ReplayConsumer::Process_ID3D12Device9_ShaderCacheControl(
     D3D12_SHADER_CACHE_KIND_FLAGS               Kinds,
     D3D12_SHADER_CACHE_CONTROL_FLAGS            Control)
 {
-    auto replay_object = MapObject<ID3D12Device9>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ShaderCacheControl(Kinds,
-                                                               Control);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device9_ShaderCacheControl>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Kinds,
+            Control);
+        auto replay_result = reinterpret_cast<ID3D12Device9*>(replay_object->object)->ShaderCacheControl(Kinds,
+                                                                                                         Control);
         CheckReplayResult("ID3D12Device9_ShaderCacheControl", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device9_ShaderCacheControl>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Kinds,
+            Control);
     }
 }
 
@@ -6903,6 +11581,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device9_CreateCommandQueue1(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device9_CreateCommandQueue1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            CreatorID,
+            riid,
+            ppCommandQueue);
         if(!ppCommandQueue->IsNull()) ppCommandQueue->SetHandleLength(1);
         DxObjectInfo object_info{};
         ppCommandQueue->SetConsumerData(0, &object_info);
@@ -6917,6 +11603,14 @@ void Dx12ReplayConsumer::Process_ID3D12Device9_CreateCommandQueue1(
             AddObject(ppCommandQueue->GetPointer(), ppCommandQueue->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device9_CreateCommandQueue1);
         }
         CheckReplayResult("ID3D12Device9_CreateCommandQueue1", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device9_CreateCommandQueue1>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            CreatorID,
+            riid,
+            ppCommandQueue);
     }
 }
 
@@ -6935,28 +11629,56 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateCommittedResource3(
     Decoded_GUID                                riidResource,
     HandlePointerDecoder<void*>*                ppvResource)
 {
-    auto replay_object = MapObject<ID3D12Device10>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device10_CreateCommittedResource3>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialLayout,
+            pOptimizedClearValue,
+            pProtectedSession,
+            NumCastableFormats,
+            pCastableFormats,
+            riidResource,
+            ppvResource);
         auto in_pProtectedSession = MapObject<ID3D12ProtectedResourceSession>(pProtectedSession);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         auto out_p_ppvResource    = ppvResource->GetPointer();
         auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
-        auto replay_result = replay_object->CreateCommittedResource3(pHeapProperties->GetPointer(),
-                                                                     HeapFlags,
-                                                                     pDesc->GetPointer(),
-                                                                     InitialLayout,
-                                                                     pOptimizedClearValue->GetPointer(),
-                                                                     in_pProtectedSession,
-                                                                     NumCastableFormats,
-                                                                     pCastableFormats->GetPointer(),
-                                                                     *riidResource.decoded_value,
-                                                                     out_hp_ppvResource);
+        auto replay_result = reinterpret_cast<ID3D12Device10*>(replay_object->object)->CreateCommittedResource3(pHeapProperties->GetPointer(),
+                                                                                                                HeapFlags,
+                                                                                                                pDesc->GetPointer(),
+                                                                                                                InitialLayout,
+                                                                                                                pOptimizedClearValue->GetPointer(),
+                                                                                                                in_pProtectedSession,
+                                                                                                                NumCastableFormats,
+                                                                                                                pCastableFormats->GetPointer(),
+                                                                                                                *riidResource.decoded_value,
+                                                                                                                out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreateCommittedResource3);
         }
         CheckReplayResult("ID3D12Device10_CreateCommittedResource3", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device10_CreateCommittedResource3>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeapProperties,
+            HeapFlags,
+            pDesc,
+            InitialLayout,
+            pOptimizedClearValue,
+            pProtectedSession,
+            NumCastableFormats,
+            pCastableFormats,
+            riidResource,
+            ppvResource);
     }
 }
 
@@ -6974,27 +11696,53 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreatePlacedResource2(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvResource)
 {
-    auto replay_object = MapObject<ID3D12Device10>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device10_CreatePlacedResource2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeap,
+            HeapOffset,
+            pDesc,
+            InitialLayout,
+            pOptimizedClearValue,
+            NumCastableFormats,
+            pCastableFormats,
+            riid,
+            ppvResource);
         auto in_pHeap = MapObject<ID3D12Heap>(pHeap);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         auto out_p_ppvResource    = ppvResource->GetPointer();
         auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
-        auto replay_result = replay_object->CreatePlacedResource2(in_pHeap,
-                                                                  HeapOffset,
-                                                                  pDesc->GetPointer(),
-                                                                  InitialLayout,
-                                                                  pOptimizedClearValue->GetPointer(),
-                                                                  NumCastableFormats,
-                                                                  pCastableFormats->GetPointer(),
-                                                                  *riid.decoded_value,
-                                                                  out_hp_ppvResource);
+        auto replay_result = reinterpret_cast<ID3D12Device10*>(replay_object->object)->CreatePlacedResource2(in_pHeap,
+                                                                                                             HeapOffset,
+                                                                                                             pDesc->GetPointer(),
+                                                                                                             InitialLayout,
+                                                                                                             pOptimizedClearValue->GetPointer(),
+                                                                                                             NumCastableFormats,
+                                                                                                             pCastableFormats->GetPointer(),
+                                                                                                             *riid.decoded_value,
+                                                                                                             out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreatePlacedResource2);
         }
         CheckReplayResult("ID3D12Device10_CreatePlacedResource2", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device10_CreatePlacedResource2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pHeap,
+            HeapOffset,
+            pDesc,
+            InitialLayout,
+            pOptimizedClearValue,
+            NumCastableFormats,
+            pCastableFormats,
+            riid,
+            ppvResource);
     }
 }
 
@@ -7011,26 +11759,50 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateReservedResource2(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvResource)
 {
-    auto replay_object = MapObject<ID3D12Device10>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device10_CreateReservedResource2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            InitialLayout,
+            pOptimizedClearValue,
+            pProtectedSession,
+            NumCastableFormats,
+            pCastableFormats,
+            riid,
+            ppvResource);
         auto in_pProtectedSession = MapObject<ID3D12ProtectedResourceSession>(pProtectedSession);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
         auto out_p_ppvResource    = ppvResource->GetPointer();
         auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
-        auto replay_result = replay_object->CreateReservedResource2(pDesc->GetPointer(),
-                                                                    InitialLayout,
-                                                                    pOptimizedClearValue->GetPointer(),
-                                                                    in_pProtectedSession,
-                                                                    NumCastableFormats,
-                                                                    pCastableFormats->GetPointer(),
-                                                                    *riid.decoded_value,
-                                                                    out_hp_ppvResource);
+        auto replay_result = reinterpret_cast<ID3D12Device10*>(replay_object->object)->CreateReservedResource2(pDesc->GetPointer(),
+                                                                                                               InitialLayout,
+                                                                                                               pOptimizedClearValue->GetPointer(),
+                                                                                                               in_pProtectedSession,
+                                                                                                               NumCastableFormats,
+                                                                                                               pCastableFormats->GetPointer(),
+                                                                                                               *riid.decoded_value,
+                                                                                                               out_hp_ppvResource);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreateReservedResource2);
         }
         CheckReplayResult("ID3D12Device10_CreateReservedResource2", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device10_CreateReservedResource2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            InitialLayout,
+            pOptimizedClearValue,
+            pProtectedSession,
+            NumCastableFormats,
+            pCastableFormats,
+            riid,
+            ppvResource);
     }
 }
 
@@ -7040,12 +11812,24 @@ void Dx12ReplayConsumer::Process_ID3D12Device11_CreateSampler2(
     StructPointerDecoder<Decoded_D3D12_SAMPLER_DESC2>* pDesc,
     Decoded_D3D12_CPU_DESCRIPTOR_HANDLE         DestDescriptor)
 {
-    auto replay_object = MapObject<ID3D12Device11>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device11_CreateSampler2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            DestDescriptor);
         MapStructObjects(&DestDescriptor, GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->CreateSampler2(pDesc->GetPointer(),
-                                      *DestDescriptor.decoded_value);
+        reinterpret_cast<ID3D12Device11*>(replay_object->object)->CreateSampler2(pDesc->GetPointer(),
+                                                                                 *DestDescriptor.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device11_CreateSampler2>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            DestDescriptor);
     }
 }
 
@@ -7079,9 +11863,15 @@ void Dx12ReplayConsumer::Process_ID3D12VirtualizationGuestDevice_ShareWithHost(
     format::HandleId                            pObject,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
-    auto replay_object = MapObject<ID3D12VirtualizationGuestDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_ShareWithHost>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pObject,
+            pHandle);
         auto in_pObject = MapObject<ID3D12DeviceChild>(pObject);
         if(!pHandle->IsNull())
         {
@@ -7089,9 +11879,15 @@ void Dx12ReplayConsumer::Process_ID3D12VirtualizationGuestDevice_ShareWithHost(
         }
         auto out_p_pHandle    = pHandle->GetPointer();
         auto out_op_pHandle   = reinterpret_cast<HANDLE*>(pHandle->GetOutputPointer());
-        auto replay_result = replay_object->ShareWithHost(in_pObject,
-                                                          out_op_pHandle);
+        auto replay_result = reinterpret_cast<ID3D12VirtualizationGuestDevice*>(replay_object->object)->ShareWithHost(in_pObject,
+                                                                                                                      out_op_pHandle);
         CheckReplayResult("ID3D12VirtualizationGuestDevice_ShareWithHost", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_ShareWithHost>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pObject,
+            pHandle);
         PostProcessExternalObject(replay_result, out_op_pHandle, out_p_pHandle, format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_ShareWithHost, "ID3D12VirtualizationGuestDevice_ShareWithHost");
     }
 }
@@ -7104,14 +11900,28 @@ void Dx12ReplayConsumer::Process_ID3D12VirtualizationGuestDevice_CreateFenceFd(
     UINT64                                      FenceValue,
     PointerDecoder<int>*                        pFenceFd)
 {
-    auto replay_object = MapObject<ID3D12VirtualizationGuestDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_CreateFenceFd>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            FenceValue,
+            pFenceFd);
         auto in_pFence = MapObject<ID3D12Fence>(pFence);
-        auto replay_result = replay_object->CreateFenceFd(in_pFence,
-                                                          FenceValue,
-                                                          pFenceFd->GetPointer());
+        auto replay_result = reinterpret_cast<ID3D12VirtualizationGuestDevice*>(replay_object->object)->CreateFenceFd(in_pFence,
+                                                                                                                      FenceValue,
+                                                                                                                      pFenceFd->GetPointer());
         CheckReplayResult("ID3D12VirtualizationGuestDevice_CreateFenceFd", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12VirtualizationGuestDevice_CreateFenceFd>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            FenceValue,
+            pFenceFd);
     }
 }
 
@@ -7120,10 +11930,20 @@ void Dx12ReplayConsumer::Process_ID3D12Tools_EnableShaderInstrumentation(
     format::HandleId                            object_id,
     BOOL                                        bEnable)
 {
-    auto replay_object = MapObject<ID3D12Tools>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->EnableShaderInstrumentation(bEnable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Tools_EnableShaderInstrumentation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            bEnable);
+        reinterpret_cast<ID3D12Tools*>(replay_object->object)->EnableShaderInstrumentation(bEnable);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Tools_EnableShaderInstrumentation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            bEnable);
     }
 }
 
@@ -7132,10 +11952,18 @@ void Dx12ReplayConsumer::Process_ID3D12Tools_ShaderInstrumentationEnabled(
     format::HandleId                            object_id,
     BOOL                                        return_value)
 {
-    auto replay_object = MapObject<ID3D12Tools>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ShaderInstrumentationEnabled();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Tools_ShaderInstrumentationEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12Tools*>(replay_object->object)->ShaderInstrumentationEnabled();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Tools_ShaderInstrumentationEnabled>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7146,12 +11974,24 @@ void Dx12ReplayConsumer::Process_ID3D12SDKConfiguration_SetSDKVersion(
     UINT                                        SDKVersion,
     StringDecoder*                              SDKPath)
 {
-    auto replay_object = MapObject<ID3D12SDKConfiguration>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetSDKVersion(SDKVersion,
-                                                          SDKPath->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SDKConfiguration_SetSDKVersion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SDKVersion,
+            SDKPath);
+        auto replay_result = reinterpret_cast<ID3D12SDKConfiguration*>(replay_object->object)->SetSDKVersion(SDKVersion,
+                                                                                                             SDKPath->GetPointer());
         CheckReplayResult("ID3D12SDKConfiguration_SetSDKVersion", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SDKConfiguration_SetSDKVersion>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SDKVersion,
+            SDKPath);
     }
 }
 
@@ -7164,21 +12004,37 @@ void Dx12ReplayConsumer::Process_ID3D12SDKConfiguration1_CreateDeviceFactory(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvFactory)
 {
-    auto replay_object = MapObject<ID3D12SDKConfiguration1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SDKConfiguration1_CreateDeviceFactory>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SDKVersion,
+            SDKPath,
+            riid,
+            ppvFactory);
         if(!ppvFactory->IsNull()) ppvFactory->SetHandleLength(1);
         auto out_p_ppvFactory    = ppvFactory->GetPointer();
         auto out_hp_ppvFactory   = ppvFactory->GetHandlePointer();
-        auto replay_result = replay_object->CreateDeviceFactory(SDKVersion,
-                                                                SDKPath->GetPointer(),
-                                                                *riid.decoded_value,
-                                                                out_hp_ppvFactory);
+        auto replay_result = reinterpret_cast<ID3D12SDKConfiguration1*>(replay_object->object)->CreateDeviceFactory(SDKVersion,
+                                                                                                                    SDKPath->GetPointer(),
+                                                                                                                    *riid.decoded_value,
+                                                                                                                    out_hp_ppvFactory);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvFactory, out_hp_ppvFactory, format::ApiCall_ID3D12SDKConfiguration1_CreateDeviceFactory);
         }
         CheckReplayResult("ID3D12SDKConfiguration1_CreateDeviceFactory", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SDKConfiguration1_CreateDeviceFactory>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            SDKVersion,
+            SDKPath,
+            riid,
+            ppvFactory);
     }
 }
 
@@ -7186,10 +12042,18 @@ void Dx12ReplayConsumer::Process_ID3D12SDKConfiguration1_FreeUnusedSDKs(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12SDKConfiguration1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->FreeUnusedSDKs();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SDKConfiguration1_FreeUnusedSDKs>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12SDKConfiguration1*>(replay_object->object)->FreeUnusedSDKs();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SDKConfiguration1_FreeUnusedSDKs>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7198,11 +12062,19 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_InitializeFromGlobalState(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12DeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->InitializeFromGlobalState();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_InitializeFromGlobalState>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DeviceFactory*>(replay_object->object)->InitializeFromGlobalState();
         CheckReplayResult("ID3D12DeviceFactory_InitializeFromGlobalState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_InitializeFromGlobalState>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7211,11 +12083,19 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_ApplyToGlobalState(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12DeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ApplyToGlobalState();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_ApplyToGlobalState>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DeviceFactory*>(replay_object->object)->ApplyToGlobalState();
         CheckReplayResult("ID3D12DeviceFactory_ApplyToGlobalState", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_ApplyToGlobalState>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7225,11 +12105,21 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_SetFlags(
     HRESULT                                     return_value,
     D3D12_DEVICE_FACTORY_FLAGS                  flags)
 {
-    auto replay_object = MapObject<ID3D12DeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetFlags(flags);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_SetFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            flags);
+        auto replay_result = reinterpret_cast<ID3D12DeviceFactory*>(replay_object->object)->SetFlags(flags);
         CheckReplayResult("ID3D12DeviceFactory_SetFlags", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_SetFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            flags);
     }
 }
 
@@ -7238,10 +12128,18 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_GetFlags(
     format::HandleId                            object_id,
     D3D12_DEVICE_FACTORY_FLAGS                  return_value)
 {
-    auto replay_object = MapObject<ID3D12DeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFlags();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_GetFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DeviceFactory*>(replay_object->object)->GetFlags();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_GetFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7253,20 +12151,34 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_GetConfigurationInterface(
     Decoded_GUID                                iid,
     HandlePointerDecoder<void*>*                ppv)
 {
-    auto replay_object = MapObject<ID3D12DeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_GetConfigurationInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            clsid,
+            iid,
+            ppv);
         if(!ppv->IsNull()) ppv->SetHandleLength(1);
         auto out_p_ppv    = ppv->GetPointer();
         auto out_hp_ppv   = ppv->GetHandlePointer();
-        auto replay_result = replay_object->GetConfigurationInterface(*clsid.decoded_value,
-                                                                      *iid.decoded_value,
-                                                                      out_hp_ppv);
+        auto replay_result = reinterpret_cast<ID3D12DeviceFactory*>(replay_object->object)->GetConfigurationInterface(*clsid.decoded_value,
+                                                                                                                      *iid.decoded_value,
+                                                                                                                      out_hp_ppv);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppv, out_hp_ppv, format::ApiCall_ID3D12DeviceFactory_GetConfigurationInterface);
         }
         CheckReplayResult("ID3D12DeviceFactory_GetConfigurationInterface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_GetConfigurationInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            clsid,
+            iid,
+            ppv);
     }
 }
 
@@ -7279,14 +12191,30 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_EnableExperimentalFeatures(
     PointerDecoder<uint8_t>*                    pConfigurationStructs,
     PointerDecoder<UINT>*                       pConfigurationStructSizes)
 {
-    auto replay_object = MapObject<ID3D12DeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->EnableExperimentalFeatures(NumFeatures,
-                                                                       pIIDs->GetPointer(),
-                                                                       pConfigurationStructs->GetPointer(),
-                                                                       pConfigurationStructSizes->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_EnableExperimentalFeatures>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumFeatures,
+            pIIDs,
+            pConfigurationStructs,
+            pConfigurationStructSizes);
+        auto replay_result = reinterpret_cast<ID3D12DeviceFactory*>(replay_object->object)->EnableExperimentalFeatures(NumFeatures,
+                                                                                                                       pIIDs->GetPointer(),
+                                                                                                                       pConfigurationStructs->GetPointer(),
+                                                                                                                       pConfigurationStructSizes->GetPointer());
         CheckReplayResult("ID3D12DeviceFactory_EnableExperimentalFeatures", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_EnableExperimentalFeatures>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumFeatures,
+            pIIDs,
+            pConfigurationStructs,
+            pConfigurationStructSizes);
     }
 }
 
@@ -7299,22 +12227,38 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceFactory_CreateDevice(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvDevice)
 {
-    auto replay_object = MapObject<ID3D12DeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_CreateDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            adapter,
+            FeatureLevel,
+            riid,
+            ppvDevice);
         auto in_adapter = MapObject<IUnknown>(adapter);
         if(!ppvDevice->IsNull()) ppvDevice->SetHandleLength(1);
         auto out_p_ppvDevice    = ppvDevice->GetPointer();
         auto out_hp_ppvDevice   = ppvDevice->GetHandlePointer();
-        auto replay_result = replay_object->CreateDevice(in_adapter,
-                                                         FeatureLevel,
-                                                         *riid.decoded_value,
-                                                         out_hp_ppvDevice);
+        auto replay_result = reinterpret_cast<ID3D12DeviceFactory*>(replay_object->object)->CreateDevice(in_adapter,
+                                                                                                         FeatureLevel,
+                                                                                                         *riid.decoded_value,
+                                                                                                         out_hp_ppvDevice);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvDevice, out_hp_ppvDevice, format::ApiCall_ID3D12DeviceFactory_CreateDevice);
         }
         CheckReplayResult("ID3D12DeviceFactory_CreateDevice", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceFactory_CreateDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            adapter,
+            FeatureLevel,
+            riid,
+            ppvDevice);
     }
 }
 
@@ -7323,10 +12267,18 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceConfiguration_GetDesc(
     format::HandleId                            object_id,
     Decoded_D3D12_DEVICE_CONFIGURATION_DESC     return_value)
 {
-    auto replay_object = MapObject<ID3D12DeviceConfiguration>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDesc();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DeviceConfiguration*>(replay_object->object)->GetDesc();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_GetDesc>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7337,12 +12289,24 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceConfiguration_GetEnabledExperimenta
     StructPointerDecoder<Decoded_GUID>*         pGuids,
     UINT                                        NumGuids)
 {
-    auto replay_object = MapObject<ID3D12DeviceConfiguration>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetEnabledExperimentalFeatures(pGuids->GetPointer(),
-                                                                           NumGuids);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_GetEnabledExperimentalFeatures>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pGuids,
+            NumGuids);
+        auto replay_result = reinterpret_cast<ID3D12DeviceConfiguration*>(replay_object->object)->GetEnabledExperimentalFeatures(pGuids->GetPointer(),
+                                                                                                                                 NumGuids);
         CheckReplayResult("ID3D12DeviceConfiguration_GetEnabledExperimentalFeatures", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_GetEnabledExperimentalFeatures>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pGuids,
+            NumGuids);
     }
 }
 
@@ -7354,24 +12318,38 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceConfiguration_SerializeVersionedRoo
     HandlePointerDecoder<ID3D10Blob*>*          ppResult,
     HandlePointerDecoder<ID3D10Blob*>*          ppError)
 {
-    auto replay_object = MapObject<ID3D12DeviceConfiguration>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_SerializeVersionedRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            ppResult,
+            ppError);
         if(!ppResult->IsNull()) ppResult->SetHandleLength(1);
         auto out_p_ppResult    = ppResult->GetPointer();
         auto out_hp_ppResult   = ppResult->GetHandlePointer();
         if(!ppError->IsNull()) ppError->SetHandleLength(1);
         auto out_p_ppError    = ppError->GetPointer();
         auto out_hp_ppError   = ppError->GetHandlePointer();
-        auto replay_result = replay_object->SerializeVersionedRootSignature(pDesc->GetPointer(),
-                                                                            out_hp_ppResult,
-                                                                            out_hp_ppError);
+        auto replay_result = reinterpret_cast<ID3D12DeviceConfiguration*>(replay_object->object)->SerializeVersionedRootSignature(pDesc->GetPointer(),
+                                                                                                                                  out_hp_ppResult,
+                                                                                                                                  out_hp_ppError);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppResult, out_hp_ppResult, format::ApiCall_ID3D12DeviceConfiguration_SerializeVersionedRootSignature);
             AddObject(out_p_ppError, out_hp_ppError, format::ApiCall_ID3D12DeviceConfiguration_SerializeVersionedRootSignature);
         }
         CheckReplayResult("ID3D12DeviceConfiguration_SerializeVersionedRootSignature", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_SerializeVersionedRootSignature>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pDesc,
+            ppResult,
+            ppError);
     }
 }
 
@@ -7384,21 +12362,37 @@ void Dx12ReplayConsumer::Process_ID3D12DeviceConfiguration_CreateVersionedRootSi
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvDeserializer)
 {
-    auto replay_object = MapObject<ID3D12DeviceConfiguration>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pBlob,
+            Size,
+            riid,
+            ppvDeserializer);
         if(!ppvDeserializer->IsNull()) ppvDeserializer->SetHandleLength(1);
         auto out_p_ppvDeserializer    = ppvDeserializer->GetPointer();
         auto out_hp_ppvDeserializer   = ppvDeserializer->GetHandlePointer();
-        auto replay_result = replay_object->CreateVersionedRootSignatureDeserializer(pBlob->GetPointer(),
-                                                                                     Size,
-                                                                                     *riid.decoded_value,
-                                                                                     out_hp_ppvDeserializer);
+        auto replay_result = reinterpret_cast<ID3D12DeviceConfiguration*>(replay_object->object)->CreateVersionedRootSignatureDeserializer(pBlob->GetPointer(),
+                                                                                                                                           Size,
+                                                                                                                                           *riid.decoded_value,
+                                                                                                                                           out_hp_ppvDeserializer);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvDeserializer, out_hp_ppvDeserializer, format::ApiCall_ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer);
         }
         CheckReplayResult("ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DeviceConfiguration_CreateVersionedRootSignatureDeserializer>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pBlob,
+            Size,
+            riid,
+            ppvDeserializer);
     }
 }
 
@@ -7408,11 +12402,23 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList5_RSSetShadingRate(
     D3D12_SHADING_RATE                          baseShadingRate,
     PointerDecoder<D3D12_SHADING_RATE_COMBINER>* combiners)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->RSSetShadingRate(baseShadingRate,
-                                        combiners->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRate>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            baseShadingRate,
+            combiners);
+        reinterpret_cast<ID3D12GraphicsCommandList5*>(replay_object->object)->RSSetShadingRate(baseShadingRate,
+                                                                                               combiners->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRate>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            baseShadingRate,
+            combiners);
     }
 }
 
@@ -7421,11 +12427,21 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList5_RSSetShadingRateImag
     format::HandleId                            object_id,
     format::HandleId                            shadingRateImage)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRateImage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            shadingRateImage);
         auto in_shadingRateImage = MapObject<ID3D12Resource>(shadingRateImage);
-        replay_object->RSSetShadingRateImage(in_shadingRateImage);
+        reinterpret_cast<ID3D12GraphicsCommandList5*>(replay_object->object)->RSSetShadingRateImage(in_shadingRateImage);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList5_RSSetShadingRateImage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            shadingRateImage);
     }
 }
 
@@ -7436,12 +12452,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList6_DispatchMesh(
     UINT                                        ThreadGroupCountY,
     UINT                                        ThreadGroupCountZ)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList6>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->DispatchMesh(ThreadGroupCountX,
-                                    ThreadGroupCountY,
-                                    ThreadGroupCountZ);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList6_DispatchMesh>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ThreadGroupCountX,
+            ThreadGroupCountY,
+            ThreadGroupCountZ);
+        reinterpret_cast<ID3D12GraphicsCommandList6*>(replay_object->object)->DispatchMesh(ThreadGroupCountX,
+                                                                                           ThreadGroupCountY,
+                                                                                           ThreadGroupCountZ);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList6_DispatchMesh>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ThreadGroupCountX,
+            ThreadGroupCountY,
+            ThreadGroupCountZ);
     }
 }
 
@@ -7451,12 +12481,24 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList7_Barrier(
     UINT32                                      NumBarrierGroups,
     StructPointerDecoder<Decoded_D3D12_BARRIER_GROUP>* pBarrierGroups)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList7>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList7_Barrier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumBarrierGroups,
+            pBarrierGroups);
         MapStructArrayObjects(pBarrierGroups->GetMetaStructPointer(), pBarrierGroups->GetLength(), GetObjectInfoTable(), GetGpuVaTable());
-        replay_object->Barrier(NumBarrierGroups,
-                               pBarrierGroups->GetPointer());
+        reinterpret_cast<ID3D12GraphicsCommandList7*>(replay_object->object)->Barrier(NumBarrierGroups,
+                                                                                      pBarrierGroups->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList7_Barrier>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            NumBarrierGroups,
+            pBarrierGroups);
     }
 }
 
@@ -7466,11 +12508,23 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList8_OMSetFrontAndBackSte
     UINT                                        FrontStencilRef,
     UINT                                        BackStencilRef)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList8>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->OMSetFrontAndBackStencilRef(FrontStencilRef,
-                                                   BackStencilRef);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList8_OMSetFrontAndBackStencilRef>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            FrontStencilRef,
+            BackStencilRef);
+        reinterpret_cast<ID3D12GraphicsCommandList8*>(replay_object->object)->OMSetFrontAndBackStencilRef(FrontStencilRef,
+                                                                                                          BackStencilRef);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList8_OMSetFrontAndBackStencilRef>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            FrontStencilRef,
+            BackStencilRef);
     }
 }
 
@@ -7535,10 +12589,18 @@ void Dx12ReplayConsumer::Process_ID3D10Blob_GetBufferPointer(
     format::HandleId                            object_id,
     uint64_t                                    return_value)
 {
-    auto replay_object = MapObject<ID3D10Blob>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetBufferPointer();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D10Blob_GetBufferPointer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D10Blob*>(replay_object->object)->GetBufferPointer();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D10Blob_GetBufferPointer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7547,10 +12609,18 @@ void Dx12ReplayConsumer::Process_ID3D10Blob_GetBufferSize(
     format::HandleId                            object_id,
     SIZE_T                                      return_value)
 {
-    auto replay_object = MapObject<ID3D10Blob>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetBufferSize();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D10Blob_GetBufferSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D10Blob*>(replay_object->object)->GetBufferSize();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D10Blob_GetBufferSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7562,14 +12632,28 @@ void Dx12ReplayConsumer::Process_ID3DDestructionNotifier_RegisterDestructionCall
     uint64_t                                    pData,
     PointerDecoder<UINT>*                       pCallbackID)
 {
-    auto replay_object = MapObject<ID3DDestructionNotifier>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3DDestructionNotifier_RegisterDestructionCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            callbackFn,
+            pData,
+            pCallbackID);
         auto in_pData = PreProcessExternalObject(pData, format::ApiCallId::ApiCall_ID3DDestructionNotifier_RegisterDestructionCallback, "ID3DDestructionNotifier_RegisterDestructionCallback");
-        auto replay_result = replay_object->RegisterDestructionCallback(reinterpret_cast<PFN_DESTRUCTION_CALLBACK>(callbackFn),
-                                                                        in_pData,
-                                                                        pCallbackID->GetPointer());
+        auto replay_result = reinterpret_cast<ID3DDestructionNotifier*>(replay_object->object)->RegisterDestructionCallback(reinterpret_cast<PFN_DESTRUCTION_CALLBACK>(callbackFn),
+                                                                                                                            in_pData,
+                                                                                                                            pCallbackID->GetPointer());
         CheckReplayResult("ID3DDestructionNotifier_RegisterDestructionCallback", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3DDestructionNotifier_RegisterDestructionCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            callbackFn,
+            pData,
+            pCallbackID);
     }
 }
 
@@ -7579,11 +12663,21 @@ void Dx12ReplayConsumer::Process_ID3DDestructionNotifier_UnregisterDestructionCa
     HRESULT                                     return_value,
     UINT                                        callbackID)
 {
-    auto replay_object = MapObject<ID3DDestructionNotifier>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->UnregisterDestructionCallback(callbackID);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3DDestructionNotifier_UnregisterDestructionCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            callbackID);
+        auto replay_result = reinterpret_cast<ID3DDestructionNotifier*>(replay_object->object)->UnregisterDestructionCallback(callbackID);
         CheckReplayResult("ID3DDestructionNotifier_UnregisterDestructionCallback", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3DDestructionNotifier_UnregisterDestructionCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            callbackID);
     }
 }
 
@@ -7594,7 +12688,15 @@ void Dx12ReplayConsumer::Process_ID3D12Debug_EnableDebugLayer(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug_EnableDebugLayer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
         OverrideEnableDebugLayer(replay_object);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug_EnableDebugLayer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7602,10 +12704,18 @@ void Dx12ReplayConsumer::Process_ID3D12Debug1_EnableDebugLayer(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12Debug1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->EnableDebugLayer();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug1_EnableDebugLayer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12Debug1*>(replay_object->object)->EnableDebugLayer();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug1_EnableDebugLayer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7614,10 +12724,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug1_SetEnableGPUBasedValidation(
     format::HandleId                            object_id,
     BOOL                                        Enable)
 {
-    auto replay_object = MapObject<ID3D12Debug1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetEnableGPUBasedValidation(Enable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug1_SetEnableGPUBasedValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
+        reinterpret_cast<ID3D12Debug1*>(replay_object->object)->SetEnableGPUBasedValidation(Enable);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug1_SetEnableGPUBasedValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
     }
 }
 
@@ -7626,10 +12746,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug1_SetEnableSynchronizedCommandQueueV
     format::HandleId                            object_id,
     BOOL                                        Enable)
 {
-    auto replay_object = MapObject<ID3D12Debug1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetEnableSynchronizedCommandQueueValidation(Enable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug1_SetEnableSynchronizedCommandQueueValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
+        reinterpret_cast<ID3D12Debug1*>(replay_object->object)->SetEnableSynchronizedCommandQueueValidation(Enable);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug1_SetEnableSynchronizedCommandQueueValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
     }
 }
 
@@ -7638,10 +12768,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug2_SetGPUBasedValidationFlags(
     format::HandleId                            object_id,
     D3D12_GPU_BASED_VALIDATION_FLAGS            Flags)
 {
-    auto replay_object = MapObject<ID3D12Debug2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetGPUBasedValidationFlags(Flags);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug2_SetGPUBasedValidationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
+        reinterpret_cast<ID3D12Debug2*>(replay_object->object)->SetGPUBasedValidationFlags(Flags);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug2_SetGPUBasedValidationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
     }
 }
 
@@ -7650,10 +12790,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug3_SetEnableGPUBasedValidation(
     format::HandleId                            object_id,
     BOOL                                        Enable)
 {
-    auto replay_object = MapObject<ID3D12Debug3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetEnableGPUBasedValidation(Enable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug3_SetEnableGPUBasedValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
+        reinterpret_cast<ID3D12Debug3*>(replay_object->object)->SetEnableGPUBasedValidation(Enable);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug3_SetEnableGPUBasedValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
     }
 }
 
@@ -7662,10 +12812,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug3_SetEnableSynchronizedCommandQueueV
     format::HandleId                            object_id,
     BOOL                                        Enable)
 {
-    auto replay_object = MapObject<ID3D12Debug3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetEnableSynchronizedCommandQueueValidation(Enable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug3_SetEnableSynchronizedCommandQueueValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
+        reinterpret_cast<ID3D12Debug3*>(replay_object->object)->SetEnableSynchronizedCommandQueueValidation(Enable);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug3_SetEnableSynchronizedCommandQueueValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
     }
 }
 
@@ -7674,10 +12834,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug3_SetGPUBasedValidationFlags(
     format::HandleId                            object_id,
     D3D12_GPU_BASED_VALIDATION_FLAGS            Flags)
 {
-    auto replay_object = MapObject<ID3D12Debug3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetGPUBasedValidationFlags(Flags);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug3_SetGPUBasedValidationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
+        reinterpret_cast<ID3D12Debug3*>(replay_object->object)->SetGPUBasedValidationFlags(Flags);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug3_SetGPUBasedValidationFlags>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
     }
 }
 
@@ -7685,10 +12855,18 @@ void Dx12ReplayConsumer::Process_ID3D12Debug4_DisableDebugLayer(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12Debug4>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->DisableDebugLayer();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug4_DisableDebugLayer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12Debug4*>(replay_object->object)->DisableDebugLayer();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug4_DisableDebugLayer>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7697,10 +12875,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug5_SetEnableAutoName(
     format::HandleId                            object_id,
     BOOL                                        Enable)
 {
-    auto replay_object = MapObject<ID3D12Debug5>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetEnableAutoName(Enable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug5_SetEnableAutoName>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
+        reinterpret_cast<ID3D12Debug5*>(replay_object->object)->SetEnableAutoName(Enable);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug5_SetEnableAutoName>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
     }
 }
 
@@ -7709,10 +12897,20 @@ void Dx12ReplayConsumer::Process_ID3D12Debug6_SetForceLegacyBarrierValidation(
     format::HandleId                            object_id,
     BOOL                                        Enable)
 {
-    auto replay_object = MapObject<ID3D12Debug6>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetForceLegacyBarrierValidation(Enable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Debug6_SetForceLegacyBarrierValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
+        reinterpret_cast<ID3D12Debug6*>(replay_object->object)->SetForceLegacyBarrierValidation(Enable);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Debug6_SetForceLegacyBarrierValidation>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Enable);
     }
 }
 
@@ -7724,13 +12922,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice1_SetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice1_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice1*>(replay_object->object)->SetDebugParameter(Type,
+                                                                                                             pData->GetPointer(),
+                                                                                                             DataSize);
         CheckReplayResult("ID3D12DebugDevice1_SetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice1_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -7742,13 +12954,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice1_GetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice1_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice1*>(replay_object->object)->GetDebugParameter(Type,
+                                                                                                             pData->GetPointer(),
+                                                                                                             DataSize);
         CheckReplayResult("ID3D12DebugDevice1_GetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice1_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -7758,11 +12984,21 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice1_ReportLiveDeviceObjects(
     HRESULT                                     return_value,
     D3D12_RLDO_FLAGS                            Flags)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ReportLiveDeviceObjects(Flags);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice1_ReportLiveDeviceObjects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice1*>(replay_object->object)->ReportLiveDeviceObjects(Flags);
         CheckReplayResult("ID3D12DebugDevice1_ReportLiveDeviceObjects", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice1_ReportLiveDeviceObjects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
     }
 }
 
@@ -7772,11 +13008,21 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice_SetFeatureMask(
     HRESULT                                     return_value,
     D3D12_DEBUG_FEATURE                         Mask)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetFeatureMask(Mask);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice_SetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mask);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice*>(replay_object->object)->SetFeatureMask(Mask);
         CheckReplayResult("ID3D12DebugDevice_SetFeatureMask", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice_SetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mask);
     }
 }
 
@@ -7785,10 +13031,18 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice_GetFeatureMask(
     format::HandleId                            object_id,
     D3D12_DEBUG_FEATURE                         return_value)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFeatureMask();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice_GetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice*>(replay_object->object)->GetFeatureMask();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice_GetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -7798,11 +13052,21 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice_ReportLiveDeviceObjects(
     HRESULT                                     return_value,
     D3D12_RLDO_FLAGS                            Flags)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->ReportLiveDeviceObjects(Flags);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice_ReportLiveDeviceObjects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice*>(replay_object->object)->ReportLiveDeviceObjects(Flags);
         CheckReplayResult("ID3D12DebugDevice_ReportLiveDeviceObjects", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice_ReportLiveDeviceObjects>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Flags);
     }
 }
 
@@ -7814,13 +13078,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice2_SetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice2_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice2*>(replay_object->object)->SetDebugParameter(Type,
+                                                                                                             pData->GetPointer(),
+                                                                                                             DataSize);
         CheckReplayResult("ID3D12DebugDevice2_SetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice2_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -7832,13 +13110,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugDevice2_GetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugDevice2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugDevice2_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugDevice2*>(replay_object->object)->GetDebugParameter(Type,
+                                                                                                             pData->GetPointer(),
+                                                                                                             DataSize);
         CheckReplayResult("ID3D12DebugDevice2_GetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugDevice2_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -7850,13 +13142,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandQueue_AssertResourceState(
     UINT                                        Subresource,
     UINT                                        State)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandQueue_AssertResourceState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            State);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        auto replay_result = replay_object->AssertResourceState(in_pResource,
-                                                                Subresource,
-                                                                State);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandQueue*>(replay_object->object)->AssertResourceState(in_pResource,
+                                                                                                                    Subresource,
+                                                                                                                    State);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandQueue_AssertResourceState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            State);
     }
 }
 
@@ -7867,13 +13173,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandQueue1_AssertResourceAccess(
     UINT                                        Subresource,
     D3D12_BARRIER_ACCESS                        Access)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandQueue1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandQueue1_AssertResourceAccess>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Access);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        replay_object->AssertResourceAccess(in_pResource,
-                                            Subresource,
-                                            Access);
+        reinterpret_cast<ID3D12DebugCommandQueue1*>(replay_object->object)->AssertResourceAccess(in_pResource,
+                                                                                                 Subresource,
+                                                                                                 Access);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandQueue1_AssertResourceAccess>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Access);
     }
 }
 
@@ -7884,13 +13204,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandQueue1_AssertTextureLayout(
     UINT                                        Subresource,
     D3D12_BARRIER_LAYOUT                        Layout)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandQueue1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandQueue1_AssertTextureLayout>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Layout);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        replay_object->AssertTextureLayout(in_pResource,
-                                           Subresource,
-                                           Layout);
+        reinterpret_cast<ID3D12DebugCommandQueue1*>(replay_object->object)->AssertTextureLayout(in_pResource,
+                                                                                                Subresource,
+                                                                                                Layout);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandQueue1_AssertTextureLayout>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Layout);
     }
 }
 
@@ -7902,13 +13236,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList1_AssertResourceState(
     UINT                                        Subresource,
     UINT                                        State)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList1_AssertResourceState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            State);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        auto replay_result = replay_object->AssertResourceState(in_pResource,
-                                                                Subresource,
-                                                                State);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList1*>(replay_object->object)->AssertResourceState(in_pResource,
+                                                                                                                    Subresource,
+                                                                                                                    State);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList1_AssertResourceState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            State);
     }
 }
 
@@ -7920,13 +13268,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList1_SetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList1_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList1*>(replay_object->object)->SetDebugParameter(Type,
+                                                                                                                  pData->GetPointer(),
+                                                                                                                  DataSize);
         CheckReplayResult("ID3D12DebugCommandList1_SetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList1_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -7938,13 +13300,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList1_GetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList1_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList1*>(replay_object->object)->GetDebugParameter(Type,
+                                                                                                                  pData->GetPointer(),
+                                                                                                                  DataSize);
         CheckReplayResult("ID3D12DebugCommandList1_GetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList1_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -7956,13 +13332,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList_AssertResourceState(
     UINT                                        Subresource,
     UINT                                        State)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList_AssertResourceState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            State);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        auto replay_result = replay_object->AssertResourceState(in_pResource,
-                                                                Subresource,
-                                                                State);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList*>(replay_object->object)->AssertResourceState(in_pResource,
+                                                                                                                   Subresource,
+                                                                                                                   State);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList_AssertResourceState>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            State);
     }
 }
 
@@ -7972,11 +13362,21 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList_SetFeatureMask(
     HRESULT                                     return_value,
     D3D12_DEBUG_FEATURE                         Mask)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetFeatureMask(Mask);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList_SetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mask);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList*>(replay_object->object)->SetFeatureMask(Mask);
         CheckReplayResult("ID3D12DebugCommandList_SetFeatureMask", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList_SetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Mask);
     }
 }
 
@@ -7985,10 +13385,18 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList_GetFeatureMask(
     format::HandleId                            object_id,
     D3D12_DEBUG_FEATURE                         return_value)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetFeatureMask();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList_GetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList*>(replay_object->object)->GetFeatureMask();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList_GetFeatureMask>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8000,13 +13408,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList2_SetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList2_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList2*>(replay_object->object)->SetDebugParameter(Type,
+                                                                                                                  pData->GetPointer(),
+                                                                                                                  DataSize);
         CheckReplayResult("ID3D12DebugCommandList2_SetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList2_SetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -8018,13 +13440,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList2_GetDebugParameter(
     PointerDecoder<uint8_t>*                    pData,
     UINT                                        DataSize)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList2>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetDebugParameter(Type,
-                                                              pData->GetPointer(),
-                                                              DataSize);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList2_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
+        auto replay_result = reinterpret_cast<ID3D12DebugCommandList2*>(replay_object->object)->GetDebugParameter(Type,
+                                                                                                                  pData->GetPointer(),
+                                                                                                                  DataSize);
         CheckReplayResult("ID3D12DebugCommandList2_GetDebugParameter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList2_GetDebugParameter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Type,
+            pData,
+            DataSize);
     }
 }
 
@@ -8035,13 +13471,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList3_AssertResourceAccess(
     UINT                                        Subresource,
     D3D12_BARRIER_ACCESS                        Access)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList3_AssertResourceAccess>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Access);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        replay_object->AssertResourceAccess(in_pResource,
-                                            Subresource,
-                                            Access);
+        reinterpret_cast<ID3D12DebugCommandList3*>(replay_object->object)->AssertResourceAccess(in_pResource,
+                                                                                                Subresource,
+                                                                                                Access);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList3_AssertResourceAccess>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Access);
     }
 }
 
@@ -8052,13 +13502,27 @@ void Dx12ReplayConsumer::Process_ID3D12DebugCommandList3_AssertTextureLayout(
     UINT                                        Subresource,
     D3D12_BARRIER_LAYOUT                        Layout)
 {
-    auto replay_object = MapObject<ID3D12DebugCommandList3>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList3_AssertTextureLayout>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Layout);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
-        replay_object->AssertTextureLayout(in_pResource,
-                                           Subresource,
-                                           Layout);
+        reinterpret_cast<ID3D12DebugCommandList3*>(replay_object->object)->AssertTextureLayout(in_pResource,
+                                                                                               Subresource,
+                                                                                               Layout);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DebugCommandList3_AssertTextureLayout>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            Layout);
     }
 }
 
@@ -8069,14 +13533,28 @@ void Dx12ReplayConsumer::Process_ID3D12SharingContract_Present(
     UINT                                        Subresource,
     uint64_t                                    window)
 {
-    auto replay_object = MapObject<ID3D12SharingContract>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SharingContract_Present>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            window);
         auto in_pResource = MapObject<ID3D12Resource>(pResource);
         auto in_window = static_cast<HWND>(PreProcessExternalObject(window, format::ApiCallId::ApiCall_ID3D12SharingContract_Present, "ID3D12SharingContract_Present"));
-        replay_object->Present(in_pResource,
-                               Subresource,
-                               in_window);
+        reinterpret_cast<ID3D12SharingContract*>(replay_object->object)->Present(in_pResource,
+                                                                                 Subresource,
+                                                                                 in_window);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SharingContract_Present>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pResource,
+            Subresource,
+            window);
     }
 }
 
@@ -8086,12 +13564,24 @@ void Dx12ReplayConsumer::Process_ID3D12SharingContract_SharedFenceSignal(
     format::HandleId                            pFence,
     UINT64                                      FenceValue)
 {
-    auto replay_object = MapObject<ID3D12SharingContract>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SharingContract_SharedFenceSignal>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            FenceValue);
         auto in_pFence = MapObject<ID3D12Fence>(pFence);
-        replay_object->SharedFenceSignal(in_pFence,
-                                         FenceValue);
+        reinterpret_cast<ID3D12SharingContract*>(replay_object->object)->SharedFenceSignal(in_pFence,
+                                                                                           FenceValue);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SharingContract_SharedFenceSignal>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFence,
+            FenceValue);
     }
 }
 
@@ -8100,10 +13590,20 @@ void Dx12ReplayConsumer::Process_ID3D12SharingContract_BeginCapturableWork(
     format::HandleId                            object_id,
     Decoded_GUID                                guid)
 {
-    auto replay_object = MapObject<ID3D12SharingContract>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->BeginCapturableWork(*guid.decoded_value);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SharingContract_BeginCapturableWork>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid);
+        reinterpret_cast<ID3D12SharingContract*>(replay_object->object)->BeginCapturableWork(*guid.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SharingContract_BeginCapturableWork>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid);
     }
 }
 
@@ -8112,10 +13612,20 @@ void Dx12ReplayConsumer::Process_ID3D12SharingContract_EndCapturableWork(
     format::HandleId                            object_id,
     Decoded_GUID                                guid)
 {
-    auto replay_object = MapObject<ID3D12SharingContract>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->EndCapturableWork(*guid.decoded_value);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12SharingContract_EndCapturableWork>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid);
+        reinterpret_cast<ID3D12SharingContract*>(replay_object->object)->EndCapturableWork(*guid.decoded_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12SharingContract_EndCapturableWork>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            guid);
     }
 }
 
@@ -8139,11 +13649,21 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_SetMessageCountLimit(
     HRESULT                                     return_value,
     UINT64                                      MessageCountLimit)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetMessageCountLimit(MessageCountLimit);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetMessageCountLimit>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MessageCountLimit);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->SetMessageCountLimit(MessageCountLimit);
         CheckReplayResult("ID3D12InfoQueue_SetMessageCountLimit", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetMessageCountLimit>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MessageCountLimit);
     }
 }
 
@@ -8151,10 +13671,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_ClearStoredMessages(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->ClearStoredMessages();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearStoredMessages>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->ClearStoredMessages();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearStoredMessages>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8166,13 +13694,27 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetMessage(
     StructPointerDecoder<Decoded_D3D12_MESSAGE>* pMessage,
     PointerDecoder<SIZE_T>*                     pMessageByteLength)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetMessage(MessageIndex,
-                                                       pMessage->GetPointer(),
-                                                       pMessageByteLength->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MessageIndex,
+            pMessage,
+            pMessageByteLength);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetMessage(MessageIndex,
+                                                                                                   pMessage->GetPointer(),
+                                                                                                   pMessageByteLength->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_GetMessage", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            MessageIndex,
+            pMessage,
+            pMessageByteLength);
     }
 }
 
@@ -8181,10 +13723,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetNumMessagesAllowedByStorageF
     format::HandleId                            object_id,
     UINT64                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetNumMessagesAllowedByStorageFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesAllowedByStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetNumMessagesAllowedByStorageFilter();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesAllowedByStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8193,10 +13743,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetNumMessagesDeniedByStorageFi
     format::HandleId                            object_id,
     UINT64                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetNumMessagesDeniedByStorageFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesDeniedByStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetNumMessagesDeniedByStorageFilter();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesDeniedByStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8205,10 +13763,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetNumStoredMessages(
     format::HandleId                            object_id,
     UINT64                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetNumStoredMessages();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumStoredMessages>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetNumStoredMessages();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumStoredMessages>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8217,10 +13783,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetNumStoredMessagesAllowedByRe
     format::HandleId                            object_id,
     UINT64                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetNumStoredMessagesAllowedByRetrievalFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumStoredMessagesAllowedByRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetNumStoredMessagesAllowedByRetrievalFilter();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumStoredMessagesAllowedByRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8229,10 +13803,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetNumMessagesDiscardedByMessag
     format::HandleId                            object_id,
     UINT64                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetNumMessagesDiscardedByMessageCountLimit();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesDiscardedByMessageCountLimit>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetNumMessagesDiscardedByMessageCountLimit();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetNumMessagesDiscardedByMessageCountLimit>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8241,10 +13823,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetMessageCountLimit(
     format::HandleId                            object_id,
     UINT64                                      return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetMessageCountLimit();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessageCountLimit>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetMessageCountLimit();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMessageCountLimit>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8254,11 +13844,21 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_AddStorageFilterEntries(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_INFO_QUEUE_FILTER>* pFilter)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->AddStorageFilterEntries(pFilter->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddStorageFilterEntries>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->AddStorageFilterEntries(pFilter->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_AddStorageFilterEntries", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddStorageFilterEntries>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
     }
 }
 
@@ -8269,12 +13869,24 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetStorageFilter(
     StructPointerDecoder<Decoded_D3D12_INFO_QUEUE_FILTER>* pFilter,
     PointerDecoder<SIZE_T>*                     pFilterByteLength)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetStorageFilter(pFilter->GetPointer(),
-                                                             pFilterByteLength->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter,
+            pFilterByteLength);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetStorageFilter(pFilter->GetPointer(),
+                                                                                                         pFilterByteLength->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_GetStorageFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter,
+            pFilterByteLength);
     }
 }
 
@@ -8282,10 +13894,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_ClearStorageFilter(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->ClearStorageFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->ClearStorageFilter();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8294,11 +13914,19 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PushEmptyStorageFilter(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->PushEmptyStorageFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushEmptyStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PushEmptyStorageFilter();
         CheckReplayResult("ID3D12InfoQueue_PushEmptyStorageFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushEmptyStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8307,11 +13935,19 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PushCopyOfStorageFilter(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->PushCopyOfStorageFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushCopyOfStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PushCopyOfStorageFilter();
         CheckReplayResult("ID3D12InfoQueue_PushCopyOfStorageFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushCopyOfStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8321,11 +13957,21 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PushStorageFilter(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_INFO_QUEUE_FILTER>* pFilter)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->PushStorageFilter(pFilter->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PushStorageFilter(pFilter->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_PushStorageFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
     }
 }
 
@@ -8333,10 +13979,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PopStorageFilter(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->PopStorageFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PopStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PopStorageFilter();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PopStorageFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8345,10 +13999,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetStorageFilterStackSize(
     format::HandleId                            object_id,
     UINT                                        return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetStorageFilterStackSize();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilterStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetStorageFilterStackSize();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetStorageFilterStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8358,11 +14020,21 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_AddRetrievalFilterEntries(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_INFO_QUEUE_FILTER>* pFilter)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->AddRetrievalFilterEntries(pFilter->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddRetrievalFilterEntries>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->AddRetrievalFilterEntries(pFilter->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_AddRetrievalFilterEntries", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddRetrievalFilterEntries>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
     }
 }
 
@@ -8373,12 +14045,24 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetRetrievalFilter(
     StructPointerDecoder<Decoded_D3D12_INFO_QUEUE_FILTER>* pFilter,
     PointerDecoder<SIZE_T>*                     pFilterByteLength)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetRetrievalFilter(pFilter->GetPointer(),
-                                                               pFilterByteLength->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter,
+            pFilterByteLength);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetRetrievalFilter(pFilter->GetPointer(),
+                                                                                                           pFilterByteLength->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_GetRetrievalFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter,
+            pFilterByteLength);
     }
 }
 
@@ -8386,10 +14070,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_ClearRetrievalFilter(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->ClearRetrievalFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->ClearRetrievalFilter();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_ClearRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8398,11 +14090,19 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PushEmptyRetrievalFilter(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->PushEmptyRetrievalFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushEmptyRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PushEmptyRetrievalFilter();
         CheckReplayResult("ID3D12InfoQueue_PushEmptyRetrievalFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushEmptyRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8411,11 +14111,19 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PushCopyOfRetrievalFilter(
     format::HandleId                            object_id,
     HRESULT                                     return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->PushCopyOfRetrievalFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushCopyOfRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PushCopyOfRetrievalFilter();
         CheckReplayResult("ID3D12InfoQueue_PushCopyOfRetrievalFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushCopyOfRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8425,11 +14133,21 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PushRetrievalFilter(
     HRESULT                                     return_value,
     StructPointerDecoder<Decoded_D3D12_INFO_QUEUE_FILTER>* pFilter)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->PushRetrievalFilter(pFilter->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PushRetrievalFilter(pFilter->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_PushRetrievalFilter", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PushRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pFilter);
     }
 }
 
@@ -8437,10 +14155,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_PopRetrievalFilter(
     const ApiCallInfo&                          call_info,
     format::HandleId                            object_id)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->PopRetrievalFilter();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PopRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->PopRetrievalFilter();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_PopRetrievalFilter>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8449,10 +14175,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetRetrievalFilterStackSize(
     format::HandleId                            object_id,
     UINT                                        return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetRetrievalFilterStackSize();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilterStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetRetrievalFilterStackSize();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetRetrievalFilterStackSize>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8465,14 +14199,30 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_AddMessage(
     D3D12_MESSAGE_ID                            ID,
     StringDecoder*                              pDescription)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->AddMessage(Category,
-                                                       Severity,
-                                                       ID,
-                                                       pDescription->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddMessage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Category,
+            Severity,
+            ID,
+            pDescription);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->AddMessage(Category,
+                                                                                                   Severity,
+                                                                                                   ID,
+                                                                                                   pDescription->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_AddMessage", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddMessage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Category,
+            Severity,
+            ID,
+            pDescription);
     }
 }
 
@@ -8483,12 +14233,24 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_AddApplicationMessage(
     D3D12_MESSAGE_SEVERITY                      Severity,
     StringDecoder*                              pDescription)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->AddApplicationMessage(Severity,
-                                                                  pDescription->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddApplicationMessage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Severity,
+            pDescription);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->AddApplicationMessage(Severity,
+                                                                                                              pDescription->GetPointer());
         CheckReplayResult("ID3D12InfoQueue_AddApplicationMessage", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_AddApplicationMessage>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Severity,
+            pDescription);
     }
 }
 
@@ -8499,12 +14261,24 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_SetBreakOnCategory(
     D3D12_MESSAGE_CATEGORY                      Category,
     BOOL                                        bEnable)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetBreakOnCategory(Category,
-                                                               bEnable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnCategory>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Category,
+            bEnable);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->SetBreakOnCategory(Category,
+                                                                                                           bEnable);
         CheckReplayResult("ID3D12InfoQueue_SetBreakOnCategory", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnCategory>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Category,
+            bEnable);
     }
 }
 
@@ -8515,12 +14289,24 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_SetBreakOnSeverity(
     D3D12_MESSAGE_SEVERITY                      Severity,
     BOOL                                        bEnable)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetBreakOnSeverity(Severity,
-                                                               bEnable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnSeverity>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Severity,
+            bEnable);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->SetBreakOnSeverity(Severity,
+                                                                                                           bEnable);
         CheckReplayResult("ID3D12InfoQueue_SetBreakOnSeverity", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnSeverity>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Severity,
+            bEnable);
     }
 }
 
@@ -8531,12 +14317,24 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_SetBreakOnID(
     D3D12_MESSAGE_ID                            ID,
     BOOL                                        bEnable)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->SetBreakOnID(ID,
-                                                         bEnable);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnID>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ID,
+            bEnable);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->SetBreakOnID(ID,
+                                                                                                     bEnable);
         CheckReplayResult("ID3D12InfoQueue_SetBreakOnID", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetBreakOnID>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ID,
+            bEnable);
     }
 }
 
@@ -8546,10 +14344,20 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetBreakOnCategory(
     BOOL                                        return_value,
     D3D12_MESSAGE_CATEGORY                      Category)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetBreakOnCategory(Category);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnCategory>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Category);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetBreakOnCategory(Category);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnCategory>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Category);
     }
 }
 
@@ -8559,10 +14367,20 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetBreakOnSeverity(
     BOOL                                        return_value,
     D3D12_MESSAGE_SEVERITY                      Severity)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetBreakOnSeverity(Severity);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnSeverity>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Severity);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetBreakOnSeverity(Severity);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnSeverity>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Severity);
     }
 }
 
@@ -8572,10 +14390,20 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetBreakOnID(
     BOOL                                        return_value,
     D3D12_MESSAGE_ID                            ID)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetBreakOnID(ID);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnID>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ID);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetBreakOnID(ID);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetBreakOnID>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            ID);
     }
 }
 
@@ -8584,10 +14412,20 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_SetMuteDebugOutput(
     format::HandleId                            object_id,
     BOOL                                        bMute)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->SetMuteDebugOutput(bMute);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetMuteDebugOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            bMute);
+        reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->SetMuteDebugOutput(bMute);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_SetMuteDebugOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            bMute);
     }
 }
 
@@ -8596,10 +14434,18 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue_GetMuteDebugOutput(
     format::HandleId                            object_id,
     BOOL                                        return_value)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetMuteDebugOutput();
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMuteDebugOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue*>(replay_object->object)->GetMuteDebugOutput();
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue_GetMuteDebugOutput>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8612,15 +14458,31 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue1_RegisterMessageCallback(
     uint64_t                                    pContext,
     PointerDecoder<DWORD>*                      pCallbackCookie)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue1_RegisterMessageCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CallbackFunc,
+            CallbackFilterFlags,
+            pContext,
+            pCallbackCookie);
         auto in_pContext = PreProcessExternalObject(pContext, format::ApiCallId::ApiCall_ID3D12InfoQueue1_RegisterMessageCallback, "ID3D12InfoQueue1_RegisterMessageCallback");
-        auto replay_result = replay_object->RegisterMessageCallback(reinterpret_cast<D3D12MessageFunc>(CallbackFunc),
-                                                                    CallbackFilterFlags,
-                                                                    in_pContext,
-                                                                    pCallbackCookie->GetPointer());
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue1*>(replay_object->object)->RegisterMessageCallback(reinterpret_cast<D3D12MessageFunc>(CallbackFunc),
+                                                                                                                 CallbackFilterFlags,
+                                                                                                                 in_pContext,
+                                                                                                                 pCallbackCookie->GetPointer());
         CheckReplayResult("ID3D12InfoQueue1_RegisterMessageCallback", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue1_RegisterMessageCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CallbackFunc,
+            CallbackFilterFlags,
+            pContext,
+            pCallbackCookie);
     }
 }
 
@@ -8630,11 +14492,21 @@ void Dx12ReplayConsumer::Process_ID3D12InfoQueue1_UnregisterMessageCallback(
     HRESULT                                     return_value,
     DWORD                                       CallbackCookie)
 {
-    auto replay_object = MapObject<ID3D12InfoQueue1>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->UnregisterMessageCallback(CallbackCookie);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12InfoQueue1_UnregisterMessageCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CallbackCookie);
+        auto replay_result = reinterpret_cast<ID3D12InfoQueue1*>(replay_object->object)->UnregisterMessageCallback(CallbackCookie);
         CheckReplayResult("ID3D12InfoQueue1_UnregisterMessageCallback", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12InfoQueue1_UnregisterMessageCallback>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            CallbackCookie);
     }
 }
 
@@ -8645,19 +14517,31 @@ void Dx12ReplayConsumer::Process_IUnknown_QueryInterface(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvObject)
 {
-    auto replay_object = MapObject<IUnknown>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IUnknown_QueryInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppvObject);
         if(!ppvObject->IsNull()) ppvObject->SetHandleLength(1);
         auto out_p_ppvObject    = ppvObject->GetPointer();
         auto out_hp_ppvObject   = ppvObject->GetHandlePointer();
-        auto replay_result = replay_object->QueryInterface(*riid.decoded_value,
-                                                           out_hp_ppvObject);
+        auto replay_result = reinterpret_cast<IUnknown*>(replay_object->object)->QueryInterface(*riid.decoded_value,
+                                                                                                out_hp_ppvObject);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvObject, out_hp_ppvObject, format::ApiCall_IUnknown_QueryInterface);
         }
         CheckReplayResult("IUnknown_QueryInterface", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IUnknown_QueryInterface>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            riid,
+            ppvObject);
     }
 }
 
@@ -8669,8 +14553,16 @@ void Dx12ReplayConsumer::Process_IUnknown_AddRef(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IUnknown_AddRef>::Dispatch(
+            this,
+            call_info,
+            replay_object);
         auto replay_result = OverrideAddRef(replay_object,
                                             return_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IUnknown_AddRef>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 
@@ -8682,8 +14574,16 @@ void Dx12ReplayConsumer::Process_IUnknown_Release(
     auto replay_object = GetObjectInfo(object_id);
     if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_IUnknown_Release>::Dispatch(
+            this,
+            call_info,
+            replay_object);
         auto replay_result = OverrideRelease(replay_object,
                                              return_value);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_IUnknown_Release>::Dispatch(
+            this,
+            call_info,
+            replay_object);
     }
 }
 

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -11844,15 +11844,35 @@ void Dx12ReplayConsumer::Process_ID3D12Device12_GetResourceAllocationInfo3(
     PointerDecoder<DXGI_FORMAT*>*               ppCastableFormats,
     StructPointerDecoder<Decoded_D3D12_RESOURCE_ALLOCATION_INFO1>* pResourceAllocationInfo1)
 {
-    auto replay_object = MapObject<ID3D12Device12>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto replay_result = replay_object->GetResourceAllocationInfo3(visibleMask,
-                                                                       numResourceDescs,
-                                                                       pResourceDescs->GetPointer(),
-                                                                       pNumCastableFormats->GetPointer(),
-                                                                       ppCastableFormats->GetPointer(),
-                                                                       pResourceAllocationInfo1->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12Device12_GetResourceAllocationInfo3>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs,
+            pNumCastableFormats,
+            ppCastableFormats,
+            pResourceAllocationInfo1);
+        auto replay_result = reinterpret_cast<ID3D12Device12*>(replay_object->object)->GetResourceAllocationInfo3(visibleMask,
+                                                                                                                  numResourceDescs,
+                                                                                                                  pResourceDescs->GetPointer(),
+                                                                                                                  pNumCastableFormats->GetPointer(),
+                                                                                                                  ppCastableFormats->GetPointer(),
+                                                                                                                  pResourceAllocationInfo1->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12Device12_GetResourceAllocationInfo3>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            visibleMask,
+            numResourceDescs,
+            pResourceDescs,
+            pNumCastableFormats,
+            ppCastableFormats,
+            pResourceAllocationInfo1);
     }
 }
 
@@ -12535,12 +12555,26 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList9_RSSetDepthBias(
     FLOAT                                       DepthBiasClamp,
     FLOAT                                       SlopeScaledDepthBias)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList9>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->RSSetDepthBias(DepthBias,
-                                      DepthBiasClamp,
-                                      SlopeScaledDepthBias);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList9_RSSetDepthBias>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DepthBias,
+            DepthBiasClamp,
+            SlopeScaledDepthBias);
+        reinterpret_cast<ID3D12GraphicsCommandList9*>(replay_object->object)->RSSetDepthBias(DepthBias,
+                                                                                             DepthBiasClamp,
+                                                                                             SlopeScaledDepthBias);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList9_RSSetDepthBias>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            DepthBias,
+            DepthBiasClamp,
+            SlopeScaledDepthBias);
     }
 }
 
@@ -12549,10 +12583,20 @@ void Dx12ReplayConsumer::Process_ID3D12GraphicsCommandList9_IASetIndexBufferStri
     format::HandleId                            object_id,
     D3D12_INDEX_BUFFER_STRIP_CUT_VALUE          IBStripCutValue)
 {
-    auto replay_object = MapObject<ID3D12GraphicsCommandList9>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->IASetIndexBufferStripCutValue(IBStripCutValue);
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList9_IASetIndexBufferStripCutValue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            IBStripCutValue);
+        reinterpret_cast<ID3D12GraphicsCommandList9*>(replay_object->object)->IASetIndexBufferStripCutValue(IBStripCutValue);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12GraphicsCommandList9_IASetIndexBufferStripCutValue>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            IBStripCutValue);
     }
 }
 
@@ -12565,22 +12609,38 @@ void Dx12ReplayConsumer::Process_ID3D12DSRDeviceFactory_CreateDSRDevice(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvDSRDevice)
 {
-    auto replay_object = MapObject<ID3D12DSRDeviceFactory>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12DSRDeviceFactory_CreateDSRDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pD3D12Device,
+            NodeMask,
+            riid,
+            ppvDSRDevice);
         auto in_pD3D12Device = MapObject<ID3D12Device>(pD3D12Device);
         if(!ppvDSRDevice->IsNull()) ppvDSRDevice->SetHandleLength(1);
         auto out_p_ppvDSRDevice    = ppvDSRDevice->GetPointer();
         auto out_hp_ppvDSRDevice   = ppvDSRDevice->GetHandlePointer();
-        auto replay_result = replay_object->CreateDSRDevice(in_pD3D12Device,
-                                                            NodeMask,
-                                                            *riid.decoded_value,
-                                                            out_hp_ppvDSRDevice);
+        auto replay_result = reinterpret_cast<ID3D12DSRDeviceFactory*>(replay_object->object)->CreateDSRDevice(in_pD3D12Device,
+                                                                                                               NodeMask,
+                                                                                                               *riid.decoded_value,
+                                                                                                               out_hp_ppvDSRDevice);
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvDSRDevice, out_hp_ppvDSRDevice, format::ApiCall_ID3D12DSRDeviceFactory_CreateDSRDevice);
         }
         CheckReplayResult("ID3D12DSRDeviceFactory_CreateDSRDevice", return_value, replay_result);
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12DSRDeviceFactory_CreateDSRDevice>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            pD3D12Device,
+            NodeMask,
+            riid,
+            ppvDSRDevice);
     }
 }
 
@@ -13635,11 +13695,23 @@ void Dx12ReplayConsumer::Process_ID3D12ManualWriteTrackingResource_TrackWrite(
     UINT                                        Subresource,
     StructPointerDecoder<Decoded_D3D12_RANGE>*  pWrittenRange)
 {
-    auto replay_object = MapObject<ID3D12ManualWriteTrackingResource>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        replay_object->TrackWrite(Subresource,
-                                  pWrittenRange->GetPointer());
+        CustomReplayPreCall<format::ApiCallId::ApiCall_ID3D12ManualWriteTrackingResource_TrackWrite>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Subresource,
+            pWrittenRange);
+        reinterpret_cast<ID3D12ManualWriteTrackingResource*>(replay_object->object)->TrackWrite(Subresource,
+                                                                                                pWrittenRange->GetPointer());
+        CustomReplayPostCall<format::ApiCallId::ApiCall_ID3D12ManualWriteTrackingResource_TrackWrite>::Dispatch(
+            this,
+            call_info,
+            replay_object,
+            Subresource,
+            pWrittenRange);
     }
 }
 

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -39,6 +39,8 @@ target_sources(gfxrecon_graphics
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_shader_id_map.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_image_renderer.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_image_renderer.cpp>
+                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_dump_resources.h>
+                    $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_dump_resources.cpp>
                     ${CMAKE_CURRENT_LIST_DIR}/fps_info.h
                     ${CMAKE_CURRENT_LIST_DIR}/fps_info.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_resources_util.h

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -151,8 +151,10 @@ HRESULT Dx12DumpResources::Init(const Dx12DumpResourcesConfig& config)
     {
         json_filename_ = json_filename_.substr(0, ext_pos);
     }
-    json_filename_ += "_resources_" + decode::GetDumpResourcesType(config.type) + "_" +
-                      std::to_string(config.argument) + "." + util::get_json_format(json_options_.format);
+    json_filename_ += "_resources_submit_" + std::to_string(config.dump_resources_target.submit_index) + "_command_" +
+                      std::to_string(config.dump_resources_target.command_index) + "_drawcall_" +
+                      std::to_string(config.dump_resources_target.drawcall_index) + "." +
+                      util::get_json_format(json_options_.format);
 
     json_options_.data_sub_dir = util::filepath::GetFilenameStem(json_filename_);
     json_options_.root_dir     = util::filepath::GetBasedir(json_filename_);

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -59,7 +59,8 @@ void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
     if (resource_data.before_resource)
     {
         util::FieldToJson(jdata["resource_id"], resource_data.source_resource_id, json_options_);
-        util::FieldToJson(jdata["size"], resource_data.size, json_options_);
+        util::FieldToJson(jdata["offset"], resource_data.source_offset, json_options_);
+        util::FieldToJson(jdata["size"], resource_data.source_size, json_options_);
 
         std::string file_name =
             prefix_file_name + "_resource_id_" + std::to_string(resource_data.source_resource_id) + "_before.bin";
@@ -70,7 +71,7 @@ void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
         resource_data.before_resource->Map(0, &read_Range, reinterpret_cast<void**>(&data_begin));
 
         std::string filepath = gfxrecon::util::filepath::Join(json_options_.root_dir, file_name);
-        WriteBinaryFile(filepath, resource_data.size, data_begin);
+        WriteBinaryFile(filepath, resource_data.source_size, data_begin);
 
         resource_data.before_resource->Unmap(0, nullptr);
     }
@@ -86,7 +87,7 @@ void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
         resource_data.after_resource->Map(0, &read_Range, reinterpret_cast<void**>(&data_begin));
 
         std::string filepath = gfxrecon::util::filepath::Join(json_options_.root_dir, file_name);
-        WriteBinaryFile(filepath, resource_data.size, data_begin);
+        WriteBinaryFile(filepath, resource_data.source_size, data_begin);
 
         resource_data.after_resource->Unmap(0, nullptr);
     }

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -1,0 +1,204 @@
+/*
+** Copyright (c) 2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "graphics/dx12_dump_resources.h"
+// TODO: It should change the file name of "vulkan"
+#include "generated/generated_vulkan_struct_to_json.h"
+#include "util/platform.h"
+#include "util/logging.h"
+#include "util/image_writer.h"
+#include "graphics/dx12_util.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+Dx12DumpResources::Dx12DumpResources() : json_file_handle_(nullptr) {}
+
+Dx12DumpResources::~Dx12DumpResources()
+{
+    EndFile();
+}
+
+void Dx12DumpResources::WriteResources(nlohmann::ordered_json&              jdata,
+                                       const std::string&                   prefix_file_name,
+                                       const std::vector<CopyResourceData>& resource_datas)
+{
+    uint32_t i = 0;
+    for (const auto& resouce : resource_datas)
+    {
+        WriteResource(jdata[i], prefix_file_name, resouce);
+        ++i;
+    }
+}
+
+void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
+                                      const std::string&      prefix_file_name,
+                                      const CopyResourceData& resource_data)
+{
+    // before
+    if (resource_data.before_resource)
+    {
+        decode::FieldToJson(jdata["size"], resource_data.size, json_options_);
+
+        std::string file_name =
+            prefix_file_name + "_resource_id_" + std::to_string(resource_data.source_resource_id) + "_before.bin";
+        decode::FieldToJson(jdata["before_file_name"], file_name.c_str(), json_options_);
+
+        uint8_t*    data_begin;
+        D3D12_RANGE read_Range = { 0, 0 };
+        resource_data.before_resource->Map(0, &read_Range, reinterpret_cast<void**>(&data_begin));
+
+        std::string filepath = gfxrecon::util::filepath::Join(json_options_.root_dir, file_name);
+        WriteBinaryFile(filepath, resource_data.size, data_begin);
+
+        resource_data.before_resource->Unmap(0, nullptr);
+    }
+    // after
+    if (resource_data.after_resource)
+    {
+        std::string file_name =
+            prefix_file_name + "_resource_id_" + std::to_string(resource_data.source_resource_id) + "_after.bin";
+        decode::FieldToJson(jdata["after_file_name"], file_name.c_str(), json_options_);
+
+        uint8_t*    data_begin;
+        D3D12_RANGE read_Range = { 0, 0 };
+        resource_data.after_resource->Map(0, &read_Range, reinterpret_cast<void**>(&data_begin));
+
+        std::string filepath = gfxrecon::util::filepath::Join(json_options_.root_dir, file_name);
+        WriteBinaryFile(filepath, resource_data.size, data_begin);
+
+        resource_data.after_resource->Unmap(0, nullptr);
+    }
+}
+
+void Dx12DumpResources::WriteResources(const TrackDumpResources& resources)
+{
+    WriteMetaCommandToFile("resources", [&](auto& jdata) {
+        // vertex
+        WriteResources(jdata["vertex"], json_options_.data_sub_dir, resources.copy_vertex_resources);
+    });
+}
+
+std::unique_ptr<Dx12DumpResources> Dx12DumpResources::Create(const Dx12DumpResourcesConfig& config)
+{
+    std::unique_ptr<Dx12DumpResources> out(new Dx12DumpResources());
+
+    if (out != nullptr)
+    {
+        if (out->Init(config) != S_OK)
+        {
+            GFXRECON_LOG_WARNING("Dx12DumpResources initialization failed");
+        }
+    }
+    return std::move(out);
+}
+
+HRESULT Dx12DumpResources::Init(const Dx12DumpResourcesConfig& config)
+{
+    HRESULT result       = S_OK;
+    json_options_.format = kDefaultDumpResourcesFileFormat;
+
+    json_filename_    = config.captured_file_name;
+    auto ext_pos      = json_filename_.find_last_of(".");
+    auto path_sep_pos = json_filename_.find_last_of(util::filepath::kPathSepStr);
+    if (ext_pos != std::string::npos && (path_sep_pos == std::string::npos || ext_pos > path_sep_pos))
+    {
+        json_filename_ = json_filename_.substr(0, ext_pos);
+    }
+    json_filename_ += "_resources_" + decode::GetDumpResourcesType(config.type) + "_" +
+                      std::to_string(config.argument) + "." + util::get_json_format(json_options_.format);
+
+    json_options_.data_sub_dir = util::filepath::GetFilenameStem(json_filename_);
+    json_options_.root_dir     = util::filepath::GetBasedir(json_filename_);
+
+    util::platform::FileOpen(&json_file_handle_, json_filename_.c_str(), "w");
+
+    header_["source-path"] = config.captured_file_name;
+
+    StartFile();
+    return result;
+}
+
+void Dx12DumpResources::StartFile()
+{
+    num_objects_ = 0;
+    if (json_options_.format == util::JsonFormat::JSON)
+    {
+        util::platform::FilePuts("[\n", json_file_handle_);
+    }
+
+    // Emit the header object as the first line of the file:
+    WriteBlockStart();
+    json_data_["header"] = header_;
+    WriteBlockEnd();
+}
+
+void Dx12DumpResources::EndFile()
+{
+    if (json_file_handle_ != nullptr)
+    {
+        if (json_options_.format == util::JsonFormat::JSON)
+        {
+            util::platform::FilePuts("\n]\n", json_file_handle_);
+        }
+        else
+        {
+            util::platform::FilePuts("\n", json_file_handle_);
+        }
+        util::platform::FileClose(json_file_handle_);
+        json_file_handle_ = nullptr;
+    }
+}
+
+void Dx12DumpResources::WriteBlockStart()
+{
+    json_data_.clear(); // < Dominates profiling (1/2).
+    num_objects_++;
+}
+
+void Dx12DumpResources::WriteBlockEnd()
+{
+    if (num_objects_ > 1)
+    {
+        util::platform::FilePuts(json_options_.format == util::JsonFormat::JSONL ? "\n" : ",\n", json_file_handle_);
+    }
+    // Dominates profiling (2/2):
+    const std::string block =
+        json_data_.dump(json_options_.format == util::JsonFormat::JSONL ? -1 : util::kJsonIndentWidth);
+    util::platform::FileWriteNoLock(block.data(), sizeof(std::string::value_type), block.length(), json_file_handle_);
+    util::platform::FileFlush(json_file_handle_); /// @todo Implement a FileFlushNoLock() for all platforms.
+}
+
+bool Dx12DumpResources::WriteBinaryFile(const std::string& filename, uint64_t data_size, const uint8_t* data)
+{
+    FILE* file_output = nullptr;
+    if (util::platform::FileOpen(&file_output, filename.c_str(), "wb") == 0)
+    {
+        util::platform::FileWrite(data, static_cast<size_t>(data_size), 1, file_output);
+        util::platform::FileClose(file_output);
+        return true;
+    }
+    return false;
+}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -96,6 +96,26 @@ void Dx12DumpResources::WriteResources(const TrackDumpResources& resources)
     WriteMetaCommandToFile("resources", [&](auto& jdata) {
         // vertex
         WriteResources(jdata["vertex"], json_options_.data_sub_dir, resources.copy_vertex_resources);
+
+        // index
+        WriteResource(jdata["index"], json_options_.data_sub_dir, resources.copy_index_resource);
+
+        // descriptor
+        uint32_t index = 0;
+        for (const auto& heap_data : resources.descriptor_heap_datas)
+        {
+            std::string filename =
+                json_options_.data_sub_dir + "_heap_id_" + std::to_string(resources.target.descriptor_heap_ids[index]);
+            WriteResources(
+                jdata["descriptor_heap"][index]["constant_buffer"], filename, heap_data.copy_constant_buffer_resources);
+            WriteResources(
+                jdata["descriptor_heap"][index]["shader_resource"], filename, heap_data.copy_shader_resources);
+            ++index;
+        }
+
+        // render target
+        WriteResources(jdata["render_target"], json_options_.data_sub_dir, resources.copy_render_target_resources);
+        WriteResource(jdata["depth_stencil"], json_options_.data_sub_dir, resources.copy_depth_stencil_resource);
     });
 }
 

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -58,6 +58,7 @@ void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
     // before
     if (resource_data.before_resource)
     {
+        util::FieldToJson(jdata["resource_id"], resource_data.source_resource_id, json_options_);
         util::FieldToJson(jdata["size"], resource_data.size, json_options_);
 
         std::string file_name =
@@ -116,6 +117,11 @@ void Dx12DumpResources::WriteResources(const TrackDumpResources& resources)
         // render target
         WriteResources(jdata["render_target"], json_options_.data_sub_dir, resources.copy_render_target_resources);
         WriteResource(jdata["depth_stencil"], json_options_.data_sub_dir, resources.copy_depth_stencil_resource);
+
+        // ExecuteIndirect
+        WriteResource(
+            jdata["ExecuteIndirect_argument"], json_options_.data_sub_dir, resources.copy_exe_indirect_argument);
+        WriteResource(jdata["ExecuteIndirect_count"], json_options_.data_sub_dir, resources.copy_exe_indirect_count);
     });
 }
 

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -26,6 +26,7 @@
 #include "util/platform.h"
 #include "util/logging.h"
 #include "util/image_writer.h"
+#include "util/json_util.h"
 #include "graphics/dx12_util.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -57,11 +58,11 @@ void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
     // before
     if (resource_data.before_resource)
     {
-        decode::FieldToJson(jdata["size"], resource_data.size, json_options_);
+        util::FieldToJson(jdata["size"], resource_data.size, json_options_);
 
         std::string file_name =
             prefix_file_name + "_resource_id_" + std::to_string(resource_data.source_resource_id) + "_before.bin";
-        decode::FieldToJson(jdata["before_file_name"], file_name.c_str(), json_options_);
+        util::FieldToJson(jdata["before_file_name"], file_name.c_str(), json_options_);
 
         uint8_t*    data_begin;
         D3D12_RANGE read_Range = { 0, 0 };
@@ -77,7 +78,7 @@ void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
     {
         std::string file_name =
             prefix_file_name + "_resource_id_" + std::to_string(resource_data.source_resource_id) + "_after.bin";
-        decode::FieldToJson(jdata["after_file_name"], file_name.c_str(), json_options_);
+        util::FieldToJson(jdata["after_file_name"], file_name.c_str(), json_options_);
 
         uint8_t*    data_begin;
         D3D12_RANGE read_Range = { 0, 0 };

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -84,6 +84,12 @@ struct TrackDumpResources
     D3D12_CPU_DESCRIPTOR_HANDLE              replay_depth_stencil_handle{ decode::kNullCpuAddress };
     CopyResourceData                         copy_depth_stencil_resource;
 
+    // record BeginRenderPass parameters
+    std::vector<D3D12_RENDER_PASS_ENDING_ACCESS> record_render_target_ending_accesses;
+    D3D12_RENDER_PASS_ENDING_ACCESS              record_depth_ending_access{};
+    D3D12_RENDER_PASS_ENDING_ACCESS              record_stencil_ending_access{};
+    D3D12_RENDER_PASS_FLAGS                      record_render_pass_flags{ D3D12_RENDER_PASS_FLAG_NONE };
+
     ~TrackDumpResources() {}
 };
 

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -49,11 +49,13 @@ struct Dx12DumpResourcesConfig
 
 struct CopyResourceData
 {
-    format::HandleId           source_resource_id{ format::kNullHandleId };
-    uint64_t                   size{ 0 };
-    D3D12_RESOURCE_DESC        desc{};
-    dx12::ID3D12ResourceComPtr before_resource{ nullptr }; // copy resource before drawcall
-    dx12::ID3D12ResourceComPtr after_resource{ nullptr };  // copy resource after drawcall
+    format::HandleId                   source_resource_id{ format::kNullHandleId };
+    uint64_t                           source_offset{ 0 };
+    uint64_t                           source_size{ 0 };
+    D3D12_PLACED_SUBRESOURCE_FOOTPRINT source_footprint{};
+    D3D12_RESOURCE_DESC                desc{};
+    dx12::ID3D12ResourceComPtr         before_resource{ nullptr }; // copy resource before drawcall
+    dx12::ID3D12ResourceComPtr         after_resource{ nullptr };  // copy resource after drawcall
 };
 
 struct DescriptorHeapData

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -1,0 +1,130 @@
+/*
+** Copyright (c) 2023 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_DX12_DUMP_RESOURCES_H
+#define GFXRECON_DECODE_DX12_DUMP_RESOURCES_H
+
+#include "decode/api_decoder.h"
+#include "decode/handle_pointer_decoder.h"
+#include "decode/dx_replay_options.h"
+#include "decode/dx12_object_info.h"
+#include "decode/dx12_browse_consumer.h"
+#include "graphics/dx12_util.h"
+#include "util/defines.h"
+#include "util/json_util.h"
+
+#include <d3d12.h>
+
+#include <memory>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+const gfxrecon::util::JsonFormat kDefaultDumpResourcesFileFormat = gfxrecon::util::JsonFormat::JSON;
+
+struct Dx12DumpResourcesConfig
+{
+    std::string               captured_file_name;
+    decode::DumpResourcesType type{ decode::DumpResourcesType::kNone };
+    int                       argument{ 0 };
+};
+
+struct CopyResourceData
+{
+    format::HandleId           source_resource_id{ format::kNullHandleId };
+    uint64_t                   size{ 0 };
+    D3D12_RESOURCE_DESC        desc{};
+    dx12::ID3D12ResourceComPtr before_resource{ nullptr }; // copy resource before drawcall
+    dx12::ID3D12ResourceComPtr after_resource{ nullptr };  // copy resource after drawcall
+};
+
+struct TrackDumpResources
+{
+    decode::TrackDumpCommandList target{};
+
+    // vertex
+    std::vector<CopyResourceData> copy_vertex_resources;
+
+    ~TrackDumpResources() {}
+};
+
+// TODO: This class copys a lot of code to write json from VulkanExportJsonConsumerBase.
+//       We might need a class for writing json.
+class Dx12DumpResources
+{
+  public:
+    static std::unique_ptr<Dx12DumpResources> Create(const Dx12DumpResourcesConfig& config);
+
+    ~Dx12DumpResources();
+
+    void WriteResources(const TrackDumpResources& resources);
+
+  private:
+    Dx12DumpResources();
+
+    HRESULT Init(const Dx12DumpResourcesConfig& config);
+
+    void WriteResources(nlohmann::ordered_json&              jdata,
+                        const std::string&                   prefix_file_name,
+                        const std::vector<CopyResourceData>& resource_datas);
+
+    void WriteResource(nlohmann::ordered_json& jdata,
+                       const std::string&      prefix_file_name,
+                       const CopyResourceData& resource_data);
+
+    void StartFile();
+    void EndFile();
+    void WriteBlockStart();
+    void WriteBlockEnd();
+
+    constexpr const char* NameMeta() const { return "meta"; }
+    constexpr const char* NameName() const { return "name"; }
+    constexpr const char* NameArgs() const { return "args"; }
+
+    template <typename ToJsonFunctionType>
+    inline void WriteMetaCommandToFile(const std::string& command_name, ToJsonFunctionType to_json_function)
+    {
+        using namespace util;
+        WriteBlockStart();
+
+        nlohmann::ordered_json& meta = json_data_[NameMeta()];
+        meta[NameName()]             = command_name;
+        to_json_function(meta[NameArgs()]);
+
+        WriteBlockEnd();
+    }
+
+    bool WriteBinaryFile(const std::string& filename, uint64_t buffer_size, const uint8_t* data);
+
+    util::JsonOptions      json_options_;
+    std::string            json_filename_;
+    FILE*                  json_file_handle_;
+    nlohmann::ordered_json header_;
+    nlohmann::ordered_json json_data_;
+    uint32_t               num_objects_{ 0 };
+    uint32_t               num_files_{ 0 };
+};
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -57,12 +57,32 @@ struct CopyResourceData
     dx12::ID3D12ResourceComPtr after_resource{ nullptr };  // copy resource after drawcall
 };
 
+struct DescriptorHeapData
+{
+    std::vector<CopyResourceData> copy_constant_buffer_resources;
+    std::vector<CopyResourceData> copy_shader_resources;
+};
+
 struct TrackDumpResources
 {
     decode::TrackDumpCommandList target{};
 
     // vertex
     std::vector<CopyResourceData> copy_vertex_resources;
+
+    // index
+    CopyResourceData copy_index_resource;
+
+    // descriptor
+    std::vector<DescriptorHeapData> descriptor_heap_datas;
+
+    // render target
+    std::vector<format::HandleId>            render_target_heap_ids;
+    std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> replay_render_target_handles;
+    std::vector<CopyResourceData>            copy_render_target_resources;
+    format::HandleId                         depth_stencil_heap_id{ format::kNullHandleId };
+    D3D12_CPU_DESCRIPTOR_HANDLE              replay_depth_stencil_handle{ decode::kNullCpuAddress };
+    CopyResourceData                         copy_depth_stencil_resource;
 
     ~TrackDumpResources() {}
 };

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -63,6 +63,8 @@ struct DescriptorHeapData
     std::vector<CopyResourceData> copy_shader_resources;
 };
 
+// TODO: The required data could be a piece of the ID3D12Resource, not the whole ID3D12Resource.
+//       we need to handle resource's views' offset, byte stride, count, ...
 struct TrackDumpResources
 {
     decode::TrackDumpCommandList target{};
@@ -89,6 +91,10 @@ struct TrackDumpResources
     D3D12_RENDER_PASS_ENDING_ACCESS              record_depth_ending_access{};
     D3D12_RENDER_PASS_ENDING_ACCESS              record_stencil_ending_access{};
     D3D12_RENDER_PASS_FLAGS                      record_render_pass_flags{ D3D12_RENDER_PASS_FLAG_NONE };
+
+    // ExecuteIndirect
+    CopyResourceData copy_exe_indirect_argument;
+    CopyResourceData copy_exe_indirect_count;
 
     ~TrackDumpResources() {}
 };

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -148,6 +148,13 @@ class Dx12DumpResources
 
     bool WriteBinaryFile(const std::string& filename, uint64_t buffer_size, const uint8_t* data);
 
+    void TestWriteFloatResources(const std::string&                   prefix_file_name,
+                                 const std::vector<CopyResourceData>& resource_datas);
+    void TestWriteFloatResource(const std::string& prefix_file_name, const CopyResourceData& resource_data);
+    void TestWriteImageResources(const std::string&                   prefix_file_name,
+                                 const std::vector<CopyResourceData>& resource_datas);
+    void TestWriteImageResource(const std::string& prefix_file_name, const CopyResourceData& resource_data);
+
     util::JsonOptions      json_options_;
     std::string            json_filename_;
     FILE*                  json_file_handle_;

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -43,9 +43,8 @@ const gfxrecon::util::JsonFormat kDefaultDumpResourcesFileFormat = gfxrecon::uti
 
 struct Dx12DumpResourcesConfig
 {
-    std::string               captured_file_name;
-    decode::DumpResourcesType type{ decode::DumpResourcesType::kNone };
-    int                       argument{ 0 };
+    std::string                           captured_file_name{};
+    gfxrecon::decode::DumpResourcesTarget dump_resources_target{};
 };
 
 struct CopyResourceData
@@ -67,7 +66,7 @@ struct DescriptorHeapData
 //       we need to handle resource's views' offset, byte stride, count, ...
 struct TrackDumpResources
 {
-    decode::TrackDumpCommandList target{};
+    decode::TrackDumpDrawcall target{};
 
     // vertex
     std::vector<CopyResourceData> copy_vertex_resources;

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -32,6 +32,12 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 GFXRECON_BEGIN_NAMESPACE(dx12)
 
+UINT GetTexturePitch(UINT64 width)
+{
+    return (width * graphics::BytesPerPixel + D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1) /
+           D3D12_TEXTURE_DATA_PITCH_ALIGNMENT * D3D12_TEXTURE_DATA_PITCH_ALIGNMENT;
+}
+
 void TakeScreenshot(std::unique_ptr<graphics::DX12ImageRenderer>& image_renderer,
                     ID3D12CommandQueue*                           queue,
                     IDXGISwapChain*                               swapchain,
@@ -76,8 +82,7 @@ void TakeScreenshot(std::unique_ptr<graphics::DX12ImageRenderer>& image_renderer
                 {
                     D3D12_RESOURCE_DESC fb_desc = frame_buffer_resource->GetDesc();
 
-                    auto pitch = (fb_desc.Width * graphics::BytesPerPixel + D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1) /
-                                 D3D12_TEXTURE_DATA_PITCH_ALIGNMENT * D3D12_TEXTURE_DATA_PITCH_ALIGNMENT;
+                    auto pitch = GetTexturePitch(fb_desc.Width);
 
                     graphics::CpuImage captured_image = {};
 

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -66,7 +66,7 @@ typedef _com_ptr_t<_com_IIID<ID3D12StateObjectProperties, &__uuidof(ID3D12StateO
     ID3D12StateObjectPropertiesComPtr;
 typedef _com_ptr_t<
     _com_IIID<ID3D12VersionedRootSignatureDeserializer, &__uuidof(ID3D12VersionedRootSignatureDeserializer)>>
-    ID3D12VersionedRootSignatureDeserializerComPtr;
+                                                                     ID3D12VersionedRootSignatureDeserializerComPtr;
 typedef _com_ptr_t<_com_IIID<ID3D12Object, &__uuidof(ID3D12Object)>> ID3D12ObjectComPtr;
 
 struct ActiveAdapterInfo
@@ -100,6 +100,8 @@ struct ResourceStateInfo
 
 const D3D12_RANGE kZeroRange       = { 0, 0 };
 const double      kMemoryTolerance = 2.1;
+
+UINT GetTexturePitch(UINT64 width);
 
 // Take a screenshot
 void TakeScreenshot(std::unique_ptr<gfxrecon::graphics::DX12ImageRenderer>& image_renderer,

--- a/framework/util/json_util.h
+++ b/framework/util/json_util.h
@@ -30,6 +30,7 @@
 
 #include "util/defines.h"
 #include "util/to_string.h"
+#include "util/logging.h"
 #include "format/format.h"
 
 #include "nlohmann/json.hpp"
@@ -48,6 +49,35 @@ enum class JsonFormat : uint8_t
     JSON,
     JSONL
 };
+
+inline std::string get_json_format(JsonFormat format)
+{
+    switch (format)
+    {
+        case gfxrecon::util::JsonFormat::JSONL:
+            return "jsonl";
+        case gfxrecon::util::JsonFormat::JSON:
+            return "json";
+        default:
+            break;
+    }
+    GFXRECON_LOG_WARNING("Unrecognized format %d. Defaulting to JSON format.", static_cast<int>(format));
+    return "json";
+}
+
+inline JsonFormat get_json_format(std::string format)
+{
+    if (format == "json")
+    {
+        return gfxrecon::util::JsonFormat::JSON;
+    }
+    else if (format == "jsonl")
+    {
+        return gfxrecon::util::JsonFormat::JSONL;
+    }
+    GFXRECON_LOG_WARNING("Unrecognized format %s. Defaulting to JSON format.", format.c_str());
+    return gfxrecon::util::JsonFormat::JSON;
+}
 
 /// Parameters potentially required in converting our datastructures to JSON.
 struct JsonOptions

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -106,15 +106,7 @@ static std::string GetOutputFileName(const gfxrecon::util::ArgumentParser& arg_p
         {
             output_filename = output_filename.substr(0, ext_pos);
         }
-        switch (output_format)
-        {
-            case JsonFormat::JSONL:
-                output_filename += ".jsonl";
-                break;
-            case JsonFormat::JSON:
-            default:
-                output_filename += ".json";
-        }
+        output_filename += "." + gfxrecon::util::get_json_format(output_format);
     }
     return output_filename;
 }
@@ -125,19 +117,7 @@ static gfxrecon::util::JsonFormat GetOutputFormat(const gfxrecon::util::Argument
     if (arg_parser.IsArgumentSet(kFormatArgument))
     {
         output_format = arg_parser.GetArgumentValue(kFormatArgument);
-        if (output_format == "json")
-        {
-            return JsonFormat::JSON;
-        }
-        else if (output_format == "jsonl")
-        {
-            return JsonFormat::JSONL;
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING("Unrecognized format %s. Defaulting to JSON format.", output_format.c_str());
-            return JsonFormat::JSON;
-        }
+        return gfxrecon::util::get_json_format(output_format);
     }
     return JsonFormat::JSON;
 }
@@ -274,8 +254,8 @@ int main(int argc, const char** argv)
 
             // If CONVERT_EXPERIMENTAL_D3D12 was set, then add DX12 consumer/decoder
 #ifdef CONVERT_EXPERIMENTAL_D3D12
-            Dx12JsonConsumer                    dx12_json_consumer;
-            gfxrecon::decode::Dx12Decoder       dx12_decoder;
+            Dx12JsonConsumer              dx12_json_consumer;
+            gfxrecon::decode::Dx12Decoder dx12_decoder;
 
             dx12_decoder.AddConsumer(&dx12_json_consumer);
             file_processor.AddDecoder(&dx12_decoder);

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -108,7 +108,8 @@ bool BrowseFile(const std::string&                      input_filename,
         dx12_decoder.AddConsumer(&dx12_browse_consumer);
         file_processor.AddDecoder(&dx12_decoder);
         file_processor.ProcessAllFrames();
-        track_dump_commandlist     = dx12_browse_consumer.GetTrackDumpTarget();
+        track_dump_commandlist = dx12_browse_consumer.GetTrackDumpTarget();
+        GFXRECON_ASSERT((track_dump_commandlist != nullptr));
         out_track_dump_commandlist = *track_dump_commandlist;
     }
     return (track_dump_commandlist != nullptr);

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -181,7 +181,7 @@ int main(int argc, const char** argv)
             }
 
 #if defined(D3D12_SUPPORT)
-            gfxrecon::decode::DxReplayOptions    dx_replay_options = GetDxReplayOptions(arg_parser);
+            gfxrecon::decode::DxReplayOptions    dx_replay_options = GetDxReplayOptions(arg_parser, filename);
             gfxrecon::decode::Dx12ReplayConsumer dx12_replay_consumer(application, dx_replay_options);
             gfxrecon::decode::Dx12Decoder        dx12_decoder;
 

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -36,7 +36,7 @@ const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
     "screenshot-dir,--screenshot-prefix,--screenshot-size,--screenshot-scale,--mfr|--measurement-frame-range,--fw|--"
-    "force-windowed,--batching-memory-usage,--measurement-file,--swapchain";
+    "force-windowed,--batching-memory-usage,--measurement-file,--swapchain,--dump-resources";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -72,6 +72,7 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>] [--log-debugview]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--batching-memory-usage <pct>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <drawcall-index>]");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--api <api>] [--no-debug-popup] <file>\n");
 #else
@@ -251,6 +252,10 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tAcceptable values range from 0 to 100 (default: 80)");
     GFXRECON_WRITE_CONSOLE("          \t\t0 means no batching at all");
     GFXRECON_WRITE_CONSOLE("          \t\t100 means use all available system and GPU memory");
+    GFXRECON_WRITE_CONSOLE("  --dump-resources <drawcall-index>");
+    GFXRECON_WRITE_CONSOLE("          \t\tOutput binaray resources for a specific drawcall.");
+    GFXRECON_WRITE_CONSOLE("          \t\tInclude vertex, index, const buffer, shader resource, render target,");
+    GFXRECON_WRITE_CONSOLE("          \t\tand depth stencil. And for before and after drawcall.");
 
 #endif
 

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -72,7 +72,7 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>] [--log-debugview]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--batching-memory-usage <pct>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <drawcall-index>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <submit-index,command-index,drawcall-index>]");
 #if defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--api <api>] [--no-debug-popup] <file>\n");
 #else
@@ -252,10 +252,12 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tAcceptable values range from 0 to 100 (default: 80)");
     GFXRECON_WRITE_CONSOLE("          \t\t0 means no batching at all");
     GFXRECON_WRITE_CONSOLE("          \t\t100 means use all available system and GPU memory");
-    GFXRECON_WRITE_CONSOLE("  --dump-resources <drawcall-index>");
+    GFXRECON_WRITE_CONSOLE("  --dump-resources <submit-index,command-index,drawcall-index>");
     GFXRECON_WRITE_CONSOLE("          \t\tOutput binaray resources for a specific drawcall.");
     GFXRECON_WRITE_CONSOLE("          \t\tInclude vertex, index, const buffer, shader resource, render target,");
     GFXRECON_WRITE_CONSOLE("          \t\tand depth stencil. And for before and after drawcall.");
+    GFXRECON_WRITE_CONSOLE("          \t\tArguments becomes three indices, submit index, command index,");
+    GFXRECON_WRITE_CONSOLE("          \t\tdrawcall index. The command index is based on its in ExecuteCommandLists.");
 
 #endif
 

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -943,21 +943,19 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     const std::string& dump_resources = arg_parser.GetArgumentValue(kDumpResourcesArgument);
     if (!dump_resources.empty())
     {
-        std::vector<std::string> values = gfxrecon::util::strings::SplitString(dump_resources, '-');
+        std::vector<std::string> values = gfxrecon::util::strings::SplitString(dump_resources, ',');
         if (!values.empty())
         {
-            if (values.size() != 2)
+            if (values.size() != 3)
             {
                 GFXRECON_LOG_ERROR("The parameter to --dump-resources is invalid. Ignore it.");
-            }
-            else if (values[0].compare("drawcall") == 0)
-            {
-                replay_options.dump_resources_type     = gfxrecon::decode::DumpResourcesType::kDrawCall;
-                replay_options.dump_resources_argument = std::stoi(values[1]);
             }
             else
             {
-                GFXRECON_LOG_ERROR("The parameter to --dump-resources is invalid. Ignore it.");
+                replay_options.enable_dump_resources                = true;
+                replay_options.dump_resources_target.submit_index   = std::stoi(values[0]);
+                replay_options.dump_resources_target.command_index  = std::stoi(values[1]);
+                replay_options.dump_resources_target.drawcall_index = std::stoi(values[2]);
             }
         }
     }

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -116,6 +116,7 @@ const char kApiFamilyOption[]             = "--api";
 const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
 const char kDxOverrideObjectNames[]       = "--dx12-override-object-names";
 const char kBatchingMemoryUsageArgument[] = "--batching-memory-usage";
+const char kDumpResourcesArgument[]       = "--dump-resources";
 #endif
 
 enum class WsiPlatform
@@ -752,8 +753,12 @@ static std::vector<int32_t> GetFilteredMsgs(const gfxrecon::util::ArgumentParser
     return msgs;
 }
 
-static void GetReplayOptions(gfxrecon::decode::ReplayOptions& options, const gfxrecon::util::ArgumentParser& arg_parser)
+static void GetReplayOptions(gfxrecon::decode::ReplayOptions&      options,
+                             const gfxrecon::util::ArgumentParser& arg_parser,
+                             const std::string&                    filename)
 {
+    options.filename = filename;
+
     if (arg_parser.IsOptionSet(kValidateOption))
     {
         options.enable_validation_layer = true;
@@ -805,7 +810,7 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
                        gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)
 {
     gfxrecon::decode::VulkanReplayOptions replay_options;
-    GetReplayOptions(replay_options, arg_parser);
+    GetReplayOptions(replay_options, arg_parser, filename);
 
 #if defined(WIN32)
     replay_options.enable_vulkan = IsApiFamilyIdEnabled(arg_parser, gfxrecon::format::ApiFamily_Vulkan);
@@ -904,10 +909,11 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
 }
 
 #if defined(D3D12_SUPPORT)
-static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util::ArgumentParser& arg_parser)
+static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util::ArgumentParser& arg_parser,
+                                                            const std::string&                    filename)
 {
     gfxrecon::decode::DxReplayOptions replay_options;
-    GetReplayOptions(replay_options, arg_parser);
+    GetReplayOptions(replay_options, arg_parser, filename);
 
     replay_options.enable_d3d12         = IsApiFamilyIdEnabled(arg_parser, gfxrecon::format::ApiFamily_D3D12);
     replay_options.DeniedDebugMessages  = GetFilteredMsgs(arg_parser, kDeniedMessages);
@@ -932,6 +938,28 @@ static gfxrecon::decode::DxReplayOptions GetDxReplayOptions(const gfxrecon::util
     if (arg_parser.IsOptionSet(kDxOverrideObjectNames))
     {
         replay_options.override_object_names = true;
+    }
+
+    const std::string& dump_resources = arg_parser.GetArgumentValue(kDumpResourcesArgument);
+    if (!dump_resources.empty())
+    {
+        std::vector<std::string> values = gfxrecon::util::strings::SplitString(dump_resources, '-');
+        if (!values.empty())
+        {
+            if (values.size() != 2)
+            {
+                GFXRECON_LOG_ERROR("The parameter to --dump-resources is invalid. Ignore it.");
+            }
+            else if (values[0].compare("drawcall") == 0)
+            {
+                replay_options.dump_resources_type     = gfxrecon::decode::DumpResourcesType::kDrawCall;
+                replay_options.dump_resources_argument = std::stoi(values[1]);
+            }
+            else
+            {
+                GFXRECON_LOG_ERROR("The parameter to --dump-resources is invalid. Ignore it.");
+            }
+        }
     }
 
     const std::string& memory_usage = arg_parser.GetArgumentValue(kBatchingMemoryUsageArgument);


### PR DESCRIPTION
Test sample: D3D12HelloTexture. It's for renderpass test. I added renderpass, constant buffer, more triangles, and test code about copy resource and separated renderpass.
https://github.com/locke-lunarg/DirectX-Graphics-Samples/tree/test-dump

For not renderpass case, now, I tested  HelloWorld project in DirectX-Graphics-Samples. I'm doing more tests.

Add option: `--dump-resources drawcall-n` . n is the index of drawcall.
To output readable data. Set `TEST_READABLE = true` in  `dx12_dump_resources.cpp`.
Float for vertex, index, constant buffer.
Image for shader resource, render target.

The basic concept:
`Not renderpass`: Add copy resource command in before and after drawcall.
E.g.:
Original
```
cmd->Reset();
...
cmd->Draw();
...
cmd->Draw();  -> Target
...
cmd->End();
```
New
```
cmd->Reset();
...
cmd->Draw();
...
cmd->CopyResource(); -> Add
cmd->draw();  -> Target
cmd->CopyResource(); -> Add
...
cmd->End();
```
`Renderpass`: Add renderpasses in before and after drawcall.
E.g.:
Original
```
cmd->Reset();
...
cmd->BeginRenderPass();
...
cmd->Draw();
...
cmd->Draw();  -> Target
...
cmd->EndRenderPass();
...
cmd->End();
```
New
```
cmd->Reset();
...
cmd->BeginRenderPass();
...
cmd->Draw();
...
cmd->EndRenderPass();    -> Add
cmd->CopyResource();     -> Add
cmd->BeginRenderPass();  -> Add
cmd->Draw();  -> Target
cmd->EndRenderPass();    -> Add
cmd->CopyResource();     -> Add
cmd->BeginRenderPass();  -> Add
...
cmd->EndRenderPass();
...
cmd->End();
```

According to my test, it is ok to insert the renderpass in anyplace in the original renderpass. And then, the EndingAcccess of the renderpass and the BeginningAccess of following renderpasses have to be PRESERVE to keep the the rendering process for this following renderpass, or it will clear the render target.



