### PR TITLE
Remove duplicate line in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,6 @@ AlignEscapedNewlines: true
 AlignOperands: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortFunctionsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false


### PR DESCRIPTION
This cases newer versions of clang-format to fail to format the file.