### PR TITLE
Add AGS to convert tool, rebased.

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -219,6 +219,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/custom_ags_consumer_base.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_ags_replay_consumer.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_ags_replay_consumer.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/custom_ags_ascii_consumer.h
+                    ${CMAKE_CURRENT_LIST_DIR}/custom_ags_ascii_consumer.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/ags_detection_consumer.h
                )
 endif()

--- a/framework/decode/custom_ags_ascii_consumer.cpp
+++ b/framework/decode/custom_ags_ascii_consumer.cpp
@@ -1,0 +1,669 @@
+/*
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "decode/custom_ags_struct_decoders.h"
+#include "custom_ags_ascii_consumer.h"
+#include "util/logging.h"
+#include "generated/generated_dx12_enum_to_string.h"
+
+#include <amd_ags.h>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+static std::string GetAgsResultValueString(AGSReturnCode result)
+{
+    switch (result)
+    {
+        case AGS_SUCCESS:
+            return "AGS_SUCCESS";
+        case AGS_FAILURE:
+            return "AGS_FAILURE";
+        case AGS_INVALID_ARGS:
+            return "AGS_INVALID_ARGS";
+        case AGS_OUT_OF_MEMORY:
+            return "AGS_OUT_OF_MEMORY";
+        case AGS_MISSING_D3D_DLL:
+            return "AGS_MISSING_D3D_DLL";
+        case AGS_LEGACY_DRIVER:
+            return "AGS_LEGACY_DRIVER";
+        case AGS_NO_AMD_DRIVER_INSTALLED:
+            return "AGS_NO_AMD_DRIVER_INSTALLED";
+        case AGS_EXTENSION_NOT_SUPPORTED:
+            return "AGS_EXTENSION_NOT_SUPPORTED";
+        case AGS_ADL_FAILURE:
+            return "AGS_ADL_FAILURE";
+        case AGS_DX_FAILURE:
+            return "AGS_DX_FAILURE";
+        default:
+            return std::to_string(result);
+    }
+}
+
+std::string DisplayModeToString(const AGSDisplaySettings::Mode mode)
+{
+    switch (mode)
+    {
+        case AGSDisplaySettings::Mode::Mode_SDR:
+            return "Mode_HDR10_PQ";
+        case AGSDisplaySettings::Mode::Mode_HDR10_PQ:
+            return "Mode_HDR10_PQ";
+        case AGSDisplaySettings::Mode::Mode_HDR10_scRGB:
+            return "Mode_HDR10_scRGB";
+        case AGSDisplaySettings::Mode::Mode_FreesyncHDR_scRGB:
+            return "Mode_FreesyncHDR_scRGB";
+        case AGSDisplaySettings::Mode::Mode_FreesyncHDR_Gamma22:
+            return "Mode_FreesyncHDR_Gamma22";
+        default:
+            break;
+    }
+    return "Unknown mode value";
+}
+
+void AgsAsciiConsumer::Initialize(FILE* file, gfxrecon::util::ToStringFlags to_string_flags)
+{
+    GFXRECON_ASSERT(file);
+    file_            = file;
+    to_string_flags_ = to_string_flags;
+}
+
+void AgsAsciiConsumer::Destroy()
+{
+    if (file_)
+    {
+        file_ = nullptr;
+    }
+}
+
+void AgsAsciiConsumer::Process_agsInitialize(const ApiCallInfo&      call_info,
+                                             AGSReturnCode           return_value,
+                                             int                     agsVersion,
+                                             const AGSConfiguration* config,
+                                             AGSContext* const       context,
+                                             const AGSGPUInfo&       gpuInfo)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsInitialize";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    int      major                       = (agsVersion & 0xFFC00000) >> 22;
+    int      minor                       = (agsVersion & 0x003FF000) >> 12;
+    int      patch                       = (agsVersion & 0x00000FFF);
+    uint64_t allocCallback{ 0 };
+    uint64_t freeCallback{ 0 };
+    if (config != nullptr)
+    {
+        allocCallback = reinterpret_cast<uint64_t>(config->allocCallback);
+        freeCallback  = reinterpret_cast<uint64_t>(config->freeCallback);
+    }
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm,
+                      true,
+                      "ags version, major",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      ToString(major, to_string_flags_, tab_count, tab_size));
+        FieldToString(str_strm,
+                      false,
+                      "ags version, minor",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      ToString(minor, to_string_flags_, tab_count, tab_size));
+        FieldToString(str_strm,
+                      false,
+                      "ags version, patch",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      ToString(patch, to_string_flags_, tab_count, tab_size));
+        FieldToString(
+            str_strm, false, "ags alloc callback", to_string_flags_, tab_count, tab_size, PtrToString(allocCallback));
+        FieldToString(
+            str_strm, false, "ags free callback", to_string_flags_, tab_count, tab_size, PtrToString(freeCallback));
+        FieldToString(str_strm, false, "[out]ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+        FieldToString(
+            str_strm,
+            false,
+            "[out]gpuInfo",
+            to_string_flags_,
+            tab_count,
+            tab_size,
+            ObjectToString(to_string_flags_, tab_count, tab_size, [&](std::stringstream& strStrm) {
+                FieldToString(
+                    strStrm, true, "driverVersion", to_string_flags_, tab_count, tab_size, gpuInfo.driverVersion);
+                FieldToString(strStrm,
+                              false,
+                              "radeonSoftwareVersion",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              gpuInfo.radeonSoftwareVersion);
+                FieldToString(
+                    strStrm, false, "numDevices", to_string_flags_, tab_count, tab_size, ToString(gpuInfo.numDevices));
+                AGSDeviceInfo* returned_devices = gpuInfo.devices;
+                FieldToString(strStrm,
+                              false,
+                              "devices",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              StringOfDevices(gpuInfo.numDevices, returned_devices, tab_count, tab_size));
+            }));
+    });
+}
+
+void AgsAsciiConsumer::Process_agsDriverExtensionsDX12_CreateDevice(
+    const ApiCallInfo&                                    call_info,
+    AGSReturnCode                                         return_value,
+    AGSContext*                                           context,
+    AGSDX12DeviceCreationParams*                          creationParams,
+    const AGSDX12ExtensionParams*                         extensionParams,
+    StructPointerDecoder<Decoded_AGS_DX12_RETURN_PARAMS>* pReturnParams)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsDriverExtensionsDX12_CreateDevice";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm, true, "ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+
+        FieldToString(str_strm,
+                      false,
+                      "creationParams",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      ObjectToString(to_string_flags_, tab_count, tab_size, [&](std::stringstream& strStrm) {
+                          FieldToString(strStrm,
+                                        true,
+                                        "pAdapter",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        PtrToString(creationParams->pAdapter));
+                          FieldToString(strStrm,
+                                        false,
+                                        "riid",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        ToString(creationParams->iid, to_string_flags_, tab_count, tab_size));
+                          FieldToString(strStrm,
+                                        false,
+                                        "FeatureLevel",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        ToString(creationParams->FeatureLevel, to_string_flags_, tab_count, tab_size));
+                      }));
+
+        FieldToString(str_strm,
+                      false,
+                      "extensionParams",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      ObjectToString(to_string_flags_, tab_count, tab_size, [&](std::stringstream& strStrm) {
+                          FieldToString(strStrm,
+                                        true,
+                                        "pAppName",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        WCharArrayToString(extensionParams->pAppName));
+                          FieldToString(strStrm,
+                                        false,
+                                        "pEngineName",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        WCharArrayToString(extensionParams->pEngineName));
+                          FieldToString(strStrm,
+                                        false,
+                                        "appVersion",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        ToString(extensionParams->appVersion));
+                          FieldToString(strStrm,
+                                        false,
+                                        "engineVersion",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        ToString(extensionParams->engineVersion));
+                          FieldToString(strStrm,
+                                        false,
+                                        "uavSlot",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        ToString(extensionParams->uavSlot));
+                      }));
+
+        auto returned_params = pReturnParams->GetMetaStructPointer();
+        FieldToString(str_strm,
+                      false,
+                      "pReturnParams",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      ObjectToString(to_string_flags_, tab_count, tab_size, [&](std::stringstream& strStrm) {
+                          FieldToString(strStrm,
+                                        true,
+                                        "pDevice",
+                                        to_string_flags_,
+                                        tab_count,
+                                        tab_size,
+                                        PtrToString(returned_params->pDevice));
+                          auto extensions_supported = returned_params->extensionsSupported->decoded_value;
+                          FieldToString(
+                              strStrm,
+                              false,
+                              "extensionsSupported",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ObjectToString(to_string_flags_, tab_count, tab_size, [&](std::stringstream& strStrm) {
+                                  FieldToString(strStrm,
+                                                true,
+                                                "intrinsics16",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->intrinsics16));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "intrinsics17",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->intrinsics17));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "userMarkers",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->userMarkers));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "appRegistration",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->appRegistration));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "UAVBindSlot",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->UAVBindSlot));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "intrinsics19",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->intrinsics19));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "baseVertex",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->baseVertex));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "baseInstance",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->baseInstance));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "getWaveSize",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->getWaveSize));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "floatConversion",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->floatConversion));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "readLaneAt",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->readLaneAt));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "rayHitToken",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->rayHitToken));
+                                  FieldToString(strStrm,
+                                                false,
+                                                "padding",
+                                                to_string_flags_,
+                                                tab_count,
+                                                tab_size,
+                                                ToString(extensions_supported->padding));
+                              }));
+                      }));
+    });
+}
+
+void AgsAsciiConsumer::Process_agsDriverExtensionsDX12_DestroyDevice(const ApiCallInfo& call_info,
+                                                                     AGSReturnCode      return_value,
+                                                                     AGSContext*        context,
+                                                                     ID3D12Device*      device,
+                                                                     unsigned int*      deviceReferences)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsDriverExtensionsDX12_DestroyDevice";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm, true, "ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+        FieldToString(str_strm, false, "device", to_string_flags_, tab_count, tab_size, PtrToString(device));
+        FieldToString(
+            str_strm, false, "deviceReferences", to_string_flags_, tab_count, tab_size, PtrToString(deviceReferences));
+    });
+}
+
+void AgsAsciiConsumer::Process_agsDeInitialize(const ApiCallInfo& call_info,
+                                               AGSReturnCode      return_value,
+                                               AGSContext*        context)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsDeInitialize";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm, true, "ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+    });
+}
+
+void AgsAsciiConsumer::Process_agsCheckDriverVersion(const ApiCallInfo&     call_info,
+                                                     AGSDriverVersionResult return_value,
+                                                     const char*            radeonSoftwareVersionReported,
+                                                     unsigned int           radeonSoftwareVersionRequired)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsCheckDriverVersion";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm,
+                      true,
+                      "radeonSoftwareVersionReported",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      radeonSoftwareVersionReported);
+        FieldToString(str_strm,
+                      false,
+                      "radeonSoftwareVersionRequired",
+                      to_string_flags_,
+                      tab_count,
+                      tab_size,
+                      ToString(radeonSoftwareVersionRequired));
+    });
+}
+
+void AgsAsciiConsumer::Process_agsGetVersionNumber(const ApiCallInfo& call_info, int return_value)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsGetVersionNumber";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {});
+}
+
+void AgsAsciiConsumer::Process_agsSetDisplayMode(const ApiCallInfo&        call_info,
+                                                 AGSReturnCode             return_value,
+                                                 AGSContext*               context,
+                                                 int                       deviceIndex,
+                                                 int                       displayIndex,
+                                                 const AGSDisplaySettings* settings)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsSetDisplayMode";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm, true, "ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+        FieldToString(str_strm, false, "deviceIndex", to_string_flags_, tab_count, tab_size, ToString(deviceIndex));
+        FieldToString(str_strm, false, "displayIndex", to_string_flags_, tab_count, tab_size, ToString(displayIndex));
+        FieldToString(
+            str_strm,
+            false,
+            "settings",
+            to_string_flags_,
+            tab_count,
+            tab_size,
+            ObjectToString(to_string_flags_, tab_count, tab_size, [&](std::stringstream& strStrm) {
+                FieldToString(
+                    strStrm, true, "Mode", to_string_flags_, tab_count, tab_size, DisplayModeToString(settings->mode));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityRedX",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityRedX));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityRedY",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityRedY));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityGreenX",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityGreenX));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityGreenY",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityGreenY));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityBlueX",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityBlueX));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityBlueY",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityBlueY));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityWhitePointX",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityWhitePointX));
+                FieldToString(strStrm,
+                              false,
+                              "chromaticityWhitePointY",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->chromaticityWhitePointY));
+                FieldToString(strStrm,
+                              false,
+                              "minLuminance",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->minLuminance));
+                FieldToString(strStrm,
+                              false,
+                              "maxLuminance",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->maxLuminance));
+                FieldToString(strStrm,
+                              false,
+                              "maxContentLightLevel",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->maxContentLightLevel));
+                FieldToString(strStrm,
+                              false,
+                              "maxFrameAverageLightLevel",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->maxFrameAverageLightLevel));
+                FieldToString(strStrm,
+                              false,
+                              "disableLocalDimming",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->disableLocalDimming));
+                FieldToString(strStrm,
+                              false,
+                              "reservedPadding",
+                              to_string_flags_,
+                              tab_count,
+                              tab_size,
+                              ToString(settings->reservedPadding));
+            }));
+    });
+}
+
+void AgsAsciiConsumer::Process_agsDriverExtensionsDX12_PushMarker(const ApiCallInfo& call_info,
+                                                                  AGSReturnCode      return_value,
+                                                                  AGSContext*        context,
+                                                                  format::HandleId   object_id,
+                                                                  const char*        data)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsDriverExtensionsDX12_PushMarker";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm, true, "ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+        FieldToString(str_strm, false, "object_id", to_string_flags_, tab_count, tab_size, ToString(object_id));
+        FieldToString(str_strm, false, "data", to_string_flags_, tab_count, tab_size, data);
+    });
+}
+
+void AgsAsciiConsumer::Process_agsDriverExtensionsDX12_PopMarker(const ApiCallInfo& call_info,
+                                                                 AGSReturnCode      return_value,
+                                                                 AGSContext*        context,
+                                                                 format::HandleId   object_id)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsDriverExtensionsDX12_PopMarker";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm, true, "ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+        FieldToString(str_strm, false, "object_id", to_string_flags_, tab_count, tab_size, ToString(object_id));
+    });
+}
+
+void AgsAsciiConsumer::Process_agsDriverExtensionsDX12_SetMarker(const ApiCallInfo& call_info,
+                                                                 AGSReturnCode      return_value,
+                                                                 AGSContext*        context,
+                                                                 format::HandleId   object_id,
+                                                                 const char*        data)
+{
+    using namespace gfxrecon::util;
+    uint32_t               tab_count = 0;
+    uint32_t               tab_size  = 4;
+    WriteAgsCallToFileInfo writeApiCallToFileInfo{};
+    writeApiCallToFileInfo.block_index   = current_block_index_;
+    writeApiCallToFileInfo.pFunctionName = "agsDriverExtensionsDX12_SetMarker";
+    std::string returnValue              = util::ToString(return_value, to_string_flags_, tab_count, tab_size);
+    writeApiCallToFileInfo.pReturnValue  = !returnValue.empty() ? returnValue.c_str() : nullptr;
+    WriteApiCallToFile(writeApiCallToFileInfo, tab_count, tab_size, [&](std::stringstream& str_strm) {
+        FieldToString(str_strm, true, "ags context", to_string_flags_, tab_count, tab_size, PtrToString(context));
+        FieldToString(str_strm, false, "object_id", to_string_flags_, tab_count, tab_size, ToString(object_id));
+        FieldToString(str_strm, false, "data", to_string_flags_, tab_count, tab_size, data);
+    });
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/custom_ags_ascii_consumer.h
+++ b/framework/decode/custom_ags_ascii_consumer.h
@@ -1,0 +1,677 @@
+/*
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_CUSTOM_AGS_ASCII_CONSUMER_H
+#define GFXRECON_CUSTOM_AGS_ASCII_CONSUMER_H
+
+#include "custom_ags_consumer_base.h"
+#include "custom_dx12_to_string.h"
+#include "util/to_string.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class AgsAsciiConsumer : public AgsConsumerBase
+{
+  public:
+    AgsAsciiConsumer() {}
+    virtual ~AgsAsciiConsumer() override {}
+
+    virtual void Process_agsInitialize(const ApiCallInfo&      call_info,
+                                       AGSReturnCode           return_value,
+                                       int                     agsVersion,
+                                       const AGSConfiguration* config,
+                                       AGSContext* const       context,
+                                       const AGSGPUInfo&       gpuInfo) override;
+
+    virtual void Process_agsDriverExtensionsDX12_CreateDevice(
+        const ApiCallInfo&                                    call_info,
+        AGSReturnCode                                         return_value,
+        AGSContext*                                           context,
+        AGSDX12DeviceCreationParams*                          creationParams,
+        const AGSDX12ExtensionParams*                         extensionParams,
+        StructPointerDecoder<Decoded_AGS_DX12_RETURN_PARAMS>* pReturnParams) override;
+
+    virtual void Process_agsDriverExtensionsDX12_DestroyDevice(const ApiCallInfo& call_info,
+                                                               AGSReturnCode      return_value,
+                                                               AGSContext*        context,
+                                                               ID3D12Device*      device,
+                                                               unsigned int*      deviceReferences) override;
+
+    virtual void
+    Process_agsDeInitialize(const ApiCallInfo& call_info, AGSReturnCode return_value, AGSContext* context) override;
+
+    virtual void Process_agsCheckDriverVersion(const ApiCallInfo&     call_info,
+                                               AGSDriverVersionResult return_value,
+                                               const char*            radeonSoftwareVersionReported,
+                                               unsigned int           radeonSoftwareVersionRequired) override;
+
+    virtual void Process_agsGetVersionNumber(const ApiCallInfo& call_info, int return_value) override;
+
+    virtual void Process_agsSetDisplayMode(const ApiCallInfo&        call_info,
+                                           AGSReturnCode             return_value,
+                                           AGSContext*               context,
+                                           int                       deviceIndex,
+                                           int                       displayIndex,
+                                           const AGSDisplaySettings* settings) override;
+
+    virtual void Process_agsDriverExtensionsDX12_PushMarker(const ApiCallInfo& call_info,
+                                                            AGSReturnCode      return_value,
+                                                            AGSContext*        context,
+                                                            format::HandleId   object_id,
+                                                            const char*        data) override;
+
+    virtual void Process_agsDriverExtensionsDX12_PopMarker(const ApiCallInfo& call_info,
+                                                           AGSReturnCode      return_value,
+                                                           AGSContext*        context,
+                                                           format::HandleId   object_id) override;
+
+    virtual void Process_agsDriverExtensionsDX12_SetMarker(const ApiCallInfo& call_info,
+                                                           AGSReturnCode      return_value,
+                                                           AGSContext*        context,
+                                                           format::HandleId   object_id,
+                                                           const char*        data) override;
+
+    void Initialize(FILE* file, gfxrecon::util::ToStringFlags toStringFlags);
+
+    void Destroy();
+
+  private:
+    struct WriteAgsCallToFileInfo
+    {
+        int         block_index{ 0 };
+        const char* pFunctionName{};
+        const char* pReturnValue{};
+    };
+
+    template <typename ToStringFunctionType>
+    inline void WriteApiCallToFile(const WriteAgsCallToFileInfo& writeApiCallToFileInfo,
+                                   uint32_t&                     tabCount,
+                                   uint32_t                      tabSize,
+                                   ToStringFunctionType          toStringFunction)
+    {
+        using namespace util;
+        using namespace util::platform;
+
+        // Add a comma between top-level JSON objects if we are not generating JSON Lines.
+        if (to_string_flags_ & kToString_Formatted)
+        {
+            FilePuts(",\n", file_);
+        }
+        else
+        {
+            FilePuts("\n", file_);
+        }
+
+        fprintf(file_,
+                "%s",
+                ObjectToString(to_string_flags_, tabCount, tabSize, [&](std::stringstream& strStrm) {
+                    // Output the call block index
+                    FieldToString(strStrm,
+                                  true,
+                                  "index",
+                                  to_string_flags_,
+                                  tabCount,
+                                  tabSize,
+                                  ToString(writeApiCallToFileInfo.block_index, to_string_flags_, tabCount, tabSize));
+
+                    auto fieldName = "function";
+                    FieldToString(strStrm,
+                                  false,
+                                  fieldName,
+                                  to_string_flags_,
+                                  tabCount,
+                                  tabSize,
+                                  '"' + std::string(writeApiCallToFileInfo.pFunctionName) + '"');
+
+                    // Output the return value
+                    if (writeApiCallToFileInfo.pReturnValue)
+                    {
+                        FieldToString(strStrm,
+                                      false,
+                                      "return",
+                                      to_string_flags_,
+                                      tabCount,
+                                      tabSize,
+                                      std::string(writeApiCallToFileInfo.pReturnValue));
+                    }
+
+                    // Output the method/function parameters
+                    const auto& parametersStr = ObjectToString(to_string_flags_, tabCount, tabSize, toStringFunction);
+                    for (auto c : parametersStr)
+                    {
+                        if (c != '{' && !isspace(static_cast<unsigned char>(c)) && c != '}')
+                        {
+                            FieldToString(
+                                strStrm, false, "parameters", to_string_flags_, tabCount, tabSize, parametersStr);
+                            break;
+                        }
+                    }
+                    return strStrm.str();
+                }).c_str());
+    }
+
+    inline void AddStringOfAGSRect(
+        std::stringstream& strStrm, const char* name, AGSRect rect, uint32_t tab_count, uint32_t tab_size)
+    {
+        using namespace util;
+        FieldToString(
+            strStrm,
+            false,
+            name,
+            to_string_flags_,
+            tab_count,
+            tab_size,
+            ObjectToString(to_string_flags_, tab_count, tab_size, [&](std::stringstream& strStrm) {
+                FieldToString(strStrm, true, "offsetX", to_string_flags_, tab_count, tab_size, ToString(rect.offsetX));
+                FieldToString(strStrm, false, "offsetY", to_string_flags_, tab_count, tab_size, ToString(rect.offsetY));
+                FieldToString(strStrm, false, "width", to_string_flags_, tab_count, tab_size, ToString(rect.width));
+                FieldToString(strStrm, false, "height", to_string_flags_, tab_count, tab_size, ToString(rect.height));
+            }));
+    }
+
+    inline std::string
+    StringOfDisplays(int num_displays, const AGSDisplayInfo* returned_displays, uint32_t tab_count, uint32_t tab_size)
+    {
+        using namespace util;
+        return ArrayToString<AGSDisplayInfo>(
+            num_displays,
+            returned_displays,
+            to_string_flags_,
+            tab_count,
+            tab_size,
+            [&]() { return returned_displays; },
+            [&](size_t i) {
+                std::stringstream local_stream;
+                uint32_t          obj_tab_count = tab_count + 1;
+                local_stream << ObjectToString(
+                    to_string_flags_, obj_tab_count, tab_size, [&](std::stringstream& strStrm) {
+                        FieldToString(strStrm,
+                                      true,
+                                      "name",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      returned_displays[i].name);
+                        FieldToString(strStrm,
+                                      false,
+                                      "displayDeviceName",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      returned_displays[i].displayDeviceName);
+                        FieldToString(strStrm,
+                                      false,
+                                      "isPrimaryDisplay",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].isPrimaryDisplay));
+                        FieldToString(strStrm,
+                                      false,
+                                      "HDR10",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].HDR10));
+                        FieldToString(strStrm,
+                                      false,
+                                      "dolbyVision",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].dolbyVision));
+                        FieldToString(strStrm,
+                                      false,
+                                      "freesyncHDR",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].freesyncHDR));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityInGroup",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].eyefinityInGroup));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityPreferredDisplay",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].eyefinityPreferredDisplay));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityInPortraitMode",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].eyefinityInPortraitMode));
+                        FieldToString(strStrm,
+                                      false,
+                                      "reservedPadding",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].reservedPadding));
+                        FieldToString(strStrm,
+                                      false,
+                                      "maxResolutionX",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].maxResolutionX));
+                        FieldToString(strStrm,
+                                      false,
+                                      "maxResolutionY",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].maxResolutionY));
+                        FieldToString(strStrm,
+                                      false,
+                                      "maxRefreshRate",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].maxRefreshRate));
+
+                        AddStringOfAGSRect(strStrm,
+                                           "currentResolution",
+                                           returned_displays[i].currentResolution,
+                                           obj_tab_count,
+                                           tab_size);
+                        AddStringOfAGSRect(strStrm,
+                                           "visibleResolution",
+                                           returned_displays[i].visibleResolution,
+                                           obj_tab_count,
+                                           tab_size);
+                        FieldToString(strStrm,
+                                      false,
+                                      "currentRefreshRate",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].currentRefreshRate));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityGridCoordX",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].eyefinityGridCoordX));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityGridCoordY",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].eyefinityGridCoordY));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityRedX",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityRedX));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityRedY",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityRedY));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityGreenX",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityGreenX));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityGreenY",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityGreenY));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityBlueX",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityBlueX));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityBlueY",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityBlueY));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityWhitePointX",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityWhitePointX));
+                        FieldToString(strStrm,
+                                      false,
+                                      "chromaticityWhitePointY",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].chromaticityWhitePointY));
+                        FieldToString(strStrm,
+                                      false,
+                                      "screenDiffuseReflectance",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].screenDiffuseReflectance));
+                        FieldToString(strStrm,
+                                      false,
+                                      "screenSpecularReflectance",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].screenSpecularReflectance));
+                        FieldToString(strStrm,
+                                      false,
+                                      "minLuminance",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].minLuminance));
+                        FieldToString(strStrm,
+                                      false,
+                                      "maxLuminance",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].maxLuminance));
+                        FieldToString(strStrm,
+                                      false,
+                                      "avgLuminance",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].avgLuminance));
+                        FieldToString(strStrm,
+                                      false,
+                                      "logicalDisplayIndex",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].logicalDisplayIndex));
+                        FieldToString(strStrm,
+                                      false,
+                                      "adlAdapterIndex",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].adlAdapterIndex));
+                        FieldToString(strStrm,
+                                      false,
+                                      "reserved",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_displays[i].reserved));
+                    });
+                return local_stream.str();
+            });
+    }
+
+    inline std::string
+    StringOfDevices(int num_devices, const AGSDeviceInfo* returned_devices, uint32_t tab_count, uint32_t tab_size)
+    {
+        using namespace util;
+        return ArrayToString<AGSDeviceInfo>(
+            num_devices,
+            returned_devices,
+            to_string_flags_,
+            tab_count,
+            tab_size,
+            [&]() { return returned_devices; },
+            [&](size_t i) {
+                std::stringstream local_stream;
+                uint32_t          obj_tab_count = tab_count + 1;
+
+                local_stream << ObjectToString(
+                    to_string_flags_, obj_tab_count, tab_size, [&](std::stringstream& strStrm) {
+                        FieldToString(strStrm,
+                                      true,
+                                      "adapterString",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      returned_devices[i].adapterString);
+                        FieldToString(strStrm,
+                                      false,
+                                      "asicFamily",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].asicFamily));
+                        FieldToString(strStrm,
+                                      false,
+                                      "isAPU",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].isAPU));
+                        FieldToString(strStrm,
+                                      false,
+                                      "isPrimaryDevice",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].isPrimaryDevice));
+                        FieldToString(strStrm,
+                                      false,
+                                      "isExternal",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].isExternal));
+                        FieldToString(strStrm,
+                                      false,
+                                      "reservedPadding",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].reservedPadding));
+                        FieldToString(strStrm,
+                                      false,
+                                      "vendorId",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].vendorId));
+                        FieldToString(strStrm,
+                                      false,
+                                      "deviceId",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].deviceId));
+                        FieldToString(strStrm,
+                                      false,
+                                      "revisionId",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].revisionId));
+                        FieldToString(strStrm,
+                                      false,
+                                      "numCUs",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].numCUs));
+                        FieldToString(strStrm,
+                                      false,
+                                      "numWGPs",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].numWGPs));
+                        FieldToString(strStrm,
+                                      false,
+                                      "numROPs",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].numROPs));
+                        FieldToString(strStrm,
+                                      false,
+                                      "coreClock",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].coreClock));
+                        FieldToString(strStrm,
+                                      false,
+                                      "memoryClock",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].memoryClock));
+                        FieldToString(strStrm,
+                                      false,
+                                      "memoryBandwidth",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].memoryBandwidth));
+                        FieldToString(strStrm,
+                                      false,
+                                      "teraFlops",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].teraFlops));
+                        FieldToString(strStrm,
+                                      false,
+                                      "localMemoryInBytes",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].localMemoryInBytes));
+                        FieldToString(strStrm,
+                                      false,
+                                      "sharedMemoryInBytes",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].sharedMemoryInBytes));
+                        FieldToString(strStrm,
+                                      false,
+                                      "numDisplays",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].numDisplays));
+
+                        AGSDisplayInfo* returned_displays = returned_devices[i].displays;
+                        FieldToString(strStrm,
+                                      false,
+                                      "displays",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      StringOfDisplays(
+                                          returned_devices[i].numDisplays, returned_displays, obj_tab_count, tab_size));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityEnabled",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].eyefinityEnabled));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityGridWidth",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].eyefinityGridWidth));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityGridHeight",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].eyefinityGridHeight));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityResolutionX",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].eyefinityResolutionX));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityResolutionY",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].eyefinityResolutionY));
+                        FieldToString(strStrm,
+                                      false,
+                                      "eyefinityBezelCompensated",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].eyefinityBezelCompensated));
+                        FieldToString(strStrm,
+                                      false,
+                                      "adlAdapterIndex",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].adlAdapterIndex));
+                        FieldToString(strStrm,
+                                      false,
+                                      "reserved",
+                                      to_string_flags_,
+                                      obj_tab_count,
+                                      tab_size,
+                                      ToString(returned_devices[i].reserved));
+                    });
+
+                return local_stream.str();
+            });
+    }
+
+    FILE*                         file_{ nullptr };
+    gfxrecon::util::ToStringFlags to_string_flags_{ gfxrecon::util::kToString_Default };
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_CUSTOM_AGS_ASCII_CONSUMER_H

--- a/framework/decode/custom_ags_consumer_base.h
+++ b/framework/decode/custom_ags_consumer_base.h
@@ -92,6 +92,11 @@ class AgsConsumerBase
                                                            AGSContext*        context,
                                                            format::HandleId   object_id,
                                                            const char*        data) = 0;
+
+    void SetCurrentBlockIndex(uint64_t index) { current_block_index_ = index; }
+
+  protected:
+    uint64_t current_block_index_{ 0 };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/custom_ags_decoder.cpp
+++ b/framework/decode/custom_ags_decoder.cpp
@@ -41,6 +41,14 @@ bool AgsDecoder::SupportsApiCall(format::ApiCallId call_id)
     return (family_id == format::ApiFamilyId::ApiFamily_AGS);
 }
 
+void AgsDecoder::SetCurrentBlockIndex(uint64_t block_index)
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->SetCurrentBlockIndex(block_index);
+    }
+}
+
 void AgsDecoder::DecodeFunctionCall(format::ApiCallId  call_id,
                                     const ApiCallInfo& call_info,
                                     const uint8_t*     parameter_buffer,

--- a/framework/decode/custom_ags_decoder.h
+++ b/framework/decode/custom_ags_decoder.h
@@ -166,7 +166,7 @@ class AgsDecoder : public ApiDecoder
                                                 const uint8_t*                              data) override
     {}
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index) override {}
+    virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
     virtual void DecodeFunctionCall(format::ApiCallId  call_id,
                                     const ApiCallInfo& call_options,

--- a/framework/decode/dx12_ascii_consumer_base.h
+++ b/framework/decode/dx12_ascii_consumer_base.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2021-2023 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -100,7 +101,7 @@ class Dx12AsciiConsumerBase : public Dx12Consumer
             [&](std::stringstream& strStrm)
             {
                 // Output the API call index
-                FieldToString(strStrm, true, "index", to_string_flags_, tabCount, tabSize, ToString(api_call_count_++, to_string_flags_, tabCount, tabSize));
+                FieldToString(strStrm, true, "index", to_string_flags_, tabCount, tabSize, ToString(GetCurrentBlockIndex(), to_string_flags_, tabCount, tabSize));
 
                 // Output the method/function name
                 assert(writeApiCallToFileInfo.pFunctionName);
@@ -145,7 +146,6 @@ class Dx12AsciiConsumerBase : public Dx12Consumer
   private:
     FILE*       file_{ nullptr };
     std::string filename_;
-    uint64_t    api_call_count_{ 0 };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -42,7 +42,7 @@ const uint32_t kFirstFrame = 0;
 FileProcessor::FileProcessor() :
     file_header_{}, file_descriptor_(nullptr), current_frame_number_(kFirstFrame), bytes_read_(0),
     error_state_(kErrorInvalidFileDescriptor), annotation_handler_(nullptr), compressor_(nullptr), block_index_(0),
-    api_call_index_(0), block_limit_(0), capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1)
+    block_limit_(0), capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1)
 {}
 
 FileProcessor::FileProcessor(uint64_t block_limit) : FileProcessor()
@@ -655,8 +655,6 @@ bool FileProcessor::ProcessMethodCall(const format::BlockHeader& block_header, f
                     DecodeAllocator::End();
                 }
             }
-
-            ++api_call_index_;
         }
     }
     else

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2023 Valve Corporation
 ** Copyright (c) 2018-2023 LunarG, Inc.
-** Copyright (c) 2020 Advanced Micro Devices, Inc.
+** Copyright (c) 2020-2023 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -31,6 +31,11 @@
 #include "generated/generated_vulkan_export_json_consumer.h"
 #if defined(CONVERT_EXPERIMENTAL_D3D12)
 #include "generated/generated_dx12_ascii_consumer.h"
+#ifdef GFXRECON_AGS_SUPPORT
+#include "decode/custom_ags_consumer_base.h"
+#include "decode/custom_ags_decoder.h"
+#include "decode/custom_ags_ascii_consumer.h"
+#endif // GFXRECON_AGS_SUPPORT
 #endif
 
 using gfxrecon::decode::JsonFormat;
@@ -270,6 +275,18 @@ int main(int argc, const char** argv)
             auto dx12_json_flags = output_format == JsonFormat::JSON ? gfxrecon::util::kToString_Formatted
                                                                      : gfxrecon::util::kToString_Unformatted;
             dx12_ascii_consumer.Initialize(out_file_handle, dx12_json_flags);
+
+#ifdef GFXRECON_AGS_SUPPORT
+            gfxrecon::decode::AgsAsciiConsumer ags_ascii_consumer;
+            ags_ascii_consumer.Initialize(out_file_handle, dx12_json_flags);
+
+            gfxrecon::decode::AgsDecoder ags_decoder;
+
+            ags_decoder.AddConsumer(&ags_ascii_consumer);
+
+            file_processor.AddDecoder(&ags_decoder);
+#endif // GFXRECON_AGS_SUPPORT
+
 #endif
 
             while (success)


### PR DESCRIPTION
**Problem**
1. AGS support is already in GFXR. The convert output file should also include the AGS calls.
2. The index values in the convert output file doesn't match anything in the replay consumer. It makes it very hard to find the matching call in the convert file when debugging an issue in the replayer.

**Solution**
1. Add AGS ascii consumer to support AGS in the convert tool. 
2. Remove api_call_count_ from the convert consumer and use block index for index values in the convert output file. Block index values provides consistent matches between different decode consumers. 

**Result**
AGS calls are included in the convert output file. Indices are block index values now.    