### PR TITLE
Remove compiler warnings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,6 @@ AlignEscapedNewlines: true
 AlignOperands: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortFunctionsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false

--- a/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
+++ b/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
@@ -1608,7 +1608,7 @@ extern "C"
 
     /// Creates #VmaAllocator object.
     VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAllocator(const VmaAllocatorCreateInfo* VMA_NOT_NULL pCreateInfo,
-                                                           VmaAllocator VMA_NULLABLE* VMA_NOT_NULL pAllocator);
+                                                           VmaAllocator VMA_NULLABLE* VMA_NOT_NULL    pAllocator);
 
     /// Destroys allocator object.
     VMA_CALL_PRE void VMA_CALL_POST vmaDestroyAllocator(VmaAllocator VMA_NULLABLE allocator);
@@ -1626,7 +1626,7 @@ extern "C"
     You can access it here, without fetching it again on your own.
     */
     VMA_CALL_PRE void VMA_CALL_POST vmaGetPhysicalDeviceProperties(
-        VmaAllocator VMA_NOT_NULL         allocator,
+        VmaAllocator VMA_NOT_NULL                                    allocator,
         const VkPhysicalDeviceProperties* VMA_NULLABLE* VMA_NOT_NULL ppPhysicalDeviceProperties);
 
     /**
@@ -1634,7 +1634,7 @@ extern "C"
     You can access it here, without fetching it again on your own.
     */
     VMA_CALL_PRE void VMA_CALL_POST vmaGetMemoryProperties(
-        VmaAllocator VMA_NOT_NULL               allocator,
+        VmaAllocator VMA_NOT_NULL                                          allocator,
         const VkPhysicalDeviceMemoryProperties* VMA_NULLABLE* VMA_NOT_NULL ppPhysicalDeviceMemoryProperties);
 
     /**
@@ -1748,7 +1748,7 @@ extern "C"
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreatePool(VmaAllocator VMA_NOT_NULL             allocator,
                                                       const VmaPoolCreateInfo* VMA_NOT_NULL pCreateInfo,
-                                                      VmaPool VMA_NULLABLE* VMA_NOT_NULL pPool);
+                                                      VmaPool VMA_NULLABLE* VMA_NOT_NULL    pPool);
 
     /** \brief Destroys #VmaPool object and frees Vulkan device memory.
      */
@@ -1812,8 +1812,8 @@ extern "C"
     containing name of the pool that was previously set. The pointer becomes invalid when the pool is
     destroyed or its name is changed using vmaSetPoolName().
     */
