### PR TITLE
Fix CommandHandleType::NumHandleTypes not last of enum

### DIFF
--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -128,8 +128,8 @@ enum CommandHandleType : uint32_t
     OpticalFlowSessionNVHandle,
     VideoSessionKHRHandle,
     VideoSessionParametersKHRHandle,
-    NumHandleTypes,
-    ShaderEXTHandle
+    ShaderEXTHandle,
+    NumHandleTypes
 };
 
 GFXRECON_END_NAMESPACE(encode)


### PR DESCRIPTION
This create random crashes and undefined behaviors when trying to iterate over handle types or accessing resources...