### PR TITLE
Fix handling for new Agility SDK resource creation methods

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -371,6 +371,19 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                              Decoded_GUID                 riid,
                                              HandlePointerDecoder<void*>* resource);
 
+    HRESULT OverrideCreateCommittedResource3(DxObjectInfo*                                        replay_object_info,
+                                             HRESULT                                              original_result,
+                                             StructPointerDecoder<Decoded_D3D12_HEAP_PROPERTIES>* pHeapProperties,
+                                             D3D12_HEAP_FLAGS                                     HeapFlags,
+                                             StructPointerDecoder<Decoded_D3D12_RESOURCE_DESC1>*  pDesc,
+                                             D3D12_BARRIER_LAYOUT                                 InitialLayout,
+                                             StructPointerDecoder<Decoded_D3D12_CLEAR_VALUE>*     pOptimizedClearValue,
+                                             DxObjectInfo*                protected_session_object_info,
+                                             UINT32                       NumCastableFormats,
+                                             PointerDecoder<DXGI_FORMAT>* pCastableFormats,
+                                             Decoded_GUID                 riid,
+                                             HandlePointerDecoder<void*>* resource);
+
     HRESULT OverrideCreateFence(DxObjectInfo*                replay_object_info,
                                 HRESULT                      original_result,
                                 UINT64                       initial_value,
@@ -565,6 +578,17 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                             D3D12_RESOURCE_STATES                              initial_state,
                                             StructPointerDecoder<Decoded_D3D12_CLEAR_VALUE>*   optimized_clear_value,
                                             DxObjectInfo*                protected_session_object_info,
+                                            Decoded_GUID                 riid,
+                                            HandlePointerDecoder<void*>* resource);
+
+    HRESULT OverrideCreateReservedResource2(DxObjectInfo*                                      device_object_info,
+                                            HRESULT                                            original_result,
+                                            StructPointerDecoder<Decoded_D3D12_RESOURCE_DESC>* desc,
+                                            D3D12_BARRIER_LAYOUT                               initial_layout,
+                                            StructPointerDecoder<Decoded_D3D12_CLEAR_VALUE>*   optimized_clear_value,
+                                            DxObjectInfo*                protected_session_object_info,
+                                            UINT32                       num_castable_formats,
+                                            PointerDecoder<DXGI_FORMAT>* castable_formats,
                                             Decoded_GUID                 riid,
                                             HandlePointerDecoder<void*>* resource);
 

--- a/framework/encode/custom_dx12_wrapper_commands.h
+++ b/framework/encode/custom_dx12_wrapper_commands.h
@@ -239,6 +239,16 @@ struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateRese
 };
 
 template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Device10_CreateReservedResource2>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_ID3D12Device10_CreateReservedResource2(args...);
+    }
+};
+
+template <>
 struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Device4_CreateHeap1>
 {
     template <typename... Args>
@@ -269,12 +279,32 @@ struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Device8_CreateComm
 };
 
 template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Device10_CreateCommittedResource3>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_ID3D12Device10_CreateCommittedResource3(args...);
+    }
+};
+
+template <>
 struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Device8_CreatePlacedResource1>
 {
     template <typename... Args>
     static void Dispatch(D3D12CaptureManager* manager, Args... args)
     {
         manager->PostProcess_ID3D12Device8_CreatePlacedResource1(args...);
+    }
+};
+
+template <>
+struct CustomWrapperPostCall<format::ApiCallId::ApiCall_ID3D12Device10_CreatePlacedResource2>
+{
+    template <typename... Args>
+    static void Dispatch(D3D12CaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_ID3D12Device10_CreatePlacedResource2(args...);
     }
 };
 

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -349,7 +349,8 @@ void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    
 
         auto layouts = std::make_unique<D3D12_PLACED_SUBRESOURCE_FOOTPRINT[]>(num_subresources);
 
