### PR TITLE
Fix the null pointer issue for State Object for trim capture.

### DIFF
--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2021 LunarG, Inc.
-** Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -1639,6 +1639,7 @@ void Dx12StateWriter::WriteStateObjectsState(const Dx12StateTable& state_table)
 
         WriteStateObjectAndDependency(
             state_object_wrapper->GetCaptureId(), state_object_wrapper->GetObjectInfo().get(), written_objs);
+        WriteAddRefAndReleaseCommands(state_object_wrapper);
     });
 }
 


### PR DESCRIPTION
**Problem**
It has been found that the AddRef and Release calls are missing for State Objects, for trim capture only. During the replay, some State Objects may end up being released before they are used again by SetPipelineState1. If this happens, the replay will crash. 

**Solution**
Add WriteAddRefAndReleaseCommands in Dx12StateWriter::WriteStateObjectsState. 

**Result**
The potential crash will be avoided. 