### PR TITLE
gfxrecon-convert: Emit index field when writing metadata JSON blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ __pycache__/
 .vscode/
 *.db
 *.pyc
+*.rdbg
 ._*
 .DS_Store

--- a/framework/decode/dx12_consumer_base.h
+++ b/framework/decode/dx12_consumer_base.h
@@ -83,7 +83,7 @@ class Dx12ConsumerBase : public MetadataConsumerBase, public MarkerConsumerBase
                                                            UINT                                     SrcDepthPitch)
     {}
 
-    void SetCurrentBlockIndex(uint64_t block_index) { current_block_index_ = block_index; }
+    virtual void SetCurrentBlockIndex(uint64_t block_index) override { block_index_ = block_index; }
 
     bool ContainsDxrWorkload() const { return dxr_workload_; }
 

--- a/framework/decode/dx12_consumer_base.h
+++ b/framework/decode/dx12_consumer_base.h
@@ -92,14 +92,11 @@ class Dx12ConsumerBase : public MetadataConsumerBase, public MarkerConsumerBase
     bool ContainsOptFillMem() const { return opt_fillmem_; }
 
   protected:
-    auto GetCurrentBlockIndex() { return current_block_index_; }
+    auto GetCurrentBlockIndex() { return block_index_; }
 
     bool dxr_workload_{ false };
     bool ei_workload_{ false };
     bool opt_fillmem_{ false };
-
-  private:
-    uint64_t current_block_index_{ 0 };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -1795,7 +1795,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                         {
                             if (decoder->SupportsMetaDataId(meta_data_id))
                             {
-                                        decoder->DispatchSetTlasToBlasDependencyCommand(header.parent_id, blases);
+                                decoder->DispatchSetTlasToBlasDependencyCommand(header.parent_id, blases);
                             }
                         }
                     }

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -797,7 +797,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchResizeWindowCommand(
                         command.thread_id, command.surface_id, command.width, command.height);
                 }
@@ -827,7 +826,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchResizeWindowCommand2(
                         command.thread_id, command.surface_id, command.width, command.height, command.pre_transform);
                 }
@@ -862,7 +860,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
-                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchExeFileInfo(header.thread_id, header);
             }
         }
@@ -878,7 +875,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
-                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchDriverInfo(header.thread_id, header);
             }
         }
@@ -1082,7 +1078,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchDestroyHardwareBufferCommand(command.thread_id, command.buffer_id);
                 }
             }
@@ -1107,7 +1102,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
-                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchCreateHeapAllocationCommand(
                     header.thread_id, header.allocation_id, header.allocation_size);
             }
@@ -1258,7 +1252,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchSetOpaqueAddressCommand(
                         header.thread_id, header.device_id, header.object_id, header.address);
                 }
@@ -1290,7 +1283,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchSetRayTracingShaderGroupHandlesCommand(header.thread_id,
                                                                             header.device_id,
                                                                             header.pipeline_id,
@@ -1379,7 +1371,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchBeginResourceInitCommand(
                         header.thread_id, header.device_id, header.max_resource_size, header.max_copy_size);
                 }
@@ -1406,7 +1397,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchEndResourceInitCommand(header.thread_id, header.device_id);
                 }
             }
@@ -1521,7 +1511,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
-                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchInitImageCommand(header.thread_id,
                                                       header.device_id,
                                                       header.image_id,
@@ -1729,7 +1718,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
-                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchGetDxgiAdapterInfo(adapter_info_header);
             }
         }
@@ -1755,7 +1743,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
-                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchGetDx12RuntimeInfo(dx12_runtime_info_header);
             }
         }

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -706,7 +706,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchFillMemoryCommand(header.thread_id,
                                                            header.memory_id,
                                                            header.memory_offset,
@@ -764,7 +763,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchFillMemoryResourceValueCommand(header, parameter_buffer_.data());
                     }
                 }