-        device->GetCopyableFootprints(&full_desc, 0, num_subresources, 0, layouts.get(), nullptr, nullptr, nullptr);
+        graphics::dx12::RobustGetCopyableFootprint(
+            device, resource, &full_desc, 0, num_subresources, 0, layouts.get(), nullptr, nullptr, nullptr);
 
         info->num_subresources    = num_subresources;
         info->mapped_subresources = std::make_unique<MappedSubresource[]>(num_subresources);

--- a/framework/encode/d3d12_capture_manager.h
+++ b/framework/encode/d3d12_capture_manager.h
@@ -340,6 +340,17 @@ class D3D12CaptureManager : public CaptureManager
                                                            REFIID                          riid,
                                                            void**                          resource);
 
+    void PostProcess_ID3D12Device10_CreateReservedResource2(ID3D12Device10_Wrapper*         wrapper,
+                                                            HRESULT                         result,
+                                                            const D3D12_RESOURCE_DESC*      desc,
+                                                            D3D12_BARRIER_LAYOUT            initial_layout,
+                                                            const D3D12_CLEAR_VALUE*        optimized_clear_value,
+                                                            ID3D12ProtectedResourceSession* protected_session,
+                                                            UINT32                          num_castable_formats,
+                                                            const DXGI_FORMAT*              castable_formats,
+                                                            REFIID                          riid,
+                                                            void**                          resource);
+
     void PreProcess_ID3D12Device3_OpenExistingHeapFromAddress(ID3D12Device3_Wrapper* wrapper,
                                                               const void*            address,
                                                               REFIID                 riid,
@@ -377,6 +388,19 @@ class D3D12CaptureManager : public CaptureManager
                                                             REFIID                          riid,
                                                             void**                          resource);
 
+    void PostProcess_ID3D12Device10_CreateCommittedResource3(ID3D12Device10_Wrapper*         wrapper,
+                                                             HRESULT                         result,
+                                                             const D3D12_HEAP_PROPERTIES*    heap_properties,
+                                                             D3D12_HEAP_FLAGS                heap_flags,
+                                                             const D3D12_RESOURCE_DESC1*     desc,
+                                                             D3D12_BARRIER_LAYOUT            initial_layout,
+                                                             const D3D12_CLEAR_VALUE*        optimized_clear_value,
+                                                             ID3D12ProtectedResourceSession* protected_session,
+                                                             UINT32                          num_castable_formats,
+                                                             const DXGI_FORMAT*              castable_formats,
+                                                             REFIID                          riid,
+                                                             void**                          resource);
+
     void PostProcess_ID3D12Device8_CreatePlacedResource1(ID3D12Device8_Wrapper*      wrapper,
                                                          HRESULT                     result,
                                                          ID3D12Heap*                 heap,
@@ -386,6 +410,18 @@ class D3D12CaptureManager : public CaptureManager
                                                          const D3D12_CLEAR_VALUE*    optimized_clear_value,
                                                          REFIID                      riid,
                                                          void**                      resource);
+
+    void PostProcess_ID3D12Device10_CreatePlacedResource2(ID3D12Device10_Wrapper*     wrapper,
+                                                          HRESULT                     result,
+                                                          ID3D12Heap*                 heap,
+                                                          UINT64                      heap_offset,
+                                                          const D3D12_RESOURCE_DESC1* desc,
+                                                          D3D12_BARRIER_LAYOUT        initial_layout,
+                                                          const D3D12_CLEAR_VALUE*    optimized_clear_value,
+                                                          UINT32                      num_castable_formats,
+                                                          const DXGI_FORMAT*          castable_formats,
+                                                          REFIID                      riid,
+                                                          void**                      resource);
 
     void PostProcess_ID3D12Resource_Map(
         ID3D12Resource_Wrapper* wrapper, HRESULT result, UINT subresource, const D3D12_RANGE* read_range, void** data);
@@ -597,6 +633,18 @@ class D3D12CaptureManager : public CaptureManager
                                                           ID3D12ProtectedResourceSession* protected_session,
                                                           REFIID                          riid_resource,
                                                           void**                          ppv_resource);