-    VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolName(VmaAllocator VMA_NOT_NULL allocator,
-                                                   VmaPool VMA_NOT_NULL      pool,
+    VMA_CALL_PRE void VMA_CALL_POST vmaGetPoolName(VmaAllocator VMA_NOT_NULL              allocator,
+                                                   VmaPool VMA_NOT_NULL                   pool,
                                                    const char* VMA_NULLABLE* VMA_NOT_NULL ppName);
 
     /** \brief Sets name of a custom pool.
@@ -1843,8 +1843,8 @@ extern "C"
     vmaAllocateMemory(VmaAllocator VMA_NOT_NULL                   allocator,
                       const VkMemoryRequirements* VMA_NOT_NULL    pVkMemoryRequirements,
                       const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                      VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                      VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
+                      VmaAllocation VMA_NULLABLE* VMA_NOT_NULL    pAllocation,
+                      VmaAllocationInfo* VMA_NULLABLE             pAllocationInfo);
 
     /** \brief General purpose memory allocation for multiple allocation objects at once.
 
@@ -1870,8 +1870,8 @@ extern "C"
         const VkMemoryRequirements* VMA_NOT_NULL    VMA_LEN_IF_NOT_NULL(allocationCount) pVkMemoryRequirements,
         const VmaAllocationCreateInfo* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pCreateInfo,
         size_t                                      allocationCount,
-        VmaAllocation VMA_NULLABLE* VMA_NOT_NULL VMA_LEN_IF_NOT_NULL(allocationCount) pAllocations,
-        VmaAllocationInfo* VMA_NULLABLE          VMA_LEN_IF_NOT_NULL(allocationCount) pAllocationInfo);
+        VmaAllocation VMA_NULLABLE* VMA_NOT_NULL    VMA_LEN_IF_NOT_NULL(allocationCount) pAllocations,
+        VmaAllocationInfo* VMA_NULLABLE             VMA_LEN_IF_NOT_NULL(allocationCount) pAllocationInfo);
 
     /** \brief Allocates memory suitable for given `VkBuffer`.
 
@@ -1892,8 +1892,8 @@ extern "C"
     vmaAllocateMemoryForBuffer(VmaAllocator VMA_NOT_NULL                   allocator,
                                VkBuffer VMA_NOT_NULL_NON_DISPATCHABLE      buffer,
                                const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                               VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                               VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
+                               VmaAllocation VMA_NULLABLE* VMA_NOT_NULL    pAllocation,
+                               VmaAllocationInfo* VMA_NULLABLE             pAllocationInfo);
 
     /** \brief Allocates memory suitable for given `VkImage`.
 
@@ -1914,8 +1914,8 @@ extern "C"
     vmaAllocateMemoryForImage(VmaAllocator VMA_NOT_NULL                   allocator,
                               VkImage VMA_NOT_NULL_NON_DISPATCHABLE       image,
                               const VmaAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
-                              VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                              VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
+                              VmaAllocation VMA_NULLABLE* VMA_NOT_NULL    pAllocation,
+                              VmaAllocationInfo* VMA_NULLABLE             pAllocationInfo);
 
     /** \brief Frees memory previously allocated using vmaAllocateMemory(), vmaAllocateMemoryForBuffer(), or
     vmaAllocateMemoryForImage().
@@ -1937,7 +1937,7 @@ extern "C"
     */
     VMA_CALL_PRE void VMA_CALL_POST vmaFreeMemoryPages(VmaAllocator VMA_NOT_NULL allocator,
                                                        size_t                    allocationCount,
-                                                       const VmaAllocation       VMA_NULLABLE* VMA_NOT_NULL
+                                                       const VmaAllocation VMA_NULLABLE* VMA_NOT_NULL
                                                            VMA_LEN_IF_NOT_NULL(allocationCount) pAllocations);
 
     /** \brief Returns current information about specified allocation.
@@ -2023,8 +2023,8 @@ extern "C"
     If the allocation is made from a memory types that is not `HOST_COHERENT`,
     you also need to use vmaInvalidateAllocation() / vmaFlushAllocation(), as required by Vulkan specification.
     */
-    VMA_CALL_PRE VkResult VMA_CALL_POST vmaMapMemory(VmaAllocator VMA_NOT_NULL  allocator,
-                                                     VmaAllocation VMA_NOT_NULL allocation,
+    VMA_CALL_PRE VkResult VMA_CALL_POST vmaMapMemory(VmaAllocator VMA_NOT_NULL        allocator,
+                                                     VmaAllocation VMA_NOT_NULL       allocation,
                                                      void* VMA_NULLABLE* VMA_NOT_NULL ppData);
 
     /** \brief Unmaps memory represented by given allocation, mapped previously using vmaMapMemory().
@@ -2106,8 +2106,8 @@ extern "C"
     called, otherwise `VK_SUCCESS`.
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaFlushAllocations(VmaAllocator VMA_NOT_NULL allocator,
-                        uint32_t                  allocationCount,
+    vmaFlushAllocations(VmaAllocator VMA_NOT_NULL                      allocator,
+                        uint32_t                                       allocationCount,
                         const VmaAllocation VMA_NOT_NULL* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) allocations,
                         const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) offsets,
                         const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) sizes);
@@ -2128,8 +2128,8 @@ extern "C"
     called, otherwise `VK_SUCCESS`.
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST vmaInvalidateAllocations(
-        VmaAllocator VMA_NOT_NULL allocator,
-        uint32_t                  allocationCount,
+        VmaAllocator VMA_NOT_NULL                      allocator,
+        uint32_t                                       allocationCount,
         const VmaAllocation VMA_NOT_NULL* VMA_NULLABLE VMA_LEN_IF_NOT_NULL(allocationCount) allocations,
         const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) offsets,
         const VkDeviceSize* VMA_NULLABLE               VMA_LEN_IF_NOT_NULL(allocationCount) sizes);
@@ -2169,8 +2169,8 @@ extern "C"
     [Defragmentation](@ref defragmentation).
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaBeginDefragmentation(VmaAllocator VMA_NOT_NULL                  allocator,
-                            const VmaDefragmentationInfo* VMA_NOT_NULL pInfo,
+    vmaBeginDefragmentation(VmaAllocator VMA_NOT_NULL                            allocator,
+                            const VmaDefragmentationInfo* VMA_NOT_NULL           pInfo,
                             VmaDefragmentationContext VMA_NULLABLE* VMA_NOT_NULL pContext);
 
     /** \brief Ends defragmentation process.
@@ -2331,12 +2331,12 @@ extern "C"
     by the user as a higher-level logic on top of VMA.
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateBuffer(VmaAllocator VMA_NOT_NULL                   allocator,
-                    const VkBufferCreateInfo* VMA_NOT_NULL      pBufferCreateInfo,
-                    const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    vmaCreateBuffer(VmaAllocator VMA_NOT_NULL                            allocator,
+                    const VkBufferCreateInfo* VMA_NOT_NULL               pBufferCreateInfo,
+                    const VmaAllocationCreateInfo* VMA_NOT_NULL          pAllocationCreateInfo,
                     VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer,
-                    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                    VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
+                    VmaAllocation VMA_NULLABLE* VMA_NOT_NULL             pAllocation,
+                    VmaAllocationInfo* VMA_NULLABLE                      pAllocationInfo);
 
     /** \brief Creates a buffer with additional minimum alignment.
 
@@ -2345,13 +2345,13 @@ extern "C"
     for interop with OpenGL.
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateBufferWithAlignment(VmaAllocator VMA_NOT_NULL                   allocator,
-                                 const VkBufferCreateInfo* VMA_NOT_NULL      pBufferCreateInfo,
-                                 const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
-                                 VkDeviceSize                                minAlignment,
+    vmaCreateBufferWithAlignment(VmaAllocator VMA_NOT_NULL                            allocator,
+                                 const VkBufferCreateInfo* VMA_NOT_NULL               pBufferCreateInfo,
+                                 const VmaAllocationCreateInfo* VMA_NOT_NULL          pAllocationCreateInfo,
+                                 VkDeviceSize                                         minAlignment,
                                  VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer,
-                                 VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                                 VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
+                                 VmaAllocation VMA_NULLABLE* VMA_NOT_NULL             pAllocation,
+                                 VmaAllocationInfo* VMA_NULLABLE                      pAllocationInfo);
 
     /** \brief Creates a new `VkBuffer`, binds already created memory for it.
 
@@ -2373,9 +2373,9 @@ extern "C"
     allocation you can use convenience function vmaDestroyBuffer().
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL              allocator,
-                            VmaAllocation VMA_NOT_NULL             allocation,
-                            const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+    vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL                            allocator,
+                            VmaAllocation VMA_NOT_NULL                           allocation,
+                            const VkBufferCreateInfo* VMA_NOT_NULL               pBufferCreateInfo,
                             VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer);
 
     /** \brief Destroys Vulkan buffer and frees allocated memory.
@@ -2395,18 +2395,18 @@ extern "C"
 
     /// Function similar to vmaCreateBuffer().
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateImage(VmaAllocator VMA_NOT_NULL                   allocator,
-                   const VkImageCreateInfo* VMA_NOT_NULL       pImageCreateInfo,
-                   const VmaAllocationCreateInfo* VMA_NOT_NULL pAllocationCreateInfo,
+    vmaCreateImage(VmaAllocator VMA_NOT_NULL                           allocator,
+                   const VkImageCreateInfo* VMA_NOT_NULL               pImageCreateInfo,
+                   const VmaAllocationCreateInfo* VMA_NOT_NULL         pAllocationCreateInfo,
                    VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage,
-                   VmaAllocation VMA_NULLABLE* VMA_NOT_NULL pAllocation,
-                   VmaAllocationInfo* VMA_NULLABLE          pAllocationInfo);
+                   VmaAllocation VMA_NULLABLE* VMA_NOT_NULL            pAllocation,
+                   VmaAllocationInfo* VMA_NULLABLE                     pAllocationInfo);
 
     /// Function similar to vmaCreateAliasingBuffer().
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaCreateAliasingImage(VmaAllocator VMA_NOT_NULL             allocator,
-                           VmaAllocation VMA_NOT_NULL            allocation,
-                           const VkImageCreateInfo* VMA_NOT_NULL pImageCreateInfo,
+    vmaCreateAliasingImage(VmaAllocator VMA_NOT_NULL                           allocator,
+                           VmaAllocation VMA_NOT_NULL                          allocation,
+                           const VkImageCreateInfo* VMA_NOT_NULL               pImageCreateInfo,
                            VkImage VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pImage);
 
     /** \brief Destroys Vulkan image and frees allocated memory.
@@ -2475,8 +2475,8 @@ extern "C"
     \param[out] pOffset Returned offset of the new allocation. Optional, can be null.
     */
     VMA_CALL_PRE VkResult VMA_CALL_POST
-    vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                       const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
+    vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL                                     virtualBlock,
+                       const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL               pCreateInfo,
                        VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pAllocation,
                        VkDeviceSize* VMA_NULLABLE                                       pOffset);
 
@@ -2536,7 +2536,7 @@ extern "C"
 
     Returned string must be freed using vmaFreeVirtualBlockStatsString().
     */
-    VMA_CALL_PRE void VMA_CALL_POST vmaBuildVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+    VMA_CALL_PRE void VMA_CALL_POST vmaBuildVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL     virtualBlock,
                                                                     char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
                                                                     VkBool32                         detailedMap);
 
