### PR TITLE
Convert DX12 Binary Blobs in Functions

### DIFF
--- a/framework/generated/dx12_generators/dx12_json_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_json_consumer_body_generator.py
@@ -57,6 +57,16 @@ class Dx12JsonConsumerBodyGenerator(Dx12JsonConsumerHeaderGenerator, Dx12JsonCom
 
     JSON_OVERRIDES = {}
 
+    ## @brief A set of tuples, each specifying an argument of a method or function which could be
+    ## represented as a binary blob.
+    ## The binary file will be named as follows: [<object_name>.]<[method|function]_name>.<argument_name>-<instance_counter>.bin
+    BINARY_BLOBS = {
+        # Methods:
+        ('ID3D12Device', 'CreateRootSignature', 'pBlobWithRootSignature'),
+        # Free Functions:
+        (None, 'FunctionWithBlob', 'pBlobArgument'), # Example of registering a free function's argument as a binary blob.
+    }
+
     def beginFile(self, genOpts):
         Dx12JsonConsumerHeaderGenerator.beginFile(self, genOpts)
         if genOpts.json_overrides:
@@ -77,6 +87,13 @@ class Dx12JsonConsumerBodyGenerator(Dx12JsonConsumerHeaderGenerator, Dx12JsonCom
         self.newline()
 
     def generate_feature(self):
+        write(format_cpp_code('''
+            inline bool RepresentBinaryFile(const util::JsonOptions& json_options, nlohmann::ordered_json& jdata, std::string_view filename_base, const uint64_t instance_counter, const PointerDecoder<uint8_t>& data)
+            {
+                return util::RepresentBinaryFile(json_options, jdata, filename_base, instance_counter, data.GetLength(), data.GetPointer());
+            }
+        '''), file=self.outFile)
+        self.newline()
         Dx12BaseGenerator.generate_feature(self)
         self.write_dx12_consumer_class('Json')
 
@@ -133,7 +150,7 @@ class Dx12JsonConsumerBodyGenerator(Dx12JsonConsumerHeaderGenerator, Dx12JsonCom
         # Generate a correct FieldToJson for each argument:
         for parameter in method_info['parameters']:
             value = self.get_value_info(parameter)
-            code += "    " + self.make_field_to_json("args", value, "options") + "\n"
+            code += "    " + self.make_field_to_json(None, method_info['name'], value, "options") + "\n"
 
         code += remove_leading_empty_lines('''
                 }}
@@ -160,7 +177,7 @@ class Dx12JsonConsumerBodyGenerator(Dx12JsonConsumerHeaderGenerator, Dx12JsonCom
             # Generate a correct FieldToJson for each argument:
             for parameter in method_info['parameters']:
                 value = self.get_value_info(parameter)
-                code += "    " + self.make_field_to_json("args", value, "options") + "\n"
+                code += "    " + self.make_field_to_json(class_name, method_info['name'], value, "options") + "\n"
             code += "}}\n"
 
         code += "writer_->WriteBlockEnd();"
@@ -168,16 +185,31 @@ class Dx12JsonConsumerBodyGenerator(Dx12JsonConsumerHeaderGenerator, Dx12JsonCom
         return code
 
     ## @param value_info A ValueInfo object from base_generator.py.
-    def make_field_to_json(self, parent_name, value_info, options_name):
-        function_name = self.choose_field_to_json_name(value_info)
+    def make_field_to_json(self, class_name, function_name, value_info, options_name):
+        # Handle arguments that are pointers to binary blobs:
+        if (class_name, function_name, value_info.name) in self.BINARY_BLOBS:
+            field_to_json  = '        static thread_local uint64_t {2}_counter{{{{ 0 }}}};\n'
+            if class_name == None:
+                # A function argument:
+                field_to_json += '        const bool written = RepresentBinaryFile(options, args["{2}"], "{1}.{2}", {2}_counter, {2});\n'
+            else:
+                # A method argument:
+                field_to_json += '        const bool written = RepresentBinaryFile(options, args["{2}"], "{0}.{1}.{2}", {2}_counter, *{2});\n'
+            field_to_json += '        {2}_counter += written;\n'
+            field_to_json = field_to_json.format(class_name, function_name, value_info.name)
+            return field_to_json
+
+        # Handle arguments that are not pointers to binary blobs:
+
+        field_to_json_name = self.choose_field_to_json_name(value_info)
         src = value_info.name
         ## Special case for pointers to flag sets defined by enums:
         ## (easier than having pointer decoder versions of each flagset type's FieldToString)
-        if value_info.is_pointer and function_name.startswith("FieldToJson_"):
+        if value_info.is_pointer and field_to_json_name.startswith("FieldToJson_"):
             src = "*" + src + "->GetPointer()"
-        field_to_json = '{0}({1}["{2}"], {3}, {4});'.format(function_name, parent_name, value_info.name, src, options_name)
+        field_to_json = '{0}({1}["{2}"], {3}, {4});'.format(field_to_json_name, "args", value_info.name, src, options_name)
         if "anon-union" in value_info.base_type:
             field_to_json += "// [anon-union] "
-            print("ALERT: anon union " + value_info.name + " in " + parent_name)
+            print("ALERT: anon union " + value_info.name)
 
         return field_to_json

--- a/framework/generated/dx12_generators/json_blocklists.json
+++ b/framework/generated/dx12_generators/json_blocklists.json
@@ -15,11 +15,9 @@
       "WriteToSubresource"
     ]
   },
-  "todo2": "Remove the ones below which can be handled with anon union support.",
   "structures": [
     "GUID Comment - We can generate the header for the decoded struct but the body needs a manual implementation.",
     "GUID",
-    "Comment: definitely need custom json conversion below",
     "D3D12_PIPELINE_STATE_STREAM_DESC",
     "D3D12_STATE_SUBOBJECT",
     "D3D12_CPU_DESCRIPTOR_HANDLE"

--- a/framework/generated/generated_dx12_json_consumer.cpp
+++ b/framework/generated/generated_dx12_json_consumer.cpp
@@ -37,6 +37,11 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+inline bool RepresentBinaryFile(const util::JsonOptions& json_options, nlohmann::ordered_json& jdata, std::string_view filename_base, const uint64_t instance_counter, const PointerDecoder<uint8_t>& data)
+{
+    return util::RepresentBinaryFile(json_options, jdata, filename_base, instance_counter, data.GetLength(), data.GetPointer());
+}
+
 /*
 ** This part is generated from dxgi.h in Windows SDK: 10.0.20348.0
 **
@@ -5175,7 +5180,10 @@ void Dx12JsonConsumer::Process_ID3D12Device_CreateRootSignature(
     nlohmann::ordered_json& args = method[format::kNameArgs];
     {
         FieldToJsonAsFixedWidthBinary(args["nodeMask"], nodeMask, options);
-        FieldToJson(args["pBlobWithRootSignature"], pBlobWithRootSignature, options);
+        static thread_local uint64_t pBlobWithRootSignature_counter{ 0 };
+        const bool written = RepresentBinaryFile(options, args["pBlobWithRootSignature"], "ID3D12Device.CreateRootSignature.pBlobWithRootSignature", pBlobWithRootSignature_counter, *pBlobWithRootSignature);
+        pBlobWithRootSignature_counter += written;
+
         FieldToJson(args["blobLengthInBytes"], blobLengthInBytes, options);
         FieldToJson(args["riid"], riid, options);
         FieldToJson(args["ppvRootSignature"], ppvRootSignature, options);

--- a/framework/util/json_util.cpp
+++ b/framework/util/json_util.cpp
@@ -272,7 +272,6 @@ void FieldToJson(nlohmann::ordered_json&                                  jdata,
                  const format::InitDx12AccelerationStructureGeometryDesc& data,
                  const util::JsonOptions&                                 options)
 {
-    /// @todo handle enums and so on.
     FieldToJson(jdata["geometry_type"], static_cast<D3D12_RAYTRACING_GEOMETRY_TYPE>(data.geometry_type), options);
     FieldToJson_D3D12_RAYTRACING_GEOMETRY_FLAGS(
         jdata["geometry_flags"], static_cast<D3D12_RAYTRACING_GEOMETRY_FLAGS>(data.geometry_flags), options);

--- a/tools/convert/main.cpp
+++ b/tools/convert/main.cpp
@@ -23,7 +23,7 @@
 */
 #include "project_version.h"
 #include "tool_settings.h"
-#include "decode/json_writer.h" /// @todo move to util?
+#include "decode/json_writer.h"
 #include "decode/decode_api_detection.h"
 #include "format/format.h"
 #include "util/file_output_stream.h"


### PR DESCRIPTION
Provide a mechanism for registering function and method arguments
 to be dumped to separate binary files with a single line in the
 Python generator of the DX12 JSON Consumer.

Example usage provided for one argument:

    ID3D12Device.CreateRootSignature(...,pBlobWithRootSignature)

Follow-up to PR https://github.com/LunarG/gfxreconstruct/pull/1362