+
+    HRESULT OverrideID3D12Device10_CreateCommittedResource3(ID3D12Device10_Wrapper*         wrapper,
+                                                            const D3D12_HEAP_PROPERTIES*    heap_properties,
+                                                            D3D12_HEAP_FLAGS                heap_flags,
+                                                            const D3D12_RESOURCE_DESC1*     desc,
+                                                            D3D12_BARRIER_LAYOUT            initial_layout,
+                                                            const D3D12_CLEAR_VALUE*        optimized_clear_value,
+                                                            ID3D12ProtectedResourceSession* protected_session,
+                                                            UINT32                          num_castable_formats,
+                                                            const DXGI_FORMAT*              castable_formats,
+                                                            REFIID                          riid_resource,
+                                                            void**                          ppv_resource);
 
     HRESULT OverrideID3D12Device_CreateHeap(ID3D12Device_Wrapper*  wrapper,
                                             const D3D12_HEAP_DESC* desc,

--- a/framework/encode/dx12_state_writer.cpp
+++ b/framework/encode/dx12_state_writer.cpp
@@ -778,8 +778,10 @@ void Dx12StateWriter::WriteResourceSnapshot(graphics::Dx12ResourceDataUtil* reso
     temp_subresource_sizes_.clear();
     temp_subresource_offsets_.clear();
 
-    bool is_reserved_resouce = (resource_info->create_call_id == format::ApiCall_ID3D12Device_CreateReservedResource) ||
-                               (resource_info->create_call_id == format::ApiCall_ID3D12Device4_CreateReservedResource1);
+    bool is_reserved_resouce =
+        (resource_info->create_call_id == format::ApiCall_ID3D12Device_CreateReservedResource) ||
+        (resource_info->create_call_id == format::ApiCall_ID3D12Device4_CreateReservedResource1) ||
+        (resource_info->create_call_id == format::ApiCall_ID3D12Device10_CreateReservedResource2);
     bool is_texture_with_unknown_layout =
         graphics::dx12::IsTextureWithUnknownLayout(resource_info->dimension, resource_info->layout);
 

--- a/framework/generated/dx12_generators/capture_overrides.json
+++ b/framework/generated/dx12_generators/capture_overrides.json
@@ -22,6 +22,9 @@
     "ID3D12Device8": {
       "CreateCommittedResource2": "D3D12CaptureManager::Get()->OverrideID3D12Device_CreateCommittedResource2"
     },
+	"ID3D12Device10": {
+      "CreateCommittedResource3": "D3D12CaptureManager::Get()->OverrideID3D12Device10_CreateCommittedResource3"
+    },
     "ID3D12Device1": {
       "CreatePipelineLibrary": "D3D12CaptureManager::Get()->OverrideID3D12Device1_CreatePipelineLibrary"
     },

--- a/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_replay_consumer_body_generator.py
@@ -22,6 +22,7 @@
 
 import json
 import sys
+import re
 from base_generator import write
 from dx12_base_generator import Dx12BaseGenerator, Dx12GeneratorOptions
 from dx12_replay_consumer_header_generator import Dx12ReplayConsumerHeaderGenerator, Dx12ReplayConsumerHeaderGeneratorOptions
@@ -185,8 +186,7 @@ class Dx12ReplayConsumerBodyGenerator(
             if class_name in self.REPLAY_OVERRIDES['classmethods']:
                 is_override = method_name in self.REPLAY_OVERRIDES[
                     'classmethods'][class_name]
-            resource_creation_methods = ["CreateCommittedResource", "CreatePlacedResource", "CreateReservedResource", "CreateCommittedResource1", "CreateReservedResource1", "CreateCommittedResource2", "CreatePlacedResource1"]
-            if method_name in resource_creation_methods:
+            if re.search("^Create.+Resource[0-9]*$", method_name) is not None:
                 is_resource_creation_methods = True
         else:
             is_override = name in self.REPLAY_OVERRIDES['functions']

--- a/framework/generated/dx12_generators/replay_overrides.json
+++ b/framework/generated/dx12_generators/replay_overrides.json
@@ -58,6 +58,10 @@
     "ID3D12Device9": {
       "CreateCommandQueue1": "OverrideCreateCommandQueue1"
     },
+    "ID3D12Device10": {
+      "CreateCommittedResource3": "OverrideCreateCommittedResource3",
+      "CreateReservedResource2": "OverrideCreateReservedResource2"
+    },
     "ID3D12DescriptorHeap": {
       "GetCPUDescriptorHandleForHeapStart": "OverrideGetCPUDescriptorHandleForHeapStart",
       "GetGPUDescriptorHandleForHeapStart": "OverrideGetGPUDescriptorHandleForHeapStart"

--- a/framework/generated/generated_dx12_replay_consumer.cpp
+++ b/framework/generated/generated_dx12_replay_consumer.cpp
@@ -6935,26 +6935,29 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateCommittedResource3(
     Decoded_GUID                                riidResource,
     HandlePointerDecoder<void*>*                ppvResource)
 {
-    auto replay_object = MapObject<ID3D12Device10>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto in_pProtectedSession = MapObject<ID3D12ProtectedResourceSession>(pProtectedSession);
+        auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
-        auto out_p_ppvResource    = ppvResource->GetPointer();
-        auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
-        auto replay_result = replay_object->CreateCommittedResource3(pHeapProperties->GetPointer(),
-                                                                     HeapFlags,
-                                                                     pDesc->GetPointer(),
-                                                                     InitialLayout,
-                                                                     pOptimizedClearValue->GetPointer(),
-                                                                     in_pProtectedSession,
-                                                                     NumCastableFormats,
-                                                                     pCastableFormats->GetPointer(),
-                                                                     *riidResource.decoded_value,
-                                                                     out_hp_ppvResource);
+        DxObjectInfo object_info{};
+        ppvResource->SetConsumerData(0, &object_info);
+        auto replay_result = OverrideCreateCommittedResource3(replay_object,
+                                                              return_value,
+                                                              pHeapProperties,
+                                                              HeapFlags,
+                                                              pDesc,
+                                                              InitialLayout,
+                                                              pOptimizedClearValue,
+                                                              in_pProtectedSession,
+                                                              NumCastableFormats,
+                                                              pCastableFormats,
+                                                              riidResource,
+                                                              ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreateCommittedResource3);
+            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device10_CreateCommittedResource3);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device10_CreateCommittedResource3", return_value, replay_result);
     }
@@ -6993,6 +6996,7 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreatePlacedResource2(
         if (SUCCEEDED(replay_result))
         {
             AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreatePlacedResource2);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device10_CreatePlacedResource2", return_value, replay_result);
     }
@@ -7011,24 +7015,27 @@ void Dx12ReplayConsumer::Process_ID3D12Device10_CreateReservedResource2(
     Decoded_GUID                                riid,
     HandlePointerDecoder<void*>*                ppvResource)
 {
-    auto replay_object = MapObject<ID3D12Device10>(object_id);
-    if (replay_object != nullptr)
+    auto replay_object = GetObjectInfo(object_id);
+    if ((replay_object != nullptr) && (replay_object->object != nullptr))
     {
-        auto in_pProtectedSession = MapObject<ID3D12ProtectedResourceSession>(pProtectedSession);
+        auto in_pProtectedSession = GetObjectInfo(pProtectedSession);
         if(!ppvResource->IsNull()) ppvResource->SetHandleLength(1);
-        auto out_p_ppvResource    = ppvResource->GetPointer();
-        auto out_hp_ppvResource   = ppvResource->GetHandlePointer();
-        auto replay_result = replay_object->CreateReservedResource2(pDesc->GetPointer(),
-                                                                    InitialLayout,
-                                                                    pOptimizedClearValue->GetPointer(),
-                                                                    in_pProtectedSession,
-                                                                    NumCastableFormats,
-                                                                    pCastableFormats->GetPointer(),
-                                                                    *riid.decoded_value,
-                                                                    out_hp_ppvResource);
+        DxObjectInfo object_info{};
+        ppvResource->SetConsumerData(0, &object_info);
+        auto replay_result = OverrideCreateReservedResource2(replay_object,
+                                                             return_value,
+                                                             pDesc,
+                                                             InitialLayout,
+                                                             pOptimizedClearValue,
+                                                             in_pProtectedSession,
+                                                             NumCastableFormats,
+                                                             pCastableFormats,
+                                                             riid,
+                                                             ppvResource);
         if (SUCCEEDED(replay_result))
         {
-            AddObject(out_p_ppvResource, out_hp_ppvResource, format::ApiCall_ID3D12Device10_CreateReservedResource2);
+            AddObject(ppvResource->GetPointer(), ppvResource->GetHandlePointer(), std::move(object_info), format::ApiCall_ID3D12Device10_CreateReservedResource2);
+            SetResourceDesc(ppvResource, pDesc);
         }
         CheckReplayResult("ID3D12Device10_CreateReservedResource2", return_value, replay_result);
     }

--- a/framework/generated/generated_dx12_wrappers.cpp
+++ b/framework/generated/generated_dx12_wrappers.cpp
@@ -23758,7 +23758,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device10_Wrapper::CreateCommittedResource3(
             riidResource,
             ppvResource);
 
-        result = GetWrappedObjectAs<ID3D12Device10>()->CreateCommittedResource3(
+        result = D3D12CaptureManager::Get()->OverrideID3D12Device10_CreateCommittedResource3(
+            this,
             pHeapProperties,
             HeapFlags,
             pDesc,

--- a/framework/graphics/dx12_resource_data_util.cpp
+++ b/framework/graphics/dx12_resource_data_util.cpp
@@ -184,14 +184,16 @@ void Dx12ResourceDataUtil::GetResourceCopyInfo(ID3D12Resource*                  
         temp_subresource_row_size_bytes_.clear();
         temp_subresource_row_size_bytes_.resize(num_subresources);
 
-        device_->GetCopyableFootprints(&resource_desc,
-                                       0,
-                                       num_subresources,
-                                       0,
-                                       layouts.data(),
-                                       temp_subresource_row_counts_.data(),
-                                       temp_subresource_row_size_bytes_.data(),
-                                       &total_size);
+        graphics::dx12::RobustGetCopyableFootprint(device_,
+                                                   resource,
+                                                   &resource_desc,
+                                                   0,
+                                                   num_subresources,
+                                                   0,
+                                                   layouts.data(),
+                                                   temp_subresource_row_counts_.data(),
+                                                   temp_subresource_row_size_bytes_.data(),
+                                                   &total_size);
 
         subresource_count = num_subresources;
         subresource_sizes.resize(num_subresources);

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -266,6 +266,17 @@ inline format::AdapterType ExtractAdapterType(uint32_t extra_info)
     return static_cast<format::AdapterType>((extra_info & kAdapterTypeMask));
 }
 
+void RobustGetCopyableFootprint(ID3D12Device*                       device,
+                                ID3D12Resource*                     resource,
+                                const D3D12_RESOURCE_DESC*          pResourceDesc,
+                                UINT                                FirstSubresource,
+                                UINT                                NumSubresources,
+                                UINT64                              BaseOffset,
+                                D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
+                                UINT*                               pNumRows,
+                                UINT64*                             pRowSizeInBytes,
+                                UINT64*                             pTotalBytes);
+
 GFXRECON_END_NAMESPACE(dx12)
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)


### PR DESCRIPTION
- Add capture and replay handling for resource creation functions added by the Agility SDK.
- Add additional handling to GetCopyableFootprints for resources created by the new creation functions.
  - This fixes a potential trimming issues when those new API calls are used.