@@ -2549,7 +2549,7 @@ extern "C"
     \param[out] ppStatsString Must be freed using vmaFreeStatsString() function.
     \param detailedMap
     */
-    VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator VMA_NOT_NULL allocator,
+    VMA_CALL_PRE void VMA_CALL_POST vmaBuildStatsString(VmaAllocator VMA_NOT_NULL        allocator,
                                                         char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
                                                         VkBool32                         detailedMap);
 
@@ -2598,7 +2598,7 @@ extern "C"
 #endif
 
 #if VMA_STATS_STRING_ENABLED
-    #include <cstdio> // For snprintf
+#include <cstdio> // For snprintf
 #endif
 
 /*******************************************************************************
@@ -2704,8 +2704,8 @@ static void* vma_aligned_alloc(size_t alignment, size_t size)
 {
     // Unfortunately, aligned_alloc causes VMA to crash due to it returning null pointers. (At least under 11.4)
     // Therefore, for now disable this specific exception until a proper solution is found.
-    //#if defined(__APPLE__) && (defined(MAC_OS_X_VERSION_10_16) || defined(__IPHONE_14_0))
-    //#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16 || __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
+    // #if defined(__APPLE__) && (defined(MAC_OS_X_VERSION_10_16) || defined(__IPHONE_14_0))
+    // #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16 || __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
     //    // For C++14, usr/include/malloc/_malloc.h declares aligned_alloc()) only
     //    // with the MacOSX11.0 SDK in Xcode 12 (which is what adds
     //    // MAC_OS_X_VERSION_10_16), even though the function is marked
@@ -2714,8 +2714,8 @@ static void* vma_aligned_alloc(size_t alignment, size_t size)
     //    // People who use C++17 could call aligned_alloc with the 10.15 SDK already.
     //    if (__builtin_available(macOS 10.15, iOS 13, *))
     //        return aligned_alloc(alignment, size);
-    //#endif
-    //#endif
+    // #endif
+    // #endif
 
     // alignment must be >= sizeof(void*)
     if (alignment < sizeof(void*))
@@ -2755,7 +2755,7 @@ static void vma_aligned_free(void* VMA_NULLABLE ptr)
 // If your compiler is not compatible with C++11 and definition of
 // aligned_alloc() function is missing, uncommeting following line may help:
 
-//#include <malloc.h>
+// #include <malloc.h>
 
 // Normal assert to check for programmer's errors, especially in Debug configuration.
 #ifndef VMA_ASSERT
@@ -3026,9 +3026,9 @@ tools like RenderDOc.
 #endif
 
 #ifndef VMA_CLASS_NO_COPY
-#define VMA_CLASS_NO_COPY(className)      \
-  private:                                \
-    className(const className&) = delete; \
+#define VMA_CLASS_NO_COPY(className)                 \
+  private:                                           \
+    className(const className&)            = delete; \
     className& operator=(const className&) = delete;
 #endif
 
@@ -4029,7 +4029,7 @@ struct VmaStlAllocator
     template <typename U>
     VmaStlAllocator(const VmaStlAllocator<U>& src) : m_pCallbacks(src.m_pCallbacks)
     {}
-    VmaStlAllocator(const VmaStlAllocator&) = default;
+    VmaStlAllocator(const VmaStlAllocator&)            = default;
     VmaStlAllocator& operator=(const VmaStlAllocator&) = delete;
 
     T*   allocate(size_t n) { return VmaAllocateArray<T>(m_pCallbacks, n); }
@@ -5246,7 +5246,7 @@ class VmaIntrusiveLinkedList
     VmaIntrusiveLinkedList() = default;
     VmaIntrusiveLinkedList(VmaIntrusiveLinkedList&& src);
     VmaIntrusiveLinkedList(const VmaIntrusiveLinkedList&) = delete;
-    VmaIntrusiveLinkedList& operator                      =(VmaIntrusiveLinkedList&& src);
+    VmaIntrusiveLinkedList& operator=(VmaIntrusiveLinkedList&& src);
     VmaIntrusiveLinkedList& operator=(const VmaIntrusiveLinkedList&) = delete;
     ~VmaIntrusiveLinkedList() { VMA_HEAVY_ASSERT(IsEmpty()); }
 
@@ -12151,9 +12151,9 @@ VkResult VmaDeviceMemoryBlock::BindImageMemory(const VmaAllocator  hAllocator,
 
 #ifndef _VMA_ALLOCATION_T_FUNCTIONS
 VmaAllocation_T::VmaAllocation_T(bool mappingAllowed) :
-    m_Alignment{ 1 }, m_Size{ 0 }, m_pUserData{ VMA_NULL }, m_pName{ VMA_NULL },
-    m_MemoryTypeIndex{ 0 }, m_Type{ (uint8_t)ALLOCATION_TYPE_NONE },
-    m_SuballocationType{ (uint8_t)VMA_SUBALLOCATION_TYPE_UNKNOWN }, m_MapCount{ 0 }, m_Flags{ 0 }
+    m_Alignment{ 1 }, m_Size{ 0 }, m_pUserData{ VMA_NULL }, m_pName{ VMA_NULL }, m_MemoryTypeIndex{ 0 },
+    m_Type{ (uint8_t)ALLOCATION_TYPE_NONE }, m_SuballocationType{ (uint8_t)VMA_SUBALLOCATION_TYPE_UNKNOWN },
+    m_MapCount{ 0 }, m_Flags{ 0 }
 {
     if (mappingAllowed)
         m_Flags |= (uint8_t)FLAG_MAPPING_ALLOWED;
@@ -13580,8 +13580,9 @@ bool VmaDefragmentationContext_T::IncrementCounters(VkDeviceSize bytes)
     // Early return when max found
     if (++m_PassStats.allocationsMoved >= m_MaxPassAllocations || m_PassStats.bytesMoved >= m_MaxPassBytes)
     {
-        VMA_ASSERT(((m_PassStats.allocationsMoved == m_MaxPassAllocations) ||
-                   (m_PassStats.bytesMoved == m_MaxPassBytes)) && "Exceeded maximal pass threshold!");
+        VMA_ASSERT(
+            ((m_PassStats.allocationsMoved == m_MaxPassAllocations) || (m_PassStats.bytesMoved == m_MaxPassBytes)) &&
+            "Exceeded maximal pass threshold!");
         return true;
     }
     return false;
@@ -15882,14 +15883,12 @@ VkResult VmaAllocator_T::FlushOrInvalidateAllocations(uint32_t             alloc
         switch (op)
         {
             case VMA_CACHE_FLUSH:
-                res = (*GetVulkanFunctions().vkFlushMappedMemoryRanges)(m_hDevice,
-                                                                        (uint32_t)ranges.size(),
-                                                                        ranges.data());
+                res = (*GetVulkanFunctions().vkFlushMappedMemoryRanges)(
+                    m_hDevice, (uint32_t)ranges.size(), ranges.data());
                 break;
             case VMA_CACHE_INVALIDATE:
-                res = (*GetVulkanFunctions().vkInvalidateMappedMemoryRanges)(m_hDevice,
-                                                                             (uint32_t)ranges.size(),
-                                                                             ranges.data());
+                res = (*GetVulkanFunctions().vkInvalidateMappedMemoryRanges)(
+                    m_hDevice, (uint32_t)ranges.size(), ranges.data());
                 break;
             default:
                 VMA_ASSERT(0);
@@ -17161,10 +17160,8 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBuffer(VmaAllocator                
     *pAllocation = VK_NULL_HANDLE;
 
     // 1. Create VkBuffer.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(allocator->m_hDevice,
-                                                                     pBufferCreateInfo,
-                                                                     allocator->GetAllocationCallbacks(),
-                                                                     pBuffer);
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(
+        allocator->m_hDevice, pBufferCreateInfo, allocator->GetAllocationCallbacks(), pBuffer);
     if (res >= 0)
     {
         // 2. vkGetBufferMemoryRequirements.
@@ -17253,10 +17250,8 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBufferWithAlignment(VmaAllocator   
     *pAllocation = VK_NULL_HANDLE;
 
     // 1. Create VkBuffer.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(allocator->m_hDevice,
-                                                                     pBufferCreateInfo,
-                                                                     allocator->GetAllocationCallbacks(),
-                                                                     pBuffer);
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(
+        allocator->m_hDevice, pBufferCreateInfo, allocator->GetAllocationCallbacks(), pBuffer);
     if (res >= 0)
     {
         // 2. vkGetBufferMemoryRequirements.
@@ -17318,9 +17313,9 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateBufferWithAlignment(VmaAllocator   
 }
 
 VMA_CALL_PRE VkResult VMA_CALL_POST
-vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL              allocator,
-                        VmaAllocation VMA_NOT_NULL             allocation,
-                        const VkBufferCreateInfo* VMA_NOT_NULL pBufferCreateInfo,
+vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL                            allocator,
+                        VmaAllocation VMA_NOT_NULL                           allocation,
+                        const VkBufferCreateInfo* VMA_NOT_NULL               pBufferCreateInfo,
                         VkBuffer VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pBuffer)
 {
     VMA_ASSERT(allocator && pBufferCreateInfo && pBuffer && allocation);
@@ -17344,10 +17339,8 @@ vmaCreateAliasingBuffer(VmaAllocator VMA_NOT_NULL              allocator,
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
     // 1. Create VkBuffer.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(allocator->m_hDevice,
-                                                                     pBufferCreateInfo,
-                                                                     allocator->GetAllocationCallbacks(),
-                                                                     pBuffer);
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateBuffer)(
+        allocator->m_hDevice, pBufferCreateInfo, allocator->GetAllocationCallbacks(), pBuffer);
     if (res >= 0)
     {
         // 2. Bind buffer with memory.
@@ -17411,10 +17404,8 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateImage(VmaAllocator                 
     *pAllocation = VK_NULL_HANDLE;
 
     // 1. Create VkImage.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(allocator->m_hDevice,
-                                                                    pImageCreateInfo,
-                                                                    allocator->GetAllocationCallbacks(),
-                                                                    pImage);
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(
+        allocator->m_hDevice, pImageCreateInfo, allocator->GetAllocationCallbacks(), pImage);
     if (res >= 0)
     {
         VmaSuballocationType suballocType = pImageCreateInfo->tiling == VK_IMAGE_TILING_OPTIMAL
@@ -17495,10 +17486,8 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAliasingImage(VmaAllocator VMA_NOT_
     VMA_DEBUG_GLOBAL_MUTEX_LOCK
 
     // 1. Create VkImage.
-    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(allocator->m_hDevice,
-                                                                    pImageCreateInfo,
-                                                                    allocator->GetAllocationCallbacks(),
-                                                                    pImage);
+    VkResult res = (*allocator->GetVulkanFunctions().vkCreateImage)(
+        allocator->m_hDevice, pImageCreateInfo, allocator->GetAllocationCallbacks(), pImage);
     if (res >= 0)
     {
         // 2. Bind image with memory.
@@ -17541,7 +17530,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(VmaAllocator VMA_NOT_NULL       
 }
 
 VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateVirtualBlock(const VmaVirtualBlockCreateInfo* VMA_NOT_NULL pCreateInfo,
-                                                          VmaVirtualBlock VMA_NULLABLE* VMA_NOT_NULL pVirtualBlock)
+                                                          VmaVirtualBlock VMA_NULLABLE* VMA_NOT_NULL    pVirtualBlock)
 {
     VMA_ASSERT(pCreateInfo && pVirtualBlock);
     VMA_ASSERT(pCreateInfo->size > 0);
@@ -17589,8 +17578,8 @@ vmaGetVirtualAllocationInfo(VmaVirtualBlock VMA_NOT_NULL                       v
 }
 
 VMA_CALL_PRE VkResult VMA_CALL_POST
-vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL                       virtualBlock,
-                   const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL pCreateInfo,
+vmaVirtualAllocate(VmaVirtualBlock VMA_NOT_NULL                                     virtualBlock,
+                   const VmaVirtualAllocationCreateInfo* VMA_NOT_NULL               pCreateInfo,
                    VmaVirtualAllocation VMA_NULLABLE_NON_DISPATCHABLE* VMA_NOT_NULL pAllocation,
                    VkDeviceSize* VMA_NULLABLE                                       pOffset)
 {
@@ -17651,7 +17640,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaCalculateVirtualBlockStatistics(VmaVirtualBlo
 
 #if VMA_STATS_STRING_ENABLED
 
-VMA_CALL_PRE void VMA_CALL_POST vmaBuildVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL virtualBlock,
+VMA_CALL_PRE void VMA_CALL_POST vmaBuildVirtualBlockStatsString(VmaVirtualBlock VMA_NOT_NULL     virtualBlock,
                                                                 char* VMA_NULLABLE* VMA_NOT_NULL ppStatsString,
                                                                 VkBool32                         detailedMap)
 {

--- a/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
+++ b/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
@@ -13580,8 +13580,8 @@ bool VmaDefragmentationContext_T::IncrementCounters(VkDeviceSize bytes)
     // Early return when max found
     if (++m_PassStats.allocationsMoved >= m_MaxPassAllocations || m_PassStats.bytesMoved >= m_MaxPassBytes)
     {
-        VMA_ASSERT(m_PassStats.allocationsMoved == m_MaxPassAllocations ||
-                   m_PassStats.bytesMoved == m_MaxPassBytes && "Exceeded maximal pass threshold!");
+        VMA_ASSERT(((m_PassStats.allocationsMoved == m_MaxPassAllocations) ||
+                   (m_PassStats.bytesMoved == m_MaxPassBytes)) && "Exceeded maximal pass threshold!");
         return true;
     }
     return false;

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -64,12 +64,8 @@ Application::Application(const std::string&     name,
                          const std::string&     cli_wsi_extension,
                          decode::FileProcessor* file_processor) :
     name_(name),
-    file_processor_(file_processor),
-    running_(false),
-    paused_(false),
-    pause_frame_(0),
-    cli_wsi_extension_(cli_wsi_extension),
-    fps_info_(nullptr)
+    file_processor_(file_processor), running_(false), paused_(false), pause_frame_(0),
+    cli_wsi_extension_(cli_wsi_extension), fps_info_(nullptr)
 {
     if (!cli_wsi_extension_.empty())
     {

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -64,8 +64,12 @@ Application::Application(const std::string&     name,
                          const std::string&     cli_wsi_extension,
                          decode::FileProcessor* file_processor) :
     name_(name),
-    file_processor_(file_processor), cli_wsi_extension_(cli_wsi_extension), running_(false), paused_(false),
-    pause_frame_(0), fps_info_(nullptr)
+    file_processor_(file_processor),
+    running_(false),
+    paused_(false),
+    pause_frame_(0),
+    cli_wsi_extension_(cli_wsi_extension),
+    fps_info_(nullptr)
 {
     if (!cli_wsi_extension_.empty())
     {

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -213,7 +213,7 @@ void WaylandWindow::UpdateWindowSize()
             scale_ = output_info.scale;
         }
 
-        if (output_info.width == width_ && output_info.height == height_)
+        if (uint32_t(output_info.width) == width_ && uint32_t(output_info.height) == height_)
         {
             wl.shell_surface_set_fullscreen(shell_surface_, WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT, 0, output_);
         }

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -66,7 +66,7 @@ bool XlibWindow::Create(
     int32_t y             = ypos;
     bool    go_fullscreen = false;
 
-    if ((root_attributes.height <= height) || (root_attributes.width <= width))
+    if ((uint32_t(root_attributes.height) <= height) || (uint32_t(root_attributes.width) <= width))
     {
         if ((screen_height_ == height) || (screen_width_ == width))
         {

--- a/framework/decode/decoder_util.h
+++ b/framework/decode/decoder_util.h
@@ -33,7 +33,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 template <typename T>
 bool IsComplete(std::vector<T>& consumers, uint64_t block_index)
 {
-    int completed_consumers = 0;
+    size_t completed_consumers = 0;
     if (consumers.size() == 0)
     {
         return true;

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -40,9 +40,18 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 const uint32_t kFirstFrame = 0;
 
 FileProcessor::FileProcessor() :
-    file_header_{}, file_descriptor_(nullptr), current_frame_number_(kFirstFrame), bytes_read_(0),
-    error_state_(kErrorInvalidFileDescriptor), annotation_handler_(nullptr), compressor_(nullptr), block_index_(0),
-    api_call_index_(0), block_limit_(0), capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1)
+    file_descriptor_(nullptr),
+    current_frame_number_(kFirstFrame),
+    annotation_handler_(nullptr),
+    error_state_(kErrorInvalidFileDescriptor),
+    block_index_(0),
+    file_header_{},
+    bytes_read_(0),
+    compressor_(nullptr),
+    api_call_index_(0),
+    block_limit_(0),
+    capture_uses_frame_markers_(false),
+    first_frame_(kFirstFrame + 1)
 {}
 
 FileProcessor::FileProcessor(uint64_t block_limit) : FileProcessor()
@@ -159,7 +168,7 @@ bool FileProcessor::ContinueDecoding()
     }
     else
     {
-        int completed_decoders = 0;
+        size_t completed_decoders = 0;
 
         for (auto& decoder : decoders_)
         {
@@ -1729,7 +1738,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
     else if (meta_data_type == format::MetaDataType::kDx12RuntimeInfoCommand)
     {
         format::Dx12RuntimeInfoCommandHeader dx12_runtime_info_header;
-        memset(&dx12_runtime_info_header, 0, sizeof(dx12_runtime_info_header));
 
         success = ReadBytes(&dx12_runtime_info_header.thread_id, sizeof(dx12_runtime_info_header.thread_id));
 

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -40,18 +40,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 const uint32_t kFirstFrame = 0;
 
 FileProcessor::FileProcessor() :
-    file_descriptor_(nullptr),
-    current_frame_number_(kFirstFrame),
-    annotation_handler_(nullptr),
-    error_state_(kErrorInvalidFileDescriptor),
-    block_index_(0),
-    file_header_{},
-    bytes_read_(0),
-    compressor_(nullptr),
-    api_call_index_(0),
-    block_limit_(0),
-    capture_uses_frame_markers_(false),
-    first_frame_(kFirstFrame + 1)
+    file_descriptor_(nullptr), current_frame_number_(kFirstFrame), annotation_handler_(nullptr),
+    error_state_(kErrorInvalidFileDescriptor), block_index_(0), file_header_{}, bytes_read_(0), compressor_(nullptr),
+    api_call_index_(0), block_limit_(0), capture_uses_frame_markers_(false), first_frame_(kFirstFrame + 1)
 {}
 
 FileProcessor::FileProcessor(uint64_t block_limit) : FileProcessor()

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -32,7 +32,11 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileTransformer::FileTransformer() :
-    file_header_{}, input_file_(nullptr), output_file_(nullptr), bytes_read_(0), bytes_written_(0),
+    input_file_(nullptr),
+    output_file_(nullptr),
+    file_header_{},
+    bytes_read_(0),
+    bytes_written_(0),
     error_state_(kErrorInvalidFileDescriptor), loading_state_(false)
 {}
 

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -32,11 +32,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileTransformer::FileTransformer() :
-    input_file_(nullptr),
-    output_file_(nullptr),
-    file_header_{},
-    bytes_read_(0),
-    bytes_written_(0),
+    input_file_(nullptr), output_file_(nullptr), file_header_{}, bytes_read_(0), bytes_written_(0),
     error_state_(kErrorInvalidFileDescriptor), loading_state_(false)
 {}
 

--- a/framework/decode/pointer_decoder.h
+++ b/framework/decode/pointer_decoder.h
@@ -83,7 +83,7 @@ class PointerDecoder : public PointerDecoderBase
 
         size_t capacity = n * m;
 
-        if ((data != nullptr) && (capacity > 0))
+        if (capacity > 0)
         {
             data_               = reinterpret_cast<T*>(data);
             capacity_           = capacity;

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -96,7 +96,7 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    VkDevice device = device = device_info->handle;
+    VkDevice device = device_info->handle;
     device_table_->GetDeviceQueue(device, default_queue_family_index_, 0, &default_queue_);
 
     return original_result;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -159,13 +159,8 @@ static uint32_t GetHardwareBufferFormatBpp(uint32_t format)
 VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::Application> application,
                                                    const VulkanReplayOptions&                options) :
     options_(options),
-    loader_handle_(nullptr),
-    get_instance_proc_addr_(nullptr),
-    create_instance_proc_(nullptr),
-    application_(application),
-    loading_trim_state_(false),
-    replaying_trimmed_capture_(false),
-    fps_info_(nullptr),
+    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr),
+    application_(application), loading_trim_state_(false), replaying_trimmed_capture_(false), fps_info_(nullptr),
     have_imported_semaphores_(false)
 {
     assert(application_ != nullptr);
@@ -3934,9 +3929,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
             VkMemoryAllocateInfo                     modified_allocate_info = (*replay_allocate_info);
             VkMemoryOpaqueCaptureAddressAllocateInfo address_info           = {
-                          VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
-                          modified_allocate_info.pNext,
-                          opaque_address
+                VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
+                modified_allocate_info.pNext,
+                opaque_address
             };
             modified_allocate_info.pNext = &address_info;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -158,9 +158,15 @@ static uint32_t GetHardwareBufferFormatBpp(uint32_t format)
 
 VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::Application> application,
                                                    const VulkanReplayOptions&                options) :
+    options_(options),
     loader_handle_(nullptr),
-    get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr), application_(application), options_(options),
-    loading_trim_state_(false), replaying_trimmed_capture_(false), have_imported_semaphores_(false), fps_info_(nullptr)
+    get_instance_proc_addr_(nullptr),
+    create_instance_proc_(nullptr),
+    application_(application),
+    loading_trim_state_(false),
+    replaying_trimmed_capture_(false),
+    fps_info_(nullptr),
+    have_imported_semaphores_(false)
 {
     assert(application_ != nullptr);
     assert(options.create_resource_allocator != nullptr);

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -41,8 +41,10 @@ const std::vector<std::string> kLoaderLibNames = {
 
 VulkanResourceTrackingConsumer::VulkanResourceTrackingConsumer(
     const VulkanReplayOptions& options, VulkanTrackedObjectInfoTable* tracked_object_info_table) :
+    loader_handle_(nullptr),
+    create_instance_function_(nullptr),
+    get_instance_proc_addr_(nullptr),
     options_(options),
-    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_function_(nullptr),
     tracked_object_info_table_(tracked_object_info_table)
 {
     assert(tracked_object_info_table != nullptr);

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -42,9 +42,7 @@ const std::vector<std::string> kLoaderLibNames = {
 VulkanResourceTrackingConsumer::VulkanResourceTrackingConsumer(
     const VulkanReplayOptions& options, VulkanTrackedObjectInfoTable* tracked_object_info_table) :
     loader_handle_(nullptr),
-    create_instance_function_(nullptr),
-    get_instance_proc_addr_(nullptr),
-    options_(options),
+    create_instance_function_(nullptr), get_instance_proc_addr_(nullptr), options_(options),
     tracked_object_info_table_(tracked_object_info_table)
 {
     assert(tracked_object_info_table != nullptr);

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -60,9 +60,11 @@ std::function<void()>                                    CaptureManager::delete_
 
 std::atomic<format::HandleId> CaptureManager::unique_id_counter_{ format::kNullHandleId };
 
-CaptureManager::ThreadData::ThreadData() :
-    thread_id_(GetThreadId()), object_id_(format::kNullHandleId), call_id_(format::ApiCallId::ApiCall_Unknown),
-    block_index_(0)
+CaptureManager::ThreadData::ThreadData()
+    : thread_id_(GetThreadId())
+    , call_id_(format::ApiCallId::ApiCall_Unknown)
+    , object_id_(format::kNullHandleId)
+    , block_index_(0)
 {
     parameter_buffer_  = std::make_unique<encode::ParameterBuffer>();
     parameter_encoder_ = std::make_unique<ParameterEncoder>(parameter_buffer_.get());
@@ -90,14 +92,14 @@ format::ThreadId CaptureManager::ThreadData::GetThreadId()
 }
 
 CaptureManager::CaptureManager(format::ApiFamilyId api_family) :
-    api_family_(api_family), force_file_flush_(false), timestamp_filename_(true),
+    screenshot_prefix_(""), api_family_(api_family), timestamp_filename_(true), force_file_flush_(false),
     memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kPageGuard), page_guard_align_buffer_sizes_(false),
     page_guard_track_ahb_memory_(false), page_guard_unblock_sigsegv_(false), page_guard_signal_handler_watcher_(false),
     page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false),
     trim_boundary_(CaptureSettings::TrimBoundary::kUnknown), trim_current_range_(0), current_frame_(kFirstFrame),
     queue_submit_count_(0), capture_mode_(kModeWrite), previous_hotkey_state_(false),
-    previous_runtime_trigger_state_(CaptureSettings::RuntimeTriggerState::kNotUsed), debug_layer_(false),
-    debug_device_lost_(false), screenshot_prefix_(""), screenshots_enabled_(false), disable_dxr_(false),
+    previous_runtime_trigger_state_(CaptureSettings::RuntimeTriggerState::kNotUsed),
+    debug_layer_(false), debug_device_lost_(false), screenshots_enabled_(false), disable_dxr_(false),
     accel_struct_padding_(0), iunknown_wrapping_(false), force_command_serialization_(false), queue_zero_only_(false),
     allow_pipeline_compile_required_(false), quit_after_frame_ranges_(false)
 {}

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -60,11 +60,9 @@ std::function<void()>                                    CaptureManager::delete_
 
 std::atomic<format::HandleId> CaptureManager::unique_id_counter_{ format::kNullHandleId };
 
-CaptureManager::ThreadData::ThreadData()
-    : thread_id_(GetThreadId())
-    , call_id_(format::ApiCallId::ApiCall_Unknown)
-    , object_id_(format::kNullHandleId)
-    , block_index_(0)
+CaptureManager::ThreadData::ThreadData() :
+    thread_id_(GetThreadId()), call_id_(format::ApiCallId::ApiCall_Unknown), object_id_(format::kNullHandleId),
+    block_index_(0)
 {
     parameter_buffer_  = std::make_unique<encode::ParameterBuffer>();
     parameter_encoder_ = std::make_unique<ParameterEncoder>(parameter_buffer_.get());
@@ -98,9 +96,9 @@ CaptureManager::CaptureManager(format::ApiFamilyId api_family) :
     page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false),
     trim_boundary_(CaptureSettings::TrimBoundary::kUnknown), trim_current_range_(0), current_frame_(kFirstFrame),
     queue_submit_count_(0), capture_mode_(kModeWrite), previous_hotkey_state_(false),
-    previous_runtime_trigger_state_(CaptureSettings::RuntimeTriggerState::kNotUsed),
-    debug_layer_(false), debug_device_lost_(false), screenshots_enabled_(false), disable_dxr_(false),
-    accel_struct_padding_(0), iunknown_wrapping_(false), force_command_serialization_(false), queue_zero_only_(false),
+    previous_runtime_trigger_state_(CaptureSettings::RuntimeTriggerState::kNotUsed), debug_layer_(false),
+    debug_device_lost_(false), screenshots_enabled_(false), disable_dxr_(false), accel_struct_padding_(0),
+    iunknown_wrapping_(false), force_command_serialization_(false), queue_zero_only_(false),
     allow_pipeline_compile_required_(false), quit_after_frame_ranges_(false)
 {}
 

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -335,7 +335,7 @@ class CaptureManager
     bool                                    page_guard_track_ahb_memory_;
     bool                                    page_guard_unblock_sigsegv_;
     bool                                    page_guard_signal_handler_watcher_;
-    uint32_t                                page_guard_signal_handler_watcher_max_restores_;
+    int                                     page_guard_signal_handler_watcher_max_restores_;
     PageGuardMemoryMode                     page_guard_memory_mode_;
     bool                                    page_guard_separate_read_;
     bool                                    page_guard_copy_on_map_;

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -65,7 +65,7 @@ FpsInfo::FpsInfo(uint64_t               measurement_start_frame,
                  const std::string_view measurement_file_name) :
     measurement_start_frame_(measurement_start_frame),
     measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
-    has_measurement_range_(has_measurement_range), quit_after_range_(quit_after_range), 
+    has_measurement_range_(has_measurement_range), quit_after_range_(quit_after_range),
     flush_measurement_range_(flush_measurement_range), started_measurement_(false), ended_measurement_(false),
     frame_start_time_(0), frame_durations_(), measurement_file_name_(measurement_file_name)
 {

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -65,8 +65,8 @@ FpsInfo::FpsInfo(uint64_t               measurement_start_frame,
                  const std::string_view measurement_file_name) :
     measurement_start_frame_(measurement_start_frame),
     measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
-    quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range),
-    has_measurement_range_(has_measurement_range), started_measurement_(false), ended_measurement_(false),
+    has_measurement_range_(has_measurement_range), quit_after_range_(quit_after_range), 
+    flush_measurement_range_(flush_measurement_range), started_measurement_(false), ended_measurement_(false),
     frame_start_time_(0), frame_durations_(), measurement_file_name_(measurement_file_name)
 {
     if (has_measurement_range_)

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -288,7 +288,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
     // Check for implementation in the layer itself
     if (!has_implementation)
     {
-        for (const auto ext_props : kDeviceExtensionProps)
+        for (const auto & ext_props : kDeviceExtensionProps)
         {
             if (std::find(ext_props.instance_funcs.begin(), ext_props.instance_funcs.end(), pName) !=
                 ext_props.instance_funcs.end())
@@ -343,7 +343,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, cons
         // Check for implementation in the layer itself
         if (!has_implementation)
         {
-            for (const auto ext_props : kDeviceExtensionProps)
+            for (const auto & ext_props : kDeviceExtensionProps)
             {
                 if (std::find(ext_props.device_funcs.begin(), ext_props.device_funcs.end(), pName) !=
                     ext_props.device_funcs.end())

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -288,7 +288,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
     // Check for implementation in the layer itself
     if (!has_implementation)
     {
-        for (const auto & ext_props : kDeviceExtensionProps)
+        for (const auto& ext_props : kDeviceExtensionProps)
         {
             if (std::find(ext_props.instance_funcs.begin(), ext_props.instance_funcs.end(), pName) !=
                 ext_props.instance_funcs.end())
@@ -343,7 +343,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, cons
         // Check for implementation in the layer itself
         if (!has_implementation)
         {
-            for (const auto & ext_props : kDeviceExtensionProps)
+            for (const auto& ext_props : kDeviceExtensionProps)
             {
                 if (std::find(ext_props.device_funcs.begin(), ext_props.device_funcs.end(), pName) !=
                     ext_props.device_funcs.end())

--- a/scripts/check_code_style.py
+++ b/scripts/check_code_style.py
@@ -38,7 +38,7 @@ def check_code_style(file_list, compare_base, style_script=None, style_config_di
     """
     git_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", compare_base]).strip()
     if git_branch == b'':
-        git_branch = "master"
+        git_branch = "dev"
     if not style_script:
         # Look for the clang-format-diff.py script in the same directory as the calling script
         style_script = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "clang-format-diff.py")


### PR DESCRIPTION
My environment is strict e.g. "warnings as errors" and CLANG is showing up a few areas for improvement. Notably parenthesis and the ordering of member variables in constructors.