### PR TITLE
Fix missing parens in to_binary_fixed_width

### DIFF
--- a/framework/util/to_string.cpp
+++ b/framework/util/to_string.cpp
@@ -39,7 +39,7 @@ std::string to_binary_fixed_width(const T value)
     std::string ret{ "0b" };
     for (auto i = num_bits; i > 0; --i)
     {
-        ret += ((value >> i - 1) & one) ? '1' : '0';
+        ret += ((value >> (i - 1)) & one) ? '1' : '0';
     }
     return ret;
 }


### PR DESCRIPTION
Clang-18 reports a warning that the '>>' operator has lower precedence than '-' in the expression `value >> i - 1`. The fix is to wrap `i - 1` with parenthesis to make it clear the intent.