### PR TITLE
resolve an overridden function with different signature

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -439,7 +439,7 @@ ParameterEncoder* CaptureManager::InitApiCallCapture(format::ApiCallId call_id)
     thread_data->call_id_ = call_id;
 
     // Reset the parameter buffer and reserve space for an uncompressed FunctionCallHeader.
-    thread_data->parameter_buffer_->ResetWithHeader(sizeof(format::FunctionCallHeader));
+    thread_data->parameter_buffer_->ClearWithHeader(sizeof(format::FunctionCallHeader));
 
     return thread_data->parameter_encoder_.get();
 }
@@ -451,7 +451,7 @@ ParameterEncoder* CaptureManager::InitMethodCallCapture(format::ApiCallId call_i
     thread_data->object_id_ = object_id;
 
     // Reset the parameter buffer and reserve space for an uncompressed MethodCallHeader.
-    thread_data->parameter_buffer_->ResetWithHeader(sizeof(format::MethodCallHeader));
+    thread_data->parameter_buffer_->ClearWithHeader(sizeof(format::MethodCallHeader));
 
     return thread_data->parameter_encoder_.get();
 }

--- a/framework/encode/dx12_state_tracker.cpp
+++ b/framework/encode/dx12_state_tracker.cpp
@@ -125,7 +125,7 @@ void Dx12StateTracker::TrackCommandExecution(ID3D12CommandList_Wrapper*      lis
         list_info->is_closed = false;
 
         // Clear command data on command buffer reset.
-        list_info->command_data.Reset();
+        list_info->command_data.Clear();
 
         // Clear pending resource transitions.
         list_info->transition_barriers.clear();
@@ -337,7 +337,7 @@ void Dx12StateTracker::TrackDescriptorCreation(ID3D12Device_Wrapper*           c
     }
     else
     {
-        descriptor_info->create_parameters->Reset();
+        descriptor_info->create_parameters->Clear();
         descriptor_info->create_parameters->Write(parameter_buffer->GetData(), parameter_buffer->GetDataSize());
     }
     descriptor_info->is_copy         = false;
@@ -371,7 +371,7 @@ void Dx12StateTracker::TrackCopyDescriptors(UINT                    num_descript
         }
         else
         {
-            dst->create_parameters->Reset();
+            dst->create_parameters->Clear();
         }
 
         // Copy the source descriptor's creation parameters to destination.

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -429,7 +429,7 @@ void Dx12StateWriter::WriteDescriptorState(const Dx12StateTable& state_table)
             WriteMethodCall(format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetCPUDescriptorHandleForHeapStart,
                             heap_wrapper->GetCaptureId(),
                             &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
 
         // Write GetGPUDescriptorHandleForHeapStart call.
@@ -441,7 +441,7 @@ void Dx12StateWriter::WriteDescriptorState(const Dx12StateTable& state_table)
             WriteMethodCall(format::ApiCallId::ApiCall_ID3D12DescriptorHeap_GetGPUDescriptorHandleForHeapStart,
                             heap_wrapper->GetCaptureId(),
                             &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
 
         // Write call to query the device for heap increment size.
@@ -450,7 +450,7 @@ void Dx12StateWriter::WriteDescriptorState(const Dx12StateTable& state_table)
         WriteMethodCall(format::ApiCallId::ApiCall_ID3D12Device_GetDescriptorHandleIncrementSize,
                         heap_info->create_object_id,
                         &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
 
         // Write descriptor creation calls, not use StandardCreateWrite.
         for (uint32_t i = 0; i < heap_desc.NumDescriptors; ++i)
@@ -476,7 +476,7 @@ void Dx12StateWriter::WriteDescriptorState(const Dx12StateTable& state_table)
                     parameter_stream_.Write(&dest_index, sizeof(dest_index));
                     WriteMethodCall(
                         descriptor_info.create_call_id, descriptor_info.create_object_id, &parameter_stream_);
-                    parameter_stream_.Reset();
+                    parameter_stream_.Clear();
                 }
                 else
                 {
@@ -519,7 +519,7 @@ void Dx12StateWriter::WritePrivateData(format::HandleId handle_id, const DxWrapp
         {
             WriteMethodCall(format::ApiCallId::ApiCall_ID3D12Object_SetPrivateData, handle_id, &parameter_stream_);
         }
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     }
 }
 
@@ -527,14 +527,14 @@ void Dx12StateWriter::WriteAddRefCommand(format::HandleId handle_id, unsigned lo
 {
     encoder_.EncodeUInt32Value(result_ref_count);
     WriteMethodCall(format::ApiCallId::ApiCall_IUnknown_AddRef, handle_id, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void Dx12StateWriter::WriteReleaseCommand(format::HandleId handle_id, unsigned long result_ref_count)
 {
     encoder_.EncodeUInt32Value(result_ref_count);
     WriteMethodCall(format::ApiCallId::ApiCall_IUnknown_Release, handle_id, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 
 #if GFXRECON_DEBUG_WRITTEN_OBJECTS
     if (result_ref_count == 0)
@@ -586,7 +586,7 @@ void Dx12StateWriter::WriteResourceCreationState(
             WriteMethodCall(format::ApiCallId::ApiCall_ID3D12Resource_GetGPUVirtualAddress,
                             resource_wrapper->GetCaptureId(),
                             &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             // Track the GPU VAs for buffers written to the trim state block. This map is used to determine if a given
             // GPU VA references a buffer that was written to the trim state block. Addresses do not need to be mapped,
@@ -677,7 +677,7 @@ void Dx12StateWriter::WriteResourceCreationState(
 
         mappable_resource->Unmap(map_info.subresource, &graphics::dx12::kZeroRange);
 
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     }
 }
 
@@ -940,7 +940,7 @@ void Dx12StateWriter::WriteFenceState(const Dx12StateTable& state_table)
                 WriteMethodCall(format::ApiCallId::ApiCall_ID3D12Fence_SetEventOnCompletion,
                                 fence_wrapper->GetCaptureId(),
                                 &parameter_stream_);
-                parameter_stream_.Reset();
+                parameter_stream_.Clear();
             }
         }
 
@@ -949,7 +949,7 @@ void Dx12StateWriter::WriteFenceState(const Dx12StateTable& state_table)
         encoder_.EncodeInt32Value(S_OK);
         WriteMethodCall(
             format::ApiCallId::ApiCall_ID3D12Fence_Signal, fence_wrapper->GetCaptureId(), &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     });
 }
 
@@ -981,7 +981,7 @@ void Dx12StateWriter::WriteResidencyPriority(const Dx12StateTable& state_table)
             encoder_.EncodeInt32Value(S_OK);
             WriteMethodCall(
                 format::ApiCallId::ApiCall_ID3D12Device1_SetResidencyPriority, handle_id, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
     });
 }
@@ -1106,7 +1106,7 @@ void Dx12StateWriter::WriteCommandListCommands(const ID3D12CommandList_Wrapper* 
                 // Ags function call, targeting command list.
                 parameter_stream_.Write(parameter_data, (*parameter_size));
                 WriteFunctionCall((*call_id), &parameter_stream_);
-                parameter_stream_.Reset();
+                parameter_stream_.Clear();
 
                 // The output below, in this case, should be skipped.
                 write_current_command = false;
@@ -1118,7 +1118,7 @@ void Dx12StateWriter::WriteCommandListCommands(const ID3D12CommandList_Wrapper* 
         {
             parameter_stream_.Write(parameter_data, (*parameter_size));
             WriteMethodCall((*call_id), list_wrapper->GetCaptureId(), &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
         offset += sizeof(size_t) + sizeof(format::ApiCallId) + (*parameter_size);
     }
@@ -1147,7 +1147,7 @@ void Dx12StateWriter::WriteCommandListClose(const ID3D12CommandList_Wrapper* lis
     encoder_.EncodeUInt32Value(S_OK);
     WriteMethodCall(
         format::ApiCallId::ApiCall_ID3D12GraphicsCommandList_Close, list_wrapper->GetCaptureId(), &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 bool Dx12StateWriter::CheckCommandListObjects(const ID3D12CommandListInfo* list_info, const Dx12StateTable& state_table)
@@ -1327,7 +1327,7 @@ void Dx12StateWriter::WriteEnableDebugLayer()
         encoder_.EncodeHandleIdPtr(&debug_object_id);
         encoder_.EncodeUInt32Value(S_OK);
         WriteFunctionCall(format::ApiCallId::ApiCall_D3D12GetDebugInterface, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
         WriteMethodCall(format::ApiCallId::ApiCall_ID3D12Debug_EnableDebugLayer, debug_object_id, &parameter_stream_);
         WriteMethodCall(format::ApiCallId::ApiCall_IUnknown_Release, debug_object_id, &parameter_stream_);
     }
@@ -1342,26 +1342,26 @@ void Dx12StateWriter::WriteEnableDRED()
         encoder_.EncodeHandleIdPtr(&enable_dred_info.dred_settings1_object_id);
         encoder_.EncodeUInt32Value(S_OK);
         WriteFunctionCall(format::ApiCallId::ApiCall_D3D12GetDebugInterface, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
 
         encoder_.EncodeEnumValue(enable_dred_info.set_auto_breadcrumbs_enablement_);
         WriteMethodCall(format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetAutoBreadcrumbsEnablement,
                         enable_dred_info.dred_settings1_object_id,
                         &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
 
         encoder_.EncodeEnumValue(enable_dred_info.set_breadcrumb_context_enablement_);
         WriteMethodCall(
             format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings1_SetBreadcrumbContextEnablement,
             enable_dred_info.dred_settings1_object_id,
             &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
 
         encoder_.EncodeEnumValue(enable_dred_info.set_page_fault_enablement_);
         WriteMethodCall(format::ApiCallId::ApiCall_ID3D12DeviceRemovedExtendedDataSettings_SetPageFaultEnablement,
                         enable_dred_info.dred_settings1_object_id,
                         &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
 
         WriteMethodCall(
             format::ApiCallId::ApiCall_IUnknown_Release, enable_dred_info.dred_settings1_object_id, &parameter_stream_);

--- a/framework/encode/parameter_buffer.h
+++ b/framework/encode/parameter_buffer.h
@@ -37,16 +37,16 @@ class ParameterBuffer : public util::MemoryOutputStream
     virtual ~ParameterBuffer() {}
 
     // Reset buffer, reserving space for a header at the start of the buffer.
-    void ResetWithHeader(size_t header_size)
+    void ClearWithHeader(size_t header_size)
     {
-        MemoryOutputStream::Reset();
+        MemoryOutputStream::Clear();
         header_size_ = header_size;
         GetBuffer()->resize(header_size_);
     }
 
-    virtual void Reset() override
+    virtual void Clear() override
     {
-        MemoryOutputStream::Reset();
+        MemoryOutputStream::Clear();
         header_size_ = 0;
     }
 

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -46,7 +46,7 @@ void VulkanStateTracker::TrackCommandExecution(CommandBufferWrapper*           w
         (call_id == format::ApiCallId::ApiCall_vkResetCommandBuffer))
     {
         // Clear command data on command buffer reset.
-        wrapper->command_data.Reset();
+        wrapper->command_data.Clear();
         wrapper->pending_layouts.clear();
         wrapper->recorded_queries.clear();
         wrapper->tlas_build_info_map.clear();
@@ -86,7 +86,7 @@ void VulkanStateTracker::TrackResetCommandPool(VkCommandPool command_pool)
 
     for (const auto& entry : wrapper->child_buffers)
     {
-        entry.second->command_data.Reset();
+        entry.second->command_data.Clear();
         entry.second->pending_layouts.clear();
         entry.second->recorded_queries.clear();
         entry.second->tlas_build_info_map.clear();

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -297,7 +297,7 @@ void VulkanStateWriter::WriteTrimCommandPool(const VulkanStateTable& state_table
             encoder_.EncodeFlagsValue(0);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkTrimCommandPool, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
     });
 }
@@ -328,7 +328,7 @@ void VulkanStateWriter::WritePrivateDataSlotState(const VulkanStateTable& state_
                 encoder_.EncodeEnumValue(VK_SUCCESS);
 
                 WriteFunctionCall(format::ApiCallId::ApiCall_vkSetPrivateData, &parameter_stream_);
-                parameter_stream_.Reset();
+                parameter_stream_.Clear();
             }
         }
     });
@@ -986,7 +986,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
             encoder_.EncodeEnumValue(result);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
 
         if (wrapper->acquire_full_screen_exclusive_mode)
@@ -1000,7 +1000,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
             encoder_.EncodeEnumValue(result);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkAcquireFullScreenExclusiveModeEXT, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
 
         if (wrapper->release_full_screen_exclusive_mode)
@@ -1014,7 +1014,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
             encoder_.EncodeEnumValue(result);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkReleaseFullScreenExclusiveModeEXT, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
 
         if (wrapper->using_local_dimming_AMD)
@@ -1028,7 +1028,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
             encoder_.EncodeVkBool32Value(wrapper->local_dimming_enable_AMD);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkSetLocalDimmingAMD, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
     });
 }
@@ -1145,7 +1145,7 @@ void VulkanStateWriter::WriteDeferredOperationJoinCommand(format::HandleId devic
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
@@ -1503,7 +1503,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
             EncodeStructPtr(&encoder_, &memory_requirements);
 
             WriteFunctionCall(format::ApiCall_vkGetBufferMemoryRequirements, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             // Write memory bind command.
             if (wrapper->bind_pnext == nullptr)
@@ -1532,7 +1532,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
 
                 WriteFunctionCall(format::ApiCall_vkBindBufferMemory2, &parameter_stream_);
             }
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             // Group buffers with memory bindings by device for memory snapshot.
             ResourceSnapshotQueueFamilyTable& snapshot_table = (*resources)[device_wrapper];
@@ -1590,7 +1590,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
             EncodeStructPtr(&encoder_, &memory_requirements);
 
             WriteFunctionCall(format::ApiCall_vkGetImageMemoryRequirements, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             // Write memory bind command.
             if (wrapper->bind_pnext == nullptr)
@@ -1619,7 +1619,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
 
                 WriteFunctionCall(format::ApiCall_vkBindImageMemory2, &parameter_stream_);
             }
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             VkMemoryPropertyFlags memory_properties = 0;
             if (memory_wrapper != nullptr)
@@ -1739,7 +1739,7 @@ void VulkanStateWriter::WriteImageSubresourceLayouts(const ImageWrapper* image_w
             EncodeStructPtr(&encoder_, &layout);
 
             WriteFunctionCall(format::ApiCall_vkGetImageSubresourceLayout, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
     }
 }
@@ -1828,7 +1828,7 @@ void VulkanStateWriter::WriteMappedMemoryState(const VulkanStateTable& state_tab
             encoder_.EncodeEnumValue(result);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkMapMemory, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
             ++blocks_written_;
         }
     });
@@ -1953,7 +1953,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceQueueFamilyProperties(format::ApiC
     EncodeStructArray<T>(&encoder_, nullptr, 0);
 
     WriteFunctionCall(call_id, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 
     // Then write the call with the data.
     encoder_.EncodeHandleIdValue(physical_device_id);
@@ -1961,7 +1961,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceQueueFamilyProperties(format::ApiC
     EncodeStructArray(&encoder_, properties, property_count);
 
     WriteFunctionCall(call_id, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceSupport(format::HandleId physical_device_id,
@@ -1978,7 +1978,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceSupport(format::HandleId ph
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceSupportKHR, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceCapabilities(format::HandleId           physical_device_id,
@@ -1994,7 +1994,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceCapabilities(format::Handle
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2KHR, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceFormats(format::HandleId        physical_device_id,
@@ -2014,7 +2014,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceFormats(format::HandleId   
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormats2KHR, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 
     // Then write the call with the data.
     encoder_.EncodeHandleIdValue(physical_device_id);
@@ -2024,7 +2024,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceFormats(format::HandleId   
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormats2KHR, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::HandleId           physical_device_id,
@@ -2046,7 +2046,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::Handle
         encoder_.EncodeEnumValue(result);
 
         WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
 
         // Then write the call with the data.
         encoder_.EncodeHandleIdValue(physical_device_id);
@@ -2056,7 +2056,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::Handle
         encoder_.EncodeEnumValue(result);
 
         WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     }
     else
     {
@@ -2074,7 +2074,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::Handle
         encoder_.EncodeEnumValue(result);
 
         WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModes2EXT, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
 
         // Then write the call with the data.
         encoder_.EncodeHandleIdValue(physical_device_id);
@@ -2084,7 +2084,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::Handle
         encoder_.EncodeEnumValue(result);
 
         WriteFunctionCall(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModes2EXT, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     }
 }
 
@@ -2103,7 +2103,7 @@ void VulkanStateWriter::WriteGetDeviceGroupSurfacePresentModes(format::HandleId 
         encoder_.EncodeEnumValue(result);
 
         WriteFunctionCall(format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModesKHR, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     }
     else
     {
@@ -2119,7 +2119,7 @@ void VulkanStateWriter::WriteGetDeviceGroupSurfacePresentModes(format::HandleId 
         encoder_.EncodeEnumValue(result);
 
         WriteFunctionCall(format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModes2EXT, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     }
 }
 
@@ -2139,7 +2139,7 @@ void VulkanStateWriter::WriteCommandProcessingCreateCommands(format::HandleId de
     encoder_.EncodeHandleIdPtr(&queue_id);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkGetDeviceQueue, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 
     // Create the command pool for the current queue family index.
     VkCommandPoolCreateInfo create_info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
@@ -2154,7 +2154,7 @@ void VulkanStateWriter::WriteCommandProcessingCreateCommands(format::HandleId de
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkCreateCommandPool, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 
     VkCommandBufferAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
     alloc_info.pNext                       = nullptr;
@@ -2168,7 +2168,7 @@ void VulkanStateWriter::WriteCommandProcessingCreateCommands(format::HandleId de
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkAllocateCommandBuffers, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteCommandBegin(format::HandleId command_buffer_id)
@@ -2185,7 +2185,7 @@ void VulkanStateWriter::WriteCommandBegin(format::HandleId command_buffer_id)
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkBeginCommandBuffer, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteCommandEnd(format::HandleId command_buffer_id)
@@ -2196,7 +2196,7 @@ void VulkanStateWriter::WriteCommandEnd(format::HandleId command_buffer_id)
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkEndCommandBuffer, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteCommandExecution(format::HandleId            queue_id,
@@ -2232,14 +2232,14 @@ void VulkanStateWriter::WriteCommandExecution(format::HandleId            queue_
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkQueueSubmit, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 
     // Write queue wait idle.
     encoder_.EncodeHandleIdValue(queue_id);
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkQueueWaitIdle, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteCommandBufferCommands(const CommandBufferWrapper* wrapper,
@@ -2263,7 +2263,7 @@ void VulkanStateWriter::WriteCommandBufferCommands(const CommandBufferWrapper* w
 
             parameter_stream_.Write(parameter_data, (*parameter_size));
             WriteFunctionCall((*call_id), &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             offset += sizeof(size_t) + sizeof(format::ApiCallId) + (*parameter_size);
         }
@@ -2330,7 +2330,7 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      devic
     EncodeStructArray(&encoder_, copy, 0);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkUpdateDescriptorSets, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteQueryPoolReset(format::HandleId                            device_id,
@@ -2350,7 +2350,7 @@ void VulkanStateWriter::WriteQueryPoolReset(format::HandleId                    
         encoder_.EncodeUInt32Value(wrapper->query_count);
 
         WriteFunctionCall(format::ApiCallId::ApiCall_vkCmdResetQueryPool, &parameter_stream_);
-        parameter_stream_.Reset();
+        parameter_stream_.Clear();
     }
 
     WriteCommandEnd(kTempCommandBufferId);
@@ -2381,7 +2381,7 @@ void VulkanStateWriter::WriteQueryActivation(format::HandleId           device_i
             encoder_.EncodeUInt32Value(query_entry.index);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkCmdWriteTimestamp, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
         else if (query_entry.type == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT)
         {
@@ -2392,7 +2392,7 @@ void VulkanStateWriter::WriteQueryActivation(format::HandleId           device_i
             encoder_.EncodeUInt32Value(query_entry.type_index);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkCmdBeginQueryIndexedEXT, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             encoder_.EncodeHandleIdValue(kTempCommandBufferId);
             encoder_.EncodeHandleIdValue(query_entry.pool_id);
@@ -2400,7 +2400,7 @@ void VulkanStateWriter::WriteQueryActivation(format::HandleId           device_i
             encoder_.EncodeUInt32Value(query_entry.type_index);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkCmdEndQueryIndexedEXT, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
         else if (query_entry.type == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV)
         {
@@ -2422,14 +2422,14 @@ void VulkanStateWriter::WriteQueryActivation(format::HandleId           device_i
             encoder_.EncodeFlagsValue(query_entry.flags);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkCmdBeginQuery, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
 
             encoder_.EncodeHandleIdValue(kTempCommandBufferId);
             encoder_.EncodeHandleIdValue(query_entry.pool_id);
             encoder_.EncodeUInt32Value(query_entry.index);
 
             WriteFunctionCall(format::ApiCallId::ApiCall_vkCmdEndQuery, &parameter_stream_);
-            parameter_stream_.Reset();
+            parameter_stream_.Clear();
         }
     }
 
@@ -2462,7 +2462,7 @@ void VulkanStateWriter::WriteCreateFence(format::HandleId device_id, format::Han
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkCreateFence, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteSetEvent(format::HandleId device_id, format::HandleId event_id)
@@ -2474,7 +2474,7 @@ void VulkanStateWriter::WriteSetEvent(format::HandleId device_id, format::Handle
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkSetEvent, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteSignalSemaphoreValue(format::ApiCallId api_call_id,
@@ -2497,7 +2497,7 @@ void VulkanStateWriter::WriteSignalSemaphoreValue(format::ApiCallId api_call_id,
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(api_call_id, &parameter_stream_);
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::WriteDestroyDeviceObject(format::ApiCallId            call_id,
@@ -2511,7 +2511,7 @@ void VulkanStateWriter::WriteDestroyDeviceObject(format::ApiCallId            ca
 
     WriteFunctionCall(call_id, &parameter_stream_);
 
-    parameter_stream_.Reset();
+    parameter_stream_.Clear();
 }
 
 void VulkanStateWriter::DestroyTemporaryDeviceObject(format::ApiCallId               call_id,

--- a/framework/util/file_output_stream.h
+++ b/framework/util/file_output_stream.h
@@ -48,7 +48,7 @@ class FileOutputStream : public OutputStream
 
     /// @brief Change from current file to a new one, closing the old only if it was owned.
     /// @param file The new file to stream writes into.
-    void Reset(FILE* file);
+    virtual void Reset(FILE* file);
 
     virtual ~FileOutputStream() override;
 

--- a/framework/util/memory_output_stream.h
+++ b/framework/util/memory_output_stream.h
@@ -49,7 +49,7 @@ class MemoryOutputStream : public OutputStream
 
     virtual bool IsValid() override { return true; }
 
-    virtual void Reset() override { buffer_.clear(); };
+    virtual void Clear() { buffer_.clear(); };
 
     virtual size_t Write(const void* data, size_t len) override;
 

--- a/framework/util/output_stream.h
+++ b/framework/util/output_stream.h
@@ -39,8 +39,6 @@ class OutputStream
 
     virtual bool IsValid() { return false; }
 
-    virtual void Reset() {}
-
     virtual size_t Write(const void* data, size_t len) = 0;
 
     virtual void Flush() {}


### PR DESCRIPTION
With full warnings enabled on macOS I saw an error with `OutputStream::Reset()` being shadowed by `FileOutputStream::Reset(FILE*)`.  Resolve this shadow by changing the name of Reset for `MemoryOutputStream` to `Clear` (to match C++ container method names), remove the base class `Reset`, and make `FileOutputStream::Reset` not be an override.