### PR TITLE
Option for offscreen frame boundary conversion

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -876,6 +876,10 @@ optional arguments:
                         in the original capture. This allows preserving frames
                         when capturing a replay that uses. offscreen swapchain.
                         (forwarded to replay tool)
+  --use-ext-frame-boundary
+                        Convert all offscreen frame boundaries to
+                        `VK_EXT_frame_boundary` frame boundaries.
+                        (forwarded to replay tool)
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -549,6 +549,9 @@ Optional arguments:
               was called in the original capture.
               This allows preserving frames when capturing a replay that uses.
               offscreen swapchain.
+  --use-ext-frame-boundary
+              Convert all offscreen frame boundaries to `VK_EXT_frame_boundary`
+              frame boundaries.
 ```
 
 ### Key Controls

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -86,6 +86,7 @@ def CreateReplayParser():
     parser.add_argument('--onhb', '--omit-null-hardware-buffers', action='store_true', default=False, help='Omit Vulkan calls that would pass a NULL AHardwareBuffer* (forwarded to replay tool)')
     parser.add_argument('--use-colorspace-fallback', action='store_true', default=False, help='Swap the swapchain color space if unsupported by replay device. Check if color space is not supported by replay device and swap to VK_COLOR_SPACE_SRGB_NONLINEAR_KHR. (forwarded to replay tool).')
     parser.add_argument('--offscreen-swapchain-frame-boundary', action='store_true', default=False, help='Should only be used with offscreen swapchain. Activates the extension VK_EXT_frame_boundary (always supported if trimming, checks for driver support otherwise) and inserts command buffer submission with VkFrameBoundaryEXT where vkQueuePresentKHR was called in the original capture. This allows preserving frames when capturing a replay that uses. offscreen swapchain. (forwarded to replay tool)')
+    parser.add_argument('--use-ext-frame-boundary', action='store_true', default=False, help='Convert all offscreen frame boundaries to `VK_EXT_frame_boundary` frame boundaries. (forwarded to replay tool)')
     parser.add_argument('--mfr', '--measurement-frame-range', metavar='START-END', help='Custom framerange to measure FPS for. This range will include the start frame but not the end frame. The measurement frame range defaults to all frames except the loading frame but can be configured for any range. If the end frame is past the last frame in the trace it will be clamped to the frame after the last (so in that case the results would include the last frame). (forwarded to replay tool)')
     parser.add_argument('--measurement-file', metavar='DEVICE_FILE', help='Write measurements to a file at the specified path. Default is: \'/sdcard/gfxrecon-measurements.json\' on android and \'./gfxrecon-measurements.json\' on desktop. (forwarded to replay tool)')
     parser.add_argument('--quit-after-measurement-range', action='store_true', default=False, help='If this is specified the replayer will abort when it reaches the <end_frame> specified in the --measurement-frame-range argument. (forwarded to replay tool)')
@@ -198,6 +199,9 @@ def MakeExtrasString(args):
     
     if args.offscreen_swapchain_frame_boundary:
         arg_list.append('--offscreen-swapchain-frame-boundary')
+    
+    if args.use_ext_frame_boundary:
+        arg_list.append('--use-ext-frame-boundary')
 
     if args.memory_translation:
         arg_list.append('-m')

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -84,6 +84,11 @@ class Application final
 
     void StopRunning() { running_ = false; }
 
+    uint32_t GetCurrentFrameNumber() const
+    {
+        return file_processor_->GetCurrentFrameNumber();
+    }
+
   private:
     // clang-format off
     std::string                                                  name_;              ///< Application name to display in window title bar.

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -460,6 +460,7 @@ struct ShaderEXTInfo : VulkanObjectInfo<VkShaderEXT>
 struct CommandBufferInfo : public VulkanPoolObjectInfo<VkCommandBuffer>
 {
     bool                                                is_frame_boundary{ false };
+    std::string                                         frame_boundary_label;
     std::vector<format::HandleId>                       frame_buffer_ids;
     std::unordered_map<format::HandleId, VkImageLayout> image_layout_barriers;
 };

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -984,9 +984,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                         CommandBufferInfo*        command_buffer_info,
                                         VkCommandBufferResetFlags flags);
 
-    void     OverrideCmdDebugMarkerInsertEXT(PFN_vkCmdDebugMarkerInsertEXT                             func,
-                                             CommandBufferInfo*                                        command_buffer_info,
-                                             StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* marker_info_decoder);
+    void OverrideCmdDebugMarkerInsertEXT(PFN_vkCmdDebugMarkerInsertEXT                             func,
+                                         CommandBufferInfo*                                        command_buffer_info,
+                                         StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* marker_info_decoder);
+
+    void OverrideCmdInsertDebugUtilsLabelEXT(PFN_vkCmdInsertDebugUtilsLabelEXT                   func,
+                                             CommandBufferInfo*                                  command_buffer_info,
+                                             StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* label_info_decoder);
+
     VkResult OverrideWaitSemaphores(PFN_vkWaitSemaphores                                     func,
                                     VkResult                                                 original_result,
                                     const DeviceInfo*                                        device_info,
@@ -1023,6 +1028,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                        StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* create_info_decoder,
                                        StructPointerDecoder<Decoded_VkAllocationCallbacks>*   allocator_decoder,
                                        HandlePointerDecoder<VkFramebuffer>*                   frame_buffer_decoder);
+
+    void OverrideFrameBoundaryANDROID(PFN_vkFrameBoundaryANDROID func,
+                                      const DeviceInfo*          device_info,
+                                      const SemaphoreInfo*       semaphore_info,
+                                      const ImageInfo*           image_info);
 
     const VulkanReplayOptions options_;
 
@@ -1137,6 +1147,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info) const;
 
+    void FillFrameBoundaryExtFromCommandBufferInfo(const CommandBufferInfo* command_buffer_info,
+                                                   VkFrameBoundaryEXT*      frame_boundary,
+                                                   std::vector<VkImage>&    frame_boundary_images);
+    void InsertFrameBoundaryExt(void* pnext_chain, const VkFrameBoundaryEXT* frame_boundary);
+
     bool CheckCommandBufferInfoForFrameBoundary(const CommandBufferInfo* command_buffer_info);
     bool CheckPNextChainForFrameBoundary(const DeviceInfo* device_info, const Decoded_VkBaseOutStructure* current);
 
@@ -1211,6 +1226,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_set<uint32_t>      removed_swapchain_indices_;
     std::vector<uint32_t>             capture_image_indices_;
     std::vector<SwapchainKHRInfo*>    swapchain_infos_;
+
+    // Resources for use-ext-frame-boundary option used by OverrideFrameBoundaryANDROID
+    std::unordered_map<VkDevice, std::pair<VkCommandPool, VkCommandBuffer>> fba_resources_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -49,6 +49,7 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         remove_unsupported_features{ false };
     bool                         use_colorspace_fallback{ false };
     bool                         offscreen_swapchain_frame_boundary{ false };
+    bool                         use_ext_frame_boundary{ false };
     util::SwapchainOption        swapchain_option{ util::SwapchainOption::kVirtual };
     int32_t                      override_gpu_group_index{ -1 };
     int32_t                      surface_index{ -1 };

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -5587,11 +5587,11 @@ void VulkanReplayConsumer::Process_vkFrameBoundaryANDROID(
     format::HandleId                            semaphore,
     format::HandleId                            image)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkSemaphore in_semaphore = MapHandle<SemaphoreInfo>(semaphore, &VulkanObjectInfoTable::GetSemaphoreInfo);
-    VkImage in_image = MapHandle<ImageInfo>(image, &VulkanObjectInfoTable::GetImageInfo);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_semaphore = GetObjectInfoTable().GetSemaphoreInfo(semaphore);
+    auto in_image = GetObjectInfoTable().GetImageInfo(image);
 
-    GetDeviceTable(in_device)->FrameBoundaryANDROID(in_device, in_semaphore, in_image);
+    OverrideFrameBoundaryANDROID(GetDeviceTable(in_device->handle)->FrameBoundaryANDROID, in_device, in_semaphore, in_image);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
@@ -6364,10 +6364,9 @@ void VulkanReplayConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
-    VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
-    const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo->GetPointer();
+    auto in_commandBuffer = GetObjectInfoTable().GetCommandBufferInfo(commandBuffer);
 
-    GetDeviceTable(in_commandBuffer)->CmdInsertDebugUtilsLabelEXT(in_commandBuffer, in_pLabelInfo);
+    OverrideCmdInsertDebugUtilsLabelEXT(GetDeviceTable(in_commandBuffer->handle)->CmdInsertDebugUtilsLabelEXT, in_commandBuffer, pLabelInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDebugUtilsMessengerEXT(

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -101,6 +101,8 @@
     "vkCreateFramebuffer": "OverrideCreateFramebuffer",
     "vkAcquireProfilingLockKHR": "OverrideAcquireProfilingLockKHR",
     "vkWaitForPresentKHR": "OverrideWaitForPresentKHR",
-    "vkWaitSemaphores": "OverrideWaitSemaphores"
+    "vkWaitSemaphores": "OverrideWaitSemaphores",
+    "vkCmdInsertDebugUtilsLabelEXT": "OverrideCmdInsertDebugUtilsLabelEXT",
+    "vkFrameBoundaryANDROID": "OverrideFrameBoundaryANDROID"
   }
 }

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -32,7 +32,7 @@ const char kOptions[] =
     "screenshot-all,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-range,--fmr|--flush-"
     "measurement-range,--flush-inside-measurement-range,--use-captured-swapchain-indices,--dcp,--"
     "discard-cached-psos,--use-colorspace-fallback,--use-cached-psos,--dx12-override-object-names,"
-    "--offscreen-swapchain-frame-boundary";
+    "--offscreen-swapchain-frame-boundary,--use-ext-frame-boundary";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -210,6 +210,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\twas called in the original capture.");
     GFXRECON_WRITE_CONSOLE("          \t\tThis allows preserving frames when capturing a replay that uses.");
     GFXRECON_WRITE_CONSOLE("          \t\toffscreen swapchain.");
+    GFXRECON_WRITE_CONSOLE("  --use-ext-frame-boundary");
+    GFXRECON_WRITE_CONSOLE("          \t\tConvert all offscreen frame boundaries to `VK_EXT_frame_boundary`");
+    GFXRECON_WRITE_CONSOLE("          \t\tframe boundaries.");
     GFXRECON_WRITE_CONSOLE("  --measurement-frame-range <start_frame>-<end_frame>");
     GFXRECON_WRITE_CONSOLE("          \t\tCustom framerange to measure FPS for.");
     GFXRECON_WRITE_CONSOLE("          \t\tThis range will include the start frame but not the end frame.");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -109,6 +109,7 @@ const char kEnableUseCapturedSwapchainIndices[] =
     "--use-captured-swapchain-indices"; // The same: util::SwapchainOption::kCaptured
 const char kColorspaceFallback[]              = "--use-colorspace-fallback";
 const char kOffscreenSwapchainFrameBoundary[] = "--offscreen-swapchain-frame-boundary";
+const char kUseExtFrameBoundaryOption[]       = "--use-ext-frame-boundary";
 const char kFormatArgument[]                  = "--format";
 const char kIncludeBinariesOption[]           = "--include-binaries";
 const char kExpandFlagsOption[]               = "--expand-flags";
@@ -898,6 +899,11 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (arg_parser.IsOptionSet(kColorspaceFallback))
     {
         replay_options.use_colorspace_fallback = true;
+    }
+
+    if (arg_parser.IsOptionSet(kUseExtFrameBoundaryOption))
+    {
+        replay_options.use_ext_frame_boundary = true;
     }
 
     if (arg_parser.IsOptionSet(kOffscreenSwapchainFrameBoundary))


### PR DESCRIPTION
Add `--use-ext-frame-boundary` option to convert all offscreen frame boundaries to `VK_EXT_frame_boundary` frame boundaries.

Extensions used to specify an offscreen frame boundary can be unsupported by the replay device. As there are many of such extensions, it seems important to be able to "convert" these frame boundaries to a more "standard" one.
The `VK_EXT_frame_boundary` seems to be the best choice as it is specialy designed for this purpose, platform independent, and supports all functionnalities supported by other extensions:
- Specifying resources attached to the frame (images and buffers)
- Depending on the execution of other commands
- Specifying frame number, label and description

This commit depends on:
- #1301 - Not mandatory, but this commit "extend" it
- #1448 - This commit relies on top of a bug corrected by it, so this should be better to merge it first then rebase this commit on top of it