### PR TITLE
Fix memory exception during memcpy in ApplyBatchedResourceInitInfo

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -438,7 +438,7 @@ void Dx12ReplayConsumerBase::ProcessInitSubresourceCommand(const format::InitSub
                                                  subresource_sizes,
                                                  temp_subresource_layouts,
                                                  required_data_size);
-        resource_init_info.subresource_sizes = subresource_sizes;
+
         resource_init_info.staging_resource  = resource_data_util_->CreateStagingBuffer(
             graphics::Dx12ResourceDataUtil::CopyType::kCopyTypeWrite, required_data_size);
         SetResourceInitInfoState(resource_init_info, command_header, data);


### PR DESCRIPTION
The memory exception happen due to the subresource_sizes.size() is not equal to layout_sizes.size(). This is because subresource_size has been set twice in Dx12ReplayConsumerBase::ProcessInitSubresourceCommand . 
Thus, this PR removes the line resource_init_info.subresource_sizes = subresource_sizes; The subresource size will be set only by SetResourceInitInfoState .