@@ -911,7 +909,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchDisplayMessageCommand(header.thread_id, message);
                     }
                 }
@@ -968,7 +965,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchCreateHardwareBufferCommand(header.thread_id,
                                                                      header.memory_id,
                                                                      header.buffer_id,
@@ -1040,7 +1036,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchCreateHardwareBufferCommand(header.thread_id,
                                                                      header.memory_id,
                                                                      header.buffer_id,
@@ -1155,7 +1150,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchSetDevicePropertiesCommand(header.thread_id,
                                                                     header.physical_device_id,
                                                                     header.api_version,
@@ -1229,7 +1223,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchSetDeviceMemoryPropertiesCommand(
                             header.thread_id, header.physical_device_id, types, heaps);
                     }
@@ -1348,7 +1341,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchSetSwapchainImageStateCommand(header.thread_id,
                                                                        header.device_id,
                                                                        header.swapchain_id,
@@ -1457,7 +1449,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchInitBufferCommand(header.thread_id,
                                                            header.device_id,
                                                            header.buffer_id,
@@ -1592,7 +1583,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchInitSubresourceCommand(header, parameter_buffer_.data());
                     }
                 }
@@ -1688,7 +1678,6 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
-                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchInitDx12AccelerationStructureCommand(
                             header, geom_descs, parameter_buffer_.data());
                     }
@@ -1806,8 +1795,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                         {
                             if (decoder->SupportsMetaDataId(meta_data_id))
                             {
-                                decoder->SetCurrentBlockIndex(block_index_);
-                                decoder->DispatchSetTlasToBlasDependencyCommand(header.parent_id, blases);
+                                        decoder->DispatchSetTlasToBlasDependencyCommand(header.parent_id, blases);
                             }
                         }
                     }

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -706,6 +706,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchFillMemoryCommand(header.thread_id,
                                                            header.memory_id,
                                                            header.memory_offset,
@@ -763,6 +764,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchFillMemoryResourceValueCommand(header, parameter_buffer_.data());
                     }
                 }
@@ -797,6 +799,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchResizeWindowCommand(
                         command.thread_id, command.surface_id, command.width, command.height);
                 }
@@ -826,6 +829,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchResizeWindowCommand2(
                         command.thread_id, command.surface_id, command.width, command.height, command.pre_transform);
                 }
@@ -860,6 +864,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
+                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchExeFileInfo(header.thread_id, header);
             }
         }
@@ -875,6 +880,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
+                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchDriverInfo(header.thread_id, header);
             }
         }
@@ -905,6 +911,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchDisplayMessageCommand(header.thread_id, message);
                     }
                 }
@@ -961,6 +968,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchCreateHardwareBufferCommand(header.thread_id,
                                                                      header.memory_id,
                                                                      header.buffer_id,
@@ -1032,6 +1040,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchCreateHardwareBufferCommand(header.thread_id,
                                                                      header.memory_id,
                                                                      header.buffer_id,
@@ -1078,6 +1087,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchDestroyHardwareBufferCommand(command.thread_id, command.buffer_id);
                 }
             }
@@ -1102,6 +1112,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
+                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchCreateHeapAllocationCommand(
                     header.thread_id, header.allocation_id, header.allocation_size);
             }
@@ -1144,6 +1155,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchSetDevicePropertiesCommand(header.thread_id,
                                                                     header.physical_device_id,
                                                                     header.api_version,
@@ -1217,6 +1229,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchSetDeviceMemoryPropertiesCommand(
                             header.thread_id, header.physical_device_id, types, heaps);
                     }
@@ -1252,6 +1265,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchSetOpaqueAddressCommand(
                         header.thread_id, header.device_id, header.object_id, header.address);
                 }
