### PR TITLE
Screenshot improvements

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -243,6 +243,7 @@ Optional arguments:
                         Image file format to use for screenshot generation.
                         Available formats are:
                             bmp         Bitmap file format.  This is the default format.
+                            png         Portable Network Graphics file format.
   --screenshot-dir <dir>
                         Directory to write screenshots.  Default is the current
                         working directory.

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -438,6 +438,7 @@ Optional arguments:
                         Image file format to use for screenshot generation.
                         Available formats are:
                             bmp         Bitmap file format.  This is the default format.
+                            png         Portable Network Graphics file format.
   --screenshot-dir <dir>
                         Directory to write screenshots.  Default is the current
                         working directory.

--- a/framework/graphics/dx12_image_renderer.cpp
+++ b/framework/graphics/dx12_image_renderer.cpp
@@ -70,6 +70,9 @@ void DX12ImageRenderer::ConvertR8G8B8A8ToB8G8R8A8(std::vector<char>& data, UINT 
 
 void DX12ImageRenderer::ConvertR10G10B10A2ToB8G8R8A8(std::vector<char>& data, UINT width, UINT height, UINT pitch)
 {
+    GFXRECON_LOG_INFO_ONCE("Converting image data form R10G10B10A2 to B8G8R8A8. Image RGB data will be truncated to 8 "
+                           "bits and alpha data will be set to 0xFF.");
+
     uint32_t* pixel;
     uint32_t  r16, g16, b16, a16, b8g8r8a8;
     for (UINT j = 0; j < height; j++)
@@ -78,10 +81,14 @@ void DX12ImageRenderer::ConvertR10G10B10A2ToB8G8R8A8(std::vector<char>& data, UI
         {
             pixel = (uint32_t*)((uint8_t*)&data[0] + i * 4 + j * pitch);
 
-            r16      = ((*pixel >> 0U) & 0x3FFU) << 6U;
-            g16      = ((*pixel >> 10U) & 0x3FFU) << 6U;
-            b16      = ((*pixel >> 20U) & 0x3FFU) << 6U;
-            a16      = ((*pixel >> 30U) & 0x03U) << 14U;
+            r16 = ((*pixel >> 0U) & 0x3FFU) << 6U;
+            g16 = ((*pixel >> 10U) & 0x3FFU) << 6U;
+            b16 = ((*pixel >> 20U) & 0x3FFU) << 6U;
+
+            // Ignore 2-bit alpha, generate opaque image data.
+            a16 = 0xFFFFU;
+
+            // This truncates 10bit RGB channels to 8 bits.
             b8g8r8a8 = ((b16 >> 8U) << 0U) | ((g16 >> 8U) << 8U) | ((r16 >> 8U) << 16U) | ((a16 >> 8U) << 24U);
             *pixel   = b8g8r8a8;
         }

--- a/framework/util/image_writer.cpp
+++ b/framework/util/image_writer.cpp
@@ -77,8 +77,10 @@ bool WriteBmpImage(
         row_pitch = pitch;
     }
 
-    uint32_t image_size = height * row_pitch;
-    if (image_size <= data_size)
+    // BMP image data doesn't require row padding, so compute size with height * width * kImageBpp, not row_pitch *
+    // height.
+    uint32_t bmp_image_size = height * width * kImageBpp;
+    if (bmp_image_size <= data_size)
     {
         FILE*   file   = nullptr;
         int32_t result = util::platform::FileOpen(&file, filename.c_str(), "wb");
@@ -92,7 +94,7 @@ bool WriteBmpImage(
             file_header.reserved1 = 0;
             file_header.reserved2 = 0;
             file_header.off_bits  = sizeof(file_header) + sizeof(info_header);
-            file_header.size      = image_size + file_header.off_bits;
+            file_header.size      = bmp_image_size + file_header.off_bits;
 
             info_header.size             = sizeof(info_header);
             info_header.width            = width;
@@ -137,6 +139,7 @@ bool WritePngImage(
 
 #ifdef GFXRECON_ENABLE_PNG_SCREENSHOT
     uint32_t row_pitch = pitch == 0 ? width * kImageBpp : pitch;
+    stbi_write_png_compression_level = 4;
     if (1 == stbi_write_png(filename.c_str(), width, height, kImageBpp, data, row_pitch))
     {
         success = true;


### PR DESCRIPTION
- Fix BMP data size calculation for BMP screenshots.
- Reduce PNG compression for better speed.
- Write opaque screenshot for R10G10B10A2 images.
- Add png format info to desktop usage readme files.