### PR TITLE
Fix pipeline cache data handling issue

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -344,9 +344,17 @@ struct ImageInfo : public VulkanObjectInfo<VkImage>
     VkImageLayout current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
 };
 
+typedef struct PipelineCacheData
+{
+    std::vector<uint8_t> capture_cache_data;
+    std::vector<uint8_t> replay_cache_data;
+} PipelineCacheData;
+
 struct PipelineCacheInfo : public VulkanObjectInfo<VkPipelineCache>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
+    // hash id of capture time pipeline cache data to capture and replay time pipeline cache data map;
+    std::unordered_map<uint32_t, std::vector<PipelineCacheData>> pipeline_cache_data;
 };
 
 struct PipelineInfo : public VulkanObjectInfo<VkPipeline>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4919,10 +4919,10 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
 
             GFXRECON_ASSERT(replay_result == VK_SUCCESS);
 
-            bool          new_cache_data                   = true;
-            VkDeviceSize* cache_data_size                  = reinterpret_cast<VkDeviceSize*>(pDataSize->GetPointer());
-            uint32_t      capture_pipeline_cache_data_hash = gfxrecon::util::hash::CheckSum(
-                reinterpret_cast<const uint32_t*>(pData->GetPointer()), *cache_data_size);
+            bool     new_cache_data  = true;
+            auto     cache_data_size = *pDataSize->GetPointer();
+            uint32_t capture_pipeline_cache_data_hash =
+                gfxrecon::util::hash::CheckSum(reinterpret_cast<const uint32_t*>(pData->GetPointer()), cache_data_size);
 
             auto iterator = pipeline_cache_info->pipeline_cache_data.find(capture_pipeline_cache_data_hash);
             if (iterator != pipeline_cache_info->pipeline_cache_data.end())