@@ -1283,6 +1297,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchSetRayTracingShaderGroupHandlesCommand(header.thread_id,
                                                                             header.device_id,
                                                                             header.pipeline_id,
@@ -1333,6 +1348,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchSetSwapchainImageStateCommand(header.thread_id,
                                                                        header.device_id,
                                                                        header.swapchain_id,
@@ -1371,6 +1387,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchBeginResourceInitCommand(
                         header.thread_id, header.device_id, header.max_resource_size, header.max_copy_size);
                 }
@@ -1397,6 +1414,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchEndResourceInitCommand(header.thread_id, header.device_id);
                 }
             }
@@ -1439,6 +1457,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchInitBufferCommand(header.thread_id,
                                                            header.device_id,
                                                            header.buffer_id,
@@ -1511,6 +1530,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             {
                 if (decoder->SupportsMetaDataId(meta_data_id))
                 {
+                    decoder->SetCurrentBlockIndex(block_index_);
                     decoder->DispatchInitImageCommand(header.thread_id,
                                                       header.device_id,
                                                       header.image_id,
@@ -1572,6 +1592,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchInitSubresourceCommand(header, parameter_buffer_.data());
                     }
                 }
@@ -1667,6 +1688,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 {
                     if (decoder->SupportsMetaDataId(meta_data_id))
                     {
+                        decoder->SetCurrentBlockIndex(block_index_);
                         decoder->DispatchInitDx12AccelerationStructureCommand(
                             header, geom_descs, parameter_buffer_.data());
                     }
@@ -1718,6 +1740,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
+                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchGetDxgiAdapterInfo(adapter_info_header);
             }
         }
@@ -1743,6 +1766,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         {
             for (auto decoder : decoders_)
             {
+                decoder->SetCurrentBlockIndex(block_index_);
                 decoder->DispatchGetDx12RuntimeInfo(dx12_runtime_info_header);
             }
         }
@@ -1782,6 +1806,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                         {
                             if (decoder->SupportsMetaDataId(meta_data_id))
                             {
+                                decoder->SetCurrentBlockIndex(block_index_);
                                 decoder->DispatchSetTlasToBlasDependencyCommand(header.parent_id, blases);
                             }
                         }

--- a/framework/decode/json_writer.cpp
+++ b/framework/decode/json_writer.cpp
@@ -175,6 +175,7 @@ nlohmann::ordered_json& JsonWriter::WriteMetaCommandStart(const std::string_view
 {
     auto& json_data = WriteBlockStart();
 
+    json_data[format::kNameIndex] = block_index_;
     nlohmann::ordered_json& meta = json_data[format::kNameMeta];
     meta[format::kNameName]      = command_name;
     return meta[format::kNameArgs];

--- a/framework/decode/json_writer.h
+++ b/framework/decode/json_writer.h
@@ -108,17 +108,14 @@ class JsonWriter : public AnnotationHandler
     std::string GenerateFilename(const std::string_view filename);
     bool        WriteBinaryFile(const std::string& filename, uint64_t data_size, const uint8_t* data);
 
-    inline void SetCurrentBlockIndex(uint64_t block_index)
-    {
-      block_index_ = block_index;
-    }
+    inline void SetCurrentBlockIndex(uint64_t block_index) { block_index_ = block_index; }
 
   private:
     util::OutputStream*    os_;
     nlohmann::ordered_json header_;
     util::JsonOptions      json_options_;
     nlohmann::ordered_json json_data_;
-    uint64_t block_index_;
+    uint64_t               block_index_;
     uint32_t               num_streams_{ 0 };
     /// Number of side-files generated for dumping binary blobs etc.
     uint32_t num_files_{ 0 };

--- a/framework/decode/json_writer.h
+++ b/framework/decode/json_writer.h
@@ -108,11 +108,17 @@ class JsonWriter : public AnnotationHandler
     std::string GenerateFilename(const std::string_view filename);
     bool        WriteBinaryFile(const std::string& filename, uint64_t data_size, const uint8_t* data);
 
+    inline void SetCurrentBlockIndex(uint64_t block_index)
+    {
+      block_index_ = block_index;
+    }
+
   private:
     util::OutputStream*    os_;
     nlohmann::ordered_json header_;
     util::JsonOptions      json_options_;
     nlohmann::ordered_json json_data_;
+    uint64_t block_index_;
     uint32_t               num_streams_{ 0 };
     /// Number of side-files generated for dumping binary blobs etc.
     uint32_t num_files_{ 0 };

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -107,10 +107,8 @@ class MetadataConsumerBase
                                                const uint8_t*                              data)
     {}
 
-    inline void SetCurrentBlockIndex(uint64_t block_index)
-    {
-      block_index_ = block_index;
-    }
+    virtual void SetCurrentBlockIndex(uint64_t block_index)
+    {}
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -34,9 +34,6 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 /// implement to handle metacommands.
 class MetadataConsumerBase
 {
-  protected:
-    uint64_t block_index_;
-
   public:
     virtual void ProcessDisplayMessageCommand(const std::string& message) {}
     virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
@@ -108,6 +105,9 @@ class MetadataConsumerBase
     {}
 
     virtual void SetCurrentBlockIndex(uint64_t block_index) {}
+
+  protected:
+    uint64_t block_index_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -107,8 +107,7 @@ class MetadataConsumerBase
                                                const uint8_t*                              data)
     {}
 
-    virtual void SetCurrentBlockIndex(uint64_t block_index)
-    {}
+    virtual void SetCurrentBlockIndex(uint64_t block_index) {}
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/metadata_consumer_base.h
+++ b/framework/decode/metadata_consumer_base.h
@@ -34,6 +34,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 /// implement to handle metacommands.
 class MetadataConsumerBase
 {
+  protected:
+    uint64_t block_index_;
+
   public:
     virtual void ProcessDisplayMessageCommand(const std::string& message) {}
     virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
@@ -103,6 +106,11 @@ class MetadataConsumerBase
     virtual void ProcessInitSubresourceCommand(const format::InitSubresourceCommandHeader& command_header,
                                                const uint8_t*                              data)
     {}
+
+    inline void SetCurrentBlockIndex(uint64_t block_index)
+    {
+      block_index_ = block_index;
+    }
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/metadata_json_consumer.h
+++ b/framework/decode/metadata_json_consumer.h
@@ -51,7 +51,7 @@ class MetadataJsonConsumer : public Base
     inline const util::JsonOptions& GetJsonOptions() const { return this->writer_->GetOptions(); } // temp
     inline nlohmann::ordered_json&  WriteMetaCommandStart(const std::string& command_name) const
     {
-        this->writer_->SetCurrentBlockIndex(block_index_);
+        this->writer_->SetCurrentBlockIndex(this->block_index_);
         return this->writer_->WriteMetaCommandStart(command_name);
     }
     inline void WriteBlockEnd() { this->writer_->WriteBlockEnd(); }

--- a/framework/decode/metadata_json_consumer.h
+++ b/framework/decode/metadata_json_consumer.h
@@ -51,6 +51,7 @@ class MetadataJsonConsumer : public Base
     inline const util::JsonOptions& GetJsonOptions() const { return this->writer_->GetOptions(); } // temp
     inline nlohmann::ordered_json&  WriteMetaCommandStart(const std::string& command_name) const
     {
+        this->writer_->SetCurrentBlockIndex(block_index_);
         return this->writer_->WriteMetaCommandStart(command_name);
     }
     inline void WriteBlockEnd() { this->writer_->WriteBlockEnd(); }
@@ -260,6 +261,7 @@ class MetadataJsonConsumer : public Base
         RepresentBinaryFile(*(this->writer_), jdata[format::kNameData], "init_image.bin", data_size, data);
         WriteBlockEnd();
     }
+
     /// @}
 };
 

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -92,6 +92,8 @@ class VulkanConsumerBase : public MetadataConsumerBase, public MarkerConsumerBas
 
     virtual void ProcessSetTlasToBlasRelationCommand(format::HandleId tlas, const std::vector<format::HandleId>& blases)
     {}
+
+    virtual void SetCurrentBlockIndex(uint64_t block_index) override { block_index_ = block_index; }
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -42,7 +42,6 @@ void VulkanDecoderBase::DispatchStateBeginMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessStateBeginMarker(frame_number);
     }
 }
