### PR TITLE
Fix measurement options for android

### DIFF
--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -181,15 +181,12 @@ def MakeExtrasString(args):
 
     if args.quit_after_measurement_range:
         arg_list.append('--quit-after-measurement-range')
-        arg_list.append('{}'.format(args.quit_after_measurement_range))
 
     if args.flush_measurement_range:
         arg_list.append('--flush-measurement-range')
-        arg_list.append('{}'.format(args.flush_measurement_range))
 
     if args.flush_inside_measurement_range:
         arg_list.append('--flush-inside-measurement-range')
-        arg_list.append('{}'.format(args.flush_inside_measurement_range))
 
     if args.swapchain:
         arg_list.append('--swapchain')


### PR DESCRIPTION
Flush/quit on measurement range options should not have an argument to parse.
Using the following commandline for android replay:
`gfxrecon.py replay --quit-after-measurement-range trace.gfxr`
Will currently generate faulty argument list:
`--quit-after-measurement-range True trace.gfxr`
that won't be parsed properly in the replayer. Correct argument list should be:
`--quit-after-measurement-range trace.gfxr`
This PR removes the extra bool parameter from quit-after-measurement-range flush-measurement-range and flush-inside-measurement-range options.
