### PR TITLE
Fix swapchain image wrappers lifetime

### DIFF
--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -423,6 +423,7 @@ CreateWrappedHandle<DeviceWrapper, SwapchainKHRWrapper, ImageWrapper>(VkDevice, 
         CreateWrappedNonDispatchHandle<ImageWrapper>(handle, get_id);
         wrapper                     = GetWrapper<ImageWrapper>(*handle);
         wrapper->is_swapchain_image = true;
+        wrapper->parent_swapchains.insert(co_parent);
         parent_wrapper->child_images.push_back(wrapper);
     }
 }
@@ -613,8 +614,12 @@ inline void DestroyWrappedHandle<SwapchainKHRWrapper>(VkSwapchainKHR handle)
 
         for (auto image_wrapper : wrapper->child_images)
         {
-            RemoveWrapper<ImageWrapper>(image_wrapper);
-            delete image_wrapper;
+            image_wrapper->parent_swapchains.erase(handle);
+            if (image_wrapper->parent_swapchains.empty())
+            {
+                RemoveWrapper<ImageWrapper>(image_wrapper);
+                delete image_wrapper;
+            }
         }
 
         RemoveWrapper<SwapchainKHRWrapper>(wrapper);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -201,18 +201,19 @@ struct ImageWrapper : public HandleWrapper<VkImage>
     const void*        bind_pnext{ nullptr };
     HandleUnwrapMemory bind_pnext_memory; // Global HandleUnwrapMemory could be reset anytime, so it should have its own
                                           // HandleUnwrapMemory.
-    format::HandleId      bind_memory_id{ format::kNullHandleId };
-    VkDeviceSize          bind_offset{ 0 };
-    uint32_t              queue_family_index{ 0 };
-    VkImageType           image_type{ VK_IMAGE_TYPE_2D };
-    VkFormat              format{ VK_FORMAT_UNDEFINED };
-    VkExtent3D            extent{ 0, 0, 0 };
-    uint32_t              mip_levels{ 0 };
-    uint32_t              array_layers{ 0 };
-    VkSampleCountFlagBits samples{};
-    VkImageTiling         tiling{};
-    VkImageLayout         current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
-    bool                  is_swapchain_image{ false };
+    format::HandleId         bind_memory_id{ format::kNullHandleId };
+    VkDeviceSize             bind_offset{ 0 };
+    uint32_t                 queue_family_index{ 0 };
+    VkImageType              image_type{ VK_IMAGE_TYPE_2D };
+    VkFormat                 format{ VK_FORMAT_UNDEFINED };
+    VkExtent3D               extent{ 0, 0, 0 };
+    uint32_t                 mip_levels{ 0 };
+    uint32_t                 array_layers{ 0 };
+    VkSampleCountFlagBits    samples{};
+    VkImageTiling            tiling{};
+    VkImageLayout            current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
+    bool                     is_swapchain_image{ false };
+    std::set<VkSwapchainKHR> parent_swapchains;
 };
 
 struct BufferViewWrapper : public HandleWrapper<VkBufferView>


### PR DESCRIPTION
If an application creates multiple swapchains, the images retrieved with vkGetSwapchainImages() can be the same for different swapchains. The parents of swapchain images were not tracked and when one swapchain was destroyed the swapchain image wrappers were as well, even though another swapchain might still be using them