@@ -51,7 +50,6 @@ void VulkanDecoderBase::DispatchStateEndMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessStateEndMarker(frame_number);
     }
 }
@@ -60,7 +58,6 @@ void VulkanDecoderBase::DispatchFrameEndMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessFrameEndMarker(frame_number);
     }
 }
@@ -71,7 +68,6 @@ void VulkanDecoderBase::DispatchDisplayMessageCommand(format::ThreadId thread_id
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessDisplayMessageCommand(message);
     }
 }
@@ -83,7 +79,6 @@ void VulkanDecoderBase::DispatchFillMemoryCommand(
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessFillMemoryCommand(memory_id, offset, size, data);
     }
 }
@@ -93,7 +88,6 @@ void VulkanDecoderBase::DispatchFillMemoryResourceValueCommand(
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessFillMemoryResourceValueCommand(command_header, data);
     }
 }
@@ -107,7 +101,6 @@ void VulkanDecoderBase::DispatchResizeWindowCommand(format::ThreadId thread_id,
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessResizeWindowCommand(surface_id, width, height);
     }
 }
@@ -119,7 +112,6 @@ void VulkanDecoderBase::DispatchResizeWindowCommand2(
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessResizeWindowCommand2(surface_id, width, height, pre_transform);
     }
 }
@@ -140,7 +132,6 @@ void VulkanDecoderBase::DispatchCreateHardwareBufferCommand(
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessCreateHardwareBufferCommand(
             memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
     }
@@ -152,7 +143,6 @@ void VulkanDecoderBase::DispatchDestroyHardwareBufferCommand(format::ThreadId th
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessDestroyHardwareBufferCommand(buffer_id);
     }
 }