@@ -4935,11 +4935,11 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
                         ->pipeline_cache_data[capture_pipeline_cache_data_hash];
                 for (auto& existing_cache_data : cache_data)
                 {
-                    if (*cache_data_size == existing_cache_data.capture_cache_data.size())
+                    if (cache_data_size == existing_cache_data.capture_cache_data.size())
                     {
                         if (memcmp(existing_cache_data.capture_cache_data.data(),
                                    pData->GetPointer(),
-                                   *cache_data_size) == 0)
+                                   cache_data_size) == 0)
                         {
                             // The pipeline cache data is not new. This is possible, by doc, two calls to
                             // vkGetPipelineCacheData with the same parameters must retrieve the same data unless a
@@ -4957,8 +4957,8 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
                                                            ->pipeline_cache_data[capture_pipeline_cache_data_hash];
                 VkDeviceSize* output_cache_data_size = reinterpret_cast<VkDeviceSize*>(pDataSize->GetOutputPointer());
                 PipelineCacheData pipeline_cache_data;
-                pipeline_cache_data.capture_cache_data.resize(*cache_data_size);
-                memcpy(pipeline_cache_data.capture_cache_data.data(), pData->GetPointer(), *cache_data_size);
+                pipeline_cache_data.capture_cache_data.resize(cache_data_size);
+                memcpy(pipeline_cache_data.capture_cache_data.data(), pData->GetPointer(), cache_data_size);
                 pipeline_cache_data.replay_cache_data.resize(*output_cache_data_size);
                 memcpy(
                     pipeline_cache_data.replay_cache_data.data(), pData->GetOutputPointer(), *output_cache_data_size);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4930,9 +4930,8 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
                 // We found some existing pipeline cache data has same hash, so we continue to check if it's same with
                 // current pipeline cache data
 
-                const std::vector<PipelineCacheData>& cache_data =
-                    const_cast<PipelineCacheInfo*>(pipeline_cache_info)
-                        ->pipeline_cache_data[capture_pipeline_cache_data_hash];
+                const std::vector<PipelineCacheData>& cache_data = iterator->second;
+
                 for (auto& existing_cache_data : cache_data)
                 {
                     if (cache_data_size == existing_cache_data.capture_cache_data.size())
@@ -5025,8 +5024,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
                 {
                     // We found pipeline cache data vector which has same hash value, will continue to check if it has
                     // same capture time pipeline cache data.
-                    auto& cache_data = const_cast<PipelineCacheInfo*>(pipeline_cache_info)
-                                           ->pipeline_cache_data[capture_pipeline_cache_data_hash_];
+                    auto& cache_data = iterator->second;
 
                     for (auto& existing_cache_data : cache_data)
                     {

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4884,14 +4884,93 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
                                                                 PointerDecoder<size_t>*    pDataSize,
                                                                 PointerDecoder<uint8_t>*   pData)
 {
-    if (options_.omit_pipeline_cache_data)
+    if ((options_.omit_pipeline_cache_data) || (original_result != VK_SUCCESS) || pData->GetPointer() == nullptr)
     {
+        // If original result is not VK_SUCCESS, it means target title cannot get valid pipeline cache data, also means
+        // there's no need to map the capture time pipeline cache data to playback time, so we can skip the call.
+        //
+        // If user set omit_pipeline_cache_data, it will be different for using pipeline cache data between capture and
+        // playback time, we don't need to track pipeline cache data, so we also skip the call.
+        //
+        // If pData->GetPointer() == nullptr, it means the call is just used to get the buffer size, so we also skip the
+        // call.
         return original_result;
     }
     else
     {
-        return func(
-            device_info->handle, pipeline_cache_info->handle, pDataSize->GetOutputPointer(), pData->GetOutputPointer());
+        // If capture/playback on same system, the pipeline cache data size should be same, otherwise it's not guarantee
+        // that the cache data size is same. So here we first query the replay time cache data size, then get the cache
+        // data.
+
+        size_t*  replay_cache_data_size = pDataSize->AllocateOutputData(1);
+        uint8_t* replay_cache_data      = nullptr;
+
+        VkResult replay_result =
+            func(device_info->handle, pipeline_cache_info->handle, replay_cache_data_size, nullptr);
+
+        GFXRECON_ASSERT(replay_result == VK_SUCCESS);
+
+        if (*replay_cache_data_size != 0)
+        {
+            replay_cache_data = pData->AllocateOutputData(*replay_cache_data_size);
+
+            replay_result =
+                func(device_info->handle, pipeline_cache_info->handle, replay_cache_data_size, replay_cache_data);
+
+            GFXRECON_ASSERT(replay_result == VK_SUCCESS);
+
+            bool     new_cache_data                   = false;
+            uint32_t capture_pipeline_cache_data_hash = gfxrecon::util::hash::CheckSum(
+                reinterpret_cast<const uint32_t*>(pData->GetPointer()), *pDataSize->GetPointer());
+
+            auto iterator = pipeline_cache_info->pipeline_cache_data.find(capture_pipeline_cache_data_hash);
+            if (iterator == pipeline_cache_info->pipeline_cache_data.end())
+            {
+                new_cache_data = true;
+            }
+            else
+            {
+                // We found some existing pipeline cache data has same hash, so we continue to check if it's same with
+                // current pipeline cache data
+
+                new_cache_data = true;
+                const std::vector<PipelineCacheData>& cache_data =
+                    const_cast<PipelineCacheInfo*>(pipeline_cache_info)
+                        ->pipeline_cache_data[capture_pipeline_cache_data_hash];
+                for (auto& existing_cache_data : cache_data)
+                {
+                    if (*pDataSize->GetPointer() == existing_cache_data.capture_cache_data.size())
+                    {
+                        if (memcmp(existing_cache_data.capture_cache_data.data(),
+                                   pData->GetPointer(),
+                                   *pDataSize->GetPointer()) == 0)
+                        {
+                            // The pipeline cache data is not new. This is possible, by doc, two calls to
+                            // vkGetPipelineCacheData with the same parameters must retrieve the same data unless a
+                            // command that modifies the contents of the cache is called between them.
+                            new_cache_data = false;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (new_cache_data)
+            {
+                std::vector<PipelineCacheData>& item = const_cast<PipelineCacheInfo*>(pipeline_cache_info)
+                                                           ->pipeline_cache_data[capture_pipeline_cache_data_hash];
+
+                PipelineCacheData pipeline_cache_data;
+                pipeline_cache_data.capture_cache_data.resize(*pDataSize->GetPointer());
+                memcpy(pipeline_cache_data.capture_cache_data.data(), pData->GetPointer(), *pDataSize->GetPointer());
+                pipeline_cache_data.replay_cache_data.resize(*pDataSize->GetOutputPointer());
+                memcpy(pipeline_cache_data.replay_cache_data.data(),
+                       pData->GetOutputPointer(),
+                       *pDataSize->GetOutputPointer());
+                item.push_back(std::move(pipeline_cache_data));
+            }
+        }
+        return replay_result;
     }
 }
 
@@ -4905,12 +4984,13 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
 {
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
 
-    assert((device_info != nullptr) && (pCreateInfo != nullptr) && (pPipelineCache != nullptr) &&
-           (pPipelineCache->GetHandlePointer() != nullptr));
+    GFXRECON_ASSERT((device_info != nullptr) && (pCreateInfo != nullptr) && (pPipelineCache != nullptr) &&
+                    (pPipelineCache->GetHandlePointer() != nullptr));
 
     auto replay_create_info = pCreateInfo->GetPointer();
+    GFXRECON_ASSERT(replay_create_info != nullptr);
 
-    if (options_.omit_pipeline_cache_data && (replay_create_info != nullptr))
+    if (options_.omit_pipeline_cache_data)
     {
         // Make a shallow copy of the create info structure and clear the cache data.
         VkPipelineCacheCreateInfo override_create_info = (*replay_create_info);
@@ -4930,10 +5010,85 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
     }
     else
     {
-        return func(device_info->handle,
-                    replay_create_info,
-                    GetAllocationCallbacks(pAllocator),
-                    pPipelineCache->GetHandlePointer());
+        auto& create_info = *pCreateInfo->GetPointer();
+        if ((create_info.pInitialData != nullptr) && (create_info.initialDataSize != 0))
+        {
+            // This vkCreatePipelineCache call has initial pipeline cache data, the data is valid for capture time,
+            // but it might not be valid for replay time if considering platform/driver version change. So in the
+            // following process, we'll try to find corresponding replay time pipeline cache data.
+            matched_replay_cache_data_exist_  = false;
+            capture_pipeline_cache_data_hash_ = gfxrecon::util::hash::CheckSum(
+                reinterpret_cast<const uint32_t*>(create_info.pInitialData), create_info.initialDataSize);
+            capture_pipeline_cache_data_      = const_cast<void*>(create_info.pInitialData);
+            capture_pipeline_cache_data_size_ = create_info.initialDataSize;
+
+            object_info_table_.VisitPipelineCacheInfo([this](const PipelineCacheInfo* pipeline_cache_info) {
+                GFXRECON_ASSERT(pipeline_cache_info != nullptr);
+
+                auto iterator = pipeline_cache_info->pipeline_cache_data.find(capture_pipeline_cache_data_hash_);
+
+                if (iterator != pipeline_cache_info->pipeline_cache_data.end())
+                {
+                    // We found pipeline cache data vector which has same hash value, will continue to check if it has
+                    // same capture time pipeline cache data.
+                    auto& cache_data = const_cast<PipelineCacheInfo*>(pipeline_cache_info)
+                                           ->pipeline_cache_data[capture_pipeline_cache_data_hash_];
+
+                    for (auto& existing_cache_data : cache_data)
+                    {
+                        if ((matched_replay_cache_data_exist_ == false) &&
+                            (capture_pipeline_cache_data_size_ == existing_cache_data.capture_cache_data.size()))
+                        {
+                            // Target pipeline cache data has same size, we continue to check if it also has same data.
+                            if (memcmp(existing_cache_data.capture_cache_data.data(),
+                                       capture_pipeline_cache_data_,
+                                       capture_pipeline_cache_data_size_) == 0)
+                            {
+                                // Now we found the pipeline cache data, here we record its replay time data because we
+                                // need this data to replace capture time cache data in the vkCreatePipelineCache call.
+                                matched_replay_cache_data_exist_ = true;
+                                matched_replay_cache_data_.resize(existing_cache_data.replay_cache_data.size());
+                                memcpy(matched_replay_cache_data_.data(),
+                                       existing_cache_data.replay_cache_data.data(),
+                                       existing_cache_data.replay_cache_data.size());
+                            }
+                        }
+                    }
+                }
+            });
+
+            if (matched_replay_cache_data_exist_)
+            {
+                VkPipelineCacheCreateInfo override_create_info = (*replay_create_info);
+                override_create_info.initialDataSize           = matched_replay_cache_data_.size();
+                override_create_info.pInitialData              = matched_replay_cache_data_.data();
+
+                return func(device_info->handle,
+                            &override_create_info,
+                            GetAllocationCallbacks(pAllocator),
+                            pPipelineCache->GetHandlePointer());
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING(
+                    "There's initial pipeline cache data in VkPipelineCacheCreateInfo, but no corresponding "
+                    "replay time cache data!");
+
+                omitted_pipeline_cache_data_ = true;
+
+                return func(device_info->handle,
+                            replay_create_info,
+                            GetAllocationCallbacks(pAllocator),
+                            pPipelineCache->GetHandlePointer());
+            }
+        }
+        else
+        {
+            return func(device_info->handle,
+                        replay_create_info,
+                        GetAllocationCallbacks(pAllocator),
+                        pPipelineCache->GetHandlePointer());
+        }
     }
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4955,13 +4955,12 @@ VkResult VulkanReplayConsumerBase::OverrideGetPipelineCacheData(PFN_vkGetPipelin
             {
                 std::vector<PipelineCacheData>& item = const_cast<PipelineCacheInfo*>(pipeline_cache_info)
                                                            ->pipeline_cache_data[capture_pipeline_cache_data_hash];
-                VkDeviceSize* output_cache_data_size = reinterpret_cast<VkDeviceSize*>(pDataSize->GetOutputPointer());
+                auto              output_cache_data_size = *pDataSize->GetOutputPointer();
                 PipelineCacheData pipeline_cache_data;
                 pipeline_cache_data.capture_cache_data.resize(cache_data_size);
                 memcpy(pipeline_cache_data.capture_cache_data.data(), pData->GetPointer(), cache_data_size);
-                pipeline_cache_data.replay_cache_data.resize(*output_cache_data_size);
-                memcpy(
-                    pipeline_cache_data.replay_cache_data.data(), pData->GetOutputPointer(), *output_cache_data_size);
+                pipeline_cache_data.replay_cache_data.resize(output_cache_data_size);
+                memcpy(pipeline_cache_data.replay_cache_data.data(), pData->GetOutputPointer(), output_cache_data_size);
                 item.push_back(std::move(pipeline_cache_data));
             }
         }

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -189,6 +189,19 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
         HandlePointerDecoder<VkPipeline>*                                pPipelines) override;
 
+    template <typename T>
+    void AllowCompileDuringPipelineCreation(uint32_t create_info_count, const T* create_infos)
+    {
+        for (uint32_t i = 0; i < create_info_count; ++i)
+        {
+            if (create_infos[i].flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)
+            {
+                T* create_infos_to_modify = const_cast<T*>(create_infos);
+                create_infos_to_modify[i].flags &= (~VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT);
+            }
+        }
+    };
+
   protected:
     const VulkanObjectInfoTable& GetObjectInfoTable() const { return object_info_table_; }
 
@@ -1203,6 +1216,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_set<uint32_t>      removed_swapchain_indices_;
     std::vector<uint32_t>             capture_image_indices_;
     std::vector<SwapchainKHRInfo*>    swapchain_infos_;
+
+  protected:
+    // Used by pipeline cache handling
+    bool omitted_pipeline_cache_data_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1218,8 +1218,24 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::vector<SwapchainKHRInfo*>    swapchain_infos_;
 
   protected:
-    // Used by pipeline cache handling
+    // Used by pipeline cache handling, there are the following two cases for the flag to be set:
+    //
+    //    1. Replay with command line option --opcd or --omit-pipeline-cache-data and some
+    //       pipeline cache data was really omitted.
+    //
+    //    2. Replay without command line option --opcd or --omit-pipeline-cache-data and there is
+    //       at least one vkCreatePipelineCache call with valid initial pipeline cache data and
+    //       the initial cache data has no corresponding replay time cache data.
     bool omitted_pipeline_cache_data_;
+
+    // Temporary data used by pipeline cache data handling
+    // The following capture time data used for calling VisitPipelineCacheInfo as input parameters
+    // , replay time data used as output result.
+    uint32_t             capture_pipeline_cache_data_hash_ = 0;
+    uint32_t             capture_pipeline_cache_data_size_ = 0;
+    void*                capture_pipeline_cache_data_;
+    bool                 matched_replay_cache_data_exist_ = false;
+    std::vector<uint8_t> matched_replay_cache_data_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -71,7 +71,6 @@ struct HandleWrapper
 
 // clang-format off
 struct ShaderModuleWrapper                  : public HandleWrapper<VkShaderModule> {};
-struct PipelineCacheWrapper                 : public HandleWrapper<VkPipelineCache> {};
 struct SamplerWrapper                       : public HandleWrapper<VkSampler> {};
 struct SamplerYcbcrConversionWrapper        : public HandleWrapper<VkSamplerYcbcrConversion> {};
 struct DebugReportCallbackEXTWrapper        : public HandleWrapper<VkDebugReportCallbackEXT> {};
@@ -494,6 +493,13 @@ struct PrivateDataSlotWrapper : public HandleWrapper<VkPrivateDataSlot>
     VkObjectType   object_type{ VK_OBJECT_TYPE_UNKNOWN };
     uint64_t       object_handle{ 0 };
     uint64_t       data{ 0 };
+};
+
+struct PipelineCacheWrapper : public HandleWrapper<VkPipelineCache>
+{
+    DeviceWrapper*            device{ nullptr };
+    VkPipelineCacheCreateInfo create_info;
+    std::vector<uint8_t>      cache_data;
 };
 
 // Handle alias types for extension handle types that have been promoted to core types.

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -227,6 +227,26 @@ inline void InitializeState<VkDevice, EventWrapper, VkEventCreateInfo>(VkDevice 
 }
 
 template <>
+inline void
+InitializeState<VkDevice, PipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
+                                                                           PipelineCacheWrapper* wrapper,
+                                                                           const VkPipelineCacheCreateInfo* create_info,
+                                                                           format::ApiCallId create_call_id,
+                                                                           CreateParameters  create_parameters)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->device = GetWrapper<DeviceWrapper>(parent_handle);
+
+    wrapper->create_info = *create_info;
+}
+
+template <>
 inline void InitializeState<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(VkDevice          parent_handle,
                                                                                SemaphoreWrapper* wrapper,
                                                                                const VkSemaphoreCreateInfo* create_info,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -549,7 +549,7 @@ void VulkanStateWriter::WritePipelineLayoutState(const VulkanStateTable& state_t
 void VulkanStateWriter::WritePipelineCacheState(const VulkanStateTable& state_table)
 {
     state_table.VisitWrappers([&](const PipelineCacheWrapper* wrapper) {
-        assert(wrapper != nullptr);
+        GFXRECON_ASSERT(wrapper != nullptr);
 
         // Pipeline cache data can be indirectly changed by pipeline creation command or directly changed by calls like
         // vkMergePipelineCaches. So here we query and write its latest state, not the state when the pipeline cache was

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -146,7 +146,7 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
     StandardCreateWrite<ShaderModuleWrapper>(state_table);
     StandardCreateWrite<DescriptorSetLayoutWrapper>(state_table);
     WritePipelineLayoutState(state_table);
-    StandardCreateWrite<PipelineCacheWrapper>(state_table);
+    WritePipelineCacheState(state_table);
     WritePipelineState(state_table);
     WriteAccelerationStructureKHRState(state_table);
     WriteTlasToBlasDependenciesMetadata(state_table);
@@ -544,6 +544,48 @@ void VulkanStateWriter::WritePipelineLayoutState(const VulkanStateTable& state_t
     {
         DestroyTemporaryDeviceObject(format::ApiCall_vkDestroyDescriptorSetLayout, entry.first, entry.second);
     }
+}
+
+void VulkanStateWriter::WritePipelineCacheState(const VulkanStateTable& state_table)
+{
+    state_table.VisitWrappers([&](const PipelineCacheWrapper* wrapper) {
+        assert(wrapper != nullptr);
+
+        // Pipeline cache data can be indirectly changed by pipeline creation command or directly changed by calls like
+        // vkMergePipelineCaches. So here we query and write its latest state, not the state when the pipeline cache was
+        // created.
+        size_t   data_size;
+        VkResult result = wrapper->device->layer_table.GetPipelineCacheData(
+            wrapper->device->handle, wrapper->handle, &data_size, nullptr);
+        GFXRECON_ASSERT(result == VK_SUCCESS);
+
+        if (data_size != 0)
+        {
+            const_cast<PipelineCacheWrapper*>(wrapper)->cache_data.resize(data_size);
+
+            result = wrapper->device->layer_table.GetPipelineCacheData(
+                wrapper->device->handle,
+                wrapper->handle,
+                &data_size,
+                const_cast<PipelineCacheWrapper*>(wrapper)->cache_data.data());
+
+            GFXRECON_ASSERT(result == VK_SUCCESS);
+
+            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.initialDataSize = data_size;
+            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.pInitialData    = wrapper->cache_data.data();
+        }
+        else
+        {
+            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.initialDataSize = 0;
+            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.pInitialData    = nullptr;
+        }
+
+        WriteCreatePipelineCache(wrapper->device->handle_id,
+                                 &wrapper->create_info,
+                                 nullptr,
+                                 const_cast<VkPipelineCache*>(&wrapper->handle),
+                                 VK_SUCCESS);
+    });
 }
 
 void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
@@ -2511,6 +2553,27 @@ void VulkanStateWriter::WriteDestroyDeviceObject(format::ApiCallId            ca
 
     WriteFunctionCall(call_id, &parameter_stream_);
 
+    parameter_stream_.Reset();
+}
+
+void VulkanStateWriter::WriteCreatePipelineCache(format::HandleId                 device_id,
+                                                 const VkPipelineCacheCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks*     allocator,
+                                                 VkPipelineCache*                 pPipelineCache,
+                                                 VkResult                         result)
+{
+    bool              omit_output_data = false;
+    format::ApiCallId call_id          = format::ApiCallId::ApiCall_vkCreatePipelineCache;
+    encoder_.EncodeHandleIdValue(device_id);
+    EncodeStructPtr(&encoder_, pCreateInfo);
+    EncodeStructPtr(&encoder_, allocator);
+    if (result < 0)
+    {
+        omit_output_data = true;
+    }
+    encoder_.EncodeHandlePtr<PipelineCacheWrapper>(pPipelineCache, omit_output_data);
+    encoder_.EncodeEnumValue(result);
+    WriteFunctionCall(call_id, &parameter_stream_);
     parameter_stream_.Reset();
 }
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -121,6 +121,8 @@ class VulkanStateWriter
 
     void WritePipelineLayoutState(const VulkanStateTable& state_table);
 
+    void WritePipelineCacheState(const VulkanStateTable& state_table);
+
     void WritePipelineState(const VulkanStateTable& state_table);
 
     void WriteDescriptorSetState(const VulkanStateTable& state_table);
@@ -251,6 +253,12 @@ class VulkanStateWriter
                                   format::HandleId             device_id,
                                   format::HandleId             object_id,
                                   const VkAllocationCallbacks* allocator);
+
+    void WriteCreatePipelineCache(format::HandleId                 device_id,
+                                  const VkPipelineCacheCreateInfo* pCreateInfo,
+                                  const VkAllocationCallbacks*     allocator,
+                                  VkPipelineCache*                 pPipelineCache,
+                                  VkResult                         result);
 
     void DestroyTemporaryDeviceObject(format::ApiCallId               call_id,
                                       format::HandleId                object_id,

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -983,6 +983,7 @@ void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
     MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pPipelines->IsNull()) { pPipelines->SetHandleLength(createInfoCount); }
+    if (omitted_pipeline_cache_data_) {AllowCompileDuringPipelineCreation(createInfoCount, in_pCreateInfos);}
     VkPipeline* out_pPipelines = pPipelines->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateGraphicsPipelines(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
@@ -1007,6 +1008,7 @@ void VulkanReplayConsumer::Process_vkCreateComputePipelines(
     MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pPipelines->IsNull()) { pPipelines->SetHandleLength(createInfoCount); }
+    if (omitted_pipeline_cache_data_) {AllowCompileDuringPipelineCreation(createInfoCount, in_pCreateInfos);}
     VkPipeline* out_pPipelines = pPipelines->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateComputePipelines(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
@@ -6708,6 +6710,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesNV(
     MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     if (!pPipelines->IsNull()) { pPipelines->SetHandleLength(createInfoCount); }
+    if (omitted_pipeline_cache_data_) {AllowCompileDuringPipelineCreation(createInfoCount, in_pCreateInfos);}
     VkPipeline* out_pPipelines = pPipelines->GetHandlePointer();
 
     VkResult replay_result = GetDeviceTable(in_device)->CreateRayTracingPipelinesNV(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2018-2020 Valve Corporation
 # Copyright (c) 2018-2023 LunarG, Inc.
+# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -561,6 +561,8 @@ class VulkanReplayConsumerBodyGenerator(
                                 'if (!{paramname}->IsNull()) {{ {paramname}->SetHandleLength({}); }}'
                                 .format(length_name, paramname=value.name)
                             )
+                            if name == 'vkCreateGraphicsPipelines' or name == 'vkCreateComputePipelines' or name == 'vkCreateRayTracingPipelinesNV':
+                                preexpr.append('if (omitted_pipeline_cache_data_) {{AllowCompileDuringPipelineCreation({}, in_pCreateInfos);}}'.format(length_name))
                             if need_temp_value:
                                 expr += '{}->GetHandlePointer();'.format(
                                     value.name


### PR DESCRIPTION
**The problem**
   
Some title proceeds pipeline creation call with pipeline cache object. Foe such title, playback may experience performance hit or failure if the pipeline cache object state is different between capture and playback. 

For example, during capture time, pipeline creation command PCC-a was called with a pipeline cache object PCO-a, therefore a compile operation CO-a is not needed because the pipeline cache data can be used for it. During playback time, if the state of the pipeline cache object PCO-a was fully restored, the compile operation CO-a should be also not needed. But there are some cases which make the playback time state of the pipeline cache object PCO-a is different with capture time due to pipeline cache object missing related data, such difference may trigger compile operation CO-a during playback time. 

For all following cases, playback may experience performance hit due to extra compile operation in pipeline creation or fail if some pipeline creation command has VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT in create info.

1. Bug with --opcd option (even with same driver and platform)

   If user start playback with --opcd option, all pipeline cache data will be omitted, so the pipeline cache state will be different between capture and playback.

2. Bug with trim handling for pipeline cache data (even with same driver and platform)

   In current trim handling, the original initial cache data is used to restore the pipeline cache object. Pipeline cache contents can be modified by some commands such as pipeline creation or pipeline cache merging, so the state of pipeline cache object is not same with the state when it was initially created. So, the handling may cause restored pipeline cache object state is not same with the state at trim starting point. 
   
3. Unsupported case for driver or platform change

   Current vkCreatePipelineCache handling directly use capture time pipeline cache data during playback time. Capture time pipeline cache data might be incompatible with replay time because of driver version or platform change, for such case, driver will ignore the incompatible cache data and it make the pipeline cache object state is not same. 


**The solution**

   The pull request tracks the pipeline cache data queried from vkGetPipelineCacheData and try to find the corresponding replay-time cache data, use it in vkCreatePipelineCache or clear VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT if it cannot find corresponding replay time data. The pull request also clears the VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT If user start playback with --opcd option.

**Result**
Tested target title full trace and trim trace capture/playback with the build of the pull request, also tested playback user provided previously failed trace files, all tests passed, the commit fixed tVK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT if it cannot find corresponding replay time data. The pull request also clears the VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT If user start playback with --opcd option.

**Result**
Tested target title full trace and trim trace capture/playback with the build of the pull request, also tested playback user provided previously failed trace files, all tests passed, the commit fixed the above issue.
he above issue.
