### PR TITLE
Propagate virtual swapchain image compression

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -35,7 +35,6 @@
 #include "vulkan/vulkan.h"
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -406,7 +405,8 @@ struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
     std::vector<uint32_t> queue_family_indices{ 0 };
 
     // For virtual swapchain, we want the compression on virtual images to be the same as on the true swapchain
-    std::optional<VkImageCompressionControlEXT> compression_control;
+    std::vector<VkImageCompressionFixedRateFlagsEXT> compression_fixed_rate_flags;
+    std::shared_ptr<VkImageCompressionControlEXT>    compression_control;
 
     // When replay is restricted to a specific surface, a dummy swapchain is created for the omitted surfaces, requiring
     // backing images.

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -35,6 +35,7 @@
 #include "vulkan/vulkan.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -390,7 +391,7 @@ struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
     uint32_t             width{ 0 };
     uint32_t             height{ 0 };
     VkFormat             format{ VK_FORMAT_UNDEFINED };
-    std::vector<VkImage> images; // This image could be virtual or real according to if it uses VirutalSwapchain.
+    std::vector<VkImage> images; // This image could be virtual or real according to if it uses VirtualSwapchain.
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // The acquired_indices value and the remapping performed with it.
@@ -403,6 +404,9 @@ struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
 
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<uint32_t> queue_family_indices{ 0 };
+
+    // For virtual swapchain, we want the compression on virtual images to be the same as on the true swapchain
+    std::optional<VkImageCompressionControlEXT> compression_control;
 
     // When replay is restricted to a specific surface, a dummy swapchain is created for the omitted surfaces, requiring
     // backing images.

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5105,6 +5105,23 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
             }
         }
 
+        const VkBaseInStructure* current = reinterpret_cast<const VkBaseInStructure*>(modified_create_info.pNext);
+        while (current != nullptr)
+        {
+            if (current->sType == VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT)
+            {
+                const VkImageCompressionControlEXT* compression_control =
+                    reinterpret_cast<const VkImageCompressionControlEXT*>(current);
+
+                swapchain_info->compression_control.emplace(*compression_control);
+                swapchain_info->compression_control->pNext = nullptr;
+
+                break;
+            }
+
+            current = current->pNext;
+        }
+
         result = swapchain_->CreateSwapchainKHR(original_result,
                                                 func,
                                                 device_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5113,9 +5113,29 @@ VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(
                 const VkImageCompressionControlEXT* compression_control =
                     reinterpret_cast<const VkImageCompressionControlEXT*>(current);
 
-                swapchain_info->compression_control.emplace(*compression_control);
-                swapchain_info->compression_control->pNext = nullptr;
+                swapchain_info->compression_control =
+                    std::make_shared<VkImageCompressionControlEXT>(*compression_control);
+                VkImageCompressionControlEXT* copy_target = swapchain_info->compression_control.get();
 
+                // If the fixed rate flags are present, then create a copy for the internal version of
+                // the structure used to pass to swapchain image creation.
+                if (compression_control->compressionControlPlaneCount > 0 &&
+                    compression_control->pFixedRateFlags != nullptr)
+                {
+                    std::copy(compression_control->pFixedRateFlags,
+                              compression_control->pFixedRateFlags + compression_control->compressionControlPlaneCount,
+                              std::back_inserter(swapchain_info->compression_fixed_rate_flags));
+                    copy_target->pFixedRateFlags = swapchain_info->compression_fixed_rate_flags.data();
+                }
+                else
+                {
+                    // Set everything as if the count was 0 because it could only get here if there was
+                    // nothing in it already, or there was no valid data.
+                    copy_target->compressionControlPlaneCount = 0;
+                    copy_target->pFixedRateFlags              = nullptr;
+                    swapchain_info->compression_fixed_rate_flags.clear();
+                }
+                copy_target->pNext = nullptr;
                 break;
             }
 

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -393,6 +393,11 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const DeviceInfo*  
             VK_IMAGE_LAYOUT_UNDEFINED                                           // initialLayout
         };
 
+        if (swapchain_info->compression_control.has_value())
+        {
+            image_create_info.pNext = &swapchain_info->compression_control.value();
+        }
+
         if ((swapchain_info->image_flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) ==
             VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)
         {

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -393,9 +393,11 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const DeviceInfo*  
             VK_IMAGE_LAYOUT_UNDEFINED                                           // initialLayout
         };
 
-        if (swapchain_info->compression_control.has_value())
+        // If compression control structure was present, pass it along to the image
+        // create info.
+        if (swapchain_info->compression_control)
         {
-            image_create_info.pNext = &swapchain_info->compression_control.value();
+            image_create_info.pNext = swapchain_info->compression_control.get();
         }
 
         if ((swapchain_info->image_flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) ==


### PR DESCRIPTION
When a `VkImageCompressionControlEXT` instance is found in the `pNext` chain of a `VkSwapchainCreateInfoKHR` instance at swapchain creation for a virtual swapchain, the same compression control should be used to create the images of virtual swapchain (the one not created by the WSI).

This is what this commit does.