@@ -165,7 +155,6 @@ void VulkanDecoderBase::DispatchCreateHeapAllocationCommand(format::ThreadId thr
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessCreateHeapAllocationCommand(allocation_id, allocation_size);
     }
 }
@@ -184,7 +173,6 @@ void VulkanDecoderBase::DispatchSetDevicePropertiesCommand(format::ThreadId   th
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetDevicePropertiesCommand(physical_device_id,
                                                     api_version,
                                                     driver_version,
@@ -206,7 +194,6 @@ void VulkanDecoderBase::DispatchSetDeviceMemoryPropertiesCommand(
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetDeviceMemoryPropertiesCommand(physical_device_id, memory_types, memory_heaps);
     }
 }
@@ -220,7 +207,6 @@ void VulkanDecoderBase::DispatchSetOpaqueAddressCommand(format::ThreadId thread_
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetOpaqueAddressCommand(device_id, object_id, address);
     }
 }
@@ -235,7 +221,6 @@ void VulkanDecoderBase::DispatchSetRayTracingShaderGroupHandlesCommand(format::T
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetRayTracingShaderGroupHandlesCommand(device_id, pipeline_id, data_size, data);
     }
 }
@@ -251,7 +236,6 @@ void VulkanDecoderBase::DispatchSetSwapchainImageStateCommand(
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetSwapchainImageStateCommand(device_id, swapchain_id, last_presented_image, image_state);
     }
 }
@@ -265,7 +249,6 @@ void VulkanDecoderBase::DispatchBeginResourceInitCommand(format::ThreadId thread
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessBeginResourceInitCommand(device_id, max_resource_size, max_copy_size);
     }
 }
@@ -276,7 +259,6 @@ void VulkanDecoderBase::DispatchEndResourceInitCommand(format::ThreadId thread_i
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessEndResourceInitCommand(device_id);
     }
 }
@@ -291,7 +273,6 @@ void VulkanDecoderBase::DispatchInitBufferCommand(format::ThreadId thread_id,
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessInitBufferCommand(device_id, buffer_id, data_size, data);
     }
 }
@@ -309,7 +290,6 @@ void VulkanDecoderBase::DispatchInitImageCommand(format::ThreadId             th
 
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessInitImageCommand(device_id, image_id, data_size, aspect, layout, level_sizes, data);
     }
 }
@@ -322,7 +302,6 @@ void VulkanDecoderBase::DispatchInitSubresourceCommand(const format::InitSubreso
 {
     for (auto consumer : consumers_)
     {
-        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessInitSubresourceCommand(command_header, data);
     }
 }
@@ -538,7 +517,9 @@ void VulkanDecoderBase::DispatchSetTlasToBlasDependencyCommand(format::HandleId 
 
 void VulkanDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
 {
-    block_index_ = block_index;
+    for (auto consumer : consumers_) {
+        consumer->SetCurrentBlockIndex(block_index);
+    }
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -517,7 +517,8 @@ void VulkanDecoderBase::DispatchSetTlasToBlasDependencyCommand(format::HandleId 
 
 void VulkanDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
 {
-    for (auto consumer : consumers_) {
+    for (auto consumer : consumers_)
+    {
         consumer->SetCurrentBlockIndex(block_index);
     }
 }

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -42,6 +42,7 @@ void VulkanDecoderBase::DispatchStateBeginMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessStateBeginMarker(frame_number);
     }
 }
@@ -50,6 +51,7 @@ void VulkanDecoderBase::DispatchStateEndMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessStateEndMarker(frame_number);
     }
 }
@@ -58,6 +60,7 @@ void VulkanDecoderBase::DispatchFrameEndMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessFrameEndMarker(frame_number);
     }
 }
@@ -68,6 +71,7 @@ void VulkanDecoderBase::DispatchDisplayMessageCommand(format::ThreadId thread_id
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessDisplayMessageCommand(message);
     }
 }
@@ -79,6 +83,7 @@ void VulkanDecoderBase::DispatchFillMemoryCommand(
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessFillMemoryCommand(memory_id, offset, size, data);
     }
 }
@@ -88,6 +93,7 @@ void VulkanDecoderBase::DispatchFillMemoryResourceValueCommand(
 {
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessFillMemoryResourceValueCommand(command_header, data);
     }
 }
@@ -101,6 +107,7 @@ void VulkanDecoderBase::DispatchResizeWindowCommand(format::ThreadId thread_id,
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessResizeWindowCommand(surface_id, width, height);
     }
 }
@@ -112,6 +119,7 @@ void VulkanDecoderBase::DispatchResizeWindowCommand2(
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessResizeWindowCommand2(surface_id, width, height, pre_transform);
     }
 }
@@ -132,6 +140,7 @@ void VulkanDecoderBase::DispatchCreateHardwareBufferCommand(
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessCreateHardwareBufferCommand(
             memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
     }
@@ -143,6 +152,7 @@ void VulkanDecoderBase::DispatchDestroyHardwareBufferCommand(format::ThreadId th
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessDestroyHardwareBufferCommand(buffer_id);
     }
 }
@@ -155,6 +165,7 @@ void VulkanDecoderBase::DispatchCreateHeapAllocationCommand(format::ThreadId thr
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessCreateHeapAllocationCommand(allocation_id, allocation_size);
     }
 }
@@ -173,6 +184,7 @@ void VulkanDecoderBase::DispatchSetDevicePropertiesCommand(format::ThreadId   th
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetDevicePropertiesCommand(physical_device_id,
                                                     api_version,
                                                     driver_version,
@@ -194,6 +206,7 @@ void VulkanDecoderBase::DispatchSetDeviceMemoryPropertiesCommand(
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetDeviceMemoryPropertiesCommand(physical_device_id, memory_types, memory_heaps);
     }
 }
@@ -207,6 +220,7 @@ void VulkanDecoderBase::DispatchSetOpaqueAddressCommand(format::ThreadId thread_
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetOpaqueAddressCommand(device_id, object_id, address);
     }
 }
@@ -221,6 +235,7 @@ void VulkanDecoderBase::DispatchSetRayTracingShaderGroupHandlesCommand(format::T
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetRayTracingShaderGroupHandlesCommand(device_id, pipeline_id, data_size, data);
     }
 }
@@ -236,6 +251,7 @@ void VulkanDecoderBase::DispatchSetSwapchainImageStateCommand(
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessSetSwapchainImageStateCommand(device_id, swapchain_id, last_presented_image, image_state);
     }
 }
@@ -249,6 +265,7 @@ void VulkanDecoderBase::DispatchBeginResourceInitCommand(format::ThreadId thread
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessBeginResourceInitCommand(device_id, max_resource_size, max_copy_size);
     }
 }
@@ -259,6 +276,7 @@ void VulkanDecoderBase::DispatchEndResourceInitCommand(format::ThreadId thread_i
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessEndResourceInitCommand(device_id);
     }
 }
@@ -273,6 +291,7 @@ void VulkanDecoderBase::DispatchInitBufferCommand(format::ThreadId thread_id,
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessInitBufferCommand(device_id, buffer_id, data_size, data);
     }
 }
@@ -290,6 +309,7 @@ void VulkanDecoderBase::DispatchInitImageCommand(format::ThreadId             th
 
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessInitImageCommand(device_id, image_id, data_size, aspect, layout, level_sizes, data);
     }
 }
@@ -302,6 +322,7 @@ void VulkanDecoderBase::DispatchInitSubresourceCommand(const format::InitSubreso
 {
     for (auto consumer : consumers_)
     {
+        consumer->SetCurrentBlockIndex(block_index_);
         consumer->ProcessInitSubresourceCommand(command_header, data);
     }
 }
@@ -513,6 +534,11 @@ void VulkanDecoderBase::DispatchSetTlasToBlasDependencyCommand(format::HandleId 
     {
         consumer->ProcessSetTlasToBlasRelationCommand(tlas, blases);
     }
+}
+
+void VulkanDecoderBase::SetCurrentBlockIndex(uint64_t block_index)
+{
+    block_index_ = block_index;
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -194,7 +194,7 @@ class VulkanDecoderBase : public ApiDecoder
     virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) override {}
 
     virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) override {}
-    
+
     virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
   protected:

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -194,6 +194,8 @@ class VulkanDecoderBase : public ApiDecoder
     virtual void DispatchDriverInfo(format::ThreadId thread_id, format::DriverInfoBlock& info) override {}
 
     virtual void DispatchExeFileInfo(format::ThreadId thread_id, format::ExeFileInfoBlock& info) override {}
+    
+    virtual void SetCurrentBlockIndex(uint64_t block_index) override;
 
   protected:
     const std::vector<VulkanConsumer*>& GetConsumers() const { return consumers_; }
@@ -229,6 +231,8 @@ class VulkanDecoderBase : public ApiDecoder
         HandlePointerDecoder<VkPipeline>                                pPipelines;
     };
     std::unordered_map<format::HandleId, DeferredOperationFunctionCallData> record_deferred_operation_function_call;
+
+    uint64_t block_index_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -231,8 +231,6 @@ class VulkanDecoderBase : public ApiDecoder
         HandlePointerDecoder<VkPipeline>                                pPipelines;
     };
     std::unordered_map<format::HandleId, DeferredOperationFunctionCallData> record_deferred_operation_function_call;
-
-    uint64_t block_index_;
 };
 
 GFXRECON_END_NAMESPACE(decode)


### PR DESCRIPTION
This PR is to fix issue https://github.com/LunarG/gfxreconstruct/issues/1343 where gfxrecon-convert would not emit indices for metadata blocks.
