### PR TITLE
Clarify Vulkan-specific items

### DIFF
--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -116,10 +116,10 @@ std::string AndroidWindow::GetWsiExtension() const
     return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
 }
 
-VkResult AndroidWindow::CreateSurface(const encode::InstanceTable* table,
-                                      VkInstance                   instance,
-                                      VkFlags                      flags,
-                                      VkSurfaceKHR*                pSurface)
+VkResult AndroidWindow::CreateSurface(const encode::VulkanInstanceTable* table,
+                                      VkInstance                         instance,
+                                      VkFlags                            flags,
+                                      VkSurfaceKHR*                      pSurface)
 {
     if (table != nullptr)
     {
@@ -133,7 +133,7 @@ VkResult AndroidWindow::CreateSurface(const encode::InstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void AndroidWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void AndroidWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -165,9 +165,9 @@ void AndroidWindowFactory::Destroy(decode::Window* window)
     GFXRECON_UNREFERENCED_PARAMETER(window);
 }
 
-VkBool32 AndroidWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                    VkPhysicalDevice             physical_device,
-                                                                    uint32_t                     queue_family_index)
+VkBool32 AndroidWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                    VkPhysicalDevice                   physical_device,
+                                                                    uint32_t queue_family_index)
 {
     GFXRECON_UNREFERENCED_PARAMETER(table);
     GFXRECON_UNREFERENCED_PARAMETER(physical_device);

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -65,12 +65,13 @@ class AndroidWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
-    virtual VkResult CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface) override;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) override;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     AndroidContext* android_context_;
@@ -94,9 +95,9 @@ class AndroidWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) override;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t queue_family_index) override;
 
   private:
     AndroidContext* android_context_;

--- a/framework/application/display_window.cpp
+++ b/framework/application/display_window.cpp
@@ -34,9 +34,9 @@ DisplayWindow::DisplayWindow(DisplayContext* display_context) : display_context_
     assert(display_context_ != nullptr);
 }
 
-VkResult DisplayWindow::SelectPhysicalDevice(const encode::InstanceTable* table,
-                                             VkInstance                   instance,
-                                             VkPhysicalDevice*            physical_device) const
+VkResult DisplayWindow::SelectPhysicalDevice(const encode::VulkanInstanceTable* table,
+                                             VkInstance                         instance,
+                                             VkPhysicalDevice*                  physical_device) const
 {
     assert(table);
     uint32_t physical_device_count = 0;
@@ -73,9 +73,9 @@ VkResult DisplayWindow::SelectPhysicalDevice(const encode::InstanceTable* table,
     return VK_SUCCESS;
 }
 
-VkResult DisplayWindow::SelectDisplay(const encode::InstanceTable* table,
-                                      VkPhysicalDevice             physical_device,
-                                      VkDisplayKHR*                display) const
+VkResult DisplayWindow::SelectDisplay(const encode::VulkanInstanceTable* table,
+                                      VkPhysicalDevice                   physical_device,
+                                      VkDisplayKHR*                      display) const
 {
     assert(table);
     uint32_t num_displays;
@@ -101,10 +101,10 @@ VkResult DisplayWindow::SelectDisplay(const encode::InstanceTable* table,
     return VK_SUCCESS;
 }
 
-VkResult DisplayWindow::SelectMode(const encode::InstanceTable* table,
-                                   VkPhysicalDevice             physical_device,
-                                   VkDisplayKHR                 display,
-                                   VkDisplayModePropertiesKHR*  mode_props) const
+VkResult DisplayWindow::SelectMode(const encode::VulkanInstanceTable* table,
+                                   VkPhysicalDevice                   physical_device,
+                                   VkDisplayKHR                       display,
+                                   VkDisplayModePropertiesKHR*        mode_props) const
 {
     assert(table);
     uint32_t num_modes;
@@ -128,11 +128,11 @@ VkResult DisplayWindow::SelectMode(const encode::InstanceTable* table,
     return VK_SUCCESS;
 }
 
-VkResult DisplayWindow::SelectPlane(const encode::InstanceTable* table,
-                                    VkPhysicalDevice             physical_device,
-                                    VkDisplayKHR                 display,
-                                    uint32_t*                    plane_index,
-                                    VkDisplayPlanePropertiesKHR* plane_props) const
+VkResult DisplayWindow::SelectPlane(const encode::VulkanInstanceTable* table,
+                                    VkPhysicalDevice                   physical_device,
+                                    VkDisplayKHR                       display,
+                                    uint32_t*                          plane_index,
+                                    VkDisplayPlanePropertiesKHR*       plane_props) const
 {
     assert(table);
     uint32_t num_planes;
@@ -199,10 +199,10 @@ std::string DisplayWindow::GetWsiExtension() const
     return VK_KHR_DISPLAY_EXTENSION_NAME;
 }
 
-VkResult DisplayWindow::CreateSurface(const encode::InstanceTable* table,
-                                      VkInstance                   instance,
-                                      VkFlags                      flags,
-                                      VkSurfaceKHR*                pSurface)
+VkResult DisplayWindow::CreateSurface(const encode::VulkanInstanceTable* table,
+                                      VkInstance                         instance,
+                                      VkFlags                            flags,
+                                      VkSurfaceKHR*                      pSurface)
 {
     VkResult error = VK_ERROR_INITIALIZATION_FAILED;
     if (table)
@@ -264,7 +264,7 @@ VkResult DisplayWindow::CreateSurface(const encode::InstanceTable* table,
     return error;
 }
 
-void DisplayWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void DisplayWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table)
     {
@@ -297,9 +297,9 @@ void DisplayWindowFactory::Destroy(decode::Window* window)
     GFXRECON_UNREFERENCED_PARAMETER(window);
 }
 
-VkBool32 DisplayWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                    VkPhysicalDevice             physical_device,
-                                                                    uint32_t                     queue_family_index)
+VkBool32 DisplayWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                    VkPhysicalDevice                   physical_device,
+                                                                    uint32_t queue_family_index)
 {
     GFXRECON_UNREFERENCED_PARAMETER(table);
     GFXRECON_UNREFERENCED_PARAMETER(physical_device);

--- a/framework/application/display_window.h
+++ b/framework/application/display_window.h
@@ -61,28 +61,30 @@ class DisplayWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
-    virtual VkResult CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface) override;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) override;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
-    VkResult SelectPhysicalDevice(const encode::InstanceTable* table,
-                                  VkInstance                   instance,
-                                  VkPhysicalDevice*            physical_device) const;
-    VkResult
-    SelectDisplay(const encode::InstanceTable* table, VkPhysicalDevice physical_device, VkDisplayKHR* display) const;
-    VkResult SelectMode(const encode::InstanceTable* table,
-                        VkPhysicalDevice             physical_device,
-                        VkDisplayKHR                 display,
-                        VkDisplayModePropertiesKHR*  mode_props) const;
-    VkResult SelectPlane(const encode::InstanceTable* table,
-                         VkPhysicalDevice             physical_device,
-                         VkDisplayKHR                 display,
-                         uint32_t*                    plane_index,
-                         VkDisplayPlanePropertiesKHR* plane_props) const;
+    VkResult SelectPhysicalDevice(const encode::VulkanInstanceTable* table,
+                                  VkInstance                         instance,
+                                  VkPhysicalDevice*                  physical_device) const;
+    VkResult SelectDisplay(const encode::VulkanInstanceTable* table,
+                           VkPhysicalDevice                   physical_device,
+                           VkDisplayKHR*                      display) const;
+    VkResult SelectMode(const encode::VulkanInstanceTable* table,
+                        VkPhysicalDevice                   physical_device,
+                        VkDisplayKHR                       display,
+                        VkDisplayModePropertiesKHR*        mode_props) const;
+    VkResult SelectPlane(const encode::VulkanInstanceTable* table,
+                         VkPhysicalDevice                   physical_device,
+                         VkDisplayKHR                       display,
+                         uint32_t*                          plane_index,
+                         VkDisplayPlanePropertiesKHR*       plane_props) const;
 
   private:
     DisplayContext* display_context_;
@@ -102,9 +104,9 @@ class DisplayWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) override;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t queue_family_index) override;
 
   private:
     DisplayContext* display_context_;

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -96,10 +96,10 @@ std::string HeadlessWindow::GetWsiExtension() const
     return VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME;
 }
 
-VkResult HeadlessWindow::CreateSurface(const encode::InstanceTable* table,
-                                       VkInstance                   instance,
-                                       VkFlags                      flags,
-                                       VkSurfaceKHR*                pSurface)
+VkResult HeadlessWindow::CreateSurface(const encode::VulkanInstanceTable* table,
+                                       VkInstance                         instance,
+                                       VkFlags                            flags,
+                                       VkSurfaceKHR*                      pSurface)
 {
     GFXRECON_UNREFERENCED_PARAMETER(flags);
 
@@ -113,7 +113,7 @@ VkResult HeadlessWindow::CreateSurface(const encode::InstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void HeadlessWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void HeadlessWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -146,9 +146,9 @@ void HeadlessWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 HeadlessWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                     VkPhysicalDevice             physical_device,
-                                                                     uint32_t                     queue_family_index)
+VkBool32 HeadlessWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                     VkPhysicalDevice                   physical_device,
+                                                                     uint32_t queue_family_index)
 {
     GFXRECON_UNREFERENCED_PARAMETER(table);
     GFXRECON_UNREFERENCED_PARAMETER(physical_device);

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -63,12 +63,13 @@ class HeadlessWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
-    virtual VkResult CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface) override;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) override;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     HeadlessContext* headless_context_;
@@ -86,9 +87,9 @@ class HeadlessWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) override;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t queue_family_index) override;
 
   private:
     HeadlessContext* headless_context_;

--- a/framework/application/metal_window.h
+++ b/framework/application/metal_window.h
@@ -65,14 +65,14 @@ public:
 
     std::string GetWsiExtension() const override;
 
-    VkResult CreateSurface(const encode::InstanceTable* table,
-                           VkInstance                   instance,
-                           VkFlags                      flags,
-                           VkSurfaceKHR*                pSurface) override;
+    VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                           VkInstance                         instance,
+                           VkFlags                            flags,
+                           VkSurfaceKHR*                      pSurface) override;
 
-    void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    void DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
-private:
+  private:
     GFXReconWindowDelegate* window_delegate_;
     MetalContext* metal_context_;
     NSWindow*     window_;
@@ -92,10 +92,11 @@ public:
 
     void Destroy(decode::Window* window) override;
 
-    VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                  VkPhysicalDevice             physical_device,
-                                                  uint32_t                     queue_family_index) override;
-private:
+    VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                  VkPhysicalDevice                   physical_device,
+                                                  uint32_t                           queue_family_index) override;
+
+  private:
     MetalContext* metal_context_;
 };
 

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -237,10 +237,10 @@ std::string MetalWindow::GetWsiExtension() const
     return VK_EXT_METAL_SURFACE_EXTENSION_NAME;
 }
 
-VkResult MetalWindow::CreateSurface(const encode::InstanceTable* table,
-                                    VkInstance                   instance,
-                                    VkFlags                      flags,
-                                    VkSurfaceKHR*                pSurface)
+VkResult MetalWindow::CreateSurface(const encode::VulkanInstanceTable* table,
+                                    VkInstance                         instance,
+                                    VkFlags                            flags,
+                                    VkSurfaceKHR*                      pSurface)
 {
     if (table)
     {
@@ -253,7 +253,7 @@ VkResult MetalWindow::CreateSurface(const encode::InstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void MetalWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void MetalWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table)
         table->DestroySurfaceKHR(instance, surface, nullptr);
@@ -282,9 +282,9 @@ void MetalWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 MetalWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                  VkPhysicalDevice             physical_device,
-                                                                  uint32_t                     queue_family_index)
+VkBool32 MetalWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                  VkPhysicalDevice                   physical_device,
+                                                                  uint32_t                           queue_family_index)
 {
     return true;
 }

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -248,10 +248,10 @@ std::string WaylandWindow::GetWsiExtension() const
     return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
 }
 
-VkResult WaylandWindow::CreateSurface(const encode::InstanceTable* table,
-                                      VkInstance                   instance,
-                                      VkFlags                      flags,
-                                      VkSurfaceKHR*                pSurface)
+VkResult WaylandWindow::CreateSurface(const encode::VulkanInstanceTable* table,
+                                      VkInstance                         instance,
+                                      VkFlags                            flags,
+                                      VkSurfaceKHR*                      pSurface)
 {
     if (table != nullptr)
     {
@@ -265,7 +265,7 @@ VkResult WaylandWindow::CreateSurface(const encode::InstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void WaylandWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void WaylandWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -371,9 +371,9 @@ void WaylandWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 WaylandWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                    VkPhysicalDevice             physical_device,
-                                                                    uint32_t                     queue_family_index)
+VkBool32 WaylandWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                    VkPhysicalDevice                   physical_device,
+                                                                    uint32_t queue_family_index)
 {
     assert(wayland_context_->GetDisplay() != nullptr);
     return table->GetPhysicalDeviceWaylandPresentationSupportKHR(

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -71,12 +71,13 @@ class WaylandWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
-    virtual VkResult CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface) override;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) override;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     static void HandleSurfaceEnter(void* data, struct wl_surface* surface, struct wl_output* output);
@@ -124,9 +125,9 @@ class WaylandWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) override;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t queue_family_index) override;
 
   private:
     WaylandContext* wayland_context_;

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -265,10 +265,10 @@ std::string Win32Window::GetWsiExtension() const
     return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
 }
 
-VkResult Win32Window::CreateSurface(const encode::InstanceTable* table,
-                                    VkInstance                   instance,
-                                    VkFlags                      flags,
-                                    VkSurfaceKHR*                pSurface)
+VkResult Win32Window::CreateSurface(const encode::VulkanInstanceTable* table,
+                                    VkInstance                         instance,
+                                    VkFlags                            flags,
+                                    VkSurfaceKHR*                      pSurface)
 {
     if (table != nullptr)
     {
@@ -282,7 +282,7 @@ VkResult Win32Window::CreateSurface(const encode::InstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void Win32Window::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void Win32Window::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -315,9 +315,9 @@ void Win32WindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 Win32WindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                  VkPhysicalDevice             physical_device,
-                                                                  uint32_t                     queue_family_index)
+VkBool32 Win32WindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                  VkPhysicalDevice                   physical_device,
+                                                                  uint32_t                           queue_family_index)
 {
     return table->GetPhysicalDeviceWin32PresentationSupportKHR(physical_device, queue_family_index);
 }

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -66,12 +66,13 @@ class Win32Window : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
-    virtual VkResult CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface) override;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) override;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     HWND          hwnd_;
@@ -96,9 +97,9 @@ class Win32WindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) override;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t queue_family_index) override;
 
   private:
     Win32Context* win32_context_;

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -403,8 +403,10 @@ std::string XcbWindow::GetWsiExtension() const
     return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
 }
 
-VkResult
-XcbWindow::CreateSurface(const encode::InstanceTable* table, VkInstance instance, VkFlags flags, VkSurfaceKHR* pSurface)
+VkResult XcbWindow::CreateSurface(const encode::VulkanInstanceTable* table,
+                                  VkInstance                         instance,
+                                  VkFlags                            flags,
+                                  VkSurfaceKHR*                      pSurface)
 {
     if (table != nullptr)
     {
@@ -418,7 +420,7 @@ XcbWindow::CreateSurface(const encode::InstanceTable* table, VkInstance instance
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void XcbWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void XcbWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -532,9 +534,9 @@ void XcbWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 XcbWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                VkPhysicalDevice             physical_device,
-                                                                uint32_t                     queue_family_index)
+VkBool32 XcbWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                VkPhysicalDevice                   physical_device,
+                                                                uint32_t                           queue_family_index)
 {
     xcb_connection_t* connection = xcb_context_->GetConnection();
     xcb_screen_t*     screen     = xcb_context_->GetScreen();

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -84,12 +84,13 @@ class XcbWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
-    virtual VkResult CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface) override;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) override;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     void SetFullscreen(bool fullscreen);
@@ -142,9 +143,9 @@ class XcbWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) override;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t queue_family_index) override;
 
   private:
     XcbContext* xcb_context_;

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -294,10 +294,10 @@ std::string XlibWindow::GetWsiExtension() const
     return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
 }
 
-VkResult XlibWindow::CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface)
+VkResult XlibWindow::CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface)
 {
     if (table != nullptr)
     {
@@ -310,7 +310,7 @@ VkResult XlibWindow::CreateSurface(const encode::InstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
-void XlibWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+void XlibWindow::DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
 {
     if (table != nullptr)
     {
@@ -342,9 +342,9 @@ void XlibWindowFactory::Destroy(decode::Window* window)
     }
 }
 
-VkBool32 XlibWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                                 VkPhysicalDevice             physical_device,
-                                                                 uint32_t                     queue_family_index)
+VkBool32 XlibWindowFactory::GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                                 VkPhysicalDevice                   physical_device,
+                                                                 uint32_t                           queue_family_index)
 {
     const auto display = xlib_context_->OpenDisplay();
     const auto xlib    = xlib_context_->GetXlibFunctionTable();

--- a/framework/application/xlib_window.h
+++ b/framework/application/xlib_window.h
@@ -62,12 +62,13 @@ class XlibWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
-    virtual VkResult CreateSurface(const encode::InstanceTable* table,
-                                   VkInstance                   instance,
-                                   VkFlags                      flags,
-                                   VkSurfaceKHR*                pSurface) override;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) override;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
     void SetFullscreen(bool fullscreen);
@@ -97,9 +98,9 @@ class XlibWindowFactory : public decode::WindowFactory
 
     void Destroy(decode::Window* window) override;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) override;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t queue_family_index) override;
 
   private:
     XlibContext* xlib_context_;

--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -76,7 +76,7 @@ inline void WriteImageFile(const std::string&     filename,
 
 void ScreenshotHandler::WriteImage(const std::string&                      filename_prefix,
                                    VkDevice                                device,
-                                   const encode::DeviceTable*              device_table,
+                                   const encode::VulkanDeviceTable*        device_table,
                                    const VkPhysicalDeviceMemoryProperties& memory_properties,
                                    VulkanResourceAllocator*                allocator,
                                    VkImage                                 image,
@@ -417,7 +417,7 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
     }
 }
 
-void ScreenshotHandler::DestroyDeviceResources(VkDevice device, const encode::DeviceTable* device_table)
+void ScreenshotHandler::DestroyDeviceResources(VkDevice device, const encode::VulkanDeviceTable* device_table)
 {
     auto entry = copy_resources_.find(device);
     if (entry != copy_resources_.end())
@@ -490,8 +490,11 @@ VkFormat ScreenshotHandler::GetConversionFormat(VkFormat image_format) const
     }
 }
 
-VkDeviceSize ScreenshotHandler::GetCopyBufferSize(
-    VkDevice device, const encode::DeviceTable* device_table, VkFormat format, uint32_t width, uint32_t height) const
+VkDeviceSize ScreenshotHandler::GetCopyBufferSize(VkDevice                         device,
+                                                  const encode::VulkanDeviceTable* device_table,
+                                                  VkFormat                         format,
+                                                  uint32_t                         width,
+                                                  uint32_t                         height) const
 {
     VkImageCreateInfo create_info     = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
     create_info.pNext                 = nullptr;
@@ -546,7 +549,7 @@ uint32_t ScreenshotHandler::GetMemoryTypeIndex(const VkPhysicalDeviceMemoryPrope
 }
 
 VkResult ScreenshotHandler::CreateCopyResource(VkDevice                                device,
-                                               const encode::DeviceTable*              device_table,
+                                               const encode::VulkanDeviceTable*        device_table,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties,
                                                VkDeviceSize                            buffer_size,
                                                VkFormat                                image_format,

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -53,7 +53,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
 
     void WriteImage(const std::string&                      filename_prefix,
                     VkDevice                                device,
-                    const encode::DeviceTable*              device_table,
+                    const encode::VulkanDeviceTable*        device_table,
                     const VkPhysicalDeviceMemoryProperties& memory_properties,
                     VulkanResourceAllocator*                allocator,
                     VkImage                                 image,
@@ -64,7 +64,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
                     uint32_t                                copy_height,
                     VkImageLayout                           image_layout);
 
-    void DestroyDeviceResources(VkDevice device, const encode::DeviceTable* device_table);
+    void DestroyDeviceResources(VkDevice device, const encode::VulkanDeviceTable* device_table);
 
   private:
     struct CopyResource
@@ -93,18 +93,18 @@ class ScreenshotHandler : public ScreenshotHandlerBase
 
     VkFormat GetConversionFormat(VkFormat image_format) const;
 
-    VkDeviceSize GetCopyBufferSize(VkDevice                   device,
-                                   const encode::DeviceTable* device_table,
-                                   VkFormat                   format,
-                                   uint32_t                   width,
-                                   uint32_t                   height) const;
+    VkDeviceSize GetCopyBufferSize(VkDevice                         device,
+                                   const encode::VulkanDeviceTable* device_table,
+                                   VkFormat                         format,
+                                   uint32_t                         width,
+                                   uint32_t                         height) const;
 
     uint32_t GetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properties,
                                 uint32_t                                type_bits,
                                 VkMemoryPropertyFlags                   property_flags) const;
 
     VkResult CreateCopyResource(VkDevice                                device,
-                                const encode::DeviceTable*              device_table,
+                                const encode::VulkanDeviceTable*        device_table,
                                 const VkPhysicalDeviceMemoryProperties& memory_properties,
                                 VkDeviceSize                            buffer_size,
                                 VkFormat                                image_format,

--- a/framework/decode/vulkan_captured_swapchain.cpp
+++ b/framework/decode/vulkan_captured_swapchain.cpp
@@ -33,7 +33,7 @@ VkResult VulkanCapturedSwapchain::CreateSwapchainKHR(VkResult                   
                                                      const VkSwapchainCreateInfoKHR*       create_info,
                                                      const VkAllocationCallbacks*          allocator,
                                                      HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                     const encode::DeviceTable*            device_table)
+                                                     const encode::VulkanDeviceTable*      device_table)
 {
     VkDevice device = VK_NULL_HANDLE;
 

--- a/framework/decode/vulkan_captured_swapchain.h
+++ b/framework/decode/vulkan_captured_swapchain.h
@@ -39,7 +39,7 @@ class VulkanCapturedSwapchain : public VulkanSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::DeviceTable*            device_table) override;
+                                        const encode::VulkanDeviceTable*      device_table) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
                                      const DeviceInfo*            device_info,

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -151,12 +151,12 @@ void ClearObjects(VulkanObjectInfoTable* table,
     }
 }
 
-void FreeAllLiveObjects(VulkanObjectInfoTable*                                   table,
-                        bool                                                     remove_entries,
-                        bool                                                     report_leaks,
-                        std::function<const encode::InstanceTable*(const void*)> get_instance_table,
-                        std::function<const encode::DeviceTable*(const void*)>   get_device_table,
-                        VulkanSwapchain*                                         swapchain)
+void FreeAllLiveObjects(VulkanObjectInfoTable*                                         table,
+                        bool                                                           remove_entries,
+                        bool                                                           report_leaks,
+                        std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
+                        std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table,
+                        VulkanSwapchain*                                               swapchain)
 {
     FreeChildObjects<DeviceInfo, EventInfo>(
         table,
@@ -709,11 +709,11 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
     }
 }
 
-void FreeAllLiveInstances(VulkanObjectInfoTable*                                   table,
-                          bool                                                     remove_entries,
-                          bool                                                     report_leaks,
-                          std::function<const encode::InstanceTable*(const void*)> get_instance_table,
-                          std::function<const encode::DeviceTable*(const void*)>   get_device_table)
+void FreeAllLiveInstances(VulkanObjectInfoTable*                                         table,
+                          bool                                                           remove_entries,
+                          bool                                                           report_leaks,
+                          std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
+                          std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table)
 {
     FreeParentObjects<InstanceInfo>(table,
                                     remove_entries,

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -34,18 +34,18 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 GFXRECON_BEGIN_NAMESPACE(object_cleanup)
 
-void FreeAllLiveObjects(VulkanObjectInfoTable*                                   table,
-                        bool                                                     remove_entries,
-                        bool                                                     report_leaks,
-                        std::function<const encode::InstanceTable*(const void*)> get_instance_table,
-                        std::function<const encode::DeviceTable*(const void*)>   get_device_table,
-                        VulkanSwapchain*                                         swapchain);
+void FreeAllLiveObjects(VulkanObjectInfoTable*                                         table,
+                        bool                                                           remove_entries,
+                        bool                                                           report_leaks,
+                        std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
+                        std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table,
+                        VulkanSwapchain*                                               swapchain);
 
-void FreeAllLiveInstances(VulkanObjectInfoTable*                                   table,
-                          bool                                                     remove_entries,
-                          bool                                                     report_leaks,
-                          std::function<const encode::InstanceTable*(const void*)> get_instance_table,
-                          std::function<const encode::DeviceTable*(const void*)>   get_device_table);
+void FreeAllLiveInstances(VulkanObjectInfoTable*                                         table,
+                          bool                                                           remove_entries,
+                          bool                                                           report_leaks,
+                          std::function<const encode::VulkanInstanceTable*(const void*)> get_instance_table,
+                          std::function<const encode::VulkanDeviceTable*(const void*)>   get_device_table);
 
 GFXRECON_END_NAMESPACE(object_cleanup)
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -31,7 +31,7 @@ VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                       
                                                  const std::string&                  wsi_extension,
                                                  VkFlags                             flags,
                                                  HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                                 const encode::InstanceTable*        instance_table,
+                                                 const encode::VulkanInstanceTable*  instance_table,
                                                  application::Application*           application,
                                                  const VulkanReplayOptions&          replay_options)
 {
@@ -82,7 +82,7 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
                                                       const VkSwapchainCreateInfoKHR*       create_info,
                                                       const VkAllocationCallbacks*          allocator,
                                                       HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                      const encode::DeviceTable*            device_table)
+                                                      const encode::VulkanDeviceTable*      device_table)
 {
     GFXRECON_ASSERT(device_info);
     device_table_ = device_table;

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -40,7 +40,7 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    const std::string&                  wsi_extension,
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                   const encode::InstanceTable*        instance_table,
+                                   const encode::VulkanInstanceTable*  instance_table,
                                    application::Application*           application,
                                    const VulkanReplayOptions&          replay_options) override;
 
@@ -55,7 +55,7 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::DeviceTable*            device_table) override;
+                                        const encode::VulkanDeviceTable*      device_table) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
                                      const DeviceInfo*            device_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1030,14 +1030,14 @@ void VulkanReplayConsumerBase::AddInstanceTable(VkInstance instance)
     create_device_procs_[dispatch_key] =
         reinterpret_cast<PFN_vkCreateDevice>(get_instance_proc_addr_(instance, "vkCreateDevice"));
 
-    encode::InstanceTable& table = instance_tables_[dispatch_key];
-    encode::LoadInstanceTable(get_instance_proc_addr_, instance, &table);
+    encode::VulkanInstanceTable& table = instance_tables_[dispatch_key];
+    encode::LoadVulkanInstanceTable(get_instance_proc_addr_, instance, &table);
 }
 
 void VulkanReplayConsumerBase::AddDeviceTable(VkDevice device, PFN_vkGetDeviceProcAddr gpa)
 {
-    encode::DeviceTable& table = device_tables_[encode::GetDispatchKey(device)];
-    encode::LoadDeviceTable(gpa, device, &table);
+    encode::VulkanDeviceTable& table = device_tables_[encode::GetDispatchKey(device)];
+    encode::LoadVulkanDeviceTable(gpa, device, &table);
 }
 
 PFN_vkGetDeviceProcAddr VulkanReplayConsumerBase::GetDeviceAddrProc(VkPhysicalDevice physical_device)
@@ -1050,14 +1050,14 @@ PFN_vkCreateDevice VulkanReplayConsumerBase::GetCreateDeviceProc(VkPhysicalDevic
     return create_device_procs_[encode::GetDispatchKey(physical_device)];
 }
 
-const encode::InstanceTable* VulkanReplayConsumerBase::GetInstanceTable(const void* handle) const
+const encode::VulkanInstanceTable* VulkanReplayConsumerBase::GetInstanceTable(const void* handle) const
 {
     auto table = instance_tables_.find(encode::GetDispatchKey(handle));
     assert(table != instance_tables_.end());
     return (table != instance_tables_.end()) ? &table->second : nullptr;
 }
 
-const encode::DeviceTable* VulkanReplayConsumerBase::GetDeviceTable(const void* handle) const
+const encode::VulkanDeviceTable* VulkanReplayConsumerBase::GetDeviceTable(const void* handle) const
 {
     auto table = device_tables_.find(encode::GetDispatchKey(handle));
     assert(table != device_tables_.end());

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -207,9 +207,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     VulkanObjectInfoTable& GetObjectInfoTable() { return object_info_table_; }
 
-    const encode::InstanceTable* GetInstanceTable(const void* handle) const;
+    const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
-    const encode::DeviceTable* GetDeviceTable(const void* handle) const;
+    const encode::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
 
     void* PreProcessExternalObject(uint64_t object_id, format::ApiCallId call_id, const char* call_name);
 
@@ -1185,8 +1185,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     PFN_vkCreateInstance                                             create_instance_proc_;
     std::unordered_map<encode::DispatchKey, PFN_vkGetDeviceProcAddr> get_device_proc_addrs_;
     std::unordered_map<encode::DispatchKey, PFN_vkCreateDevice>      create_device_procs_;
-    std::unordered_map<encode::DispatchKey, encode::InstanceTable>   instance_tables_;
-    std::unordered_map<encode::DispatchKey, encode::DeviceTable>     device_tables_;
+    std::unordered_map<encode::DispatchKey, encode::VulkanInstanceTable> instance_tables_;
+    std::unordered_map<encode::DispatchKey, encode::VulkanDeviceTable>   device_tables_;
     std::function<void(const char*)>                                 fatal_error_handler_;
     std::shared_ptr<application::Application>                        application_;
     VulkanObjectInfoTable                                            object_info_table_;

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -38,7 +38,7 @@ VulkanResourceInitializer::VulkanResourceInitializer(const DeviceInfo*          
                                                      const VkPhysicalDeviceMemoryProperties& memory_properties,
                                                      bool                                    have_shader_stencil_write,
                                                      VulkanResourceAllocator*                resource_allocator,
-                                                     const encode::DeviceTable*              device_table) :
+                                                     const encode::VulkanDeviceTable*        device_table) :
     device_(device_info->handle),
     staging_memory_(VK_NULL_HANDLE), staging_memory_data_(0), staging_buffer_(VK_NULL_HANDLE), staging_buffer_data_(0),
     draw_sampler_(VK_NULL_HANDLE), draw_pool_(VK_NULL_HANDLE), draw_set_layout_(VK_NULL_HANDLE),

--- a/framework/decode/vulkan_resource_initializer.h
+++ b/framework/decode/vulkan_resource_initializer.h
@@ -45,7 +45,7 @@ class VulkanResourceInitializer
                               const VkPhysicalDeviceMemoryProperties& memory_properties,
                               bool                                    have_shader_stencil_write,
                               VulkanResourceAllocator*                resource_allocator,
-                              const encode::DeviceTable*              device_table);
+                              const encode::VulkanDeviceTable*        device_table);
 
     ~VulkanResourceInitializer();
 
@@ -202,7 +202,7 @@ class VulkanResourceInitializer
     VkPhysicalDeviceMemoryProperties      memory_properties_;
     bool                                  have_shader_stencil_write_;
     VulkanResourceAllocator*              resource_allocator_;
-    const encode::DeviceTable*            device_table_;
+    const encode::VulkanDeviceTable*      device_table_;
     const DeviceInfo*                     device_info_;
 };
 

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -92,14 +92,14 @@ void VulkanResourceTrackingConsumer::AddInstanceTable(VkInstance instance)
     create_device_procs_[dispatch_key] =
         reinterpret_cast<PFN_vkCreateDevice>(get_instance_proc_addr_(instance, "vkCreateDevice"));
 
-    encode::InstanceTable& table = instance_tables_[dispatch_key];
-    encode::LoadInstanceTable(get_instance_proc_addr_, instance, &table);
+    encode::VulkanInstanceTable& table = instance_tables_[dispatch_key];
+    encode::LoadVulkanInstanceTable(get_instance_proc_addr_, instance, &table);
 }
 
 void VulkanResourceTrackingConsumer::AddDeviceTable(VkDevice device, PFN_vkGetDeviceProcAddr gpa)
 {
-    encode::DeviceTable& table = device_tables_[encode::GetDispatchKey(device)];
-    encode::LoadDeviceTable(gpa, device, &table);
+    encode::VulkanDeviceTable& table = device_tables_[encode::GetDispatchKey(device)];
+    encode::LoadVulkanDeviceTable(gpa, device, &table);
 }
 
 PFN_vkGetDeviceProcAddr VulkanResourceTrackingConsumer::GetDeviceAddrProc(VkPhysicalDevice physical_device)
@@ -112,14 +112,14 @@ PFN_vkCreateDevice VulkanResourceTrackingConsumer::GetCreateDeviceProc(VkPhysica
     return create_device_procs_[encode::GetDispatchKey(physical_device)];
 }
 
-const encode::InstanceTable* VulkanResourceTrackingConsumer::GetInstanceTable(const void* handle) const
+const encode::VulkanInstanceTable* VulkanResourceTrackingConsumer::GetInstanceTable(const void* handle) const
 {
     auto table = instance_tables_.find(encode::GetDispatchKey(handle));
     assert(table != instance_tables_.end());
     return (table != instance_tables_.end()) ? &table->second : nullptr;
 }
 
-const encode::DeviceTable* VulkanResourceTrackingConsumer::GetDeviceTable(const void* handle) const
+const encode::VulkanDeviceTable* VulkanResourceTrackingConsumer::GetDeviceTable(const void* handle) const
 {
     auto table = device_tables_.find(encode::GetDispatchKey(handle));
     assert(table != device_tables_.end());

--- a/framework/decode/vulkan_resource_tracking_consumer.h
+++ b/framework/decode/vulkan_resource_tracking_consumer.h
@@ -58,9 +58,9 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
 
     PFN_vkCreateDevice GetCreateDeviceProc(VkPhysicalDevice physical_device);
 
-    const encode::InstanceTable* GetInstanceTable(const void* handle) const;
+    const encode::VulkanInstanceTable* GetInstanceTable(const void* handle) const;
 
-    const encode::DeviceTable* GetDeviceTable(const void* handle) const;
+    const encode::VulkanDeviceTable* GetDeviceTable(const void* handle) const;
 
     virtual void Process_vkCreateInstance(const ApiCallInfo&                                   call_info,
                                           VkResult                                             returnValue,
@@ -180,10 +180,10 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
     util::platform::LibraryHandle loader_handle_;
 
     // map to function pointers to API calls
-    std::unordered_map<encode::DispatchKey, PFN_vkGetDeviceProcAddr> get_device_proc_addrs_;
-    std::unordered_map<encode::DispatchKey, PFN_vkCreateDevice>      create_device_procs_;
-    std::unordered_map<encode::DispatchKey, encode::InstanceTable>   instance_tables_;
-    std::unordered_map<encode::DispatchKey, encode::DeviceTable>     device_tables_;
+    std::unordered_map<encode::DispatchKey, PFN_vkGetDeviceProcAddr>     get_device_proc_addrs_;
+    std::unordered_map<encode::DispatchKey, PFN_vkCreateDevice>          create_device_procs_;
+    std::unordered_map<encode::DispatchKey, encode::VulkanInstanceTable> instance_tables_;
+    std::unordered_map<encode::DispatchKey, encode::VulkanDeviceTable>   device_tables_;
     // funtion pointers to the API calls that will be made during the first pass of replay
     PFN_vkCreateInstance      create_instance_function_;
     PFN_vkGetInstanceProcAddr get_instance_proc_addr_;

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -55,7 +55,7 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
                                         const std::string&                  wsi_extension,
                                         VkFlags                             flags,
                                         HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                        const encode::InstanceTable*        instance_table,
+                                        const encode::VulkanInstanceTable*  instance_table,
                                         application::Application*           application,
                                         const VulkanReplayOptions&          replay_options)
 {

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -53,7 +53,7 @@ class VulkanSwapchain
                                    const std::string&                  wsi_extension,
                                    VkFlags                             flags,
                                    HandlePointerDecoder<VkSurfaceKHR>* surface,
-                                   const encode::InstanceTable*        instance_table,
+                                   const encode::VulkanInstanceTable*  instance_table,
                                    application::Application*           application,
                                    const VulkanReplayOptions&          replay_options);
 
@@ -68,7 +68,7 @@ class VulkanSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::DeviceTable*            device_table) = 0;
+                                        const encode::VulkanDeviceTable*      device_table) = 0;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
                                      const DeviceInfo*            device_info,
@@ -154,8 +154,8 @@ class VulkanSwapchain
   protected:
     typedef std::unordered_set<Window*> ActiveWindows;
 
-    const encode::InstanceTable* instance_table_{ nullptr };
-    const encode::DeviceTable*   device_table_{ nullptr };
+    const encode::VulkanInstanceTable* instance_table_{ nullptr };
+    const encode::VulkanDeviceTable*   device_table_{ nullptr };
 
     application::Application* application_{ nullptr };
     ActiveWindows             active_windows_;

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -47,7 +47,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                    
                                                     const VkSwapchainCreateInfoKHR*       create_info,
                                                     const VkAllocationCallbacks*          allocator,
                                                     HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                                    const encode::DeviceTable*            device_table)
+                                                    const encode::VulkanDeviceTable*      device_table)
 {
     VkDevice                 device = VK_NULL_HANDLE;
     VkSurfaceCapabilitiesKHR surfCapabilities{};

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -39,7 +39,7 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
                                         const VkSwapchainCreateInfoKHR*       create_info,
                                         const VkAllocationCallbacks*          allocator,
                                         HandlePointerDecoder<VkSwapchainKHR>* swapchain,
-                                        const encode::DeviceTable*            device_table) override;
+                                        const encode::VulkanDeviceTable*      device_table) override;
 
     virtual void DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    func,
                                      const DeviceInfo*            device_info,

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -80,10 +80,13 @@ class Window
 
     virtual std::string GetWsiExtension() const = 0;
 
-    virtual VkResult
-    CreateSurface(const encode::InstanceTable* table, VkInstance instance, VkFlags flags, VkSurfaceKHR* pSurface) = 0;
+    virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
+                                   VkInstance                         instance,
+                                   VkFlags                            flags,
+                                   VkSurfaceKHR*                      pSurface) = 0;
 
-    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) = 0;
+    virtual void
+    DestroySurface(const encode::VulkanInstanceTable* table, VkInstance instance, VkSurfaceKHR surface) = 0;
 };
 
 class WindowFactory
@@ -99,9 +102,9 @@ class WindowFactory
 
     virtual void Destroy(Window* window) = 0;
 
-    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
-                                                          VkPhysicalDevice             physical_device,
-                                                          uint32_t                     queue_family_index) = 0;
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::VulkanInstanceTable* table,
+                                                          VkPhysicalDevice                   physical_device,
+                                                          uint32_t                           queue_family_index) = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -164,7 +164,7 @@ static void EncodeDescriptorUpdateTemplateInfo(VulkanCaptureManager*     manager
             {
                 size_t              offset = entry_info.offset + (entry_info.stride * i);
                 const VkBufferView* entry  = reinterpret_cast<const VkBufferView*>(bytes + offset);
-                encoder->EncodeHandleValue<VulkanBufferViewWrapper>(*entry);
+                encoder->EncodeHandleValue<vulkan_wrappers::BufferViewWrapper>(*entry);
             }
         }
 
@@ -181,7 +181,7 @@ static void EncodeDescriptorUpdateTemplateInfo(VulkanCaptureManager*     manager
                     size_t                            offset = entry_info.offset + (entry_info.stride * i);
                     const VkAccelerationStructureKHR* entry =
                         reinterpret_cast<const VkAccelerationStructureKHR*>(bytes + offset);
-                    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(*entry);
+                    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(*entry);
                 }
             }
         }
@@ -214,9 +214,9 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplate(VkDevice             
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplate);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(descriptorSet);
-        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetWrapper>(descriptorSet);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pData);
 
@@ -256,9 +256,9 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer  
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
-        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(layout);
         encoder->EncodeUInt32Value(set);
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pData);
@@ -298,9 +298,9 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice          
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(descriptorSet);
-        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetWrapper>(descriptorSet);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pData);
 
@@ -392,7 +392,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice                 
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanPipelineCacheWrapper, VulkanPipelineWrapper>(
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper,
+                                   vulkan_wrappers::PipelineCacheWrapper,
+                                   vulkan_wrappers::PipelineWrapper>(
             device, pipelineCache, pPipelines, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
@@ -404,17 +406,17 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice                 
         VulkanCaptureManager::Get()->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateGraphicsPipelines);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
         VulkanCaptureManager::Get()
             ->EndGroupCreateApiCallCapture<VkDevice,
                                            VkPipelineCache,
-                                           VulkanPipelineWrapper,
+                                           vulkan_wrappers::PipelineWrapper,
                                            VkGraphicsPipelineCreateInfo>(
                 result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos);
     }
@@ -478,7 +480,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice                  
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanPipelineCacheWrapper, VulkanPipelineWrapper>(
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper,
+                                   vulkan_wrappers::PipelineCacheWrapper,
+                                   vulkan_wrappers::PipelineWrapper>(
             device, pipelineCache, pPipelines, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
@@ -490,17 +494,17 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice                  
         VulkanCaptureManager::Get()->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateComputePipelines);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
         VulkanCaptureManager::Get()
             ->EndGroupCreateApiCallCapture<VkDevice,
                                            VkPipelineCache,
-                                           VulkanPipelineWrapper,
+                                           vulkan_wrappers::PipelineWrapper,
                                            VkComputePipelineCreateInfo>(
                 result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos);
     }
@@ -565,7 +569,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice             
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanPipelineCacheWrapper, VulkanPipelineWrapper>(
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper,
+                                   vulkan_wrappers::PipelineCacheWrapper,
+                                   vulkan_wrappers::PipelineWrapper>(
             device, pipelineCache, pPipelines, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
@@ -577,17 +583,17 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice             
         format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
         VulkanCaptureManager::Get()
             ->EndGroupCreateApiCallCapture<VkDevice,
                                            VkPipelineCache,
-                                           VulkanPipelineWrapper,
+                                           vulkan_wrappers::PipelineWrapper,
                                            VkRayTracingPipelineCreateInfoNV>(
                 result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos);
     }
@@ -659,7 +665,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice            
         omit_output_data = true;
     }
 
-    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
+    auto device_wrapper = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
     if (result != VK_OPERATION_DEFERRED_KHR)
     {
         // If the operation is not deferred by driver. or the system doesn't support
@@ -677,18 +683,18 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice            
             format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR);
         if (encoder)
         {
-            encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-            encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
-            encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
+            encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+            encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
+            encoder->EncodeHandleValue<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
             encoder->EncodeUInt32Value(createInfoCount);
             EncodeStructArray(encoder, pCreateInfos, createInfoCount);
             EncodeStructPtr(encoder, pAllocator);
-            encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+            encoder->EncodeHandleArray<vulkan_wrappers::PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
             encoder->EncodeEnumValue(result);
             VulkanCaptureManager::Get()
                 ->EndGroupCreateApiCallCapture<VkDevice,
                                                VkDeferredOperationKHR,
-                                               VulkanPipelineWrapper,
+                                               vulkan_wrappers::PipelineWrapper,
                                                VkRayTracingPipelineCreateInfoKHR>(
                     result, device, deferredOperation, createInfoCount, pPipelines, pCreateInfos);
         }

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -164,7 +164,7 @@ static void EncodeDescriptorUpdateTemplateInfo(VulkanCaptureManager*     manager
             {
                 size_t              offset = entry_info.offset + (entry_info.stride * i);
                 const VkBufferView* entry  = reinterpret_cast<const VkBufferView*>(bytes + offset);
-                encoder->EncodeHandleValue<BufferViewWrapper>(*entry);
+                encoder->EncodeHandleValue<VulkanBufferViewWrapper>(*entry);
             }
         }
 
@@ -181,7 +181,7 @@ static void EncodeDescriptorUpdateTemplateInfo(VulkanCaptureManager*     manager
                     size_t                            offset = entry_info.offset + (entry_info.stride * i);
                     const VkAccelerationStructureKHR* entry =
                         reinterpret_cast<const VkAccelerationStructureKHR*>(bytes + offset);
-                    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(*entry);
+                    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(*entry);
                 }
             }
         }
@@ -214,9 +214,9 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplate(VkDevice             
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplate);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorSetWrapper>(descriptorSet);
-        encoder->EncodeHandleValue<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(descriptorSet);
+        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pData);
 
@@ -256,9 +256,9 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer  
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
-        encoder->EncodeHandleValue<PipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
         encoder->EncodeUInt32Value(set);
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pData);
@@ -298,9 +298,9 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice          
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorSetWrapper>(descriptorSet);
-        encoder->EncodeHandleValue<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(descriptorSet);
+        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pData);
 
@@ -392,7 +392,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice                 
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, PipelineCacheWrapper, PipelineWrapper>(
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanPipelineCacheWrapper, VulkanPipelineWrapper>(
             device, pipelineCache, pPipelines, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
@@ -404,15 +404,18 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice                 
         VulkanCaptureManager::Get()->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateGraphicsPipelines);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
         VulkanCaptureManager::Get()
-            ->EndGroupCreateApiCallCapture<VkDevice, VkPipelineCache, PipelineWrapper, VkGraphicsPipelineCreateInfo>(
+            ->EndGroupCreateApiCallCapture<VkDevice,
+                                           VkPipelineCache,
+                                           VulkanPipelineWrapper,
+                                           VkGraphicsPipelineCreateInfo>(
                 result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos);
     }
 
@@ -475,7 +478,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice                  
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, PipelineCacheWrapper, PipelineWrapper>(
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanPipelineCacheWrapper, VulkanPipelineWrapper>(
             device, pipelineCache, pPipelines, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
@@ -487,15 +490,18 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice                  
         VulkanCaptureManager::Get()->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateComputePipelines);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
         VulkanCaptureManager::Get()
-            ->EndGroupCreateApiCallCapture<VkDevice, VkPipelineCache, PipelineWrapper, VkComputePipelineCreateInfo>(
+            ->EndGroupCreateApiCallCapture<VkDevice,
+                                           VkPipelineCache,
+                                           VulkanPipelineWrapper,
+                                           VkComputePipelineCreateInfo>(
                 result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos);
     }
 
@@ -559,7 +565,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice             
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, PipelineCacheWrapper, PipelineWrapper>(
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanPipelineCacheWrapper, VulkanPipelineWrapper>(
             device, pipelineCache, pPipelines, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
@@ -571,17 +577,17 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice             
         format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
         VulkanCaptureManager::Get()
             ->EndGroupCreateApiCallCapture<VkDevice,
                                            VkPipelineCache,
-                                           PipelineWrapper,
+                                           VulkanPipelineWrapper,
                                            VkRayTracingPipelineCreateInfoNV>(
                 result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos);
     }
@@ -653,7 +659,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice            
         omit_output_data = true;
     }
 
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     if (result != VK_OPERATION_DEFERRED_KHR)
     {
         // If the operation is not deferred by driver. or the system doesn't support
@@ -671,18 +677,18 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice            
             format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR);
         if (encoder)
         {
-            encoder->EncodeHandleValue<DeviceWrapper>(device);
-            encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
-            encoder->EncodeHandleValue<PipelineCacheWrapper>(pipelineCache);
+            encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+            encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+            encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
             encoder->EncodeUInt32Value(createInfoCount);
             EncodeStructArray(encoder, pCreateInfos, createInfoCount);
             EncodeStructPtr(encoder, pAllocator);
-            encoder->EncodeHandleArray<PipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
+            encoder->EncodeHandleArray<VulkanPipelineWrapper>(pPipelines, createInfoCount, omit_output_data);
             encoder->EncodeEnumValue(result);
             VulkanCaptureManager::Get()
                 ->EndGroupCreateApiCallCapture<VkDevice,
                                                VkDeferredOperationKHR,
-                                               PipelineWrapper,
+                                               VulkanPipelineWrapper,
                                                VkRayTracingPipelineCreateInfoKHR>(
                     result, device, deferredOperation, createInfoCount, pPipelines, pCreateInfos);
         }

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -226,7 +226,7 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplate(VkDevice             
     auto handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
     auto pData_unwrapped      = UnwrapDescriptorUpdateTemplateInfoHandles(info, pData, handle_unwrap_memory);
 
-    GetDeviceTable(device)->UpdateDescriptorSetWithTemplate(
+    GetVulkanDeviceTable(device)->UpdateDescriptorSetWithTemplate(
         device, descriptorSet, descriptorUpdateTemplate, pData_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplate>::Dispatch(
@@ -269,7 +269,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer  
     auto handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
     auto pData_unwrapped      = UnwrapDescriptorUpdateTemplateInfoHandles(info, pData, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)
+    GetVulkanDeviceTable(commandBuffer)
         ->CmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR>::Dispatch(
@@ -310,7 +310,7 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice          
     auto handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
     auto pData_unwrapped      = UnwrapDescriptorUpdateTemplateInfoHandles(info, pData, handle_unwrap_memory);
 
-    GetDeviceTable(device)->UpdateDescriptorSetWithTemplateKHR(
+    GetVulkanDeviceTable(device)->UpdateDescriptorSetWithTemplateKHR(
         device, descriptorSet, descriptorUpdateTemplate, pData_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplateKHR>::Dispatch(
@@ -326,7 +326,7 @@ BuildAccelerationStructuresKHR(VkDevice                                         
 {
     // TODO
     GFXRECON_LOG_ERROR("BuildAccelerationStructuresKHR encoding is not supported");
-    return GetDeviceTable(device)->BuildAccelerationStructuresKHR(
+    return GetVulkanDeviceTable(device)->BuildAccelerationStructuresKHR(
         device, deferredOperation, infoCount, pInfos, ppRangeInfos);
 }
 
@@ -336,7 +336,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(VkDevice            
 {
     // TODO
     GFXRECON_LOG_ERROR("CopyAccelerationStructureKHR encoding is not supported");
-    return GetDeviceTable(device)->CopyAccelerationStructureKHR(device, deferredOperation, pInfo);
+    return GetVulkanDeviceTable(device)->CopyAccelerationStructureKHR(device, deferredOperation, pInfo);
 }
 
 VKAPI_ATTR uint64_t VKAPI_CALL GetBlockIndexGFXR()
@@ -387,7 +387,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice                 
     const VkGraphicsPipelineCreateInfo* pCreateInfos_unwrapped =
         UnwrapStructArrayHandles(pCreateInfos, createInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateGraphicsPipelines(
+    VkResult result = GetVulkanDeviceTable(device)->CreateGraphicsPipelines(
         device, pipelineCache, createInfoCount, pCreateInfos_unwrapped, pAllocator, pPipelines);
 
     if (result >= 0)
@@ -470,7 +470,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice                  
     const VkComputePipelineCreateInfo* pCreateInfos_unwrapped =
         UnwrapStructArrayHandles(pCreateInfos, createInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateComputePipelines(
+    VkResult result = GetVulkanDeviceTable(device)->CreateComputePipelines(
         device, pipelineCache, createInfoCount, pCreateInfos_unwrapped, pAllocator, pPipelines);
 
     if (result >= 0)
@@ -554,7 +554,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice             
     const VkRayTracingPipelineCreateInfoNV* pCreateInfos_unwrapped =
         UnwrapStructArrayHandles(pCreateInfos, createInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateRayTracingPipelinesNV(
+    VkResult result = GetVulkanDeviceTable(device)->CreateRayTracingPipelinesNV(
         device, pipelineCache, createInfoCount, pCreateInfos_unwrapped, pAllocator, pPipelines);
 
     if (result >= 0)

--- a/framework/encode/custom_vulkan_command_buffer_util.cpp
+++ b/framework/encode/custom_vulkan_command_buffer_util.cpp
@@ -30,17 +30,17 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
-                                         VkPipelineLayout            layout,
-                                         uint32_t                    descriptorWriteCount,
-                                         const VkWriteDescriptorSet* pDescriptorWrites)
+void TrackCmdPushDescriptorSetKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper,
+                                         VkPipelineLayout                       layout,
+                                         uint32_t                               descriptorWriteCount,
+                                         const VkWriteDescriptorSet*            pDescriptorWrites)
 {
     assert(wrapper != nullptr);
 
     if (layout != VK_NULL_HANDLE)
     {
-        wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(
-            GetWrappedId<VulkanPipelineLayoutWrapper>(layout));
+        wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(
+            GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(layout));
     }
 
     if (pDescriptorWrites != nullptr)
@@ -66,8 +66,10 @@ void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
                                 if (pnext_value->pAccelerationStructures[pAccelerationStructures_index] !=
                                     VK_NULL_HANDLE)
                                 {
-                                    wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(
-                                        GetWrappedId<VulkanAccelerationStructureKHRWrapper>(
+                                    wrapper
+                                        ->command_handles
+                                            [vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle]
+                                        .insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(
                                             pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
@@ -87,8 +89,10 @@ void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
                                 if (pnext_value->pAccelerationStructures[pAccelerationStructures_index] !=
                                     VK_NULL_HANDLE)
                                 {
-                                    wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(
-                                        GetWrappedId<VulkanAccelerationStructureNVWrapper>(
+                                    wrapper
+                                        ->command_handles
+                                            [vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle]
+                                        .insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(
                                             pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
@@ -105,8 +109,8 @@ void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
 
             if (descriptorWrite.dstSet != VK_NULL_HANDLE)
             {
-                wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(
-                    GetWrappedId<VulkanDescriptorSetWrapper>(descriptorWrite.dstSet));
+                wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetHandle].insert(
+                    GetVulkanWrappedId<vulkan_wrappers::DescriptorSetWrapper>(descriptorWrite.dstSet));
             }
 
             switch (descriptorWrite.descriptorType)
@@ -129,14 +133,14 @@ void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
                             //  VkSampler provided in the VkDescriptorWrite.
                             if (descriptorWrite.pImageInfo[pImageInfo_index].sampler != VK_NULL_HANDLE)
                             {
-                                wrapper->command_handles[CommandHandleType::SamplerHandle].insert(
-                                    GetWrappedId<VulkanSamplerWrapper>(
+                                wrapper->command_handles[vulkan_state_info::CommandHandleType::SamplerHandle].insert(
+                                    GetVulkanWrappedId<vulkan_wrappers::SamplerWrapper>(
                                         descriptorWrite.pImageInfo[pImageInfo_index].sampler));
                             }
                             if (descriptorWrite.pImageInfo[pImageInfo_index].imageView != VK_NULL_HANDLE)
                             {
-                                wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(
-                                    GetWrappedId<VulkanImageViewWrapper>(
+                                wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(
+                                    GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(
                                         descriptorWrite.pImageInfo[pImageInfo_index].imageView));
                             }
                         }
@@ -155,8 +159,8 @@ void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
                         {
                             if (descriptorWrite.pBufferInfo[pBufferInfo_index].buffer != VK_NULL_HANDLE)
                             {
-                                wrapper->command_handles[CommandHandleType::BufferHandle].insert(
-                                    GetWrappedId<VulkanBufferWrapper>(
+                                wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(
+                                    GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(
                                         descriptorWrite.pBufferInfo[pBufferInfo_index].buffer));
                             }
                         }
@@ -174,8 +178,8 @@ void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
                         {
                             if (descriptorWrite.pTexelBufferView[pTexelBufferView_index] != VK_NULL_HANDLE)
                             {
-                                wrapper->command_handles[CommandHandleType::BufferViewHandle].insert(
-                                    GetWrappedId<VulkanBufferViewWrapper>(
+                                wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferViewHandle].insert(
+                                    GetVulkanWrappedId<vulkan_wrappers::BufferViewWrapper>(
                                         descriptorWrite.pTexelBufferView[pTexelBufferView_index]));
                             }
                         }

--- a/framework/encode/custom_vulkan_command_buffer_util.cpp
+++ b/framework/encode/custom_vulkan_command_buffer_util.cpp
@@ -30,7 +30,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
+void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper,
                                          VkPipelineLayout            layout,
                                          uint32_t                    descriptorWriteCount,
                                          const VkWriteDescriptorSet* pDescriptorWrites)
@@ -40,7 +40,7 @@ void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
     if (layout != VK_NULL_HANDLE)
     {
         wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(
-            GetWrappedId<PipelineLayoutWrapper>(layout));
+            GetWrappedId<VulkanPipelineLayoutWrapper>(layout));
     }
 
     if (pDescriptorWrites != nullptr)
@@ -67,7 +67,7 @@ void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
                                     VK_NULL_HANDLE)
                                 {
                                     wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(
-                                        GetWrappedId<AccelerationStructureKHRWrapper>(
+                                        GetWrappedId<VulkanAccelerationStructureKHRWrapper>(
                                             pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
@@ -88,7 +88,7 @@ void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
                                     VK_NULL_HANDLE)
                                 {
                                     wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(
-                                        GetWrappedId<AccelerationStructureNVWrapper>(
+                                        GetWrappedId<VulkanAccelerationStructureNVWrapper>(
                                             pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
@@ -106,7 +106,7 @@ void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
             if (descriptorWrite.dstSet != VK_NULL_HANDLE)
             {
                 wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(
-                    GetWrappedId<DescriptorSetWrapper>(descriptorWrite.dstSet));
+                    GetWrappedId<VulkanDescriptorSetWrapper>(descriptorWrite.dstSet));
             }
 
             switch (descriptorWrite.descriptorType)
@@ -130,12 +130,13 @@ void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
                             if (descriptorWrite.pImageInfo[pImageInfo_index].sampler != VK_NULL_HANDLE)
                             {
                                 wrapper->command_handles[CommandHandleType::SamplerHandle].insert(
-                                    GetWrappedId<SamplerWrapper>(descriptorWrite.pImageInfo[pImageInfo_index].sampler));
+                                    GetWrappedId<VulkanSamplerWrapper>(
+                                        descriptorWrite.pImageInfo[pImageInfo_index].sampler));
                             }
                             if (descriptorWrite.pImageInfo[pImageInfo_index].imageView != VK_NULL_HANDLE)
                             {
                                 wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(
-                                    GetWrappedId<ImageViewWrapper>(
+                                    GetWrappedId<VulkanImageViewWrapper>(
                                         descriptorWrite.pImageInfo[pImageInfo_index].imageView));
                             }
                         }
@@ -155,7 +156,8 @@ void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
                             if (descriptorWrite.pBufferInfo[pBufferInfo_index].buffer != VK_NULL_HANDLE)
                             {
                                 wrapper->command_handles[CommandHandleType::BufferHandle].insert(
-                                    GetWrappedId<BufferWrapper>(descriptorWrite.pBufferInfo[pBufferInfo_index].buffer));
+                                    GetWrappedId<VulkanBufferWrapper>(
+                                        descriptorWrite.pBufferInfo[pBufferInfo_index].buffer));
                             }
                         }
                     }
@@ -173,7 +175,7 @@ void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper*       wrapper,
                             if (descriptorWrite.pTexelBufferView[pTexelBufferView_index] != VK_NULL_HANDLE)
                             {
                                 wrapper->command_handles[CommandHandleType::BufferViewHandle].insert(
-                                    GetWrappedId<BufferViewWrapper>(
+                                    GetWrappedId<VulkanBufferViewWrapper>(
                                         descriptorWrite.pTexelBufferView[pTexelBufferView_index]));
                             }
                         }

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -38,7 +38,7 @@ void EncodeStruct(ParameterEncoder* encoder, VkDescriptorType type, const VkDesc
     if ((type == VK_DESCRIPTOR_TYPE_SAMPLER) || (type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
     {
         // TODO: This should be ignored if the descriptor set layout was created with an immutable sampler.
-        encoder->EncodeHandleValue<VulkanSamplerWrapper>(value.sampler);
+        encoder->EncodeHandleValue<vulkan_wrappers::SamplerWrapper>(value.sampler);
     }
     else
     {
@@ -51,7 +51,7 @@ void EncodeStruct(ParameterEncoder* encoder, VkDescriptorType type, const VkDesc
     // Conditional encoding for image view handle based on descriptor type.
     if (type != VK_DESCRIPTOR_TYPE_SAMPLER)
     {
-        encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(value.imageView);
     }
     else
     {
@@ -116,7 +116,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(value.dstSet);
+    encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetWrapper>(value.dstSet);
     encoder->EncodeUInt32Value(value.dstBinding);
     encoder->EncodeUInt32Value(value.dstArrayElement);
     encoder->EncodeUInt32Value(value.descriptorCount);
@@ -169,7 +169,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
     }
 
     EncodeStructArray(encoder, value.pBufferInfo, value.descriptorCount, omit_buffer_data);
-    encoder->EncodeHandleArray<VulkanBufferViewWrapper>(
+    encoder->EncodeHandleArray<vulkan_wrappers::BufferViewWrapper>(
         value.pTexelBufferView, value.descriptorCount, omit_texel_buffer_data);
 }
 

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -38,7 +38,7 @@ void EncodeStruct(ParameterEncoder* encoder, VkDescriptorType type, const VkDesc
     if ((type == VK_DESCRIPTOR_TYPE_SAMPLER) || (type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
     {
         // TODO: This should be ignored if the descriptor set layout was created with an immutable sampler.
-        encoder->EncodeHandleValue<SamplerWrapper>(value.sampler);
+        encoder->EncodeHandleValue<VulkanSamplerWrapper>(value.sampler);
     }
     else
     {
@@ -51,7 +51,7 @@ void EncodeStruct(ParameterEncoder* encoder, VkDescriptorType type, const VkDesc
     // Conditional encoding for image view handle based on descriptor type.
     if (type != VK_DESCRIPTOR_TYPE_SAMPLER)
     {
-        encoder->EncodeHandleValue<ImageViewWrapper>(value.imageView);
+        encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
     }
     else
     {
@@ -116,7 +116,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DescriptorSetWrapper>(value.dstSet);
+    encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(value.dstSet);
     encoder->EncodeUInt32Value(value.dstBinding);
     encoder->EncodeUInt32Value(value.dstArrayElement);
     encoder->EncodeUInt32Value(value.descriptorCount);
@@ -169,7 +169,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
     }
 
     EncodeStructArray(encoder, value.pBufferInfo, value.descriptorCount, omit_buffer_data);
-    encoder->EncodeHandleArray<BufferViewWrapper>(
+    encoder->EncodeHandleArray<VulkanBufferViewWrapper>(
         value.pTexelBufferView, value.descriptorCount, omit_texel_buffer_data);
 }
 

--- a/framework/encode/parameter_encoder.h
+++ b/framework/encode/parameter_encoder.h
@@ -78,7 +78,7 @@ class ParameterEncoder
     void EncodeFunctionPtr(T value)                                                                                   { EncodeValue(reinterpret_cast<format::AddressEncodeType>(value)); }
 
     template<typename Wrapper>
-    void EncodeHandleValue(typename Wrapper::HandleType value)                                                        { EncodeHandleIdValue(GetWrappedId<Wrapper>(value)); }
+    void EncodeHandleValue(typename Wrapper::HandleType value)                                                        { EncodeHandleIdValue(GetVulkanWrappedId<Wrapper>(value)); }
     template<typename T>
     void EncodeEnumValue(T value)                                                                                     { EncodeValue(static_cast<format::EnumEncodeType>(value)); }
     template<typename T>

--- a/framework/encode/test/main.cpp
+++ b/framework/encode/test/main.cpp
@@ -46,26 +46,30 @@ TEST_CASE("handles can be wrapped and unwrapped", "[wrapper]")
     gfxrecon::util::Log::Init(gfxrecon::util::Log::kErrorSeverity);
 
     VkBuffer buffer = kBufferHandle;
-    gfxrecon::encode::CreateWrappedHandle<gfxrecon::encode::DeviceWrapper,
-                                          gfxrecon::encode::NoParentWrapper,
-                                          gfxrecon::encode::BufferWrapper>(
-        VK_NULL_HANDLE, gfxrecon::encode::NoParentWrapper::kHandleValue, &buffer, GetHandleId);
+    gfxrecon::encode::CreateWrappedVulkanHandle<gfxrecon::encode::vulkan_wrappers::DeviceWrapper,
+                                                gfxrecon::encode::VulkanNoParentWrapper,
+                                                gfxrecon::encode::vulkan_wrappers::BufferWrapper>(
+        VK_NULL_HANDLE, gfxrecon::encode::VulkanNoParentWrapper::kHandleValue, &buffer, GetHandleId);
 
-    SECTION("The handle retrieved from the wrapper is the original buffer handle") { REQUIRE(buffer == kBufferHandle); }
+    SECTION("The handle retrieved from the wrapper is the original buffer handle")
+    {
+        REQUIRE(buffer == kBufferHandle);
+    }
 
     SECTION("The handle ID retrieved from the wrapper is 12")
     {
-        REQUIRE(gfxrecon::encode::GetWrappedId<gfxrecon::encode::BufferWrapper>(buffer) == kBufferId);
+        REQUIRE(gfxrecon::encode::GetVulkanWrappedId<gfxrecon::encode::vulkan_wrappers::BufferWrapper>(buffer) ==
+                kBufferId);
     }
 
     SECTION("The handle ID retrieved from an integer handle with type VK_OBJECT_TYPE_BUFFER is 12")
     {
         uint64_t object = gfxrecon::format::ToHandleId(buffer);
 
-        REQUIRE(gfxrecon::encode::GetWrappedId(object, VK_OBJECT_TYPE_BUFFER) == 12);
+        REQUIRE(gfxrecon::encode::GetVulkanWrappedId(object, VK_OBJECT_TYPE_BUFFER) == 12);
     }
 
-    gfxrecon::encode::DestroyWrappedHandle<gfxrecon::encode::BufferWrapper>(buffer);
+    gfxrecon::encode::DestroyWrappedVulkanHandle<gfxrecon::encode::vulkan_wrappers::BufferWrapper>(buffer);
 
     gfxrecon::util::Log::Release();
 }

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -114,10 +114,10 @@ void VulkanCaptureManager::InitVkInstance(VkInstance* instance, PFN_vkGetInstanc
 {
     assert(instance != nullptr);
 
-    CreateWrappedHandle<NoParentWrapper, NoParentWrapper, InstanceWrapper>(
-        NoParentWrapper::kHandleValue, NoParentWrapper::kHandleValue, instance, GetUniqueId);
+    CreateWrappedHandle<VulkanNoParentWrapper, VulkanNoParentWrapper, VulkanInstanceWrapper>(
+        VulkanNoParentWrapper::kHandleValue, VulkanNoParentWrapper::kHandleValue, instance, GetUniqueId);
 
-    auto wrapper = GetWrapper<InstanceWrapper>(*instance);
+    auto wrapper = GetWrapper<VulkanInstanceWrapper>(*instance);
     LoadVulkanInstanceTable(gpa, wrapper->handle, &wrapper->layer_table);
 }
 
@@ -125,10 +125,10 @@ void VulkanCaptureManager::InitVkDevice(VkDevice* device, PFN_vkGetDeviceProcAdd
 {
     assert((device != nullptr) && ((*device) != VK_NULL_HANDLE));
 
-    CreateWrappedHandle<PhysicalDeviceWrapper, NoParentWrapper, DeviceWrapper>(
-        VK_NULL_HANDLE, NoParentWrapper::kHandleValue, device, GetUniqueId);
+    CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDeviceWrapper>(
+        VK_NULL_HANDLE, VulkanNoParentWrapper::kHandleValue, device, GetUniqueId);
 
-    auto wrapper = GetWrapper<DeviceWrapper>(*device);
+    auto wrapper = GetWrapper<VulkanDeviceWrapper>(*device);
     LoadVulkanDeviceTable(gpa, wrapper->handle, &wrapper->layer_table);
 }
 
@@ -418,7 +418,7 @@ void VulkanCaptureManager::SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTem
 
     if (create_info->descriptorUpdateEntryCount > 0)
     {
-        auto                wrapper = GetWrapper<DescriptorUpdateTemplateWrapper>(update_template);
+        auto                wrapper = GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(update_template);
         UpdateTemplateInfo* info    = &wrapper->info;
 
         for (size_t i = 0; i < create_info->descriptorUpdateEntryCount; ++i)
@@ -522,7 +522,7 @@ bool VulkanCaptureManager::GetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTem
 
     if (update_template != VK_NULL_HANDLE)
     {
-        auto wrapper = GetWrapper<DescriptorUpdateTemplateWrapper>(update_template);
+        auto wrapper = GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(update_template);
         (*info)      = &wrapper->info;
         found        = true;
     }
@@ -605,7 +605,7 @@ VkResult VulkanCaptureManager::OverrideCreateInstance(const VkInstanceCreateInfo
     if ((result == VK_SUCCESS) && (pCreateInfo->pApplicationInfo != nullptr))
     {
         auto api_version              = pCreateInfo->pApplicationInfo->apiVersion;
-        auto instance_wrapper         = GetWrapper<InstanceWrapper>(*pInstance);
+        auto instance_wrapper         = GetWrapper<VulkanInstanceWrapper>(*pInstance);
         instance_wrapper->api_version = api_version;
 
         // Warn when enabled API version is newer than the supported API version.
@@ -636,7 +636,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
     assert(pCreateInfo_unwrapped != nullptr);
 
     const VulkanInstanceTable* instance_table          = GetVulkanInstanceTable(physicalDevice);
-    auto                       physical_device_wrapper = GetWrapper<PhysicalDeviceWrapper>(physicalDevice);
+    auto                       physical_device_wrapper = GetWrapper<VulkanPhysicalDeviceWrapper>(physicalDevice);
 
     graphics::VulkanDeviceUtil                device_util;
     graphics::VulkanDevicePropertyFeatureInfo property_feature_info = device_util.EnableRequiredPhysicalDeviceFeatures(
@@ -726,7 +726,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
     {
         assert((pDevice != nullptr) && (*pDevice != VK_NULL_HANDLE));
 
-        auto wrapper = GetWrapper<DeviceWrapper>(*pDevice);
+        auto wrapper = GetWrapper<VulkanDeviceWrapper>(*pDevice);
 
         // Track state of physical device properties and features at device creation
         wrapper->property_feature_info = property_feature_info;
@@ -759,7 +759,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
                                                     VkBuffer*                    pBuffer)
 {
     VkResult result               = VK_SUCCESS;
-    auto     device_wrapper       = GetWrapper<DeviceWrapper>(device);
+    auto     device_wrapper       = GetWrapper<VulkanDeviceWrapper>(device);
     VkDevice device_unwrapped     = device_wrapper->handle;
     auto     device_table         = GetVulkanDeviceTable(device);
     auto     handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
@@ -810,15 +810,15 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
 
     if ((result == VK_SUCCESS) && (pBuffer != nullptr))
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, BufferWrapper>(
-            device, NoParentWrapper::kHandleValue, pBuffer, GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanBufferWrapper>(
+            device, VulkanNoParentWrapper::kHandleValue, pBuffer, GetUniqueId);
 
         if (uses_address)
         {
             // If the buffer has a device address, write the 'set buffer address' command before writing the API call to
             // create the buffer.  The address will need to be passed to vkCreateBuffer through the pCreateInfo pNext
             // list.
-            auto                      buffer_wrapper = GetWrapper<BufferWrapper>(*pBuffer);
+            auto                      buffer_wrapper = GetWrapper<VulkanBufferWrapper>(*pBuffer);
             VkBufferDeviceAddressInfo info           = { VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO };
             info.pNext                               = nullptr;
             info.buffer                              = buffer_wrapper->handle;
@@ -864,8 +864,8 @@ VkResult VulkanCaptureManager::OverrideCreateImage(VkDevice                     
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, ImageWrapper>(
-            device, NoParentWrapper::kHandleValue, pImage, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanImageWrapper>(
+            device, VulkanNoParentWrapper::kHandleValue, pImage, VulkanCaptureManager::GetUniqueId);
     }
     return result;
 }
@@ -877,7 +877,7 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
                                                              VkAccelerationStructureKHR* pAccelerationStructureKHR)
 {
     auto                     handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
-    auto                     device_wrapper       = GetWrapper<DeviceWrapper>(device);
+    auto                     device_wrapper       = GetWrapper<VulkanDeviceWrapper>(device);
     VkDevice                 device_unwrapped     = device_wrapper->handle;
     const VulkanDeviceTable* device_table         = GetVulkanDeviceTable(device);
     const VkAccelerationStructureCreateInfoKHR* pCreateInfo_unwrapped =
@@ -900,12 +900,12 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
 
     if ((result == VK_SUCCESS) && (pAccelerationStructureKHR != nullptr))
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, AccelerationStructureKHRWrapper>(
-            device, NoParentWrapper::kHandleValue, pAccelerationStructureKHR, GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanAccelerationStructureKHRWrapper>(
+            device, VulkanNoParentWrapper::kHandleValue, pAccelerationStructureKHR, GetUniqueId);
 
         if (device_wrapper->property_feature_info.feature_accelerationStructureCaptureReplay)
         {
-            auto accel_struct_wrapper = GetWrapper<AccelerationStructureKHRWrapper>(*pAccelerationStructureKHR);
+            auto accel_struct_wrapper = GetWrapper<VulkanAccelerationStructureKHRWrapper>(*pAccelerationStructureKHR);
 
             VkAccelerationStructureDeviceAddressInfoKHR address_info{
                 VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR, nullptr, accel_struct_wrapper->handle
@@ -951,7 +951,7 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
     void*                            external_memory = nullptr;
     VkImportMemoryHostPointerInfoEXT import_info;
 
-    auto                  device_wrapper       = GetWrapper<DeviceWrapper>(device);
+    auto                  device_wrapper       = GetWrapper<VulkanDeviceWrapper>(device);
     VkDevice              device_unwrapped     = device_wrapper->handle;
     auto                  handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
     VkMemoryAllocateInfo* pAllocateInfo_unwrapped =
@@ -1035,11 +1035,11 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
 
     if (result == VK_SUCCESS)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, DeviceMemoryWrapper>(
-            device, NoParentWrapper::kHandleValue, pMemory, GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDeviceMemoryWrapper>(
+            device, VulkanNoParentWrapper::kHandleValue, pMemory, GetUniqueId);
 
         assert(pMemory != nullptr);
-        auto memory_wrapper = GetWrapper<DeviceMemoryWrapper>(*pMemory);
+        auto memory_wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(*pMemory);
 
         if (uses_address)
         {
@@ -1159,9 +1159,9 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                            const VkAllocationCallbacks*             pAllocator,
                                                            VkPipeline*                              pPipelines)
 {
-    auto                     device_wrapper             = GetWrapper<DeviceWrapper>(device);
-    const VulkanDeviceTable* device_table               = GetVulkanDeviceTable(device);
-    auto                     deferred_operation_wrapper = GetWrapper<DeferredOperationKHRWrapper>(deferredOperation);
+    auto                     device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
+    const VulkanDeviceTable* device_table   = GetVulkanDeviceTable(device);
+    auto deferred_operation_wrapper         = GetWrapper<VulkanDeferredOperationKHRWrapper>(deferredOperation);
 
     HandleUnwrapMemory* handle_unwrap_memory = nullptr;
 
@@ -1298,19 +1298,19 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
     {
         // If the return result show the creation is successfully finished, we do the following process.
 
-        CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanDeferredOperationKHRWrapper, VulkanPipelineWrapper>(
             device, deferredOperation, pPipelines, createInfoCount, GetUniqueId);
 
         for (uint32_t i = 0; i < createInfoCount; ++i)
         {
-            auto pipeline_wrapper = GetWrapper<PipelineWrapper>(pPipelines[i]);
+            auto pipeline_wrapper = GetWrapper<VulkanPipelineWrapper>(pPipelines[i]);
 
             if (deferred_operation_wrapper)
             {
                 // We need to set device_id here because some hardware may not have the feature
                 // rayTracingPipelineShaderGroupHandleCaptureReplay so the device_id cannot be set by
                 // VulkanStateTracker::TrackRayTracingShaderGroupHandles
-                pipeline_wrapper->device_id                            = GetWrappedId<DeviceWrapper>(device);
+                pipeline_wrapper->device_id                            = GetWrappedId<VulkanDeviceWrapper>(device);
                 pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
                 pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
                 pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
@@ -1347,10 +1347,10 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
                                                         bool                   capture_manager_tracking)
 {
     const std::lock_guard<std::mutex> lock(deferred_operation_mutex);
-    VkResult                          result            = VK_SUCCESS;
-    auto                     deferred_operation_wrapper = GetWrapper<DeferredOperationKHRWrapper>(deferredOperation);
-    auto                     device_wrapper             = GetWrapper<DeviceWrapper>(device);
-    const VulkanDeviceTable* device_table               = GetVulkanDeviceTable(device);
+    VkResult                          result = VK_SUCCESS;
+    auto deferred_operation_wrapper          = GetWrapper<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+    auto device_wrapper                      = GetWrapper<VulkanDeviceWrapper>(device);
+    const VulkanDeviceTable* device_table    = GetVulkanDeviceTable(device);
 
     GFXRECON_ASSERT(device_table != nullptr);
 
@@ -1362,19 +1362,19 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
                     deferred_operation_wrapper->pipelines.data(),
                     sizeof(VkPipeline) * deferred_operation_wrapper->create_infos.size());
 
-        CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanDeferredOperationKHRWrapper, VulkanPipelineWrapper>(
             device, deferredOperation, deferred_operation_wrapper->pPipelines, create_info_count, GetUniqueId);
 
         for (uint32_t i = 0; i < create_info_count; ++i)
         {
-            auto pipeline_wrapper = GetWrapper<PipelineWrapper>(deferred_operation_wrapper->pPipelines[i]);
+            auto pipeline_wrapper = GetWrapper<VulkanPipelineWrapper>(deferred_operation_wrapper->pPipelines[i]);
 
             if (deferred_operation_wrapper)
             {
                 // We need to set device_id here because some hardware may not have the feature
                 // rayTracingPipelineShaderGroupHandleCaptureReplay so the device_id cannot be set by
                 // VulkanStateTracker::TrackRayTracingShaderGroupHandles
-                pipeline_wrapper->device_id                            = GetWrappedId<DeviceWrapper>(device);
+                pipeline_wrapper->device_id                            = GetWrappedId<VulkanDeviceWrapper>(device);
                 pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
                 pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
                 pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
@@ -1420,18 +1420,18 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
 
         if (encoder)
         {
-            encoder->EncodeHandleValue<DeviceWrapper>(device);
-            encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
-            encoder->EncodeHandleValue<PipelineCacheWrapper>(deferred_operation_wrapper->pipelineCache);
+            encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+            encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+            encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(deferred_operation_wrapper->pipelineCache);
             encoder->EncodeUInt32Value(create_info_count);
             EncodeStructArray(encoder, deferred_operation_wrapper->create_infos.data(), create_info_count);
             EncodeStructPtr(encoder, deferred_operation_wrapper->p_allocator);
-            encoder->EncodeHandleArray<PipelineWrapper>(
+            encoder->EncodeHandleArray<VulkanPipelineWrapper>(
                 deferred_operation_wrapper->pPipelines, create_info_count, false);
             encoder->EncodeEnumValue(VK_OPERATION_DEFERRED_KHR);
             EndGroupCreateApiCallCapture<VkDevice,
                                          VkDeferredOperationKHR,
-                                         PipelineWrapper,
+                                         VulkanPipelineWrapper,
                                          VkRayTracingPipelineCreateInfoKHR>(
                 result,
                 device,
@@ -1549,7 +1549,7 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
 {
     assert(devices != nullptr);
 
-    auto instance_wrapper = GetWrapper<InstanceWrapper>(instance);
+    auto instance_wrapper = GetWrapper<VulkanInstanceWrapper>(instance);
     assert(instance_wrapper != nullptr);
 
     // Write meta-data describing physical device properties on first call to vkEnumeratePhysicalDevices or
@@ -1571,7 +1571,7 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
                 const VulkanInstanceTable* instance_table = GetVulkanInstanceTable(physical_device);
                 assert(instance_table != nullptr);
 
-                auto             physical_device_wrapper = GetWrapper<PhysicalDeviceWrapper>(physical_device);
+                auto             physical_device_wrapper = GetWrapper<VulkanPhysicalDeviceWrapper>(physical_device);
                 format::HandleId physical_device_id      = physical_device_wrapper->handle_id;
                 VkPhysicalDevice physical_device_handle  = physical_device_wrapper->handle;
                 uint32_t         count                   = 0;
@@ -1603,10 +1603,10 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
     }
 }
 
-VkMemoryPropertyFlags VulkanCaptureManager::GetMemoryProperties(DeviceWrapper* device_wrapper,
-                                                                uint32_t       memory_type_index)
+VkMemoryPropertyFlags VulkanCaptureManager::GetMemoryProperties(VulkanDeviceWrapper* device_wrapper,
+                                                                uint32_t             memory_type_index)
 {
-    PhysicalDeviceWrapper*                  physical_device_wrapper = device_wrapper->physical_device;
+    VulkanPhysicalDeviceWrapper*            physical_device_wrapper = device_wrapper->physical_device;
     const VkPhysicalDeviceMemoryProperties* memory_properties       = &physical_device_wrapper->memory_properties;
 
     assert(memory_type_index < memory_properties->memoryTypeCount);
@@ -1644,7 +1644,7 @@ bool VulkanCaptureManager::ProcessReferenceToAndroidHardwareBuffer(VkDevice devi
 {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     assert(hardware_buffer != nullptr);
-    auto     device_wrapper   = GetWrapper<DeviceWrapper>(device);
+    auto     device_wrapper   = GetWrapper<VulkanDeviceWrapper>(device);
     VkDevice device_unwrapped = device_wrapper->handle;
     auto     device_table     = GetVulkanDeviceTable(device);
 
@@ -1787,7 +1787,7 @@ void VulkanCaptureManager::ProcessImportAndroidHardwareBuffer(VkDevice         d
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     GFXRECON_UNREFERENCED_PARAMETER(device);
 
-    auto memory_wrapper = GetWrapper<DeviceMemoryWrapper>(memory);
+    auto memory_wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
     assert((memory_wrapper != nullptr) && (hardware_buffer != nullptr));
 
     bool processing_succeeded = ProcessReferenceToAndroidHardwareBuffer(device, hardware_buffer);
@@ -1960,7 +1960,7 @@ void VulkanCaptureManager::PreProcess_vkCreateSwapchain(VkDevice                
 
     if (pCreateInfo)
     {
-        WriteResizeWindowCmd2(GetWrappedId<SurfaceKHRWrapper>(pCreateInfo->surface),
+        WriteResizeWindowCmd2(GetWrappedId<VulkanSurfaceKHRWrapper>(pCreateInfo->surface),
                               pCreateInfo->imageExtent.width,
                               pCreateInfo->imageExtent.height,
                               pCreateInfo->preTransform);
@@ -1977,7 +1977,7 @@ void VulkanCaptureManager::PostProcess_vkMapMemory(VkResult         result,
 {
     if ((result == VK_SUCCESS) && (ppData != nullptr))
     {
-        auto wrapper = GetWrapper<DeviceMemoryWrapper>(memory);
+        auto wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
         assert(wrapper != nullptr);
 
         if (wrapper->mapped_data == nullptr)
@@ -2089,13 +2089,13 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
         if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kPageGuard ||
             GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
         {
-            const DeviceMemoryWrapper* current_memory_wrapper = nullptr;
-            util::PageGuardManager*    manager                = util::PageGuardManager::Get();
+            const VulkanDeviceMemoryWrapper* current_memory_wrapper = nullptr;
+            util::PageGuardManager*          manager                = util::PageGuardManager::Get();
             assert(manager != nullptr);
 
             for (uint32_t i = 0; i < memoryRangeCount; ++i)
             {
-                auto next_memory_wrapper = GetWrapper<DeviceMemoryWrapper>(pMemoryRanges[i].memory);
+                auto next_memory_wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(pMemoryRanges[i].memory);
 
                 // Currently processing all dirty pages for the mapped memory, so filter multiple ranges from the same
                 // object.
@@ -2120,11 +2120,11 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
         }
         else if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kAssisted)
         {
-            const DeviceMemoryWrapper* current_memory_wrapper = nullptr;
+            const VulkanDeviceMemoryWrapper* current_memory_wrapper = nullptr;
 
             for (uint32_t i = 0; i < memoryRangeCount; ++i)
             {
-                current_memory_wrapper = GetWrapper<DeviceMemoryWrapper>(pMemoryRanges[i].memory);
+                current_memory_wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(pMemoryRanges[i].memory);
 
                 if ((current_memory_wrapper != nullptr) && (current_memory_wrapper->mapped_data != nullptr))
                 {
@@ -2151,7 +2151,7 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
 
 void VulkanCaptureManager::PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMemory memory)
 {
-    auto wrapper = GetWrapper<DeviceMemoryWrapper>(memory);
+    auto wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
     assert(wrapper != nullptr);
 
     if (wrapper->mapped_data != nullptr)
@@ -2218,7 +2218,7 @@ void VulkanCaptureManager::PreProcess_vkFreeMemory(VkDevice                     
 
     if (memory != VK_NULL_HANDLE)
     {
-        auto wrapper = GetWrapper<DeviceMemoryWrapper>(memory);
+        auto wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
 
         if (wrapper->mapped_data != nullptr)
         {
@@ -2250,7 +2250,7 @@ void VulkanCaptureManager::PostProcess_vkFreeMemory(VkDevice                    
     if (memory != VK_NULL_HANDLE)
     {
         // Destroy external resources.
-        auto wrapper = GetWrapper<DeviceMemoryWrapper>(memory);
+        auto wrapper = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
 
         if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kPageGuard ||
             GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
@@ -2493,7 +2493,7 @@ void VulkanCaptureManager::PreProcess_vkCreateDescriptorUpdateTemplateKHR(
 
 void VulkanCaptureManager::PreProcess_vkGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo)
 {
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     if (!device_wrapper->property_feature_info.feature_bufferDeviceAddressCaptureReplay)
     {
         GFXRECON_LOG_ERROR_ONCE(
@@ -2506,7 +2506,7 @@ void VulkanCaptureManager::PreProcess_vkGetBufferDeviceAddress(VkDevice device, 
 void VulkanCaptureManager::PreProcess_vkGetBufferOpaqueCaptureAddress(VkDevice                         device,
                                                                       const VkBufferDeviceAddressInfo* pInfo)
 {
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     if (!device_wrapper->property_feature_info.feature_bufferDeviceAddressCaptureReplay)
     {
         GFXRECON_LOG_ERROR_ONCE(
@@ -2520,7 +2520,7 @@ void VulkanCaptureManager::PreProcess_vkGetBufferOpaqueCaptureAddress(VkDevice  
 void VulkanCaptureManager::PreProcess_vkGetDeviceMemoryOpaqueCaptureAddress(
     VkDevice device, const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo)
 {
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     if (!device_wrapper->property_feature_info.feature_bufferDeviceAddressCaptureReplay)
     {
         GFXRECON_LOG_ERROR_ONCE(
@@ -2534,7 +2534,7 @@ void VulkanCaptureManager::PreProcess_vkGetDeviceMemoryOpaqueCaptureAddress(
 void VulkanCaptureManager::PreProcess_vkGetAccelerationStructureDeviceAddressKHR(
     VkDevice device, const VkAccelerationStructureDeviceAddressInfoKHR* pInfo)
 {
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     if (!device_wrapper->property_feature_info.feature_accelerationStructureCaptureReplay)
     {
         GFXRECON_LOG_WARNING_ONCE(
@@ -2547,7 +2547,7 @@ void VulkanCaptureManager::PreProcess_vkGetAccelerationStructureDeviceAddressKHR
 void VulkanCaptureManager::PreProcess_vkGetRayTracingShaderGroupHandlesKHR(
     VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData)
 {
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     if (!device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
     {
         GFXRECON_LOG_WARNING_ONCE(
@@ -2564,7 +2564,7 @@ void VulkanCaptureManager::PreProcess_vkGetAndroidHardwareBufferPropertiesANDROI
 {
     GFXRECON_UNREFERENCED_PARAMETER(pProperties);
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     if (hardware_buffer != nullptr)
     {
         ProcessReferenceToAndroidHardwareBuffer(device, const_cast<AHardwareBuffer*>(hardware_buffer));
@@ -2618,7 +2618,7 @@ void VulkanCaptureManager::PostProcess_vkCmdDebugMarkerInsertEXT(VkCommandBuffer
         // Look for the debug marker that identifies this command buffer as a VR frame boundary.
         if (util::platform::StringContains(pMarkerInfo->pMarkerName, graphics::kVulkanVrFrameDelimiterString))
         {
-            auto cmd_buffer_wrapper = GetWrapper<CommandBufferWrapper>(commandBuffer);
+            auto cmd_buffer_wrapper = GetWrapper<VulkanCommandBufferWrapper>(commandBuffer);
             GFXRECON_ASSERT(cmd_buffer_wrapper != nullptr);
             cmd_buffer_wrapper->is_frame_boundary = true;
         }
@@ -2650,7 +2650,8 @@ bool VulkanCaptureManager::CheckBindAlignment(VkDeviceSize memoryOffset)
     return true;
 }
 
-bool VulkanCaptureManager::CheckCommandBufferWrapperForFrameBoundary(const CommandBufferWrapper* command_buffer_wrapper)
+bool VulkanCaptureManager::CheckCommandBufferWrapperForFrameBoundary(
+    const VulkanCommandBufferWrapper* command_buffer_wrapper)
 {
     GFXRECON_ASSERT(command_buffer_wrapper != nullptr);
     if (command_buffer_wrapper->is_frame_boundary)

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1,26 +1,26 @@
 /*
-** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
-** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and associated documentation files (the "Software"),
-** to deal in the Software without restriction, including without limitation
-** the rights to use, copy, modify, merge, publish, distribute, sublicense,
-** and/or sell copies of the Software, and to permit persons to whom the
-** Software is furnished to do so, subject to the following conditions:
-**
-** The above copyright notice and this permission notice shall be included in
-** all copies or substantial portions of the Software.
-**
-** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-** DEALINGS IN THE SOFTWARE.
-*/
+ ** Copyright (c) 2018-2021 Valve Corporation
+ ** Copyright (c) 2018-2023 LunarG, Inc.
+ ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
 
 #include "project_version.h"
 
@@ -420,8 +420,8 @@ void VulkanCaptureManager::SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTem
 
     if (create_info->descriptorUpdateEntryCount > 0)
     {
-        auto wrapper = GetVulkanWrapper<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(update_template);
-        UpdateTemplateInfo* info    = &wrapper->info;
+        auto wrapper             = GetVulkanWrapper<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(update_template);
+        UpdateTemplateInfo* info = &wrapper->info;
 
         for (size_t i = 0; i < create_info->descriptorUpdateEntryCount; ++i)
         {
@@ -637,7 +637,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
 
     assert(pCreateInfo_unwrapped != nullptr);
 
-    const VulkanInstanceTable* instance_table          = GetVulkanInstanceTable(physicalDevice);
+    const VulkanInstanceTable* instance_table = GetVulkanInstanceTable(physicalDevice);
     auto physical_device_wrapper = GetVulkanWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
 
     graphics::VulkanDeviceUtil                device_util;
@@ -1361,7 +1361,7 @@ void VulkanCaptureManager::DeferredOperationPostProcess(VkDevice               d
     VkResult                          result = VK_SUCCESS;
     auto deferred_operation_wrapper = GetVulkanWrapper<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
     auto device_wrapper             = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
-    const VulkanDeviceTable* device_table    = GetVulkanDeviceTable(device);
+    const VulkanDeviceTable* device_table = GetVulkanDeviceTable(device);
 
     GFXRECON_ASSERT(device_table != nullptr);
 
@@ -1588,9 +1588,9 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
 
                 auto physical_device_wrapper =
                     GetVulkanWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device);
-                format::HandleId physical_device_id      = physical_device_wrapper->handle_id;
-                VkPhysicalDevice physical_device_handle  = physical_device_wrapper->handle;
-                uint32_t         count                   = 0;
+                format::HandleId physical_device_id     = physical_device_wrapper->handle_id;
+                VkPhysicalDevice physical_device_handle = physical_device_wrapper->handle;
+                uint32_t         count                  = 0;
 
                 VkPhysicalDeviceProperties       properties;
                 VkPhysicalDeviceMemoryProperties memory_properties;
@@ -2106,7 +2106,7 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
             GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
         {
             const vulkan_wrappers::DeviceMemoryWrapper* current_memory_wrapper = nullptr;
-            util::PageGuardManager*          manager                = util::PageGuardManager::Get();
+            util::PageGuardManager*                     manager                = util::PageGuardManager::Get();
             assert(manager != nullptr);
 
             for (uint32_t i = 0; i < memoryRangeCount; ++i)

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -220,7 +220,7 @@ class VulkanCaptureManager : public CaptureManager
         if ((call_id == format::ApiCallId::ApiCall_vkBeginCommandBuffer) ||
             (call_id == format::ApiCallId::ApiCall_vkResetCommandBuffer))
         {
-            auto cmd_buffer_wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+            auto cmd_buffer_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
             GFXRECON_ASSERT(cmd_buffer_wrapper != nullptr);
             cmd_buffer_wrapper->is_frame_boundary = false;
         }
@@ -940,7 +940,7 @@ class VulkanCaptureManager : public CaptureManager
 
             for (uint32_t j = 0; j < pSubmits[i].commandBufferCount; ++j)
             {
-                auto cmd_buffer_wrapper = GetWrapper<CommandBufferWrapper>(pSubmits[i].pCommandBuffers[j]);
+                auto cmd_buffer_wrapper = GetWrapper<VulkanCommandBufferWrapper>(pSubmits[i].pCommandBuffers[j]);
                 if (CheckCommandBufferWrapperForFrameBoundary(cmd_buffer_wrapper))
                 {
                     break;
@@ -980,7 +980,7 @@ class VulkanCaptureManager : public CaptureManager
             for (uint32_t j = 0; j < pSubmits[i].commandBufferInfoCount; ++j)
             {
                 auto cmd_buffer_wrapper =
-                    GetWrapper<CommandBufferWrapper>(pSubmits[i].pCommandBufferInfos[j].commandBuffer);
+                    GetWrapper<VulkanCommandBufferWrapper>(pSubmits[i].pCommandBufferInfos[j].commandBuffer);
                 if (CheckCommandBufferWrapperForFrameBoundary(cmd_buffer_wrapper))
                 {
                     break;
@@ -1262,9 +1262,15 @@ class VulkanCaptureManager : public CaptureManager
 
     virtual ~VulkanCaptureManager() override {}
 
-    virtual void CreateStateTracker() override { state_tracker_ = std::make_unique<VulkanStateTracker>(); }
+    virtual void CreateStateTracker() override
+    {
+        state_tracker_ = std::make_unique<VulkanStateTracker>();
+    }
 
-    virtual void DestroyStateTracker() override { state_tracker_ = nullptr; }
+    virtual void DestroyStateTracker() override
+    {
+        state_tracker_ = nullptr;
+    }
 
     virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
 
@@ -1307,7 +1313,7 @@ class VulkanCaptureManager : public CaptureManager
     void
     ProcessEnumeratePhysicalDevices(VkResult result, VkInstance instance, uint32_t count, VkPhysicalDevice* devices);
 
-    VkMemoryPropertyFlags GetMemoryProperties(DeviceWrapper* device_wrapper, uint32_t memory_type_index);
+    VkMemoryPropertyFlags GetMemoryProperties(VulkanDeviceWrapper* device_wrapper, uint32_t memory_type_index);
 
     const VkImportAndroidHardwareBufferInfoANDROID*
     FindAllocateMemoryExtensions(const VkMemoryAllocateInfo* allocate_info);
@@ -1317,19 +1323,19 @@ class VulkanCaptureManager : public CaptureManager
     void ReleaseAndroidHardwareBuffer(AHardwareBuffer* hardware_buffer);
     bool CheckBindAlignment(VkDeviceSize memoryOffset);
 
-    bool CheckCommandBufferWrapperForFrameBoundary(const CommandBufferWrapper* command_buffer_wrapper);
+    bool CheckCommandBufferWrapperForFrameBoundary(const VulkanCommandBufferWrapper* command_buffer_wrapper);
 
     bool CheckPNextChainForFrameBoundary(const VkBaseInStructure* current);
 
   private:
     void QueueSubmitWriteFillMemoryCmd();
 
-    static VulkanCaptureManager*        instance_;
-    static VulkanLayerTable             vulkan_layer_table_;
-    std::set<DeviceMemoryWrapper*>      mapped_memory_; // Track mapped memory for unassisted tracking mode.
-    std::unique_ptr<VulkanStateTracker> state_tracker_;
-    HardwareBufferMap                   hardware_buffers_;
-    std::mutex                          deferred_operation_mutex;
+    static VulkanCaptureManager*         instance_;
+    static VulkanLayerTable              vulkan_layer_table_;
+    std::set<VulkanDeviceMemoryWrapper*> mapped_memory_; // Track mapped memory for unassisted tracking mode.
+    std::unique_ptr<VulkanStateTracker>  state_tracker_;
+    HardwareBufferMap                    hardware_buffers_;
+    std::mutex                           deferred_operation_mutex;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -77,7 +77,7 @@ class VulkanCaptureManager : public CaptureManager
     // the appropriate resource cleanup.
     static void CheckVkCreateInstanceStatus(VkResult result);
 
-    static const LayerTable* GetLayerTable() { return &layer_table_; }
+    static const VulkanLayerTable* GetVulkanLayerTable() { return &vulkan_layer_table_; }
 
     void InitVkInstance(VkInstance* instance, PFN_vkGetInstanceProcAddr gpa);
 
@@ -1325,7 +1325,7 @@ class VulkanCaptureManager : public CaptureManager
     void QueueSubmitWriteFillMemoryCmd();
 
     static VulkanCaptureManager*        instance_;
-    static LayerTable                   layer_table_;
+    static VulkanLayerTable             vulkan_layer_table_;
     std::set<DeviceMemoryWrapper*>      mapped_memory_; // Track mapped memory for unassisted tracking mode.
     std::unique_ptr<VulkanStateTracker> state_tracker_;
     HardwareBufferMap                   hardware_buffers_;

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -220,7 +220,7 @@ class VulkanCaptureManager : public CaptureManager
         if ((call_id == format::ApiCallId::ApiCall_vkBeginCommandBuffer) ||
             (call_id == format::ApiCallId::ApiCall_vkResetCommandBuffer))
         {
-            auto cmd_buffer_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+            auto cmd_buffer_wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
             GFXRECON_ASSERT(cmd_buffer_wrapper != nullptr);
             cmd_buffer_wrapper->is_frame_boundary = false;
         }
@@ -940,7 +940,8 @@ class VulkanCaptureManager : public CaptureManager
 
             for (uint32_t j = 0; j < pSubmits[i].commandBufferCount; ++j)
             {
-                auto cmd_buffer_wrapper = GetWrapper<VulkanCommandBufferWrapper>(pSubmits[i].pCommandBuffers[j]);
+                auto cmd_buffer_wrapper =
+                    GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(pSubmits[i].pCommandBuffers[j]);
                 if (CheckCommandBufferWrapperForFrameBoundary(cmd_buffer_wrapper))
                 {
                     break;
@@ -979,8 +980,8 @@ class VulkanCaptureManager : public CaptureManager
 
             for (uint32_t j = 0; j < pSubmits[i].commandBufferInfoCount; ++j)
             {
-                auto cmd_buffer_wrapper =
-                    GetWrapper<VulkanCommandBufferWrapper>(pSubmits[i].pCommandBufferInfos[j].commandBuffer);
+                auto cmd_buffer_wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(
+                    pSubmits[i].pCommandBufferInfos[j].commandBuffer);
                 if (CheckCommandBufferWrapperForFrameBoundary(cmd_buffer_wrapper))
                 {
                     break;
@@ -1077,7 +1078,8 @@ class VulkanCaptureManager : public CaptureManager
         if ((GetCaptureMode() & kModeTrack) == kModeTrack)
         {
             assert(state_tracker_ != nullptr);
-            state_tracker_->TrackQueryActivation(commandBuffer, queryPool, query, flags, QueryInfo::kInvalidIndex);
+            state_tracker_->TrackQueryActivation(
+                commandBuffer, queryPool, query, flags, vulkan_state_info::QueryInfo::kInvalidIndex);
         }
     }
 
@@ -1099,7 +1101,8 @@ class VulkanCaptureManager : public CaptureManager
         if ((GetCaptureMode() & kModeTrack) == kModeTrack)
         {
             assert(state_tracker_ != nullptr);
-            state_tracker_->TrackQueryActivation(commandBuffer, queryPool, query, 0, QueryInfo::kInvalidIndex);
+            state_tracker_->TrackQueryActivation(
+                commandBuffer, queryPool, query, 0, vulkan_state_info::QueryInfo::kInvalidIndex);
         }
     }
 
@@ -1111,7 +1114,8 @@ class VulkanCaptureManager : public CaptureManager
         if ((GetCaptureMode() & kModeTrack) == kModeTrack)
         {
             assert(state_tracker_ != nullptr);
-            state_tracker_->TrackQueryActivation(commandBuffer, queryPool, query, 0, QueryInfo::kInvalidIndex);
+            state_tracker_->TrackQueryActivation(
+                commandBuffer, queryPool, query, 0, vulkan_state_info::QueryInfo::kInvalidIndex);
         }
     }
 
@@ -1313,7 +1317,8 @@ class VulkanCaptureManager : public CaptureManager
     void
     ProcessEnumeratePhysicalDevices(VkResult result, VkInstance instance, uint32_t count, VkPhysicalDevice* devices);
 
-    VkMemoryPropertyFlags GetMemoryProperties(VulkanDeviceWrapper* device_wrapper, uint32_t memory_type_index);
+    VkMemoryPropertyFlags GetMemoryProperties(vulkan_wrappers::DeviceWrapper* device_wrapper,
+                                              uint32_t                        memory_type_index);
 
     const VkImportAndroidHardwareBufferInfoANDROID*
     FindAllocateMemoryExtensions(const VkMemoryAllocateInfo* allocate_info);
@@ -1323,7 +1328,7 @@ class VulkanCaptureManager : public CaptureManager
     void ReleaseAndroidHardwareBuffer(AHardwareBuffer* hardware_buffer);
     bool CheckBindAlignment(VkDeviceSize memoryOffset);
 
-    bool CheckCommandBufferWrapperForFrameBoundary(const VulkanCommandBufferWrapper* command_buffer_wrapper);
+    bool CheckCommandBufferWrapperForFrameBoundary(const vulkan_wrappers::CommandBufferWrapper* command_buffer_wrapper);
 
     bool CheckPNextChainForFrameBoundary(const VkBaseInStructure* current);
 
@@ -1332,7 +1337,7 @@ class VulkanCaptureManager : public CaptureManager
 
     static VulkanCaptureManager*         instance_;
     static VulkanLayerTable              vulkan_layer_table_;
-    std::set<VulkanDeviceMemoryWrapper*> mapped_memory_; // Track mapped memory for unassisted tracking mode.
+    std::set<vulkan_wrappers::DeviceMemoryWrapper*> mapped_memory_; // Track mapped memory for unassisted tracking mode.
     std::unique_ptr<VulkanStateTracker>  state_tracker_;
     HardwareBufferMap                    hardware_buffers_;
     std::mutex                           deferred_operation_mutex;

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1,26 +1,26 @@
 /*
-** Copyright (c) 2018-2021 Valve Corporation
-** Copyright (c) 2018-2023 LunarG, Inc.
-** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and associated documentation files (the "Software"),
-** to deal in the Software without restriction, including without limitation
-** the rights to use, copy, modify, merge, publish, distribute, sublicense,
-** and/or sell copies of the Software, and to permit persons to whom the
-** Software is furnished to do so, subject to the following conditions:
-**
-** The above copyright notice and this permission notice shall be included in
-** all copies or substantial portions of the Software.
-**
-** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-** DEALINGS IN THE SOFTWARE.
-*/
+ ** Copyright (c) 2018-2021 Valve Corporation
+ ** Copyright (c) 2018-2023 LunarG, Inc.
+ ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
 
 #ifndef GFXRECON_ENCODE_VULKAN_CAPTURE_MANAGER_H
 #define GFXRECON_ENCODE_VULKAN_CAPTURE_MANAGER_H
@@ -1335,12 +1335,12 @@ class VulkanCaptureManager : public CaptureManager
   private:
     void QueueSubmitWriteFillMemoryCmd();
 
-    static VulkanCaptureManager*         instance_;
-    static VulkanLayerTable              vulkan_layer_table_;
+    static VulkanCaptureManager*                    instance_;
+    static VulkanLayerTable                         vulkan_layer_table_;
     std::set<vulkan_wrappers::DeviceMemoryWrapper*> mapped_memory_; // Track mapped memory for unassisted tracking mode.
-    std::unique_ptr<VulkanStateTracker>  state_tracker_;
-    HardwareBufferMap                    hardware_buffers_;
-    std::mutex                           deferred_operation_mutex;
+    std::unique_ptr<VulkanStateTracker>             state_tracker_;
+    HardwareBufferMap                               hardware_buffers_;
+    std::mutex                                      deferred_operation_mutex;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -32,89 +32,93 @@ uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
     switch (object_type)
     {
         case VK_OBJECT_TYPE_INSTANCE:
-            return GetWrappedId<InstanceWrapper>(format::FromHandleId<VkInstance>(object));
+            return GetWrappedId<VulkanInstanceWrapper>(format::FromHandleId<VkInstance>(object));
         case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
-            return GetWrappedId<PhysicalDeviceWrapper>(format::FromHandleId<VkPhysicalDevice>(object));
+            return GetWrappedId<VulkanPhysicalDeviceWrapper>(format::FromHandleId<VkPhysicalDevice>(object));
         case VK_OBJECT_TYPE_DEVICE:
-            return GetWrappedId<DeviceWrapper>(format::FromHandleId<VkDevice>(object));
+            return GetWrappedId<VulkanDeviceWrapper>(format::FromHandleId<VkDevice>(object));
         case VK_OBJECT_TYPE_QUEUE:
-            return GetWrappedId<QueueWrapper>(format::FromHandleId<VkQueue>(object));
+            return GetWrappedId<VulkanQueueWrapper>(format::FromHandleId<VkQueue>(object));
         case VK_OBJECT_TYPE_SEMAPHORE:
-            return GetWrappedId<SemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
+            return GetWrappedId<VulkanSemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
         case VK_OBJECT_TYPE_COMMAND_BUFFER:
-            return GetWrappedId<CommandBufferWrapper>(format::FromHandleId<VkCommandBuffer>(object));
+            return GetWrappedId<VulkanCommandBufferWrapper>(format::FromHandleId<VkCommandBuffer>(object));
         case VK_OBJECT_TYPE_FENCE:
-            return GetWrappedId<FenceWrapper>(format::FromHandleId<VkFence>(object));
+            return GetWrappedId<VulkanFenceWrapper>(format::FromHandleId<VkFence>(object));
         case VK_OBJECT_TYPE_DEVICE_MEMORY:
-            return GetWrappedId<DeviceMemoryWrapper>(format::FromHandleId<VkDeviceMemory>(object));
+            return GetWrappedId<VulkanDeviceMemoryWrapper>(format::FromHandleId<VkDeviceMemory>(object));
         case VK_OBJECT_TYPE_BUFFER:
-            return GetWrappedId<BufferWrapper>(format::FromHandleId<VkBuffer>(object));
+            return GetWrappedId<VulkanBufferWrapper>(format::FromHandleId<VkBuffer>(object));
         case VK_OBJECT_TYPE_IMAGE:
-            return GetWrappedId<ImageWrapper>(format::FromHandleId<VkImage>(object));
+            return GetWrappedId<VulkanImageWrapper>(format::FromHandleId<VkImage>(object));
         case VK_OBJECT_TYPE_EVENT:
-            return GetWrappedId<EventWrapper>(format::FromHandleId<VkEvent>(object));
+            return GetWrappedId<VulkanEventWrapper>(format::FromHandleId<VkEvent>(object));
         case VK_OBJECT_TYPE_QUERY_POOL:
-            return GetWrappedId<QueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
+            return GetWrappedId<VulkanQueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
         case VK_OBJECT_TYPE_BUFFER_VIEW:
-            return GetWrappedId<BufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
+            return GetWrappedId<VulkanBufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
         case VK_OBJECT_TYPE_IMAGE_VIEW:
-            return GetWrappedId<ImageViewWrapper>(format::FromHandleId<VkImageView>(object));
+            return GetWrappedId<VulkanImageViewWrapper>(format::FromHandleId<VkImageView>(object));
         case VK_OBJECT_TYPE_SHADER_MODULE:
-            return GetWrappedId<ShaderModuleWrapper>(format::FromHandleId<VkShaderModule>(object));
+            return GetWrappedId<VulkanShaderModuleWrapper>(format::FromHandleId<VkShaderModule>(object));
         case VK_OBJECT_TYPE_PIPELINE_CACHE:
-            return GetWrappedId<PipelineCacheWrapper>(format::FromHandleId<VkPipelineCache>(object));
+            return GetWrappedId<VulkanPipelineCacheWrapper>(format::FromHandleId<VkPipelineCache>(object));
         case VK_OBJECT_TYPE_PIPELINE_LAYOUT:
-            return GetWrappedId<PipelineLayoutWrapper>(format::FromHandleId<VkPipelineLayout>(object));
+            return GetWrappedId<VulkanPipelineLayoutWrapper>(format::FromHandleId<VkPipelineLayout>(object));
         case VK_OBJECT_TYPE_RENDER_PASS:
-            return GetWrappedId<RenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
+            return GetWrappedId<VulkanRenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
         case VK_OBJECT_TYPE_PIPELINE:
-            return GetWrappedId<PipelineWrapper>(format::FromHandleId<VkPipeline>(object));
+            return GetWrappedId<VulkanPipelineWrapper>(format::FromHandleId<VkPipeline>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT:
-            return GetWrappedId<DescriptorSetLayoutWrapper>(format::FromHandleId<VkDescriptorSetLayout>(object));
+            return GetWrappedId<VulkanDescriptorSetLayoutWrapper>(format::FromHandleId<VkDescriptorSetLayout>(object));
         case VK_OBJECT_TYPE_SAMPLER:
-            return GetWrappedId<SamplerWrapper>(format::FromHandleId<VkSampler>(object));
+            return GetWrappedId<VulkanSamplerWrapper>(format::FromHandleId<VkSampler>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_POOL:
-            return GetWrappedId<DescriptorPoolWrapper>(format::FromHandleId<VkDescriptorPool>(object));
+            return GetWrappedId<VulkanDescriptorPoolWrapper>(format::FromHandleId<VkDescriptorPool>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET:
-            return GetWrappedId<DescriptorSetWrapper>(format::FromHandleId<VkDescriptorSet>(object));
+            return GetWrappedId<VulkanDescriptorSetWrapper>(format::FromHandleId<VkDescriptorSet>(object));
         case VK_OBJECT_TYPE_FRAMEBUFFER:
-            return GetWrappedId<FramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
+            return GetWrappedId<VulkanFramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
         case VK_OBJECT_TYPE_COMMAND_POOL:
-            return GetWrappedId<CommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
+            return GetWrappedId<VulkanCommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
         case VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION:
-            return GetWrappedId<SamplerYcbcrConversionWrapper>(format::FromHandleId<VkSamplerYcbcrConversion>(object));
+            return GetWrappedId<VulkanSamplerYcbcrConversionWrapper>(
+                format::FromHandleId<VkSamplerYcbcrConversion>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE:
-            return GetWrappedId<DescriptorUpdateTemplateWrapper>(
+            return GetWrappedId<VulkanDescriptorUpdateTemplateWrapper>(
                 format::FromHandleId<VkDescriptorUpdateTemplate>(object));
         case VK_OBJECT_TYPE_SURFACE_KHR:
-            return GetWrappedId<SurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
+            return GetWrappedId<VulkanSurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
         case VK_OBJECT_TYPE_SWAPCHAIN_KHR:
-            return GetWrappedId<SwapchainKHRWrapper>(format::FromHandleId<VkSwapchainKHR>(object));
+            return GetWrappedId<VulkanSwapchainKHRWrapper>(format::FromHandleId<VkSwapchainKHR>(object));
         case VK_OBJECT_TYPE_DISPLAY_KHR:
-            return GetWrappedId<DisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
+            return GetWrappedId<VulkanDisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
         case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
-            return GetWrappedId<DisplayModeKHRWrapper>(format::FromHandleId<VkDisplayModeKHR>(object));
+            return GetWrappedId<VulkanDisplayModeKHRWrapper>(format::FromHandleId<VkDisplayModeKHR>(object));
         case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
-            return GetWrappedId<DebugReportCallbackEXTWrapper>(format::FromHandleId<VkDebugReportCallbackEXT>(object));
+            return GetWrappedId<VulkanDebugReportCallbackEXTWrapper>(
+                format::FromHandleId<VkDebugReportCallbackEXT>(object));
         case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
-            return GetWrappedId<DebugUtilsMessengerEXTWrapper>(format::FromHandleId<VkDebugUtilsMessengerEXT>(object));
+            return GetWrappedId<VulkanDebugUtilsMessengerEXTWrapper>(
+                format::FromHandleId<VkDebugUtilsMessengerEXT>(object));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
-            return GetWrappedId<AccelerationStructureKHRWrapper>(
+            return GetWrappedId<VulkanAccelerationStructureKHRWrapper>(
                 format::FromHandleId<VkAccelerationStructureKHR>(object));
         case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
-            return GetWrappedId<ValidationCacheEXTWrapper>(format::FromHandleId<VkValidationCacheEXT>(object));
+            return GetWrappedId<VulkanValidationCacheEXTWrapper>(format::FromHandleId<VkValidationCacheEXT>(object));
         case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
-            return GetWrappedId<PerformanceConfigurationINTELWrapper>(
+            return GetWrappedId<VulkanPerformanceConfigurationINTELWrapper>(
                 format::FromHandleId<VkPerformanceConfigurationINTEL>(object));
         case VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR:
-            return GetWrappedId<DeferredOperationKHRWrapper>(format::FromHandleId<VkDeferredOperationKHR>(object));
+            return GetWrappedId<VulkanDeferredOperationKHRWrapper>(
+                format::FromHandleId<VkDeferredOperationKHR>(object));
         case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
-            return GetWrappedId<IndirectCommandsLayoutNVWrapper>(
+            return GetWrappedId<VulkanIndirectCommandsLayoutNVWrapper>(
                 format::FromHandleId<VkIndirectCommandsLayoutNV>(object));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
-            return GetWrappedId<PrivateDataSlotEXTWrapper>(format::FromHandleId<VkPrivateDataSlotEXT>(object));
+            return GetWrappedId<VulkanPrivateDataSlotEXTWrapper>(format::FromHandleId<VkPrivateDataSlotEXT>(object));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
-            return GetWrappedId<AccelerationStructureNVWrapper>(
+            return GetWrappedId<VulkanAccelerationStructureNVWrapper>(
                 format::FromHandleId<VkAccelerationStructureNV>(object));
         case VK_OBJECT_TYPE_UNKNOWN:
             // No conversion will be performed for unknown objects.
@@ -132,77 +136,79 @@ uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type)
     switch (object_type)
     {
         case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
-            return GetWrappedId<InstanceWrapper>(format::FromHandleId<VkInstance>(object));
+            return GetWrappedId<VulkanInstanceWrapper>(format::FromHandleId<VkInstance>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
-            return GetWrappedId<PhysicalDeviceWrapper>(format::FromHandleId<VkPhysicalDevice>(object));
+            return GetWrappedId<VulkanPhysicalDeviceWrapper>(format::FromHandleId<VkPhysicalDevice>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
-            return GetWrappedId<DeviceWrapper>(format::FromHandleId<VkDevice>(object));
+            return GetWrappedId<VulkanDeviceWrapper>(format::FromHandleId<VkDevice>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
-            return GetWrappedId<QueueWrapper>(format::FromHandleId<VkQueue>(object));
+            return GetWrappedId<VulkanQueueWrapper>(format::FromHandleId<VkQueue>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
-            return GetWrappedId<SemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
+            return GetWrappedId<VulkanSemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
-            return GetWrappedId<CommandBufferWrapper>(format::FromHandleId<VkCommandBuffer>(object));
+            return GetWrappedId<VulkanCommandBufferWrapper>(format::FromHandleId<VkCommandBuffer>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
-            return GetWrappedId<FenceWrapper>(format::FromHandleId<VkFence>(object));
+            return GetWrappedId<VulkanFenceWrapper>(format::FromHandleId<VkFence>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
-            return GetWrappedId<DeviceMemoryWrapper>(format::FromHandleId<VkDeviceMemory>(object));
+            return GetWrappedId<VulkanDeviceMemoryWrapper>(format::FromHandleId<VkDeviceMemory>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
-            return GetWrappedId<BufferWrapper>(format::FromHandleId<VkBuffer>(object));
+            return GetWrappedId<VulkanBufferWrapper>(format::FromHandleId<VkBuffer>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
-            return GetWrappedId<ImageWrapper>(format::FromHandleId<VkImage>(object));
+            return GetWrappedId<VulkanImageWrapper>(format::FromHandleId<VkImage>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
-            return GetWrappedId<EventWrapper>(format::FromHandleId<VkEvent>(object));
+            return GetWrappedId<VulkanEventWrapper>(format::FromHandleId<VkEvent>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
-            return GetWrappedId<QueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
+            return GetWrappedId<VulkanQueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
-            return GetWrappedId<BufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
+            return GetWrappedId<VulkanBufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
-            return GetWrappedId<ImageViewWrapper>(format::FromHandleId<VkImageView>(object));
+            return GetWrappedId<VulkanImageViewWrapper>(format::FromHandleId<VkImageView>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
-            return GetWrappedId<ShaderModuleWrapper>(format::FromHandleId<VkShaderModule>(object));
+            return GetWrappedId<VulkanShaderModuleWrapper>(format::FromHandleId<VkShaderModule>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
-            return GetWrappedId<PipelineCacheWrapper>(format::FromHandleId<VkPipelineCache>(object));
+            return GetWrappedId<VulkanPipelineCacheWrapper>(format::FromHandleId<VkPipelineCache>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
-            return GetWrappedId<PipelineLayoutWrapper>(format::FromHandleId<VkPipelineLayout>(object));
+            return GetWrappedId<VulkanPipelineLayoutWrapper>(format::FromHandleId<VkPipelineLayout>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
-            return GetWrappedId<RenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
+            return GetWrappedId<VulkanRenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
-            return GetWrappedId<PipelineWrapper>(format::FromHandleId<VkPipeline>(object));
+            return GetWrappedId<VulkanPipelineWrapper>(format::FromHandleId<VkPipeline>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
-            return GetWrappedId<DescriptorSetLayoutWrapper>(format::FromHandleId<VkDescriptorSetLayout>(object));
+            return GetWrappedId<VulkanDescriptorSetLayoutWrapper>(format::FromHandleId<VkDescriptorSetLayout>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
-            return GetWrappedId<SamplerWrapper>(format::FromHandleId<VkSampler>(object));
+            return GetWrappedId<VulkanSamplerWrapper>(format::FromHandleId<VkSampler>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
-            return GetWrappedId<DescriptorPoolWrapper>(format::FromHandleId<VkDescriptorPool>(object));
+            return GetWrappedId<VulkanDescriptorPoolWrapper>(format::FromHandleId<VkDescriptorPool>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
-            return GetWrappedId<DescriptorSetWrapper>(format::FromHandleId<VkDescriptorSet>(object));
+            return GetWrappedId<VulkanDescriptorSetWrapper>(format::FromHandleId<VkDescriptorSet>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
-            return GetWrappedId<FramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
+            return GetWrappedId<VulkanFramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
-            return GetWrappedId<CommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
+            return GetWrappedId<VulkanCommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
-            return GetWrappedId<SurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
+            return GetWrappedId<VulkanSurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
-            return GetWrappedId<SwapchainKHRWrapper>(format::FromHandleId<VkSwapchainKHR>(object));
+            return GetWrappedId<VulkanSwapchainKHRWrapper>(format::FromHandleId<VkSwapchainKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
-            return GetWrappedId<DebugReportCallbackEXTWrapper>(format::FromHandleId<VkDebugReportCallbackEXT>(object));
+            return GetWrappedId<VulkanDebugReportCallbackEXTWrapper>(
+                format::FromHandleId<VkDebugReportCallbackEXT>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
-            return GetWrappedId<DisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
+            return GetWrappedId<VulkanDisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
-            return GetWrappedId<DisplayModeKHRWrapper>(format::FromHandleId<VkDisplayModeKHR>(object));
+            return GetWrappedId<VulkanDisplayModeKHRWrapper>(format::FromHandleId<VkDisplayModeKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
-            return GetWrappedId<ValidationCacheEXTWrapper>(format::FromHandleId<VkValidationCacheEXT>(object));
+            return GetWrappedId<VulkanValidationCacheEXTWrapper>(format::FromHandleId<VkValidationCacheEXT>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
-            return GetWrappedId<SamplerYcbcrConversionWrapper>(format::FromHandleId<VkSamplerYcbcrConversion>(object));
+            return GetWrappedId<VulkanSamplerYcbcrConversionWrapper>(
+                format::FromHandleId<VkSamplerYcbcrConversion>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
-            return GetWrappedId<DescriptorUpdateTemplateWrapper>(
+            return GetWrappedId<VulkanDescriptorUpdateTemplateWrapper>(
                 format::FromHandleId<VkDescriptorUpdateTemplate>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
-            return GetWrappedId<AccelerationStructureKHRWrapper>(
+            return GetWrappedId<VulkanAccelerationStructureKHRWrapper>(
                 format::FromHandleId<VkAccelerationStructureKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
-            return GetWrappedId<AccelerationStructureNVWrapper>(
+            return GetWrappedId<VulkanAccelerationStructureNVWrapper>(
                 format::FromHandleId<VkAccelerationStructureNV>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
             // No conversion will be performed for unknown objects.

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -27,98 +27,111 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 VulkanStateHandleTable state_handle_table_;
 
-uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
+uint64_t GetVulkanWrappedId(uint64_t object, VkObjectType object_type)
 {
     switch (object_type)
     {
         case VK_OBJECT_TYPE_INSTANCE:
-            return GetWrappedId<VulkanInstanceWrapper>(format::FromHandleId<VkInstance>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::InstanceWrapper>(format::FromHandleId<VkInstance>(object));
         case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
-            return GetWrappedId<VulkanPhysicalDeviceWrapper>(format::FromHandleId<VkPhysicalDevice>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(
+                format::FromHandleId<VkPhysicalDevice>(object));
         case VK_OBJECT_TYPE_DEVICE:
-            return GetWrappedId<VulkanDeviceWrapper>(format::FromHandleId<VkDevice>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DeviceWrapper>(format::FromHandleId<VkDevice>(object));
         case VK_OBJECT_TYPE_QUEUE:
-            return GetWrappedId<VulkanQueueWrapper>(format::FromHandleId<VkQueue>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::QueueWrapper>(format::FromHandleId<VkQueue>(object));
         case VK_OBJECT_TYPE_SEMAPHORE:
-            return GetWrappedId<VulkanSemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
         case VK_OBJECT_TYPE_COMMAND_BUFFER:
-            return GetWrappedId<VulkanCommandBufferWrapper>(format::FromHandleId<VkCommandBuffer>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::CommandBufferWrapper>(
+                format::FromHandleId<VkCommandBuffer>(object));
         case VK_OBJECT_TYPE_FENCE:
-            return GetWrappedId<VulkanFenceWrapper>(format::FromHandleId<VkFence>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::FenceWrapper>(format::FromHandleId<VkFence>(object));
         case VK_OBJECT_TYPE_DEVICE_MEMORY:
-            return GetWrappedId<VulkanDeviceMemoryWrapper>(format::FromHandleId<VkDeviceMemory>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(
+                format::FromHandleId<VkDeviceMemory>(object));
         case VK_OBJECT_TYPE_BUFFER:
-            return GetWrappedId<VulkanBufferWrapper>(format::FromHandleId<VkBuffer>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(format::FromHandleId<VkBuffer>(object));
         case VK_OBJECT_TYPE_IMAGE:
-            return GetWrappedId<VulkanImageWrapper>(format::FromHandleId<VkImage>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(format::FromHandleId<VkImage>(object));
         case VK_OBJECT_TYPE_EVENT:
-            return GetWrappedId<VulkanEventWrapper>(format::FromHandleId<VkEvent>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(format::FromHandleId<VkEvent>(object));
         case VK_OBJECT_TYPE_QUERY_POOL:
-            return GetWrappedId<VulkanQueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
         case VK_OBJECT_TYPE_BUFFER_VIEW:
-            return GetWrappedId<VulkanBufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::BufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
         case VK_OBJECT_TYPE_IMAGE_VIEW:
-            return GetWrappedId<VulkanImageViewWrapper>(format::FromHandleId<VkImageView>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(format::FromHandleId<VkImageView>(object));
         case VK_OBJECT_TYPE_SHADER_MODULE:
-            return GetWrappedId<VulkanShaderModuleWrapper>(format::FromHandleId<VkShaderModule>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ShaderModuleWrapper>(
+                format::FromHandleId<VkShaderModule>(object));
         case VK_OBJECT_TYPE_PIPELINE_CACHE:
-            return GetWrappedId<VulkanPipelineCacheWrapper>(format::FromHandleId<VkPipelineCache>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PipelineCacheWrapper>(
+                format::FromHandleId<VkPipelineCache>(object));
         case VK_OBJECT_TYPE_PIPELINE_LAYOUT:
-            return GetWrappedId<VulkanPipelineLayoutWrapper>(format::FromHandleId<VkPipelineLayout>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(
+                format::FromHandleId<VkPipelineLayout>(object));
         case VK_OBJECT_TYPE_RENDER_PASS:
-            return GetWrappedId<VulkanRenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::RenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
         case VK_OBJECT_TYPE_PIPELINE:
-            return GetWrappedId<VulkanPipelineWrapper>(format::FromHandleId<VkPipeline>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PipelineWrapper>(format::FromHandleId<VkPipeline>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT:
-            return GetWrappedId<VulkanDescriptorSetLayoutWrapper>(format::FromHandleId<VkDescriptorSetLayout>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(
+                format::FromHandleId<VkDescriptorSetLayout>(object));
         case VK_OBJECT_TYPE_SAMPLER:
-            return GetWrappedId<VulkanSamplerWrapper>(format::FromHandleId<VkSampler>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SamplerWrapper>(format::FromHandleId<VkSampler>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_POOL:
-            return GetWrappedId<VulkanDescriptorPoolWrapper>(format::FromHandleId<VkDescriptorPool>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorPoolWrapper>(
+                format::FromHandleId<VkDescriptorPool>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_SET:
-            return GetWrappedId<VulkanDescriptorSetWrapper>(format::FromHandleId<VkDescriptorSet>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorSetWrapper>(
+                format::FromHandleId<VkDescriptorSet>(object));
         case VK_OBJECT_TYPE_FRAMEBUFFER:
-            return GetWrappedId<VulkanFramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::FramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
         case VK_OBJECT_TYPE_COMMAND_POOL:
-            return GetWrappedId<VulkanCommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::CommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
         case VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION:
-            return GetWrappedId<VulkanSamplerYcbcrConversionWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::SamplerYcbcrConversionWrapper>(
                 format::FromHandleId<VkSamplerYcbcrConversion>(object));
         case VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE:
-            return GetWrappedId<VulkanDescriptorUpdateTemplateWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(
                 format::FromHandleId<VkDescriptorUpdateTemplate>(object));
         case VK_OBJECT_TYPE_SURFACE_KHR:
-            return GetWrappedId<VulkanSurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
         case VK_OBJECT_TYPE_SWAPCHAIN_KHR:
-            return GetWrappedId<VulkanSwapchainKHRWrapper>(format::FromHandleId<VkSwapchainKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SwapchainKHRWrapper>(
+                format::FromHandleId<VkSwapchainKHR>(object));
         case VK_OBJECT_TYPE_DISPLAY_KHR:
-            return GetWrappedId<VulkanDisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
         case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
-            return GetWrappedId<VulkanDisplayModeKHRWrapper>(format::FromHandleId<VkDisplayModeKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DisplayModeKHRWrapper>(
+                format::FromHandleId<VkDisplayModeKHR>(object));
         case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
-            return GetWrappedId<VulkanDebugReportCallbackEXTWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::DebugReportCallbackEXTWrapper>(
                 format::FromHandleId<VkDebugReportCallbackEXT>(object));
         case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
-            return GetWrappedId<VulkanDebugUtilsMessengerEXTWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(
                 format::FromHandleId<VkDebugUtilsMessengerEXT>(object));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
-            return GetWrappedId<VulkanAccelerationStructureKHRWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(
                 format::FromHandleId<VkAccelerationStructureKHR>(object));
         case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
-            return GetWrappedId<VulkanValidationCacheEXTWrapper>(format::FromHandleId<VkValidationCacheEXT>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ValidationCacheEXTWrapper>(
+                format::FromHandleId<VkValidationCacheEXT>(object));
         case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
-            return GetWrappedId<VulkanPerformanceConfigurationINTELWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(
                 format::FromHandleId<VkPerformanceConfigurationINTEL>(object));
         case VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR:
-            return GetWrappedId<VulkanDeferredOperationKHRWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::DeferredOperationKHRWrapper>(
                 format::FromHandleId<VkDeferredOperationKHR>(object));
         case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
-            return GetWrappedId<VulkanIndirectCommandsLayoutNVWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(
                 format::FromHandleId<VkIndirectCommandsLayoutNV>(object));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
-            return GetWrappedId<VulkanPrivateDataSlotEXTWrapper>(format::FromHandleId<VkPrivateDataSlotEXT>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PrivateDataSlotEXTWrapper>(
+                format::FromHandleId<VkPrivateDataSlotEXT>(object));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
-            return GetWrappedId<VulkanAccelerationStructureNVWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(
                 format::FromHandleId<VkAccelerationStructureNV>(object));
         case VK_OBJECT_TYPE_UNKNOWN:
             // No conversion will be performed for unknown objects.
@@ -131,84 +144,96 @@ uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
     }
 }
 
-uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type)
+uint64_t GetVulkanWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type)
 {
     switch (object_type)
     {
         case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
-            return GetWrappedId<VulkanInstanceWrapper>(format::FromHandleId<VkInstance>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::InstanceWrapper>(format::FromHandleId<VkInstance>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
-            return GetWrappedId<VulkanPhysicalDeviceWrapper>(format::FromHandleId<VkPhysicalDevice>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(
+                format::FromHandleId<VkPhysicalDevice>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
-            return GetWrappedId<VulkanDeviceWrapper>(format::FromHandleId<VkDevice>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DeviceWrapper>(format::FromHandleId<VkDevice>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
-            return GetWrappedId<VulkanQueueWrapper>(format::FromHandleId<VkQueue>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::QueueWrapper>(format::FromHandleId<VkQueue>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
-            return GetWrappedId<VulkanSemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SemaphoreWrapper>(format::FromHandleId<VkSemaphore>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
-            return GetWrappedId<VulkanCommandBufferWrapper>(format::FromHandleId<VkCommandBuffer>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::CommandBufferWrapper>(
+                format::FromHandleId<VkCommandBuffer>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
-            return GetWrappedId<VulkanFenceWrapper>(format::FromHandleId<VkFence>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::FenceWrapper>(format::FromHandleId<VkFence>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
-            return GetWrappedId<VulkanDeviceMemoryWrapper>(format::FromHandleId<VkDeviceMemory>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(
+                format::FromHandleId<VkDeviceMemory>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
-            return GetWrappedId<VulkanBufferWrapper>(format::FromHandleId<VkBuffer>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(format::FromHandleId<VkBuffer>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
-            return GetWrappedId<VulkanImageWrapper>(format::FromHandleId<VkImage>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(format::FromHandleId<VkImage>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
-            return GetWrappedId<VulkanEventWrapper>(format::FromHandleId<VkEvent>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(format::FromHandleId<VkEvent>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
-            return GetWrappedId<VulkanQueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(format::FromHandleId<VkQueryPool>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
-            return GetWrappedId<VulkanBufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::BufferViewWrapper>(format::FromHandleId<VkBufferView>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
-            return GetWrappedId<VulkanImageViewWrapper>(format::FromHandleId<VkImageView>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(format::FromHandleId<VkImageView>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
-            return GetWrappedId<VulkanShaderModuleWrapper>(format::FromHandleId<VkShaderModule>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ShaderModuleWrapper>(
+                format::FromHandleId<VkShaderModule>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
-            return GetWrappedId<VulkanPipelineCacheWrapper>(format::FromHandleId<VkPipelineCache>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PipelineCacheWrapper>(
+                format::FromHandleId<VkPipelineCache>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
-            return GetWrappedId<VulkanPipelineLayoutWrapper>(format::FromHandleId<VkPipelineLayout>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(
+                format::FromHandleId<VkPipelineLayout>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
-            return GetWrappedId<VulkanRenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::RenderPassWrapper>(format::FromHandleId<VkRenderPass>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
-            return GetWrappedId<VulkanPipelineWrapper>(format::FromHandleId<VkPipeline>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::PipelineWrapper>(format::FromHandleId<VkPipeline>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
-            return GetWrappedId<VulkanDescriptorSetLayoutWrapper>(format::FromHandleId<VkDescriptorSetLayout>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(
+                format::FromHandleId<VkDescriptorSetLayout>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
-            return GetWrappedId<VulkanSamplerWrapper>(format::FromHandleId<VkSampler>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SamplerWrapper>(format::FromHandleId<VkSampler>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
-            return GetWrappedId<VulkanDescriptorPoolWrapper>(format::FromHandleId<VkDescriptorPool>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorPoolWrapper>(
+                format::FromHandleId<VkDescriptorPool>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
-            return GetWrappedId<VulkanDescriptorSetWrapper>(format::FromHandleId<VkDescriptorSet>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorSetWrapper>(
+                format::FromHandleId<VkDescriptorSet>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
-            return GetWrappedId<VulkanFramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::FramebufferWrapper>(format::FromHandleId<VkFramebuffer>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
-            return GetWrappedId<VulkanCommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::CommandPoolWrapper>(format::FromHandleId<VkCommandPool>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
-            return GetWrappedId<VulkanSurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SurfaceKHRWrapper>(format::FromHandleId<VkSurfaceKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
-            return GetWrappedId<VulkanSwapchainKHRWrapper>(format::FromHandleId<VkSwapchainKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::SwapchainKHRWrapper>(
+                format::FromHandleId<VkSwapchainKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
-            return GetWrappedId<VulkanDebugReportCallbackEXTWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::DebugReportCallbackEXTWrapper>(
                 format::FromHandleId<VkDebugReportCallbackEXT>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
-            return GetWrappedId<VulkanDisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DisplayKHRWrapper>(format::FromHandleId<VkDisplayKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
-            return GetWrappedId<VulkanDisplayModeKHRWrapper>(format::FromHandleId<VkDisplayModeKHR>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::DisplayModeKHRWrapper>(
+                format::FromHandleId<VkDisplayModeKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
-            return GetWrappedId<VulkanValidationCacheEXTWrapper>(format::FromHandleId<VkValidationCacheEXT>(object));
+            return GetVulkanWrappedId<vulkan_wrappers::ValidationCacheEXTWrapper>(
+                format::FromHandleId<VkValidationCacheEXT>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
-            return GetWrappedId<VulkanSamplerYcbcrConversionWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::SamplerYcbcrConversionWrapper>(
                 format::FromHandleId<VkSamplerYcbcrConversion>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
-            return GetWrappedId<VulkanDescriptorUpdateTemplateWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(
                 format::FromHandleId<VkDescriptorUpdateTemplate>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
-            return GetWrappedId<VulkanAccelerationStructureKHRWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(
                 format::FromHandleId<VkAccelerationStructureKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
-            return GetWrappedId<VulkanAccelerationStructureNVWrapper>(
+            return GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(
                 format::FromHandleId<VkAccelerationStructureNV>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
             // No conversion will be performed for unknown objects.

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -122,14 +122,14 @@ uint64_t GetWrappedId(uint64_t, VkObjectType object_type);
 
 uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type);
 
-inline const InstanceTable* GetInstanceTable(VkInstance handle)
+inline const VulkanInstanceTable* GetVulkanInstanceTable(VkInstance handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<InstanceWrapper>(handle);
     return &wrapper->layer_table;
 }
 
-inline const InstanceTable* GetInstanceTable(VkPhysicalDevice handle)
+inline const VulkanInstanceTable* GetVulkanInstanceTable(VkPhysicalDevice handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<PhysicalDeviceWrapper>(handle);
@@ -137,14 +137,14 @@ inline const InstanceTable* GetInstanceTable(VkPhysicalDevice handle)
     return wrapper->layer_table_ref;
 }
 
-inline const DeviceTable* GetDeviceTable(VkDevice handle)
+inline const VulkanDeviceTable* GetVulkanDeviceTable(VkDevice handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<DeviceWrapper>(handle);
     return &wrapper->layer_table;
 }
 
-inline const DeviceTable* GetDeviceTable(VkQueue handle)
+inline const VulkanDeviceTable* GetVulkanDeviceTable(VkQueue handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<QueueWrapper>(handle);
@@ -152,7 +152,7 @@ inline const DeviceTable* GetDeviceTable(VkQueue handle)
     return wrapper->layer_table_ref;
 }
 
-inline const DeviceTable* GetDeviceTable(VkCommandBuffer handle)
+inline const VulkanDeviceTable* GetVulkanDeviceTable(VkCommandBuffer handle)
 {
     assert(handle != VK_NULL_HANDLE);
     auto wrapper = GetWrapper<CommandBufferWrapper>(handle);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -106,7 +106,7 @@ struct DisplayKHRWrapper : public HandleWrapper<VkDisplayKHR>
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
 struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
-    InstanceTable*                  layer_table_ref{ nullptr };
+    VulkanInstanceTable*            layer_table_ref{ nullptr };
     std::vector<DisplayKHRWrapper*> child_displays;
     uint32_t                        instance_api_version{ 0 };
 
@@ -124,7 +124,7 @@ struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 
 struct InstanceWrapper : public HandleWrapper<VkInstance>
 {
-    InstanceTable                       layer_table;
+    VulkanInstanceTable                 layer_table;
     std::vector<PhysicalDeviceWrapper*> child_physical_devices;
     bool                                have_device_properties{ false };
     uint32_t                            api_version{ VK_MAKE_VERSION(1, 0, 0) };
@@ -132,12 +132,12 @@ struct InstanceWrapper : public HandleWrapper<VkInstance>
 
 struct QueueWrapper : public HandleWrapper<VkQueue>
 {
-    DeviceTable* layer_table_ref{ nullptr };
+    VulkanDeviceTable* layer_table_ref{ nullptr };
 };
 
 struct DeviceWrapper : public HandleWrapper<VkDevice>
 {
-    DeviceTable                layer_table;
+    VulkanDeviceTable          layer_table;
     PhysicalDeviceWrapper*     physical_device{ nullptr };
     std::vector<QueueWrapper*> child_queues;
 
@@ -274,7 +274,7 @@ struct AccelerationStructureKHRWrapper;
 struct CommandPoolWrapper;
 struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
 {
-    DeviceTable* layer_table_ref{ nullptr };
+    VulkanDeviceTable* layer_table_ref{ nullptr };
 
     // Members for general wrapper support.
     // Pool from which command buffer was allocated. The command buffer must be removed from the pool's allocation list

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -1,25 +1,25 @@
 /*
-** Copyright (c) 2019-2020 LunarG, Inc.
-** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and associated documentation files (the "Software"),
-** to deal in the Software without restriction, including without limitation
-** the rights to use, copy, modify, merge, publish, distribute, sublicense,
-** and/or sell copies of the Software, and to permit persons to whom the
-** Software is furnished to do so, subject to the following conditions:
-**
-** The above copyright notice and this permission notice shall be included in
-** all copies or substantial portions of the Software.
-**
-** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-** DEALINGS IN THE SOFTWARE.
-*/
+ ** Copyright (c) 2019-2020 LunarG, Inc.
+ ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
 
 #ifndef GFXRECON_ENCODE_VULKAN_HANDLE_WRAPPERS_H
 #define GFXRECON_ENCODE_VULKAN_HANDLE_WRAPPERS_H
@@ -107,9 +107,9 @@ struct DisplayKHRWrapper : public HandleWrapper<VkDisplayKHR>
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
 struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
-    VulkanInstanceTable*                  layer_table_ref{ nullptr };
-    std::vector<DisplayKHRWrapper*>       child_displays;
-    uint32_t                              instance_api_version{ 0 };
+    VulkanInstanceTable*            layer_table_ref{ nullptr };
+    std::vector<DisplayKHRWrapper*> child_displays;
+    uint32_t                        instance_api_version{ 0 };
 
     // Track memory types for use when creating snapshots of buffer and image resource memory content.
     VkPhysicalDeviceMemoryProperties memory_properties{};
@@ -125,10 +125,10 @@ struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 
 struct InstanceWrapper : public HandleWrapper<VkInstance>
 {
-    VulkanInstanceTable                       layer_table;
-    std::vector<PhysicalDeviceWrapper*>       child_physical_devices;
-    bool                                      have_device_properties{ false };
-    uint32_t                                  api_version{ VK_MAKE_VERSION(1, 0, 0) };
+    VulkanInstanceTable                 layer_table;
+    std::vector<PhysicalDeviceWrapper*> child_physical_devices;
+    bool                                have_device_properties{ false };
+    uint32_t                            api_version{ VK_MAKE_VERSION(1, 0, 0) };
 };
 
 struct QueueWrapper : public HandleWrapper<VkQueue>
@@ -138,9 +138,9 @@ struct QueueWrapper : public HandleWrapper<VkQueue>
 
 struct DeviceWrapper : public HandleWrapper<VkDevice>
 {
-    VulkanDeviceTable                layer_table;
-    PhysicalDeviceWrapper*           physical_device{ nullptr };
-    std::vector<QueueWrapper*>       child_queues;
+    VulkanDeviceTable          layer_table;
+    PhysicalDeviceWrapper*     physical_device{ nullptr };
+    std::vector<QueueWrapper*> child_queues;
 
     // Physical device property & feature state at device creation
     graphics::VulkanDevicePropertyFeatureInfo              property_feature_info;
@@ -151,8 +151,8 @@ struct FenceWrapper : public HandleWrapper<VkFence>
 {
     // Signaled state at creation to be compared with signaled state at snapshot write. If states are different, the
     // create parameters will need to be modified to reflect the state at snapshot write.
-    bool                 created_signaled{ false };
-    DeviceWrapper*       device{ nullptr };
+    bool           created_signaled{ false };
+    DeviceWrapper* device{ nullptr };
 };
 
 struct EventWrapper : public HandleWrapper<VkEvent>
@@ -169,15 +169,15 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     // The device wrapper will be initialized when allocating the memory. Some handling
     // like StateTracker::TrackTlasToBlasDependencies may use it before mapping
     // the memory.
-    DeviceWrapper*       parent_device{ nullptr };
-    const void*          mapped_data{ nullptr };
-    VkDeviceSize         mapped_offset{ 0 };
-    VkDeviceSize         mapped_size{ 0 };
-    VkMemoryMapFlags     mapped_flags{ 0 };
-    void*                external_allocation{ nullptr };
-    uintptr_t            shadow_allocation{ util::PageGuardManager::kNullShadowHandle };
-    AHardwareBuffer*     hardware_buffer{ nullptr };
-    format::HandleId     hardware_buffer_memory_id{ format::kNullHandleId };
+    DeviceWrapper*   parent_device{ nullptr };
+    const void*      mapped_data{ nullptr };
+    VkDeviceSize     mapped_offset{ 0 };
+    VkDeviceSize     mapped_size{ 0 };
+    VkMemoryMapFlags mapped_flags{ 0 };
+    void*            external_allocation{ nullptr };
+    uintptr_t        shadow_allocation{ util::PageGuardManager::kNullShadowHandle };
+    AHardwareBuffer* hardware_buffer{ nullptr };
+    format::HandleId hardware_buffer_memory_id{ format::kNullHandleId };
 
     // State tracking info for memory with device addresses.
     format::HandleId device_id{ format::kNullHandleId };
@@ -186,8 +186,8 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
 
 struct BufferWrapper : public HandleWrapper<VkBuffer>
 {
-    DeviceWrapper*       bind_device{ nullptr };
-    const void*          bind_pnext{ nullptr };
+    DeviceWrapper*     bind_device{ nullptr };
+    const void*        bind_pnext{ nullptr };
     HandleUnwrapMemory bind_pnext_memory; // Global HandleUnwrapMemory could be reset anytime, so it should have its own
                                           // HandleUnwrapMemory.
     format::HandleId bind_memory_id{ format::kNullHandleId };
@@ -202,8 +202,8 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>
 
 struct ImageWrapper : public HandleWrapper<VkImage>
 {
-    DeviceWrapper*       bind_device{ nullptr };
-    const void*          bind_pnext{ nullptr };
+    DeviceWrapper*     bind_device{ nullptr };
+    const void*        bind_pnext{ nullptr };
     HandleUnwrapMemory bind_pnext_memory; // Global HandleUnwrapMemory could be reset anytime, so it should have its own
                                           // HandleUnwrapMemory.
     format::HandleId         bind_memory_id{ format::kNullHandleId };
@@ -228,8 +228,8 @@ struct BufferViewWrapper : public HandleWrapper<VkBufferView>
 
 struct ImageViewWrapper : public HandleWrapper<VkImageView>
 {
-    format::HandleId    image_id{ format::kNullHandleId };
-    ImageWrapper*       image{ nullptr };
+    format::HandleId image_id{ format::kNullHandleId };
+    ImageWrapper*    image{ nullptr };
 };
 
 struct FramebufferWrapper : public HandleWrapper<VkFramebuffer>
@@ -251,9 +251,9 @@ struct SemaphoreWrapper : public HandleWrapper<VkSemaphore>
     // AcquireNextImageKHR, or AcquireNextImage2KHR as a signal semaphore. State is not signaled when a semaphore is
     // submitted to QueueSubmit, QueueBindSparse, or QueuePresentKHR as a wait semaphore. Initial state after creation
     // is not signaled.
-    bool                 signaled{ false };
-    VkSemaphoreType      type{ VK_SEMAPHORE_TYPE_BINARY_KHR };
-    DeviceWrapper*       device{ nullptr };
+    bool            signaled{ false };
+    VkSemaphoreType type{ VK_SEMAPHORE_TYPE_BINARY_KHR };
+    DeviceWrapper*  device{ nullptr };
 };
 
 struct QueryPoolWrapper : public HandleWrapper<VkQueryPool>
@@ -405,8 +405,8 @@ struct CommandPoolWrapper : public HandleWrapper<VkCommandPool>
     // Members for trimming state tracking.
     uint32_t queue_family_index{ 0 };
 
-    DeviceWrapper*       device{ nullptr };
-    bool                 trim_command_pool{ false };
+    DeviceWrapper* device{ nullptr };
+    bool           trim_command_pool{ false };
 };
 
 // For vkGetPhysicalDeviceSurfaceCapabilitiesKHR
@@ -497,10 +497,10 @@ struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStruc
 
 struct PrivateDataSlotWrapper : public HandleWrapper<VkPrivateDataSlot>
 {
-    DeviceWrapper*       device{ nullptr };
-    VkObjectType         object_type{ VK_OBJECT_TYPE_UNKNOWN };
-    uint64_t             object_handle{ 0 };
-    uint64_t             data{ 0 };
+    DeviceWrapper* device{ nullptr };
+    VkObjectType   object_type{ VK_OBJECT_TYPE_UNKNOWN };
+    uint64_t       object_handle{ 0 };
+    uint64_t       data{ 0 };
 };
 
 struct PipelineCacheWrapper : public HandleWrapper<VkPipelineCache>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -50,7 +50,7 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 //
 
 template <typename T>
-struct HandleWrapper
+struct VulkanHandleWrapper
 {
     typedef T HandleType;
 
@@ -70,24 +70,24 @@ struct HandleWrapper
 //
 
 // clang-format off
-struct ShaderModuleWrapper                  : public HandleWrapper<VkShaderModule> {};
-struct SamplerWrapper                       : public HandleWrapper<VkSampler> {};
-struct SamplerYcbcrConversionWrapper        : public HandleWrapper<VkSamplerYcbcrConversion> {};
-struct DebugReportCallbackEXTWrapper        : public HandleWrapper<VkDebugReportCallbackEXT> {};
-struct DebugUtilsMessengerEXTWrapper        : public HandleWrapper<VkDebugUtilsMessengerEXT> {};
-struct ValidationCacheEXTWrapper            : public HandleWrapper<VkValidationCacheEXT> {};
-struct IndirectCommandsLayoutNVWrapper      : public HandleWrapper<VkIndirectCommandsLayoutNV> {};
-struct PerformanceConfigurationINTELWrapper : public HandleWrapper<VkPerformanceConfigurationINTEL> {};
-struct MicromapEXTWrapper                   : public HandleWrapper<VkMicromapEXT> {};
-struct OpticalFlowSessionNVWrapper          : public HandleWrapper<VkOpticalFlowSessionNV> {};
-struct VideoSessionKHRWrapper               : public HandleWrapper<VkVideoSessionKHR> {};
-struct VideoSessionParametersKHRWrapper     : public HandleWrapper<VkVideoSessionParametersKHR> {};
-struct ShaderEXTWrapper                     : public HandleWrapper<VkShaderEXT> {};
-
+struct VulkanShaderModuleWrapper                  : public VulkanHandleWrapper<VkShaderModule> {};
+struct VulkanPipelineCacheWrapper                 : public VulkanHandleWrapper<VkPipelineCache> {};
+struct VulkanSamplerWrapper                       : public VulkanHandleWrapper<VkSampler> {};
+struct VulkanSamplerYcbcrConversionWrapper        : public VulkanHandleWrapper<VkSamplerYcbcrConversion> {};
+struct VulkanDebugReportCallbackEXTWrapper        : public VulkanHandleWrapper<VkDebugReportCallbackEXT> {};
+struct VulkanDebugUtilsMessengerEXTWrapper        : public VulkanHandleWrapper<VkDebugUtilsMessengerEXT> {};
+struct VulkanValidationCacheEXTWrapper            : public VulkanHandleWrapper<VkValidationCacheEXT> {};
+struct VulkanIndirectCommandsLayoutNVWrapper      : public VulkanHandleWrapper<VkIndirectCommandsLayoutNV> {};
+struct VulkanPerformanceConfigurationINTELWrapper : public VulkanHandleWrapper<VkPerformanceConfigurationINTEL> {};
+struct VulkanMicromapEXTWrapper                   : public VulkanHandleWrapper<VkMicromapEXT> {};
+struct VulkanOpticalFlowSessionNVWrapper          : public VulkanHandleWrapper<VkOpticalFlowSessionNV> {};
+struct VulkanVideoSessionKHRWrapper               : public VulkanHandleWrapper<VkVideoSessionKHR> {};
+struct VulkanVideoSessionParametersKHRWrapper     : public VulkanHandleWrapper<VkVideoSessionParametersKHR> {};
+struct VulkanShaderEXTWrapper                     : public VulkanHandleWrapper<VkShaderEXT> {};
 
 // This handle type has a create function, but no destroy function. The handle wrapper will be owned by its parent VkDisplayKHR
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
-struct DisplayModeKHRWrapper            : public HandleWrapper<VkDisplayModeKHR> {};
+struct VulkanDisplayModeKHRWrapper            : public VulkanHandleWrapper<VkDisplayModeKHR> {};
 // clang-format on
 
 //
@@ -97,18 +97,18 @@ struct DisplayModeKHRWrapper            : public HandleWrapper<VkDisplayModeKHR>
 // This handle type is retrieved and has no destroy function. The handle wrapper will be owned by its parent
 // VkPhysicalDevice handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is
 // destroyed.
-struct DisplayKHRWrapper : public HandleWrapper<VkDisplayKHR>
+struct VulkanDisplayKHRWrapper : public VulkanHandleWrapper<VkDisplayKHR>
 {
-    std::vector<DisplayModeKHRWrapper*> child_display_modes;
+    std::vector<VulkanDisplayModeKHRWrapper*> child_display_modes;
 };
 
 // This handle type is retrieved and has no destroy function. The handle wrapper will be owned by its parent VkInstance
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
-struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
+struct VulkanPhysicalDeviceWrapper : public VulkanHandleWrapper<VkPhysicalDevice>
 {
-    VulkanInstanceTable*            layer_table_ref{ nullptr };
-    std::vector<DisplayKHRWrapper*> child_displays;
-    uint32_t                        instance_api_version{ 0 };
+    VulkanInstanceTable*                  layer_table_ref{ nullptr };
+    std::vector<VulkanDisplayKHRWrapper*> child_displays;
+    uint32_t                              instance_api_version{ 0 };
 
     // Track memory types for use when creating snapshots of buffer and image resource memory content.
     VkPhysicalDeviceMemoryProperties memory_properties{};
@@ -122,44 +122,44 @@ struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
     std::vector<std::unique_ptr<VkQueueFamilyCheckpointPropertiesNV>> queue_family_checkpoint_properties;
 };
 
-struct InstanceWrapper : public HandleWrapper<VkInstance>
+struct VulkanInstanceWrapper : public VulkanHandleWrapper<VkInstance>
 {
-    VulkanInstanceTable                 layer_table;
-    std::vector<PhysicalDeviceWrapper*> child_physical_devices;
-    bool                                have_device_properties{ false };
-    uint32_t                            api_version{ VK_MAKE_VERSION(1, 0, 0) };
+    VulkanInstanceTable                       layer_table;
+    std::vector<VulkanPhysicalDeviceWrapper*> child_physical_devices;
+    bool                                      have_device_properties{ false };
+    uint32_t                                  api_version{ VK_MAKE_VERSION(1, 0, 0) };
 };
 
-struct QueueWrapper : public HandleWrapper<VkQueue>
+struct VulkanQueueWrapper : public VulkanHandleWrapper<VkQueue>
 {
     VulkanDeviceTable* layer_table_ref{ nullptr };
 };
 
-struct DeviceWrapper : public HandleWrapper<VkDevice>
+struct VulkanDeviceWrapper : public VulkanHandleWrapper<VkDevice>
 {
-    VulkanDeviceTable          layer_table;
-    PhysicalDeviceWrapper*     physical_device{ nullptr };
-    std::vector<QueueWrapper*> child_queues;
+    VulkanDeviceTable                layer_table;
+    VulkanPhysicalDeviceWrapper*     physical_device{ nullptr };
+    std::vector<VulkanQueueWrapper*> child_queues;
 
     // Physical device property & feature state at device creation
     graphics::VulkanDevicePropertyFeatureInfo              property_feature_info;
     std::unordered_map<uint32_t, VkDeviceQueueCreateFlags> queue_family_creation_flags;
 };
 
-struct FenceWrapper : public HandleWrapper<VkFence>
+struct VulkanFenceWrapper : public VulkanHandleWrapper<VkFence>
 {
     // Signaled state at creation to be compared with signaled state at snapshot write. If states are different, the
     // create parameters will need to be modified to reflect the state at snapshot write.
-    bool           created_signaled{ false };
-    DeviceWrapper* device{ nullptr };
+    bool                 created_signaled{ false };
+    VulkanDeviceWrapper* device{ nullptr };
 };
 
-struct EventWrapper : public HandleWrapper<VkEvent>
+struct VulkanEventWrapper : public VulkanHandleWrapper<VkEvent>
 {
-    DeviceWrapper* device{ nullptr };
+    VulkanDeviceWrapper* device{ nullptr };
 };
 
-struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
+struct VulkanDeviceMemoryWrapper : public VulkanHandleWrapper<VkDeviceMemory>
 {
     uint32_t     memory_type_index{ std::numeric_limits<uint32_t>::max() };
     VkDeviceSize allocation_size{ 0 };
@@ -168,25 +168,25 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     // The device wrapper will be initialized when allocating the memory. Some handling
     // like VulkanStateTracker::TrackTlasToBlasDependencies may use it before mapping
     // the memory.
-    DeviceWrapper*   parent_device{ nullptr };
-    const void*      mapped_data{ nullptr };
-    VkDeviceSize     mapped_offset{ 0 };
-    VkDeviceSize     mapped_size{ 0 };
-    VkMemoryMapFlags mapped_flags{ 0 };
-    void*            external_allocation{ nullptr };
-    uintptr_t        shadow_allocation{ util::PageGuardManager::kNullShadowHandle };
-    AHardwareBuffer* hardware_buffer{ nullptr };
-    format::HandleId hardware_buffer_memory_id{ format::kNullHandleId };
+    VulkanDeviceWrapper* parent_device{ nullptr };
+    const void*          mapped_data{ nullptr };
+    VkDeviceSize         mapped_offset{ 0 };
+    VkDeviceSize         mapped_size{ 0 };
+    VkMemoryMapFlags     mapped_flags{ 0 };
+    void*                external_allocation{ nullptr };
+    uintptr_t            shadow_allocation{ util::PageGuardManager::kNullShadowHandle };
+    AHardwareBuffer*     hardware_buffer{ nullptr };
+    format::HandleId     hardware_buffer_memory_id{ format::kNullHandleId };
 
     // State tracking info for memory with device addresses.
     format::HandleId device_id{ format::kNullHandleId };
     VkDeviceAddress  address{ 0 };
 };
 
-struct BufferWrapper : public HandleWrapper<VkBuffer>
+struct VulkanBufferWrapper : public VulkanHandleWrapper<VkBuffer>
 {
-    DeviceWrapper*     bind_device{ nullptr };
-    const void*        bind_pnext{ nullptr };
+    VulkanDeviceWrapper* bind_device{ nullptr };
+    const void*          bind_pnext{ nullptr };
     HandleUnwrapMemory bind_pnext_memory; // Global HandleUnwrapMemory could be reset anytime, so it should have its own
                                           // HandleUnwrapMemory.
     format::HandleId bind_memory_id{ format::kNullHandleId };
@@ -199,10 +199,10 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>
     VkDeviceAddress  address{ 0 };
 };
 
-struct ImageWrapper : public HandleWrapper<VkImage>
+struct VulkanImageWrapper : public VulkanHandleWrapper<VkImage>
 {
-    DeviceWrapper*     bind_device{ nullptr };
-    const void*        bind_pnext{ nullptr };
+    VulkanDeviceWrapper* bind_device{ nullptr };
+    const void*          bind_pnext{ nullptr };
     HandleUnwrapMemory bind_pnext_memory; // Global HandleUnwrapMemory could be reset anytime, so it should have its own
                                           // HandleUnwrapMemory.
     format::HandleId         bind_memory_id{ format::kNullHandleId };
@@ -220,18 +220,18 @@ struct ImageWrapper : public HandleWrapper<VkImage>
     std::set<VkSwapchainKHR> parent_swapchains;
 };
 
-struct BufferViewWrapper : public HandleWrapper<VkBufferView>
+struct VulkanBufferViewWrapper : public VulkanHandleWrapper<VkBufferView>
 {
     format::HandleId buffer_id{ format::kNullHandleId };
 };
 
-struct ImageViewWrapper : public HandleWrapper<VkImageView>
+struct VulkanImageViewWrapper : public VulkanHandleWrapper<VkImageView>
 {
-    format::HandleId image_id{ format::kNullHandleId };
-    ImageWrapper*    image{ nullptr };
+    format::HandleId    image_id{ format::kNullHandleId };
+    VulkanImageWrapper* image{ nullptr };
 };
 
-struct FramebufferWrapper : public HandleWrapper<VkFramebuffer>
+struct VulkanFramebufferWrapper : public VulkanHandleWrapper<VkFramebuffer>
 {
     // Creation info for objects used to create the framebuffer, which may have been destroyed after creation.
     format::HandleId  render_pass_id{ format::kNullHandleId };
@@ -241,45 +241,45 @@ struct FramebufferWrapper : public HandleWrapper<VkFramebuffer>
     std::vector<format::HandleId> image_view_ids;
 
     // Track handles of image attachments for processing render pass layout transitions.
-    std::vector<ImageWrapper*> attachments;
+    std::vector<VulkanImageWrapper*> attachments;
 };
 
-struct SemaphoreWrapper : public HandleWrapper<VkSemaphore>
+struct VulkanSemaphoreWrapper : public VulkanHandleWrapper<VkSemaphore>
 {
     // Track semaphore signaled state. State is signaled when a sempahore is submitted to QueueSubmit, QueueBindSparse,
     // AcquireNextImageKHR, or AcquireNextImage2KHR as a signal semaphore. State is not signaled when a semaphore is
     // submitted to QueueSubmit, QueueBindSparse, or QueuePresentKHR as a wait semaphore. Initial state after creation
     // is not signaled.
-    bool            signaled{ false };
-    VkSemaphoreType type{ VK_SEMAPHORE_TYPE_BINARY_KHR };
-    DeviceWrapper*  device{ nullptr };
+    bool                 signaled{ false };
+    VkSemaphoreType      type{ VK_SEMAPHORE_TYPE_BINARY_KHR };
+    VulkanDeviceWrapper* device{ nullptr };
 };
 
-struct QueryPoolWrapper : public HandleWrapper<VkQueryPool>
+struct VulkanQueryPoolWrapper : public VulkanHandleWrapper<VkQueryPool>
 {
-    DeviceWrapper*         device{ nullptr };
+    VulkanDeviceWrapper*   device{ nullptr };
     VkQueryType            query_type{};
     uint32_t               query_count{ 0 };
     std::vector<QueryInfo> pending_queries;
 };
 
-struct RenderPassWrapper : public HandleWrapper<VkRenderPass>
+struct VulkanRenderPassWrapper : public VulkanHandleWrapper<VkRenderPass>
 {
     // Final image attachment layouts to be used for processing image layout transitions after calls to
     // vkCmdEndRenderPass.
     std::vector<VkImageLayout> attachment_final_layouts;
 };
 
-struct AccelerationStructureKHRWrapper;
-struct CommandPoolWrapper;
-struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
+struct VulkanAccelerationStructureKHRWrapper;
+struct VulkanCommandPoolWrapper;
+struct VulkanCommandBufferWrapper : public VulkanHandleWrapper<VkCommandBuffer>
 {
     VulkanDeviceTable* layer_table_ref{ nullptr };
 
     // Members for general wrapper support.
     // Pool from which command buffer was allocated. The command buffer must be removed from the pool's allocation list
     // when destroyed.
-    CommandPoolWrapper* parent_pool{ nullptr };
+    VulkanCommandPoolWrapper* parent_pool{ nullptr };
 
     // Members for trimming state tracking.
     VkCommandBufferLevel       level{ VK_COMMAND_BUFFER_LEVEL_PRIMARY };
@@ -289,17 +289,17 @@ struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
     // Image layout info tracked for image barriers recorded to the command buffer. To be updated on calls to
     // vkCmdPipelineBarrier and vkCmdEndRenderPass and applied to the image wrapper on calls to vkQueueSubmit. To be
     // transferred from secondary command buffers to primary command buffers on calls to vkCmdExecuteCommands.
-    std::unordered_map<ImageWrapper*, VkImageLayout> pending_layouts;
+    std::unordered_map<VulkanImageWrapper*, VkImageLayout> pending_layouts;
 
     // Active query info for queries that have been recorded to this command buffer, which will be transfered to the
     // QueryPoolWrapper as pending queries when the command buffer is submitted to a queue.
-    std::unordered_map<QueryPoolWrapper*, std::unordered_map<uint32_t, QueryInfo>> recorded_queries;
+    std::unordered_map<VulkanQueryPoolWrapper*, std::unordered_map<uint32_t, QueryInfo>> recorded_queries;
 
     // Render pass object tracking for processing image layout transitions. Render pass and framebuffer values
     // for the active render pass instance will be set on calls to vkCmdBeginRenderPass and will be used to update the
     // pending image layout on calls to vkCmdEndRenderPass.
-    RenderPassWrapper*  active_render_pass{ nullptr };
-    FramebufferWrapper* render_pass_framebuffer{ nullptr };
+    VulkanRenderPassWrapper*  active_render_pass{ nullptr };
+    VulkanFramebufferWrapper* render_pass_framebuffer{ nullptr };
 
     // Treat the sumbission of this command buffer as a frame boundary.
     bool is_frame_boundary{ false };
@@ -317,17 +317,17 @@ struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
         // The offset from the above address to start reading the VkAccelerationStructureInstanceKHR structures
         uint32_t offset;
     };
-    std::vector<std::pair<AccelerationStructureKHRWrapper*, tlas_build_info>> tlas_build_info_map;
+    std::vector<std::pair<VulkanAccelerationStructureKHRWrapper*, tlas_build_info>> tlas_build_info_map;
 };
 
-struct PipelineLayoutWrapper : public HandleWrapper<VkPipelineLayout>
+struct VulkanPipelineLayoutWrapper : public VulkanHandleWrapper<VkPipelineLayout>
 {
     // Creation info for objects used to create the pipeline layout, which may have been destroyed after pipeline layout
     // creation.
     std::shared_ptr<PipelineLayoutDependencies> layout_dependencies;
 };
 
-struct PipelineWrapper : public HandleWrapper<VkPipeline>
+struct VulkanPipelineWrapper : public VulkanHandleWrapper<VkPipeline>
 {
     // Creation info for objects used to create the pipeline, which may have been destroyed after pipeline creation.
     std::vector<CreateDependencyInfo>           shader_module_dependencies;
@@ -344,7 +344,7 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
     // TODO: Pipeline cache
 };
 
-struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR>
+struct VulkanDeferredOperationKHRWrapper : public VulkanHandleWrapper<VkDeferredOperationKHR>
 {
     // Record CreateRayTracingPipelinesKHR parameters for safety.
     HandleUnwrapMemory                             handle_unwrap_memory;
@@ -357,27 +357,27 @@ struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR
     bool                                           pending_state = false;
 };
 
-struct DescriptorUpdateTemplateWrapper : public HandleWrapper<VkDescriptorUpdateTemplate>
+struct VulkanDescriptorUpdateTemplateWrapper : public VulkanHandleWrapper<VkDescriptorUpdateTemplate>
 {
     // Members for general wrapper support.
     UpdateTemplateInfo info;
 };
 
-struct DescriptorSetLayoutWrapper : public HandleWrapper<VkDescriptorSetLayout>
+struct VulkanDescriptorSetLayoutWrapper : public VulkanHandleWrapper<VkDescriptorSetLayout>
 {
     // Members for trimming state tracking.
     std::vector<DescriptorBindingInfo> binding_info;
 };
 
-struct DescriptorPoolWrapper;
-struct DescriptorSetWrapper : public HandleWrapper<VkDescriptorSet>
+struct VulkanDescriptorPoolWrapper;
+struct VulkanDescriptorSetWrapper : public VulkanHandleWrapper<VkDescriptorSet>
 {
     // Members for general wrapper support.
     // Pool from which set was allocated. The set must be removed from the pool's allocation list when destroyed.
-    DescriptorPoolWrapper* parent_pool{ nullptr };
+    VulkanDescriptorPoolWrapper* parent_pool{ nullptr };
 
     // Members for trimming state tracking.
-    DeviceWrapper* device{ nullptr };
+    VulkanDeviceWrapper* device{ nullptr };
 
     // Map for descriptor binding index to array of descriptor info.
     std::unordered_map<uint32_t, DescriptorInfo> bindings;
@@ -387,28 +387,28 @@ struct DescriptorSetWrapper : public HandleWrapper<VkDescriptorSet>
     CreateDependencyInfo set_layout_dependency;
 };
 
-struct DescriptorPoolWrapper : public HandleWrapper<VkDescriptorPool>
+struct VulkanDescriptorPoolWrapper : public VulkanHandleWrapper<VkDescriptorPool>
 {
     // Members for general wrapper support.
     // Track descriptor set info, which must be destroyed on descriptor pool reset.
-    std::unordered_map<format::HandleId, DescriptorSetWrapper*> child_sets;
+    std::unordered_map<format::HandleId, VulkanDescriptorSetWrapper*> child_sets;
 };
 
-struct CommandPoolWrapper : public HandleWrapper<VkCommandPool>
+struct VulkanCommandPoolWrapper : public VulkanHandleWrapper<VkCommandPool>
 {
     // Members for general wrapper support.
     // Track command buffer info, which must be destroyed on command pool reset.
-    std::unordered_map<format::HandleId, CommandBufferWrapper*> child_buffers;
+    std::unordered_map<format::HandleId, VulkanCommandBufferWrapper*> child_buffers;
 
     // Members for trimming state tracking.
     uint32_t queue_family_index{ 0 };
 
-    DeviceWrapper* device{ nullptr };
-    bool           trim_command_pool{ false };
+    VulkanDeviceWrapper* device{ nullptr };
+    bool                 trim_command_pool{ false };
 };
 
 // For vkGetPhysicalDeviceSurfaceCapabilitiesKHR
-struct SurfaceCapabilities
+struct VulkanSurfaceCapabilities
 {
     VkPhysicalDeviceSurfaceInfo2KHR surface_info;
     HandleUnwrapMemory              surface_info_pnext_memory;
@@ -418,7 +418,7 @@ struct SurfaceCapabilities
 };
 
 // For vkGetPhysicalDeviceSurfaceFormatsKHR
-struct SurfaceFormats
+struct VulkanSurfaceFormats
 {
     VkPhysicalDeviceSurfaceInfo2KHR surface_info;
     HandleUnwrapMemory              surface_info_pnext_memory;
@@ -428,7 +428,7 @@ struct SurfaceFormats
 };
 
 // For vkGetPhysicalDeviceSurfacePresentModesKHR
-struct SurfacePresentModes
+struct VulkanSurfacePresentModes
 {
     std::vector<VkPresentModeKHR> present_modes;
     const void*                   surface_info_pnext{ nullptr };
@@ -436,35 +436,35 @@ struct SurfacePresentModes
 };
 
 // For vkGetDeviceGroupSurfacePresentModesKHR
-struct GroupSurfacePresentModes
+struct VulkanGroupSurfacePresentModes
 {
     VkDeviceGroupPresentModeFlagsKHR present_modes{ 0 };
     const void*                      surface_info_pnext{ nullptr };
     HandleUnwrapMemory               surface_info_pnext_memory;
 };
 
-struct SurfaceKHRWrapper : public HandleWrapper<VkSurfaceKHR>
+struct VulkanSurfaceKHRWrapper : public VulkanHandleWrapper<VkSurfaceKHR>
 {
     // Track results from calls to vkGetPhysicalDeviceSurfaceSupportKHR to write to the state snapshot after surface
     // creation. The call is only written to the state snapshot if it was previously called by the application.
     // Keys are the VkPhysicalDevice handle ID.
     std::unordered_map<format::HandleId, std::unordered_map<uint32_t, VkBool32>> surface_support;
-    std::unordered_map<format::HandleId, SurfaceCapabilities>                    surface_capabilities;
-    std::unordered_map<format::HandleId, SurfaceFormats>                         surface_formats;
-    std::unordered_map<format::HandleId, SurfacePresentModes>                    surface_present_modes;
+    std::unordered_map<format::HandleId, VulkanSurfaceCapabilities>              surface_capabilities;
+    std::unordered_map<format::HandleId, VulkanSurfaceFormats>                   surface_formats;
+    std::unordered_map<format::HandleId, VulkanSurfacePresentModes>              surface_present_modes;
 
     // Keys are the VkDevice handle ID.
-    std::unordered_map<format::HandleId, GroupSurfacePresentModes> group_surface_present_modes;
+    std::unordered_map<format::HandleId, VulkanGroupSurfacePresentModes> group_surface_present_modes;
 };
 
-struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
+struct VulkanSwapchainKHRWrapper : public VulkanHandleWrapper<VkSwapchainKHR>
 {
     // Members for general wrapper support.
-    std::vector<ImageWrapper*> child_images;
+    std::vector<VulkanImageWrapper*> child_images;
 
     // Members for trimming state tracking.
-    DeviceWrapper*                 device{ nullptr };
-    SurfaceKHRWrapper*             surface{ nullptr };
+    VulkanDeviceWrapper*           device{ nullptr };
+    VulkanSurfaceKHRWrapper*       surface{ nullptr };
     uint32_t                       queue_family_index{ 0 };
     VkFormat                       format{ VK_FORMAT_UNDEFINED };
     VkExtent3D                     extent{ 0, 0, 0 };
@@ -478,27 +478,27 @@ struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
     VkBool32                       local_dimming_enable_AMD{ false };
 };
 
-struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStructureKHR>
+struct VulkanAccelerationStructureKHRWrapper : public VulkanHandleWrapper<VkAccelerationStructureKHR>
 {
     // State tracking info for buffers with device addresses.
     format::HandleId device_id{ format::kNullHandleId };
     VkDeviceAddress  address{ 0 };
 
     // List of BLASes this AS references. Used only while tracking.
-    std::vector<AccelerationStructureKHRWrapper*> blas;
+    std::vector<VulkanAccelerationStructureKHRWrapper*> blas;
 };
 
-struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStructureNV>
+struct VulkanAccelerationStructureNVWrapper : public VulkanHandleWrapper<VkAccelerationStructureNV>
 {
     // TODO: Determine what additional state tracking is needed.
 };
 
-struct PrivateDataSlotWrapper : public HandleWrapper<VkPrivateDataSlot>
+struct VulkanPrivateDataSlotWrapper : public VulkanHandleWrapper<VkPrivateDataSlot>
 {
-    DeviceWrapper* device{ nullptr };
-    VkObjectType   object_type{ VK_OBJECT_TYPE_UNKNOWN };
-    uint64_t       object_handle{ 0 };
-    uint64_t       data{ 0 };
+    VulkanDeviceWrapper* device{ nullptr };
+    VkObjectType         object_type{ VK_OBJECT_TYPE_UNKNOWN };
+    uint64_t             object_handle{ 0 };
+    uint64_t             data{ 0 };
 };
 
 struct PipelineCacheWrapper : public HandleWrapper<VkPipelineCache>
@@ -509,9 +509,9 @@ struct PipelineCacheWrapper : public HandleWrapper<VkPipelineCache>
 };
 
 // Handle alias types for extension handle types that have been promoted to core types.
-typedef SamplerYcbcrConversionWrapper   SamplerYcbcrConversionKHRWrapper;
-typedef DescriptorUpdateTemplateWrapper DescriptorUpdateTemplateKHRWrapper;
-typedef PrivateDataSlotWrapper          PrivateDataSlotEXTWrapper;
+typedef VulkanSamplerYcbcrConversionWrapper   VulkanSamplerYcbcrConversionKHRWrapper;
+typedef VulkanDescriptorUpdateTemplateWrapper VulkanDescriptorUpdateTemplateKHRWrapper;
+typedef VulkanPrivateDataSlotWrapper          VulkanPrivateDataSlotEXTWrapper;
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -72,7 +72,7 @@ struct HandleWrapper
 
 // clang-format off
 struct ShaderModuleWrapper                  : public HandleWrapper<VkShaderModule> {};
-struct PipelineCacheWrapper                 : public HandleWrapper<VkPipelineCache> {};
+// struct PipelineCacheWrapper                 : public HandleWrapper<VkPipelineCache> {};
 struct SamplerWrapper                       : public HandleWrapper<VkSampler> {};
 struct SamplerYcbcrConversionWrapper        : public HandleWrapper<VkSamplerYcbcrConversion> {};
 struct DebugReportCallbackEXTWrapper        : public HandleWrapper<VkDebugReportCallbackEXT> {};

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -36,6 +36,7 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
+GFXRECON_BEGIN_NAMESPACE(vulkan_state_info)
 
 //
 // Types for state tracking.
@@ -135,6 +136,7 @@ enum CommandHandleType : uint32_t
     NumHandleTypes // THIS MUST BE THE LAST ENUM VALUE !
 };
 
+GFXRECON_END_NAMESPACE(vulkan_state_info)
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -646,8 +646,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
     {
         for (uint32_t i = 0; i < write_count; ++i)
         {
-            const VkWriteDescriptorSet* write   = &writes[i];
-            auto wrapper = GetVulkanWrapper<vulkan_wrappers::DescriptorSetWrapper>(write->dstSet);
+            const VkWriteDescriptorSet* write = &writes[i];
+            auto wrapper                      = GetVulkanWrapper<vulkan_wrappers::DescriptorSetWrapper>(write->dstSet);
             assert(wrapper != nullptr);
 
             // Descriptor update rules specify that a write descriptorCount that is greater than the binding's count
@@ -1141,7 +1141,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                     const auto* accel_struct = reinterpret_cast<const VkAccelerationStructureKHR*>(src_address);
                     dst_view_ids[i] =
                         GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(*accel_struct);
-                    dst_info[i]              = *accel_struct;
+                    dst_info[i] = *accel_struct;
 
                     src_address += entry.stride;
                 }
@@ -1197,9 +1197,9 @@ void VulkanStateTracker::TrackQueryActivation(
     const vulkan_wrappers::CommandPoolWrapper* command_pool_wrapper = wrapper->parent_pool;
 
     auto& query_pool_info = wrapper->recorded_queries[GetVulkanWrapper<vulkan_wrappers::QueryPoolWrapper>(query_pool)];
-    auto& query_info              = query_pool_info[query];
-    query_info.active             = true;
-    query_info.flags              = flags;
+    auto& query_info      = query_pool_info[query];
+    query_info.active     = true;
+    query_info.flags      = flags;
     query_info.query_type_index   = index;
     query_info.queue_family_index = command_pool_wrapper->queue_family_index;
 }
@@ -1546,7 +1546,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
             assert(tlas_build_info.second.blas_count);
 
             // Find to which device memory this address belongs
-            const VkDeviceAddress            address         = tlas_build_info.second.address;
+            const VkDeviceAddress                       address         = tlas_build_info.second.address;
             const vulkan_wrappers::DeviceMemoryWrapper* dev_mem_wrapper = nullptr;
             for (const auto& dev_mem : device_memory_addresses_map)
             {

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -37,9 +37,9 @@ VulkanStateTracker::VulkanStateTracker() {}
 
 VulkanStateTracker::~VulkanStateTracker() {}
 
-void VulkanStateTracker::TrackCommandExecution(VulkanCommandBufferWrapper*     wrapper,
-                                               format::ApiCallId               call_id,
-                                               const util::MemoryOutputStream* parameter_buffer)
+void VulkanStateTracker::TrackCommandExecution(vulkan_wrappers::CommandBufferWrapper* wrapper,
+                                               format::ApiCallId                      call_id,
+                                               const util::MemoryOutputStream*        parameter_buffer)
 {
     assert(wrapper != nullptr);
 
@@ -52,7 +52,7 @@ void VulkanStateTracker::TrackCommandExecution(VulkanCommandBufferWrapper*     w
         wrapper->recorded_queries.clear();
         wrapper->tlas_build_info_map.clear();
 
-        for (size_t i = 0; i < CommandHandleType::NumHandleTypes; ++i)
+        for (size_t i = 0; i < vulkan_state_info::CommandHandleType::NumHandleTypes; ++i)
         {
             wrapper->command_handles[i].clear();
         }
@@ -72,10 +72,10 @@ void VulkanStateTracker::TrackTrimCommandPool(VkDevice device, VkCommandPool com
 {
     assert(command_pool != VK_NULL_HANDLE);
 
-    auto wrapper               = GetWrapper<VulkanCommandPoolWrapper>(command_pool);
+    auto wrapper               = GetVulkanWrapper<vulkan_wrappers::CommandPoolWrapper>(command_pool);
     wrapper->trim_command_pool = true;
 
-    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
+    auto device_wrapper = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->device     = device_wrapper;
 }
 
@@ -83,7 +83,7 @@ void VulkanStateTracker::TrackResetCommandPool(VkCommandPool command_pool)
 {
     assert(command_pool != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<VulkanCommandPoolWrapper>(command_pool);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::CommandPoolWrapper>(command_pool);
 
     for (const auto& entry : wrapper->child_buffers)
     {
@@ -92,7 +92,7 @@ void VulkanStateTracker::TrackResetCommandPool(VkCommandPool command_pool)
         entry.second->recorded_queries.clear();
         entry.second->tlas_build_info_map.clear();
 
-        for (size_t i = 0; i < CommandHandleType::NumHandleTypes; ++i)
+        for (size_t i = 0; i < vulkan_state_info::CommandHandleType::NumHandleTypes; ++i)
         {
             entry.second->command_handles[i].clear();
         }
@@ -104,7 +104,7 @@ void VulkanStateTracker::TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice   
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper = GetWrapper<VulkanPhysicalDeviceWrapper>(physical_device);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device);
 
     wrapper->memory_properties = *properties;
 }
@@ -115,7 +115,7 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties(VkPhysicalDevi
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper                             = GetWrapper<VulkanPhysicalDeviceWrapper>(physical_device);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device);
     wrapper->queue_family_properties_call_id = format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties         = std::make_unique<VkQueueFamilyProperties[]>(property_count);
@@ -129,7 +129,7 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties2(format::ApiCa
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper                             = GetWrapper<VulkanPhysicalDeviceWrapper>(physical_device);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device);
     wrapper->queue_family_properties_call_id = call_id;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties2        = std::make_unique<VkQueueFamilyProperties2[]>(property_count);
@@ -176,8 +176,8 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceSupport(VkPhysicalDevice phys
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE));
 
-    auto  wrapper             = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
-    auto& entry               = wrapper->surface_support[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(surface);
+    auto& entry = wrapper->surface_support[GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device)];
     entry[queue_family_index] = supported;
 }
 
@@ -187,8 +187,9 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceCapabilities(VkPhysicalDevice
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (capabilities != nullptr));
 
-    auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
-    auto& entry   = wrapper->surface_capabilities[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(surface);
+    auto& entry =
+        wrapper->surface_capabilities[GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device)];
 
     entry.surface_info_pnext_memory.Reset();
     entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -207,8 +208,9 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceCapabilities2(VkPhysicalDevic
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface_info.surface != VK_NULL_HANDLE));
 
-    auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface_info.surface);
-    auto& entry   = wrapper->surface_capabilities[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(surface_info.surface);
+    auto& entry =
+        wrapper->surface_capabilities[GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device)];
 
     entry.surface_info_pnext_memory.Reset();
     entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -241,8 +243,9 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceFormats(VkPhysicalDevice     
 
     if (surface != VK_NULL_HANDLE && format_count > 0)
     {
-        auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
-        auto& entry   = wrapper->surface_formats[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
+        auto  wrapper = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(surface);
+        auto& entry =
+            wrapper->surface_formats[GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device)];
 
         entry.surface_info_pnext_memory.Reset();
         entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -270,8 +273,9 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceFormats2(VkPhysicalDevice    
 
     if (surface_info.surface != VK_NULL_HANDLE && surface_format_count > 0)
     {
-        auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface_info.surface);
-        auto& entry   = wrapper->surface_formats[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
+        auto  wrapper = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(surface_info.surface);
+        auto& entry =
+            wrapper->surface_formats[GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device)];
 
         entry.surface_info_pnext_memory.Reset();
         entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -309,8 +313,9 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfacePresentModes(VkPhysicalDevice
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (modes != nullptr));
 
-    auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
-    auto& entry   = wrapper->surface_present_modes[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(surface);
+    auto& entry =
+        wrapper->surface_present_modes[GetVulkanWrappedId<vulkan_wrappers::PhysicalDeviceWrapper>(physical_device)];
     entry.present_modes.assign(modes, modes + mode_count);
 
     entry.surface_info_pnext = nullptr;
@@ -328,8 +333,8 @@ void VulkanStateTracker::TrackDeviceGroupSurfacePresentModes(VkDevice           
 {
     assert((device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (pModes != nullptr));
 
-    auto  wrapper       = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
-    auto& entry         = wrapper->group_surface_present_modes[GetWrappedId<VulkanDeviceWrapper>(device)];
+    auto  wrapper = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(surface);
+    auto& entry   = wrapper->group_surface_present_modes[GetVulkanWrappedId<vulkan_wrappers::DeviceWrapper>(device)];
     entry.present_modes = *pModes;
 
     entry.surface_info_pnext = nullptr;
@@ -344,8 +349,8 @@ void VulkanStateTracker::TrackBufferDeviceAddress(VkDevice device, VkBuffer buff
 {
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE));
 
-    auto wrapper       = GetWrapper<VulkanBufferWrapper>(buffer);
-    wrapper->device_id = GetWrappedId<VulkanDeviceWrapper>(device);
+    auto wrapper       = GetVulkanWrapper<vulkan_wrappers::BufferWrapper>(buffer);
+    wrapper->device_id = GetVulkanWrappedId<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->address   = address;
 }
 
@@ -354,9 +359,9 @@ void VulkanStateTracker::TrackBufferMemoryBinding(
 {
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper            = GetWrapper<VulkanBufferWrapper>(buffer);
-    wrapper->bind_device    = GetWrapper<VulkanDeviceWrapper>(device);
-    wrapper->bind_memory_id = GetWrappedId<VulkanDeviceMemoryWrapper>(memory);
+    auto wrapper            = GetVulkanWrapper<vulkan_wrappers::BufferWrapper>(buffer);
+    wrapper->bind_device    = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->bind_memory_id = GetVulkanWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
     wrapper->bind_pnext_memory.Reset();
@@ -375,15 +380,17 @@ void VulkanStateTracker::TrackTLASBuildCommand(
 {
     if (info_count && infos && pp_buildRange_infos)
     {
-        VulkanCommandBufferWrapper* buf_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+        vulkan_wrappers::CommandBufferWrapper* buf_wrapper =
+            GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
 
         for (uint32_t i = 0; i < info_count; ++i)
         {
             if (infos[i].type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
                 infos[i].dstAccelerationStructure != VK_NULL_HANDLE && infos[i].geometryCount && infos[i].pGeometries)
             {
-                VulkanAccelerationStructureKHRWrapper* tlas_wrapper =
-                    GetWrapper<VulkanAccelerationStructureKHRWrapper>(infos[i].dstAccelerationStructure);
+                vulkan_wrappers::AccelerationStructureKHRWrapper* tlas_wrapper =
+                    GetVulkanWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(
+                        infos[i].dstAccelerationStructure);
 
                 tlas_wrapper->blas.clear();
 
@@ -397,7 +404,7 @@ void VulkanStateTracker::TrackTLASBuildCommand(
                         // Nothing to handle in these cases.
                         if (address && primitive_count)
                         {
-                            const VulkanCommandBufferWrapper::tlas_build_info tlas_info = {
+                            const vulkan_wrappers::CommandBufferWrapper::tlas_build_info tlas_info = {
                                 address, primitive_count, pp_buildRange_infos[i]->primitiveOffset
                             };
 
@@ -417,9 +424,9 @@ void VulkanStateTracker::TrackImageMemoryBinding(
     // If VkBindImageMemorySwapchainInfoKHR is in pnext, memory must be VK_NULL_HANDLE.
     assert((device != VK_NULL_HANDLE) && (image != VK_NULL_HANDLE));
 
-    auto wrapper            = GetWrapper<VulkanImageWrapper>(image);
-    wrapper->bind_device    = GetWrapper<VulkanDeviceWrapper>(device);
-    wrapper->bind_memory_id = GetWrappedId<VulkanDeviceMemoryWrapper>(memory);
+    auto wrapper            = GetVulkanWrapper<vulkan_wrappers::ImageWrapper>(image);
+    wrapper->bind_device    = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
+    wrapper->bind_memory_id = GetVulkanWrappedId<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
     wrapper->bind_pnext_memory.Reset();
@@ -439,7 +446,7 @@ void VulkanStateTracker::TrackMappedMemory(VkDevice         device,
 {
     assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper           = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
+    auto wrapper           = GetVulkanWrapper<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     wrapper->mapped_data   = mapped_data;
     wrapper->mapped_offset = mapped_offset;
     wrapper->mapped_size   = mapped_size;
@@ -450,16 +457,16 @@ void VulkanStateTracker::TrackBeginRenderPass(VkCommandBuffer command_buffer, co
 {
     assert((command_buffer != VK_NULL_HANDLE) && (begin_info != nullptr));
 
-    auto wrapper                     = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
-    wrapper->active_render_pass      = GetWrapper<VulkanRenderPassWrapper>(begin_info->renderPass);
-    wrapper->render_pass_framebuffer = GetWrapper<VulkanFramebufferWrapper>(begin_info->framebuffer);
+    auto wrapper                     = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
+    wrapper->active_render_pass      = GetVulkanWrapper<vulkan_wrappers::RenderPassWrapper>(begin_info->renderPass);
+    wrapper->render_pass_framebuffer = GetVulkanWrapper<vulkan_wrappers::FramebufferWrapper>(begin_info->framebuffer);
 }
 
 void VulkanStateTracker::TrackEndRenderPass(VkCommandBuffer command_buffer)
 {
     assert(command_buffer != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
     assert((wrapper->active_render_pass != VK_NULL_HANDLE) && (wrapper->render_pass_framebuffer != VK_NULL_HANDLE));
 
     auto render_pass_wrapper = wrapper->active_render_pass;
@@ -486,11 +493,11 @@ void VulkanStateTracker::TrackExecuteCommands(VkCommandBuffer        command_buf
 {
     assert((command_buffer != VK_NULL_HANDLE) && (command_buffers != nullptr));
 
-    auto primary_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+    auto primary_wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
 
     for (uint32_t i = 0; i < command_buffer_count; ++i)
     {
-        auto secondary_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffers[i]);
+        auto secondary_wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffers[i]);
         assert(secondary_wrapper != nullptr);
 
         for (const auto& layout_entry : secondary_wrapper->pending_layouts)
@@ -526,11 +533,11 @@ void VulkanStateTracker::TrackImageBarriers(VkCommandBuffer             command_
 
     if ((image_barrier_count > 0) && (image_barriers != nullptr))
     {
-        auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+        auto wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
 
         for (uint32_t i = 0; i < image_barrier_count; ++i)
         {
-            auto image_wrapper                      = GetWrapper<VulkanImageWrapper>(image_barriers[i].image);
+            auto image_wrapper = GetVulkanWrapper<vulkan_wrappers::ImageWrapper>(image_barriers[i].image);
             wrapper->pending_layouts[image_wrapper] = image_barriers[i].newLayout;
         }
     }
@@ -544,11 +551,11 @@ void VulkanStateTracker::TrackImageBarriers2KHR(VkCommandBuffer                 
 
     if ((image_barrier_count > 0) && (image_barriers != nullptr))
     {
-        auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+        auto wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
 
         for (uint32_t i = 0; i < image_barrier_count; ++i)
         {
-            auto image_wrapper                      = GetWrapper<VulkanImageWrapper>(image_barriers[i].image);
+            auto image_wrapper = GetVulkanWrapper<vulkan_wrappers::ImageWrapper>(image_barriers[i].image);
             wrapper->pending_layouts[image_wrapper] = image_barriers[i].newLayout;
         }
     }
@@ -565,7 +572,7 @@ void VulkanStateTracker::TrackCommandBufferSubmissions(uint32_t submit_count, co
 
             for (uint32_t cmd = 0; cmd < command_buffer_count; ++cmd)
             {
-                auto command_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffers[cmd]);
+                auto command_wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffers[cmd]);
                 assert(command_wrapper != nullptr);
 
                 TrackQuerySubmissions(command_wrapper);
@@ -585,7 +592,8 @@ void VulkanStateTracker::TrackCommandBufferSubmissions2(uint32_t submit_count, c
 
             for (uint32_t cmd = 0; cmd < command_buffer_count; ++cmd)
             {
-                auto command_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer_infos[cmd].commandBuffer);
+                auto command_wrapper =
+                    GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer_infos[cmd].commandBuffer);
                 assert(command_wrapper != nullptr);
 
                 TrackQuerySubmissions(command_wrapper);
@@ -594,7 +602,7 @@ void VulkanStateTracker::TrackCommandBufferSubmissions2(uint32_t submit_count, c
     }
 }
 
-void VulkanStateTracker::TrackQuerySubmissions(VulkanCommandBufferWrapper* command_wrapper)
+void VulkanStateTracker::TrackQuerySubmissions(vulkan_wrappers::CommandBufferWrapper* command_wrapper)
 {
     // Apply pending image layouts.
     for (const auto& layout_entry : command_wrapper->pending_layouts)
@@ -639,7 +647,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
         for (uint32_t i = 0; i < write_count; ++i)
         {
             const VkWriteDescriptorSet* write   = &writes[i];
-            auto                        wrapper = GetWrapper<VulkanDescriptorSetWrapper>(write->dstSet);
+            auto wrapper = GetVulkanWrapper<vulkan_wrappers::DescriptorSetWrapper>(write->dstSet);
             assert(wrapper != nullptr);
 
             // Descriptor update rules specify that a write descriptorCount that is greater than the binding's count
@@ -703,7 +711,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_sampler_ids[i] = GetWrappedId<VulkanSamplerWrapper>(src_info[i].sampler);
+                            dst_sampler_ids[i] =
+                                GetVulkanWrappedId<vulkan_wrappers::SamplerWrapper>(src_info[i].sampler);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -717,8 +726,10 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_sampler_ids[i] = GetWrappedId<VulkanSamplerWrapper>(src_info[i].sampler);
-                            dst_image_ids[i]   = GetWrappedId<VulkanImageViewWrapper>(src_info[i].imageView);
+                            dst_sampler_ids[i] =
+                                GetVulkanWrappedId<vulkan_wrappers::SamplerWrapper>(src_info[i].sampler);
+                            dst_image_ids[i] =
+                                GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(src_info[i].imageView);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -733,7 +744,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_image_ids[i] = GetWrappedId<VulkanImageViewWrapper>(src_info[i].imageView);
+                            dst_image_ids[i] =
+                                GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(src_info[i].imageView);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -749,7 +761,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_buffer_ids[i] = GetWrappedId<VulkanBufferWrapper>(src_info[i].buffer);
+                            dst_buffer_ids[i] = GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(src_info[i].buffer);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -763,7 +775,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_view_ids[i] = GetWrappedId<VulkanBufferViewWrapper>(src_info[i]);
+                            dst_view_ids[i] = GetVulkanWrappedId<vulkan_wrappers::BufferViewWrapper>(src_info[i]);
                             dst_info[i]     = src_info[i];
                         }
                         break;
@@ -791,7 +803,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
                             for (uint32_t i = 0; i < current_writes; ++i)
                             {
                                 dst_accel_struct_ids[i] =
-                                    GetWrappedId<VulkanAccelerationStructureKHRWrapper>(src_accel_struct[i]);
+                                    GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(
+                                        src_accel_struct[i]);
                                 dst_accel_struct[i] = src_accel_struct[i];
                             }
                         }
@@ -823,8 +836,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
         for (uint32_t i = 0; i < copy_count; ++i)
         {
             auto copy        = &copies[i];
-            auto dst_wrapper = GetWrapper<VulkanDescriptorSetWrapper>(copy->dstSet);
-            auto src_wrapper = GetWrapper<VulkanDescriptorSetWrapper>(copy->srcSet);
+            auto dst_wrapper = GetVulkanWrapper<vulkan_wrappers::DescriptorSetWrapper>(copy->dstSet);
+            auto src_wrapper = GetVulkanWrapper<vulkan_wrappers::DescriptorSetWrapper>(copy->srcSet);
             assert((dst_wrapper != nullptr) && (src_wrapper != nullptr));
 
             // Descriptor update rules specify that a write descriptorCount that is greater than the binding's count
@@ -937,7 +950,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
     // exists at state write time by checking for the ID in the active state table.
     if ((template_info != nullptr) && (data != nullptr))
     {
-        auto           wrapper = GetWrapper<VulkanDescriptorSetWrapper>(set);
+        auto           wrapper = GetVulkanWrapper<vulkan_wrappers::DescriptorSetWrapper>(set);
         const uint8_t* bytes   = reinterpret_cast<const uint8_t*>(data);
 
         for (const auto& entry : template_info->image_info)
@@ -972,12 +985,12 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                     if ((binding.type == VK_DESCRIPTOR_TYPE_SAMPLER) ||
                         (binding.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
                     {
-                        dst_sampler_ids[i] = GetWrappedId<VulkanSamplerWrapper>(image_info->sampler);
+                        dst_sampler_ids[i] = GetVulkanWrappedId<vulkan_wrappers::SamplerWrapper>(image_info->sampler);
                     }
 
                     if (binding.type != VK_DESCRIPTOR_TYPE_SAMPLER)
                     {
-                        dst_image_ids[i] = GetWrappedId<VulkanImageViewWrapper>(image_info->imageView);
+                        dst_image_ids[i] = GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(image_info->imageView);
                     }
 
                     memcpy(&dst_info[i], image_info, sizeof(dst_info[i]));
@@ -1028,7 +1041,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 for (uint32_t i = 0; i < current_writes; ++i)
                 {
                     auto buffer_info  = reinterpret_cast<const VkDescriptorBufferInfo*>(src_address);
-                    dst_buffer_ids[i] = GetWrappedId<VulkanBufferWrapper>(buffer_info->buffer);
+                    dst_buffer_ids[i] = GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer_info->buffer);
                     memcpy(&dst_info[i], buffer_info, sizeof(dst_info[i]));
 
                     src_address += entry.stride;
@@ -1077,7 +1090,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 for (uint32_t i = 0; i < current_writes; ++i)
                 {
                     auto buffer_view = reinterpret_cast<const VkBufferView*>(src_address);
-                    dst_view_ids[i]  = GetWrappedId<VulkanBufferViewWrapper>(*buffer_view);
+                    dst_view_ids[i]  = GetVulkanWrappedId<vulkan_wrappers::BufferViewWrapper>(*buffer_view);
                     dst_info[i]      = *buffer_view;
 
                     src_address += entry.stride;
@@ -1126,7 +1139,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 for (uint32_t i = 0; i < current_writes; ++i)
                 {
                     const auto* accel_struct = reinterpret_cast<const VkAccelerationStructureKHR*>(src_address);
-                    dst_view_ids[i]          = GetWrappedId<VulkanAccelerationStructureKHRWrapper>(*accel_struct);
+                    dst_view_ids[i] =
+                        GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(*accel_struct);
                     dst_info[i]              = *accel_struct;
 
                     src_address += entry.stride;
@@ -1164,7 +1178,7 @@ void VulkanStateTracker::TrackResetDescriptorPool(VkDescriptorPool descriptor_po
 {
     assert(descriptor_pool != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<VulkanDescriptorPoolWrapper>(descriptor_pool);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::DescriptorPoolWrapper>(descriptor_pool);
 
     // Pool reset implicitly frees descriptor sets, so remove all wrappers from the state tracker.
     std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -1179,10 +1193,10 @@ void VulkanStateTracker::TrackQueryActivation(
 {
     assert((command_buffer != VK_NULL_HANDLE) && (query_pool != VK_NULL_HANDLE));
 
-    auto                            wrapper              = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
-    const VulkanCommandPoolWrapper* command_pool_wrapper = wrapper->parent_pool;
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
+    const vulkan_wrappers::CommandPoolWrapper* command_pool_wrapper = wrapper->parent_pool;
 
-    auto& query_pool_info         = wrapper->recorded_queries[GetWrapper<VulkanQueryPoolWrapper>(query_pool)];
+    auto& query_pool_info = wrapper->recorded_queries[GetVulkanWrapper<vulkan_wrappers::QueryPoolWrapper>(query_pool)];
     auto& query_info              = query_pool_info[query];
     query_info.active             = true;
     query_info.flags              = flags;
@@ -1197,8 +1211,8 @@ void VulkanStateTracker::TrackQueryReset(VkCommandBuffer command_buffer,
 {
     assert((command_buffer != VK_NULL_HANDLE) && (query_pool != VK_NULL_HANDLE));
 
-    auto  wrapper         = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
-    auto& query_pool_info = wrapper->recorded_queries[GetWrapper<VulkanQueryPoolWrapper>(query_pool)];
+    auto  wrapper         = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
+    auto& query_pool_info = wrapper->recorded_queries[GetVulkanWrapper<vulkan_wrappers::QueryPoolWrapper>(query_pool)];
 
     for (uint32_t i = first_query; i < query_count; ++i)
     {
@@ -1210,7 +1224,7 @@ void VulkanStateTracker::TrackQueryReset(VkQueryPool query_pool, uint32_t first_
 {
     assert(query_pool != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<VulkanQueryPoolWrapper>(query_pool);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::QueryPoolWrapper>(query_pool);
     assert((first_query + query_count) <= wrapper->pending_queries.size());
 
     for (uint32_t i = first_query; i < query_count; ++i)
@@ -1223,7 +1237,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(VkSemaphore signal)
 {
     if (signal != VK_NULL_HANDLE)
     {
-        auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(signal);
+        auto wrapper = GetVulkanWrapper<vulkan_wrappers::SemaphoreWrapper>(signal);
         assert(wrapper != nullptr);
         wrapper->signaled = true;
     }
@@ -1240,7 +1254,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
         {
             for (uint32_t i = 0; i < wait_count; ++i)
             {
-                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(waits[i]);
+                auto wrapper = GetVulkanWrapper<vulkan_wrappers::SemaphoreWrapper>(waits[i]);
                 assert(wrapper != nullptr);
                 wrapper->signaled = false;
             }
@@ -1250,7 +1264,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
         {
             for (uint32_t i = 0; i < signal_count; ++i)
             {
-                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(signals[i]);
+                auto wrapper = GetVulkanWrapper<vulkan_wrappers::SemaphoreWrapper>(signals[i]);
                 assert(wrapper != nullptr);
                 wrapper->signaled = true;
             }
@@ -1269,7 +1283,7 @@ void VulkanStateTracker::TrackSemaphoreInfoSignalState(uint32_t                 
         {
             for (uint32_t i = 0; i < wait_count; ++i)
             {
-                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(wait_infos[i].semaphore);
+                auto wrapper = GetVulkanWrapper<vulkan_wrappers::SemaphoreWrapper>(wait_infos[i].semaphore);
                 assert(wrapper != nullptr);
                 wrapper->signaled = false;
             }
@@ -1279,7 +1293,7 @@ void VulkanStateTracker::TrackSemaphoreInfoSignalState(uint32_t                 
         {
             for (uint32_t i = 0; i < signal_count; ++i)
             {
-                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(signal_infos[i].semaphore);
+                auto wrapper = GetVulkanWrapper<vulkan_wrappers::SemaphoreWrapper>(signal_infos[i].semaphore);
                 assert(wrapper != nullptr);
                 wrapper->signaled = true;
             }
@@ -1290,7 +1304,7 @@ void VulkanStateTracker::TrackSemaphoreInfoSignalState(uint32_t                 
 void VulkanStateTracker::TrackAcquireImage(
     uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t deviceMask)
 {
-    auto wrapper = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain);
+    auto wrapper = GetVulkanWrapper<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
 
     assert(wrapper != nullptr);
 
@@ -1300,10 +1314,12 @@ void VulkanStateTracker::TrackAcquireImage(
         wrapper->image_acquired_info[image_index].last_presented_queue = VK_NULL_HANDLE;
     }
 
-    wrapper->image_acquired_info[image_index].is_acquired           = true;
-    wrapper->image_acquired_info[image_index].acquired_device_mask  = deviceMask;
-    wrapper->image_acquired_info[image_index].acquired_semaphore_id = GetWrappedId<VulkanSemaphoreWrapper>(semaphore);
-    wrapper->image_acquired_info[image_index].acquired_fence_id     = GetWrappedId<VulkanFenceWrapper>(fence);
+    wrapper->image_acquired_info[image_index].is_acquired          = true;
+    wrapper->image_acquired_info[image_index].acquired_device_mask = deviceMask;
+    wrapper->image_acquired_info[image_index].acquired_semaphore_id =
+        GetVulkanWrappedId<vulkan_wrappers::SemaphoreWrapper>(semaphore);
+    wrapper->image_acquired_info[image_index].acquired_fence_id =
+        GetVulkanWrappedId<vulkan_wrappers::FenceWrapper>(fence);
 }
 
 void VulkanStateTracker::TrackPresentedImages(uint32_t              count,
@@ -1315,7 +1331,7 @@ void VulkanStateTracker::TrackPresentedImages(uint32_t              count,
 
     for (uint32_t i = 0; i < count; ++i)
     {
-        auto     wrapper     = GetWrapper<VulkanSwapchainKHRWrapper>(swapchains[i]);
+        auto     wrapper     = GetVulkanWrapper<vulkan_wrappers::SwapchainKHRWrapper>(swapchains[i]);
         uint32_t image_index = image_indices[i];
 
         assert((wrapper != nullptr) && (image_index < wrapper->image_acquired_info.size()));
@@ -1332,8 +1348,8 @@ void VulkanStateTracker::TrackAccelerationStructureKHRDeviceAddress(VkDevice    
 {
     assert((device != VK_NULL_HANDLE) && (accel_struct != VK_NULL_HANDLE));
 
-    auto wrapper       = GetWrapper<VulkanAccelerationStructureKHRWrapper>(accel_struct);
-    wrapper->device_id = GetWrappedId<VulkanDeviceWrapper>(device);
+    auto wrapper       = GetVulkanWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(accel_struct);
+    wrapper->device_id = GetVulkanWrappedId<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->address   = address;
 
     assert(address);
@@ -1344,8 +1360,8 @@ void VulkanStateTracker::TrackDeviceMemoryDeviceAddress(VkDevice device, VkDevic
 {
     assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper       = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
-    wrapper->device_id = GetWrappedId<VulkanDeviceWrapper>(device);
+    auto wrapper       = GetVulkanWrapper<vulkan_wrappers::DeviceMemoryWrapper>(memory);
+    wrapper->device_id = GetVulkanWrappedId<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->address   = address;
 
     device_memory_addresses_map.emplace(address, wrapper);
@@ -1358,9 +1374,9 @@ void VulkanStateTracker::TrackRayTracingShaderGroupHandles(VkDevice    device,
 {
     assert((device != VK_NULL_HANDLE) && (pipeline != VK_NULL_HANDLE));
 
-    auto           wrapper   = GetWrapper<VulkanPipelineWrapper>(pipeline);
+    auto           wrapper   = GetVulkanWrapper<vulkan_wrappers::PipelineWrapper>(pipeline);
     const uint8_t* byte_data = reinterpret_cast<const uint8_t*>(data);
-    wrapper->device_id       = GetWrappedId<VulkanDeviceWrapper>(device);
+    wrapper->device_id       = GetVulkanWrappedId<vulkan_wrappers::DeviceWrapper>(device);
     wrapper->shader_group_handle_data.assign(byte_data, byte_data + data_size);
 }
 
@@ -1368,7 +1384,7 @@ void VulkanStateTracker::TrackAcquireFullScreenExclusiveMode(VkDevice device, Vk
 {
     assert(swapchain != VK_NULL_HANDLE);
 
-    auto wrapper                                = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain);
+    auto wrapper                                = GetVulkanWrapper<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
     wrapper->acquire_full_screen_exclusive_mode = true;
 }
 
@@ -1376,7 +1392,7 @@ void VulkanStateTracker::TrackReleaseFullScreenExclusiveMode(VkDevice device, Vk
 {
     assert(swapchain != VK_NULL_HANDLE);
 
-    auto wrapper                                = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain);
+    auto wrapper                                = GetVulkanWrapper<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
     wrapper->release_full_screen_exclusive_mode = true;
 }
 
@@ -1385,12 +1401,12 @@ void VulkanStateTracker::TrackSetPrivateData(
 {
     assert(privateDataSlot != VK_NULL_HANDLE);
 
-    auto wrapper        = GetWrapper<VulkanPrivateDataSlotWrapper>(privateDataSlot);
-    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
+    auto wrapper        = GetVulkanWrapper<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
+    auto device_wrapper = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
 
     wrapper->device        = device_wrapper;
     wrapper->object_type   = objectType;
-    wrapper->object_handle = GetWrappedId(objectHandle, objectType);
+    wrapper->object_handle = GetVulkanWrappedId(objectHandle, objectType);
     wrapper->data          = data;
 }
 
@@ -1398,15 +1414,15 @@ void VulkanStateTracker::TrackSetLocalDimmingAMD(VkDevice device, VkSwapchainKHR
 {
     assert(swapChain != VK_NULL_HANDLE);
 
-    auto wrapper        = GetWrapper<VulkanSwapchainKHRWrapper>(swapChain);
-    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
+    auto wrapper        = GetVulkanWrapper<vulkan_wrappers::SwapchainKHRWrapper>(swapChain);
+    auto device_wrapper = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
 
     wrapper->device                   = device_wrapper;
     wrapper->using_local_dimming_AMD  = true;
     wrapper->local_dimming_enable_AMD = localDimmingEnable;
 }
 
-void VulkanStateTracker::DestroyState(VulkanInstanceWrapper* wrapper)
+void VulkanStateTracker::DestroyState(vulkan_wrappers::InstanceWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1430,7 +1446,7 @@ void VulkanStateTracker::DestroyState(VulkanInstanceWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(VulkanDeviceWrapper* wrapper)
+void VulkanStateTracker::DestroyState(vulkan_wrappers::DeviceWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1444,7 +1460,7 @@ void VulkanStateTracker::DestroyState(VulkanDeviceWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(VulkanCommandPoolWrapper* wrapper)
+void VulkanStateTracker::DestroyState(vulkan_wrappers::CommandPoolWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1458,7 +1474,7 @@ void VulkanStateTracker::DestroyState(VulkanCommandPoolWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(VulkanDescriptorPoolWrapper* wrapper)
+void VulkanStateTracker::DestroyState(vulkan_wrappers::DescriptorPoolWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1472,7 +1488,7 @@ void VulkanStateTracker::DestroyState(VulkanDescriptorPoolWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(VulkanSwapchainKHRWrapper* wrapper)
+void VulkanStateTracker::DestroyState(vulkan_wrappers::SwapchainKHRWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1486,7 +1502,7 @@ void VulkanStateTracker::DestroyState(VulkanSwapchainKHRWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(VulkanDeviceMemoryWrapper* wrapper)
+void VulkanStateTracker::DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1498,7 +1514,7 @@ void VulkanStateTracker::DestroyState(VulkanDeviceMemoryWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(VulkanAccelerationStructureKHRWrapper* wrapper)
+void VulkanStateTracker::DestroyState(vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1520,7 +1536,8 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
 
     for (uint32_t c = 0; c < command_buffer_count; ++c)
     {
-        const VulkanCommandBufferWrapper* cmd_buf_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffers[c]);
+        const vulkan_wrappers::CommandBufferWrapper* cmd_buf_wrapper =
+            GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffers[c]);
 
         for (const auto& tlas_build_info : cmd_buf_wrapper->tlas_build_info_map)
         {
@@ -1530,7 +1547,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
 
             // Find to which device memory this address belongs
             const VkDeviceAddress            address         = tlas_build_info.second.address;
-            const VulkanDeviceMemoryWrapper* dev_mem_wrapper = nullptr;
+            const vulkan_wrappers::DeviceMemoryWrapper* dev_mem_wrapper = nullptr;
             for (const auto& dev_mem : device_memory_addresses_map)
             {
                 if (address >= dev_mem.second->address &&
@@ -1599,7 +1616,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
 
             if (instances)
             {
-                VulkanAccelerationStructureKHRWrapper* tlas_wrapper = tlas_build_info.first;
+                vulkan_wrappers::AccelerationStructureKHRWrapper* tlas_wrapper = tlas_build_info.first;
 
                 for (uint32_t b = 0; b < blas_count; ++b)
                 {

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -37,7 +37,7 @@ VulkanStateTracker::VulkanStateTracker() {}
 
 VulkanStateTracker::~VulkanStateTracker() {}
 
-void VulkanStateTracker::TrackCommandExecution(CommandBufferWrapper*           wrapper,
+void VulkanStateTracker::TrackCommandExecution(VulkanCommandBufferWrapper*     wrapper,
                                                format::ApiCallId               call_id,
                                                const util::MemoryOutputStream* parameter_buffer)
 {
@@ -72,10 +72,10 @@ void VulkanStateTracker::TrackTrimCommandPool(VkDevice device, VkCommandPool com
 {
     assert(command_pool != VK_NULL_HANDLE);
 
-    auto wrapper               = GetWrapper<CommandPoolWrapper>(command_pool);
+    auto wrapper               = GetWrapper<VulkanCommandPoolWrapper>(command_pool);
     wrapper->trim_command_pool = true;
 
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     wrapper->device     = device_wrapper;
 }
 
@@ -83,7 +83,7 @@ void VulkanStateTracker::TrackResetCommandPool(VkCommandPool command_pool)
 {
     assert(command_pool != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<CommandPoolWrapper>(command_pool);
+    auto wrapper = GetWrapper<VulkanCommandPoolWrapper>(command_pool);
 
     for (const auto& entry : wrapper->child_buffers)
     {
@@ -104,7 +104,7 @@ void VulkanStateTracker::TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice   
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper = GetWrapper<PhysicalDeviceWrapper>(physical_device);
+    auto wrapper = GetWrapper<VulkanPhysicalDeviceWrapper>(physical_device);
 
     wrapper->memory_properties = *properties;
 }
@@ -115,7 +115,7 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties(VkPhysicalDevi
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper                             = GetWrapper<PhysicalDeviceWrapper>(physical_device);
+    auto wrapper                             = GetWrapper<VulkanPhysicalDeviceWrapper>(physical_device);
     wrapper->queue_family_properties_call_id = format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties         = std::make_unique<VkQueueFamilyProperties[]>(property_count);
@@ -129,7 +129,7 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties2(format::ApiCa
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper                             = GetWrapper<PhysicalDeviceWrapper>(physical_device);
+    auto wrapper                             = GetWrapper<VulkanPhysicalDeviceWrapper>(physical_device);
     wrapper->queue_family_properties_call_id = call_id;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties2        = std::make_unique<VkQueueFamilyProperties2[]>(property_count);
@@ -176,8 +176,8 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceSupport(VkPhysicalDevice phys
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE));
 
-    auto  wrapper             = GetWrapper<SurfaceKHRWrapper>(surface);
-    auto& entry               = wrapper->surface_support[GetWrappedId<PhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper             = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
+    auto& entry               = wrapper->surface_support[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
     entry[queue_family_index] = supported;
 }
 
@@ -187,8 +187,8 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceCapabilities(VkPhysicalDevice
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (capabilities != nullptr));
 
-    auto  wrapper = GetWrapper<SurfaceKHRWrapper>(surface);
-    auto& entry   = wrapper->surface_capabilities[GetWrappedId<PhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
+    auto& entry   = wrapper->surface_capabilities[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
 
     entry.surface_info_pnext_memory.Reset();
     entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -207,8 +207,8 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceCapabilities2(VkPhysicalDevic
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface_info.surface != VK_NULL_HANDLE));
 
-    auto  wrapper = GetWrapper<SurfaceKHRWrapper>(surface_info.surface);
-    auto& entry   = wrapper->surface_capabilities[GetWrappedId<PhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface_info.surface);
+    auto& entry   = wrapper->surface_capabilities[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
 
     entry.surface_info_pnext_memory.Reset();
     entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -241,8 +241,8 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceFormats(VkPhysicalDevice     
 
     if (surface != VK_NULL_HANDLE && format_count > 0)
     {
-        auto  wrapper = GetWrapper<SurfaceKHRWrapper>(surface);
-        auto& entry   = wrapper->surface_formats[GetWrappedId<PhysicalDeviceWrapper>(physical_device)];
+        auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
+        auto& entry   = wrapper->surface_formats[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
 
         entry.surface_info_pnext_memory.Reset();
         entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -270,8 +270,8 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceFormats2(VkPhysicalDevice    
 
     if (surface_info.surface != VK_NULL_HANDLE && surface_format_count > 0)
     {
-        auto  wrapper = GetWrapper<SurfaceKHRWrapper>(surface_info.surface);
-        auto& entry   = wrapper->surface_formats[GetWrappedId<PhysicalDeviceWrapper>(physical_device)];
+        auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface_info.surface);
+        auto& entry   = wrapper->surface_formats[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
 
         entry.surface_info_pnext_memory.Reset();
         entry.surface_info.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
@@ -309,8 +309,8 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfacePresentModes(VkPhysicalDevice
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (modes != nullptr));
 
-    auto  wrapper = GetWrapper<SurfaceKHRWrapper>(surface);
-    auto& entry   = wrapper->surface_present_modes[GetWrappedId<PhysicalDeviceWrapper>(physical_device)];
+    auto  wrapper = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
+    auto& entry   = wrapper->surface_present_modes[GetWrappedId<VulkanPhysicalDeviceWrapper>(physical_device)];
     entry.present_modes.assign(modes, modes + mode_count);
 
     entry.surface_info_pnext = nullptr;
@@ -328,8 +328,8 @@ void VulkanStateTracker::TrackDeviceGroupSurfacePresentModes(VkDevice           
 {
     assert((device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (pModes != nullptr));
 
-    auto  wrapper       = GetWrapper<SurfaceKHRWrapper>(surface);
-    auto& entry         = wrapper->group_surface_present_modes[GetWrappedId<DeviceWrapper>(device)];
+    auto  wrapper       = GetWrapper<VulkanSurfaceKHRWrapper>(surface);
+    auto& entry         = wrapper->group_surface_present_modes[GetWrappedId<VulkanDeviceWrapper>(device)];
     entry.present_modes = *pModes;
 
     entry.surface_info_pnext = nullptr;
@@ -344,8 +344,8 @@ void VulkanStateTracker::TrackBufferDeviceAddress(VkDevice device, VkBuffer buff
 {
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE));
 
-    auto wrapper       = GetWrapper<BufferWrapper>(buffer);
-    wrapper->device_id = GetWrappedId<DeviceWrapper>(device);
+    auto wrapper       = GetWrapper<VulkanBufferWrapper>(buffer);
+    wrapper->device_id = GetWrappedId<VulkanDeviceWrapper>(device);
     wrapper->address   = address;
 }
 
@@ -354,9 +354,9 @@ void VulkanStateTracker::TrackBufferMemoryBinding(
 {
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper            = GetWrapper<BufferWrapper>(buffer);
-    wrapper->bind_device    = GetWrapper<DeviceWrapper>(device);
-    wrapper->bind_memory_id = GetWrappedId<DeviceMemoryWrapper>(memory);
+    auto wrapper            = GetWrapper<VulkanBufferWrapper>(buffer);
+    wrapper->bind_device    = GetWrapper<VulkanDeviceWrapper>(device);
+    wrapper->bind_memory_id = GetWrappedId<VulkanDeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
     wrapper->bind_pnext_memory.Reset();
@@ -375,15 +375,15 @@ void VulkanStateTracker::TrackTLASBuildCommand(
 {
     if (info_count && infos && pp_buildRange_infos)
     {
-        CommandBufferWrapper* buf_wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+        VulkanCommandBufferWrapper* buf_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
 
         for (uint32_t i = 0; i < info_count; ++i)
         {
             if (infos[i].type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
                 infos[i].dstAccelerationStructure != VK_NULL_HANDLE && infos[i].geometryCount && infos[i].pGeometries)
             {
-                AccelerationStructureKHRWrapper* tlas_wrapper =
-                    GetWrapper<AccelerationStructureKHRWrapper>(infos[i].dstAccelerationStructure);
+                VulkanAccelerationStructureKHRWrapper* tlas_wrapper =
+                    GetWrapper<VulkanAccelerationStructureKHRWrapper>(infos[i].dstAccelerationStructure);
 
                 tlas_wrapper->blas.clear();
 
@@ -397,7 +397,7 @@ void VulkanStateTracker::TrackTLASBuildCommand(
                         // Nothing to handle in these cases.
                         if (address && primitive_count)
                         {
-                            const CommandBufferWrapper::tlas_build_info tlas_info = {
+                            const VulkanCommandBufferWrapper::tlas_build_info tlas_info = {
                                 address, primitive_count, pp_buildRange_infos[i]->primitiveOffset
                             };
 
@@ -417,9 +417,9 @@ void VulkanStateTracker::TrackImageMemoryBinding(
     // If VkBindImageMemorySwapchainInfoKHR is in pnext, memory must be VK_NULL_HANDLE.
     assert((device != VK_NULL_HANDLE) && (image != VK_NULL_HANDLE));
 
-    auto wrapper            = GetWrapper<ImageWrapper>(image);
-    wrapper->bind_device    = GetWrapper<DeviceWrapper>(device);
-    wrapper->bind_memory_id = GetWrappedId<DeviceMemoryWrapper>(memory);
+    auto wrapper            = GetWrapper<VulkanImageWrapper>(image);
+    wrapper->bind_device    = GetWrapper<VulkanDeviceWrapper>(device);
+    wrapper->bind_memory_id = GetWrappedId<VulkanDeviceMemoryWrapper>(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
     wrapper->bind_pnext_memory.Reset();
@@ -439,7 +439,7 @@ void VulkanStateTracker::TrackMappedMemory(VkDevice         device,
 {
     assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper           = GetWrapper<DeviceMemoryWrapper>(memory);
+    auto wrapper           = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
     wrapper->mapped_data   = mapped_data;
     wrapper->mapped_offset = mapped_offset;
     wrapper->mapped_size   = mapped_size;
@@ -450,16 +450,16 @@ void VulkanStateTracker::TrackBeginRenderPass(VkCommandBuffer command_buffer, co
 {
     assert((command_buffer != VK_NULL_HANDLE) && (begin_info != nullptr));
 
-    auto wrapper                     = GetWrapper<CommandBufferWrapper>(command_buffer);
-    wrapper->active_render_pass      = GetWrapper<RenderPassWrapper>(begin_info->renderPass);
-    wrapper->render_pass_framebuffer = GetWrapper<FramebufferWrapper>(begin_info->framebuffer);
+    auto wrapper                     = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+    wrapper->active_render_pass      = GetWrapper<VulkanRenderPassWrapper>(begin_info->renderPass);
+    wrapper->render_pass_framebuffer = GetWrapper<VulkanFramebufferWrapper>(begin_info->framebuffer);
 }
 
 void VulkanStateTracker::TrackEndRenderPass(VkCommandBuffer command_buffer)
 {
     assert(command_buffer != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+    auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
     assert((wrapper->active_render_pass != VK_NULL_HANDLE) && (wrapper->render_pass_framebuffer != VK_NULL_HANDLE));
 
     auto render_pass_wrapper = wrapper->active_render_pass;
@@ -486,11 +486,11 @@ void VulkanStateTracker::TrackExecuteCommands(VkCommandBuffer        command_buf
 {
     assert((command_buffer != VK_NULL_HANDLE) && (command_buffers != nullptr));
 
-    auto primary_wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+    auto primary_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
 
     for (uint32_t i = 0; i < command_buffer_count; ++i)
     {
-        auto secondary_wrapper = GetWrapper<CommandBufferWrapper>(command_buffers[i]);
+        auto secondary_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffers[i]);
         assert(secondary_wrapper != nullptr);
 
         for (const auto& layout_entry : secondary_wrapper->pending_layouts)
@@ -526,11 +526,11 @@ void VulkanStateTracker::TrackImageBarriers(VkCommandBuffer             command_
 
     if ((image_barrier_count > 0) && (image_barriers != nullptr))
     {
-        auto wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+        auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
 
         for (uint32_t i = 0; i < image_barrier_count; ++i)
         {
-            auto image_wrapper                      = GetWrapper<ImageWrapper>(image_barriers[i].image);
+            auto image_wrapper                      = GetWrapper<VulkanImageWrapper>(image_barriers[i].image);
             wrapper->pending_layouts[image_wrapper] = image_barriers[i].newLayout;
         }
     }
@@ -544,11 +544,11 @@ void VulkanStateTracker::TrackImageBarriers2KHR(VkCommandBuffer                 
 
     if ((image_barrier_count > 0) && (image_barriers != nullptr))
     {
-        auto wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+        auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
 
         for (uint32_t i = 0; i < image_barrier_count; ++i)
         {
-            auto image_wrapper                      = GetWrapper<ImageWrapper>(image_barriers[i].image);
+            auto image_wrapper                      = GetWrapper<VulkanImageWrapper>(image_barriers[i].image);
             wrapper->pending_layouts[image_wrapper] = image_barriers[i].newLayout;
         }
     }
@@ -565,7 +565,7 @@ void VulkanStateTracker::TrackCommandBufferSubmissions(uint32_t submit_count, co
 
             for (uint32_t cmd = 0; cmd < command_buffer_count; ++cmd)
             {
-                auto command_wrapper = GetWrapper<CommandBufferWrapper>(command_buffers[cmd]);
+                auto command_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffers[cmd]);
                 assert(command_wrapper != nullptr);
 
                 TrackQuerySubmissions(command_wrapper);
@@ -585,7 +585,7 @@ void VulkanStateTracker::TrackCommandBufferSubmissions2(uint32_t submit_count, c
 
             for (uint32_t cmd = 0; cmd < command_buffer_count; ++cmd)
             {
-                auto command_wrapper = GetWrapper<CommandBufferWrapper>(command_buffer_infos[cmd].commandBuffer);
+                auto command_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer_infos[cmd].commandBuffer);
                 assert(command_wrapper != nullptr);
 
                 TrackQuerySubmissions(command_wrapper);
@@ -594,7 +594,7 @@ void VulkanStateTracker::TrackCommandBufferSubmissions2(uint32_t submit_count, c
     }
 }
 
-void VulkanStateTracker::TrackQuerySubmissions(CommandBufferWrapper* command_wrapper)
+void VulkanStateTracker::TrackQuerySubmissions(VulkanCommandBufferWrapper* command_wrapper)
 {
     // Apply pending image layouts.
     for (const auto& layout_entry : command_wrapper->pending_layouts)
@@ -639,7 +639,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
         for (uint32_t i = 0; i < write_count; ++i)
         {
             const VkWriteDescriptorSet* write   = &writes[i];
-            auto                        wrapper = GetWrapper<DescriptorSetWrapper>(write->dstSet);
+            auto                        wrapper = GetWrapper<VulkanDescriptorSetWrapper>(write->dstSet);
             assert(wrapper != nullptr);
 
             // Descriptor update rules specify that a write descriptorCount that is greater than the binding's count
@@ -703,7 +703,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_sampler_ids[i] = GetWrappedId<SamplerWrapper>(src_info[i].sampler);
+                            dst_sampler_ids[i] = GetWrappedId<VulkanSamplerWrapper>(src_info[i].sampler);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -717,8 +717,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_sampler_ids[i] = GetWrappedId<SamplerWrapper>(src_info[i].sampler);
-                            dst_image_ids[i]   = GetWrappedId<ImageViewWrapper>(src_info[i].imageView);
+                            dst_sampler_ids[i] = GetWrappedId<VulkanSamplerWrapper>(src_info[i].sampler);
+                            dst_image_ids[i]   = GetWrappedId<VulkanImageViewWrapper>(src_info[i].imageView);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -733,7 +733,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_image_ids[i] = GetWrappedId<ImageViewWrapper>(src_info[i].imageView);
+                            dst_image_ids[i] = GetWrappedId<VulkanImageViewWrapper>(src_info[i].imageView);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -749,7 +749,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_buffer_ids[i] = GetWrappedId<BufferWrapper>(src_info[i].buffer);
+                            dst_buffer_ids[i] = GetWrappedId<VulkanBufferWrapper>(src_info[i].buffer);
                             memcpy(&dst_info[i], &src_info[i], sizeof(dst_info[i]));
                         }
                         break;
@@ -763,7 +763,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
 
                         for (uint32_t i = 0; i < current_writes; ++i)
                         {
-                            dst_view_ids[i] = GetWrappedId<BufferViewWrapper>(src_info[i]);
+                            dst_view_ids[i] = GetWrappedId<VulkanBufferViewWrapper>(src_info[i]);
                             dst_info[i]     = src_info[i];
                         }
                         break;
@@ -791,7 +791,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
                             for (uint32_t i = 0; i < current_writes; ++i)
                             {
                                 dst_accel_struct_ids[i] =
-                                    GetWrappedId<AccelerationStructureKHRWrapper>(src_accel_struct[i]);
+                                    GetWrappedId<VulkanAccelerationStructureKHRWrapper>(src_accel_struct[i]);
                                 dst_accel_struct[i] = src_accel_struct[i];
                             }
                         }
@@ -823,8 +823,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
         for (uint32_t i = 0; i < copy_count; ++i)
         {
             auto copy        = &copies[i];
-            auto dst_wrapper = GetWrapper<DescriptorSetWrapper>(copy->dstSet);
-            auto src_wrapper = GetWrapper<DescriptorSetWrapper>(copy->srcSet);
+            auto dst_wrapper = GetWrapper<VulkanDescriptorSetWrapper>(copy->dstSet);
+            auto src_wrapper = GetWrapper<VulkanDescriptorSetWrapper>(copy->srcSet);
             assert((dst_wrapper != nullptr) && (src_wrapper != nullptr));
 
             // Descriptor update rules specify that a write descriptorCount that is greater than the binding's count
@@ -937,7 +937,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
     // exists at state write time by checking for the ID in the active state table.
     if ((template_info != nullptr) && (data != nullptr))
     {
-        auto           wrapper = GetWrapper<DescriptorSetWrapper>(set);
+        auto           wrapper = GetWrapper<VulkanDescriptorSetWrapper>(set);
         const uint8_t* bytes   = reinterpret_cast<const uint8_t*>(data);
 
         for (const auto& entry : template_info->image_info)
@@ -972,12 +972,12 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                     if ((binding.type == VK_DESCRIPTOR_TYPE_SAMPLER) ||
                         (binding.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
                     {
-                        dst_sampler_ids[i] = GetWrappedId<SamplerWrapper>(image_info->sampler);
+                        dst_sampler_ids[i] = GetWrappedId<VulkanSamplerWrapper>(image_info->sampler);
                     }
 
                     if (binding.type != VK_DESCRIPTOR_TYPE_SAMPLER)
                     {
-                        dst_image_ids[i] = GetWrappedId<ImageViewWrapper>(image_info->imageView);
+                        dst_image_ids[i] = GetWrappedId<VulkanImageViewWrapper>(image_info->imageView);
                     }
 
                     memcpy(&dst_info[i], image_info, sizeof(dst_info[i]));
@@ -1028,7 +1028,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 for (uint32_t i = 0; i < current_writes; ++i)
                 {
                     auto buffer_info  = reinterpret_cast<const VkDescriptorBufferInfo*>(src_address);
-                    dst_buffer_ids[i] = GetWrappedId<BufferWrapper>(buffer_info->buffer);
+                    dst_buffer_ids[i] = GetWrappedId<VulkanBufferWrapper>(buffer_info->buffer);
                     memcpy(&dst_info[i], buffer_info, sizeof(dst_info[i]));
 
                     src_address += entry.stride;
@@ -1077,7 +1077,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 for (uint32_t i = 0; i < current_writes; ++i)
                 {
                     auto buffer_view = reinterpret_cast<const VkBufferView*>(src_address);
-                    dst_view_ids[i]  = GetWrappedId<BufferViewWrapper>(*buffer_view);
+                    dst_view_ids[i]  = GetWrappedId<VulkanBufferViewWrapper>(*buffer_view);
                     dst_info[i]      = *buffer_view;
 
                     src_address += entry.stride;
@@ -1126,7 +1126,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
                 for (uint32_t i = 0; i < current_writes; ++i)
                 {
                     const auto* accel_struct = reinterpret_cast<const VkAccelerationStructureKHR*>(src_address);
-                    dst_view_ids[i]          = GetWrappedId<AccelerationStructureKHRWrapper>(*accel_struct);
+                    dst_view_ids[i]          = GetWrappedId<VulkanAccelerationStructureKHRWrapper>(*accel_struct);
                     dst_info[i]              = *accel_struct;
 
                     src_address += entry.stride;
@@ -1164,7 +1164,7 @@ void VulkanStateTracker::TrackResetDescriptorPool(VkDescriptorPool descriptor_po
 {
     assert(descriptor_pool != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<DescriptorPoolWrapper>(descriptor_pool);
+    auto wrapper = GetWrapper<VulkanDescriptorPoolWrapper>(descriptor_pool);
 
     // Pool reset implicitly frees descriptor sets, so remove all wrappers from the state tracker.
     std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -1179,10 +1179,10 @@ void VulkanStateTracker::TrackQueryActivation(
 {
     assert((command_buffer != VK_NULL_HANDLE) && (query_pool != VK_NULL_HANDLE));
 
-    auto                      wrapper              = GetWrapper<CommandBufferWrapper>(command_buffer);
-    const CommandPoolWrapper* command_pool_wrapper = wrapper->parent_pool;
+    auto                            wrapper              = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+    const VulkanCommandPoolWrapper* command_pool_wrapper = wrapper->parent_pool;
 
-    auto& query_pool_info         = wrapper->recorded_queries[GetWrapper<QueryPoolWrapper>(query_pool)];
+    auto& query_pool_info         = wrapper->recorded_queries[GetWrapper<VulkanQueryPoolWrapper>(query_pool)];
     auto& query_info              = query_pool_info[query];
     query_info.active             = true;
     query_info.flags              = flags;
@@ -1197,8 +1197,8 @@ void VulkanStateTracker::TrackQueryReset(VkCommandBuffer command_buffer,
 {
     assert((command_buffer != VK_NULL_HANDLE) && (query_pool != VK_NULL_HANDLE));
 
-    auto  wrapper         = GetWrapper<CommandBufferWrapper>(command_buffer);
-    auto& query_pool_info = wrapper->recorded_queries[GetWrapper<QueryPoolWrapper>(query_pool)];
+    auto  wrapper         = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+    auto& query_pool_info = wrapper->recorded_queries[GetWrapper<VulkanQueryPoolWrapper>(query_pool)];
 
     for (uint32_t i = first_query; i < query_count; ++i)
     {
@@ -1210,7 +1210,7 @@ void VulkanStateTracker::TrackQueryReset(VkQueryPool query_pool, uint32_t first_
 {
     assert(query_pool != VK_NULL_HANDLE);
 
-    auto wrapper = GetWrapper<QueryPoolWrapper>(query_pool);
+    auto wrapper = GetWrapper<VulkanQueryPoolWrapper>(query_pool);
     assert((first_query + query_count) <= wrapper->pending_queries.size());
 
     for (uint32_t i = first_query; i < query_count; ++i)
@@ -1223,7 +1223,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(VkSemaphore signal)
 {
     if (signal != VK_NULL_HANDLE)
     {
-        auto wrapper = GetWrapper<SemaphoreWrapper>(signal);
+        auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(signal);
         assert(wrapper != nullptr);
         wrapper->signaled = true;
     }
@@ -1240,7 +1240,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
         {
             for (uint32_t i = 0; i < wait_count; ++i)
             {
-                auto wrapper = GetWrapper<SemaphoreWrapper>(waits[i]);
+                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(waits[i]);
                 assert(wrapper != nullptr);
                 wrapper->signaled = false;
             }
@@ -1250,7 +1250,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
         {
             for (uint32_t i = 0; i < signal_count; ++i)
             {
-                auto wrapper = GetWrapper<SemaphoreWrapper>(signals[i]);
+                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(signals[i]);
                 assert(wrapper != nullptr);
                 wrapper->signaled = true;
             }
@@ -1269,7 +1269,7 @@ void VulkanStateTracker::TrackSemaphoreInfoSignalState(uint32_t                 
         {
             for (uint32_t i = 0; i < wait_count; ++i)
             {
-                auto wrapper = GetWrapper<SemaphoreWrapper>(wait_infos[i].semaphore);
+                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(wait_infos[i].semaphore);
                 assert(wrapper != nullptr);
                 wrapper->signaled = false;
             }
@@ -1279,7 +1279,7 @@ void VulkanStateTracker::TrackSemaphoreInfoSignalState(uint32_t                 
         {
             for (uint32_t i = 0; i < signal_count; ++i)
             {
-                auto wrapper = GetWrapper<SemaphoreWrapper>(signal_infos[i].semaphore);
+                auto wrapper = GetWrapper<VulkanSemaphoreWrapper>(signal_infos[i].semaphore);
                 assert(wrapper != nullptr);
                 wrapper->signaled = true;
             }
@@ -1290,7 +1290,7 @@ void VulkanStateTracker::TrackSemaphoreInfoSignalState(uint32_t                 
 void VulkanStateTracker::TrackAcquireImage(
     uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t deviceMask)
 {
-    auto wrapper = GetWrapper<SwapchainKHRWrapper>(swapchain);
+    auto wrapper = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain);
 
     assert(wrapper != nullptr);
 
@@ -1302,8 +1302,8 @@ void VulkanStateTracker::TrackAcquireImage(
 
     wrapper->image_acquired_info[image_index].is_acquired           = true;
     wrapper->image_acquired_info[image_index].acquired_device_mask  = deviceMask;
-    wrapper->image_acquired_info[image_index].acquired_semaphore_id = GetWrappedId<SemaphoreWrapper>(semaphore);
-    wrapper->image_acquired_info[image_index].acquired_fence_id     = GetWrappedId<FenceWrapper>(fence);
+    wrapper->image_acquired_info[image_index].acquired_semaphore_id = GetWrappedId<VulkanSemaphoreWrapper>(semaphore);
+    wrapper->image_acquired_info[image_index].acquired_fence_id     = GetWrappedId<VulkanFenceWrapper>(fence);
 }
 
 void VulkanStateTracker::TrackPresentedImages(uint32_t              count,
@@ -1315,7 +1315,7 @@ void VulkanStateTracker::TrackPresentedImages(uint32_t              count,
 
     for (uint32_t i = 0; i < count; ++i)
     {
-        auto     wrapper     = GetWrapper<SwapchainKHRWrapper>(swapchains[i]);
+        auto     wrapper     = GetWrapper<VulkanSwapchainKHRWrapper>(swapchains[i]);
         uint32_t image_index = image_indices[i];
 
         assert((wrapper != nullptr) && (image_index < wrapper->image_acquired_info.size()));
@@ -1332,8 +1332,8 @@ void VulkanStateTracker::TrackAccelerationStructureKHRDeviceAddress(VkDevice    
 {
     assert((device != VK_NULL_HANDLE) && (accel_struct != VK_NULL_HANDLE));
 
-    auto wrapper       = GetWrapper<AccelerationStructureKHRWrapper>(accel_struct);
-    wrapper->device_id = GetWrappedId<DeviceWrapper>(device);
+    auto wrapper       = GetWrapper<VulkanAccelerationStructureKHRWrapper>(accel_struct);
+    wrapper->device_id = GetWrappedId<VulkanDeviceWrapper>(device);
     wrapper->address   = address;
 
     assert(address);
@@ -1344,8 +1344,8 @@ void VulkanStateTracker::TrackDeviceMemoryDeviceAddress(VkDevice device, VkDevic
 {
     assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper       = GetWrapper<DeviceMemoryWrapper>(memory);
-    wrapper->device_id = GetWrappedId<DeviceWrapper>(device);
+    auto wrapper       = GetWrapper<VulkanDeviceMemoryWrapper>(memory);
+    wrapper->device_id = GetWrappedId<VulkanDeviceWrapper>(device);
     wrapper->address   = address;
 
     device_memory_addresses_map.emplace(address, wrapper);
@@ -1358,9 +1358,9 @@ void VulkanStateTracker::TrackRayTracingShaderGroupHandles(VkDevice    device,
 {
     assert((device != VK_NULL_HANDLE) && (pipeline != VK_NULL_HANDLE));
 
-    auto           wrapper   = GetWrapper<PipelineWrapper>(pipeline);
+    auto           wrapper   = GetWrapper<VulkanPipelineWrapper>(pipeline);
     const uint8_t* byte_data = reinterpret_cast<const uint8_t*>(data);
-    wrapper->device_id       = GetWrappedId<DeviceWrapper>(device);
+    wrapper->device_id       = GetWrappedId<VulkanDeviceWrapper>(device);
     wrapper->shader_group_handle_data.assign(byte_data, byte_data + data_size);
 }
 
@@ -1368,7 +1368,7 @@ void VulkanStateTracker::TrackAcquireFullScreenExclusiveMode(VkDevice device, Vk
 {
     assert(swapchain != VK_NULL_HANDLE);
 
-    auto wrapper                                = GetWrapper<SwapchainKHRWrapper>(swapchain);
+    auto wrapper                                = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain);
     wrapper->acquire_full_screen_exclusive_mode = true;
 }
 
@@ -1376,7 +1376,7 @@ void VulkanStateTracker::TrackReleaseFullScreenExclusiveMode(VkDevice device, Vk
 {
     assert(swapchain != VK_NULL_HANDLE);
 
-    auto wrapper                                = GetWrapper<SwapchainKHRWrapper>(swapchain);
+    auto wrapper                                = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain);
     wrapper->release_full_screen_exclusive_mode = true;
 }
 
@@ -1385,8 +1385,8 @@ void VulkanStateTracker::TrackSetPrivateData(
 {
     assert(privateDataSlot != VK_NULL_HANDLE);
 
-    auto wrapper        = GetWrapper<PrivateDataSlotWrapper>(privateDataSlot);
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto wrapper        = GetWrapper<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
 
     wrapper->device        = device_wrapper;
     wrapper->object_type   = objectType;
@@ -1398,15 +1398,15 @@ void VulkanStateTracker::TrackSetLocalDimmingAMD(VkDevice device, VkSwapchainKHR
 {
     assert(swapChain != VK_NULL_HANDLE);
 
-    auto wrapper        = GetWrapper<SwapchainKHRWrapper>(swapChain);
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto wrapper        = GetWrapper<VulkanSwapchainKHRWrapper>(swapChain);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
 
     wrapper->device                   = device_wrapper;
     wrapper->using_local_dimming_AMD  = true;
     wrapper->local_dimming_enable_AMD = localDimmingEnable;
 }
 
-void VulkanStateTracker::DestroyState(InstanceWrapper* wrapper)
+void VulkanStateTracker::DestroyState(VulkanInstanceWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1430,7 +1430,7 @@ void VulkanStateTracker::DestroyState(InstanceWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(DeviceWrapper* wrapper)
+void VulkanStateTracker::DestroyState(VulkanDeviceWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1444,7 +1444,7 @@ void VulkanStateTracker::DestroyState(DeviceWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(CommandPoolWrapper* wrapper)
+void VulkanStateTracker::DestroyState(VulkanCommandPoolWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1458,7 +1458,7 @@ void VulkanStateTracker::DestroyState(CommandPoolWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(DescriptorPoolWrapper* wrapper)
+void VulkanStateTracker::DestroyState(VulkanDescriptorPoolWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1472,7 +1472,7 @@ void VulkanStateTracker::DestroyState(DescriptorPoolWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(SwapchainKHRWrapper* wrapper)
+void VulkanStateTracker::DestroyState(VulkanSwapchainKHRWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1486,7 +1486,7 @@ void VulkanStateTracker::DestroyState(SwapchainKHRWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(DeviceMemoryWrapper* wrapper)
+void VulkanStateTracker::DestroyState(VulkanDeviceMemoryWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1498,7 +1498,7 @@ void VulkanStateTracker::DestroyState(DeviceMemoryWrapper* wrapper)
     }
 }
 
-void VulkanStateTracker::DestroyState(AccelerationStructureKHRWrapper* wrapper)
+void VulkanStateTracker::DestroyState(VulkanAccelerationStructureKHRWrapper* wrapper)
 {
     assert(wrapper != nullptr);
     wrapper->create_parameters = nullptr;
@@ -1520,7 +1520,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
 
     for (uint32_t c = 0; c < command_buffer_count; ++c)
     {
-        const CommandBufferWrapper* cmd_buf_wrapper = GetWrapper<CommandBufferWrapper>(command_buffers[c]);
+        const VulkanCommandBufferWrapper* cmd_buf_wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffers[c]);
 
         for (const auto& tlas_build_info : cmd_buf_wrapper->tlas_build_info_map)
         {
@@ -1529,8 +1529,8 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
             assert(tlas_build_info.second.blas_count);
 
             // Find to which device memory this address belongs
-            const VkDeviceAddress      address         = tlas_build_info.second.address;
-            const DeviceMemoryWrapper* dev_mem_wrapper = nullptr;
+            const VkDeviceAddress            address         = tlas_build_info.second.address;
+            const VulkanDeviceMemoryWrapper* dev_mem_wrapper = nullptr;
             for (const auto& dev_mem : device_memory_addresses_map)
             {
                 if (address >= dev_mem.second->address &&
@@ -1576,17 +1576,17 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
                 }
             }
 
-            const uint32_t blas_count = tlas_build_info.second.blas_count;
-            bool needs_unmapping = false;
+            const uint32_t blas_count      = tlas_build_info.second.blas_count;
+            bool           needs_unmapping = false;
             if (!instances)
             {
                 // If PageGuardManager is not used or if it couldn't find the memory id it means that
                 // we need to map the memory.
-                VkDevice           device        = dev_mem_wrapper->parent_device->handle;
+                VkDevice                 device        = dev_mem_wrapper->parent_device->handle;
                 const VulkanDeviceTable* device_table  = GetVulkanDeviceTable(device);
-                const VkDeviceSize map_size      = sizeof(VkAccelerationStructureInstanceKHR) * blas_count;
-                void*              mapped_memory = nullptr;
-                const VkResult     result =
+                const VkDeviceSize       map_size      = sizeof(VkAccelerationStructureInstanceKHR) * blas_count;
+                void*                    mapped_memory = nullptr;
+                const VkResult           result =
                     device_table->MapMemory(device, dev_mem_wrapper->handle, total_offset, map_size, 0, &mapped_memory);
 
                 if (result == VK_SUCCESS)
@@ -1599,7 +1599,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
 
             if (instances)
             {
-                AccelerationStructureKHRWrapper* tlas_wrapper = tlas_build_info.first;
+                VulkanAccelerationStructureKHRWrapper* tlas_wrapper = tlas_build_info.first;
 
                 for (uint32_t b = 0; b < blas_count; ++b)
                 {
@@ -1617,7 +1617,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
                 // If we had to map the device memory unmap it now
                 if (needs_unmapping)
                 {
-                    VkDevice           device       = dev_mem_wrapper->parent_device->handle;
+                    VkDevice                 device       = dev_mem_wrapper->parent_device->handle;
                     const VulkanDeviceTable* device_table = GetVulkanDeviceTable(device);
                     device_table->UnmapMemory(device, dev_mem_wrapper->handle);
                 }

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1583,7 +1583,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
                 // If PageGuardManager is not used or if it couldn't find the memory id it means that
                 // we need to map the memory.
                 VkDevice           device        = dev_mem_wrapper->parent_device->handle;
-                const DeviceTable* device_table  = GetDeviceTable(device);
+                const VulkanDeviceTable* device_table  = GetVulkanDeviceTable(device);
                 const VkDeviceSize map_size      = sizeof(VkAccelerationStructureInstanceKHR) * blas_count;
                 void*              mapped_memory = nullptr;
                 const VkResult     result =
@@ -1618,7 +1618,7 @@ void VulkanStateTracker::TrackTlasToBlasDependencies(uint32_t               comm
                 if (needs_unmapping)
                 {
                     VkDevice           device       = dev_mem_wrapper->parent_device->handle;
-                    const DeviceTable* device_table = GetDeviceTable(device);
+                    const VulkanDeviceTable* device_table = GetVulkanDeviceTable(device);
                     device_table->UnmapMemory(device, dev_mem_wrapper->handle);
                 }
             }

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -75,7 +75,7 @@ class VulkanStateTracker
 
         if (*new_handle != VK_NULL_HANDLE)
         {
-            auto wrapper = GetWrapper<Wrapper>(*new_handle);
+            auto wrapper = GetVulkanWrapper<Wrapper>(*new_handle);
 
             // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
             std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -103,7 +103,7 @@ class VulkanStateTracker
         assert(new_handles != nullptr);
         assert(create_parameter_buffer != nullptr);
 
-        CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
+        vulkan_state_info::CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
             create_parameter_buffer->GetData(), create_parameter_buffer->GetDataSize());
 
         std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -111,7 +111,7 @@ class VulkanStateTracker
         {
             if (new_handles[i] != VK_NULL_HANDLE)
             {
-                auto wrapper = GetWrapper<Wrapper>(new_handles[i]);
+                auto wrapper = GetVulkanWrapper<Wrapper>(new_handles[i]);
 
                 // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
                 if (state_table_.InsertWrapper(wrapper->handle_id, wrapper))
@@ -134,7 +134,7 @@ class VulkanStateTracker
     {
         assert(create_parameter_buffer != nullptr);
 
-        CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
+        vulkan_state_info::CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
             create_parameter_buffer->GetData(), create_parameter_buffer->GetDataSize());
 
         {
@@ -155,7 +155,7 @@ class VulkanStateTracker
         assert(unwrap_struct_handle != nullptr);
         assert(create_parameter_buffer != nullptr);
 
-        CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
+        vulkan_state_info::CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
             create_parameter_buffer->GetData(), create_parameter_buffer->GetDataSize());
 
         std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -173,30 +173,31 @@ class VulkanStateTracker
     }
 
     void AddStructGroupEntry(
-        VkInstance                                                                    parent_handle,
-        uint32_t                                                                      count,
-        VkPhysicalDeviceGroupProperties*                                              handle_structs,
-        std::function<VulkanPhysicalDeviceWrapper*(VkPhysicalDeviceGroupProperties*)> unwrap_struct_handle,
-        format::ApiCallId                                                             create_call_id,
-        const util::MemoryOutputStream*                                               create_parameter_buffer)
+        VkInstance                                                                               parent_handle,
+        uint32_t                                                                                 count,
+        VkPhysicalDeviceGroupProperties*                                                         handle_structs,
+        std::function<vulkan_wrappers::PhysicalDeviceWrapper*(VkPhysicalDeviceGroupProperties*)> unwrap_struct_handle,
+        format::ApiCallId                                                                        create_call_id,
+        const util::MemoryOutputStream* create_parameter_buffer)
     {
         assert(handle_structs != nullptr);
         assert(create_parameter_buffer != nullptr);
 
         GFXRECON_UNREFERENCED_PARAMETER(unwrap_struct_handle);
 
-        CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
+        vulkan_state_info::CreateParameters create_parameters = std::make_shared<util::MemoryOutputStream>(
             create_parameter_buffer->GetData(), create_parameter_buffer->GetDataSize());
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            AddGroupHandles<VkInstance, void*, VulkanPhysicalDeviceWrapper, void>(parent_handle,
-                                                                                  nullptr,
-                                                                                  handle_structs[i].physicalDeviceCount,
-                                                                                  handle_structs[i].physicalDevices,
-                                                                                  nullptr,
-                                                                                  create_call_id,
-                                                                                  create_parameters);
+            AddGroupHandles<VkInstance, void*, vulkan_wrappers::PhysicalDeviceWrapper, void>(
+                parent_handle,
+                nullptr,
+                handle_structs[i].physicalDeviceCount,
+                handle_structs[i].physicalDevices,
+                nullptr,
+                create_call_id,
+                create_parameters);
         }
     }
 
@@ -205,7 +206,7 @@ class VulkanStateTracker
     {
         if (handle != VK_NULL_HANDLE)
         {
-            auto wrapper = GetWrapper<Wrapper>(handle);
+            auto wrapper = GetVulkanWrapper<Wrapper>(handle);
 
             // Scope the state table mutex lock because DestroyState also modifies the state table and will attempt to
             // lock the mutex.
@@ -228,7 +229,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+            auto wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
         }
@@ -243,7 +244,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
+            auto wrapper = GetVulkanWrapper<vulkan_wrappers::CommandBufferWrapper>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
             func(wrapper, args...);
@@ -412,13 +413,13 @@ class VulkanStateTracker
 
   private:
     template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
-    void AddGroupHandles(ParentHandle                  parent_handle,
-                         SecondaryHandle               secondary_handle,
-                         uint32_t                      count,
-                         typename Wrapper::HandleType* new_handles,
-                         const CreateInfo*             create_infos,
-                         format::ApiCallId             create_call_id,
-                         CreateParameters              create_parameters)
+    void AddGroupHandles(ParentHandle                        parent_handle,
+                         SecondaryHandle                     secondary_handle,
+                         uint32_t                            count,
+                         typename Wrapper::HandleType*       new_handles,
+                         const CreateInfo*                   create_infos,
+                         format::ApiCallId                   create_call_id,
+                         vulkan_state_info::CreateParameters create_parameters)
     {
         assert(new_handles != nullptr);
         assert(create_parameters != nullptr);
@@ -428,7 +429,7 @@ class VulkanStateTracker
         {
             if (new_handles[i] != VK_NULL_HANDLE)
             {
-                auto wrapper = GetWrapper<Wrapper>(new_handles[i]);
+                auto wrapper = GetVulkanWrapper<Wrapper>(new_handles[i]);
 
                 // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
                 if (state_table_.InsertWrapper(wrapper->handle_id, wrapper))
@@ -450,9 +451,9 @@ class VulkanStateTracker
         }
     }
 
-    void TrackCommandExecution(VulkanCommandBufferWrapper*     wrapper,
-                               format::ApiCallId               call_id,
-                               const util::MemoryOutputStream* parameter_buffer);
+    void TrackCommandExecution(vulkan_wrappers::CommandBufferWrapper* wrapper,
+                               format::ApiCallId                      call_id,
+                               const util::MemoryOutputStream*        parameter_buffer);
 
     template <typename Wrapper>
     void DestroyState(Wrapper* wrapper)
@@ -461,30 +462,30 @@ class VulkanStateTracker
         wrapper->create_parameters = nullptr;
     }
 
-    void DestroyState(VulkanInstanceWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::InstanceWrapper* wrapper);
 
-    void DestroyState(VulkanDeviceWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::DeviceWrapper* wrapper);
 
-    void DestroyState(VulkanCommandPoolWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::CommandPoolWrapper* wrapper);
 
-    void DestroyState(VulkanDescriptorPoolWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::DescriptorPoolWrapper* wrapper);
 
-    void DestroyState(VulkanSwapchainKHRWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::SwapchainKHRWrapper* wrapper);
 
-    void DestroyState(VulkanDeviceMemoryWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::DeviceMemoryWrapper* wrapper);
 
-    void DestroyState(VulkanAccelerationStructureKHRWrapper* wrapper);
+    void DestroyState(vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper);
 
-    void TrackQuerySubmissions(VulkanCommandBufferWrapper* command_wrapper);
+    void TrackQuerySubmissions(vulkan_wrappers::CommandBufferWrapper* command_wrapper);
 
     std::mutex       state_table_mutex_;
     VulkanStateTable state_table_;
 
     // Keeps track of device memories' device addresses
-    std::unordered_map<VkDeviceAddress, const VulkanDeviceMemoryWrapper*> device_memory_addresses_map;
+    std::unordered_map<VkDeviceAddress, const vulkan_wrappers::DeviceMemoryWrapper*> device_memory_addresses_map;
 
     // Keeps track of acceleration structures' device addresses
-    std::unordered_map<VkDeviceAddress, VulkanAccelerationStructureKHRWrapper*> as_device_addresses_map;
+    std::unordered_map<VkDeviceAddress, vulkan_wrappers::AccelerationStructureKHRWrapper*> as_device_addresses_map;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -172,13 +172,13 @@ class VulkanStateTracker
         }
     }
 
-    void
-    AddStructGroupEntry(VkInstance                                                              parent_handle,
-                        uint32_t                                                                count,
-                        VkPhysicalDeviceGroupProperties*                                        handle_structs,
-                        std::function<PhysicalDeviceWrapper*(VkPhysicalDeviceGroupProperties*)> unwrap_struct_handle,
-                        format::ApiCallId                                                       create_call_id,
-                        const util::MemoryOutputStream*                                         create_parameter_buffer)
+    void AddStructGroupEntry(
+        VkInstance                                                                    parent_handle,
+        uint32_t                                                                      count,
+        VkPhysicalDeviceGroupProperties*                                              handle_structs,
+        std::function<VulkanPhysicalDeviceWrapper*(VkPhysicalDeviceGroupProperties*)> unwrap_struct_handle,
+        format::ApiCallId                                                             create_call_id,
+        const util::MemoryOutputStream*                                               create_parameter_buffer)
     {
         assert(handle_structs != nullptr);
         assert(create_parameter_buffer != nullptr);
@@ -190,13 +190,13 @@ class VulkanStateTracker
 
         for (uint32_t i = 0; i < count; ++i)
         {
-            AddGroupHandles<VkInstance, void*, PhysicalDeviceWrapper, void>(parent_handle,
-                                                                            nullptr,
-                                                                            handle_structs[i].physicalDeviceCount,
-                                                                            handle_structs[i].physicalDevices,
-                                                                            nullptr,
-                                                                            create_call_id,
-                                                                            create_parameters);
+            AddGroupHandles<VkInstance, void*, VulkanPhysicalDeviceWrapper, void>(parent_handle,
+                                                                                  nullptr,
+                                                                                  handle_structs[i].physicalDeviceCount,
+                                                                                  handle_structs[i].physicalDevices,
+                                                                                  nullptr,
+                                                                                  create_call_id,
+                                                                                  create_parameters);
         }
     }
 
@@ -228,7 +228,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+            auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
         }
@@ -243,7 +243,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = GetWrapper<CommandBufferWrapper>(command_buffer);
+            auto wrapper = GetWrapper<VulkanCommandBufferWrapper>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
             func(wrapper, args...);
@@ -450,7 +450,7 @@ class VulkanStateTracker
         }
     }
 
-    void TrackCommandExecution(CommandBufferWrapper*           wrapper,
+    void TrackCommandExecution(VulkanCommandBufferWrapper*     wrapper,
                                format::ApiCallId               call_id,
                                const util::MemoryOutputStream* parameter_buffer);
 
@@ -461,30 +461,30 @@ class VulkanStateTracker
         wrapper->create_parameters = nullptr;
     }
 
-    void DestroyState(InstanceWrapper* wrapper);
+    void DestroyState(VulkanInstanceWrapper* wrapper);
 
-    void DestroyState(DeviceWrapper* wrapper);
+    void DestroyState(VulkanDeviceWrapper* wrapper);
 
-    void DestroyState(CommandPoolWrapper* wrapper);
+    void DestroyState(VulkanCommandPoolWrapper* wrapper);
 
-    void DestroyState(DescriptorPoolWrapper* wrapper);
+    void DestroyState(VulkanDescriptorPoolWrapper* wrapper);
 
-    void DestroyState(SwapchainKHRWrapper* wrapper);
+    void DestroyState(VulkanSwapchainKHRWrapper* wrapper);
 
-    void DestroyState(DeviceMemoryWrapper* wrapper);
+    void DestroyState(VulkanDeviceMemoryWrapper* wrapper);
 
-    void DestroyState(AccelerationStructureKHRWrapper* wrapper);
+    void DestroyState(VulkanAccelerationStructureKHRWrapper* wrapper);
 
-    void TrackQuerySubmissions(CommandBufferWrapper* command_wrapper);
+    void TrackQuerySubmissions(VulkanCommandBufferWrapper* command_wrapper);
 
     std::mutex       state_table_mutex_;
     VulkanStateTable state_table_;
 
     // Keeps track of device memories' device addresses
-    std::unordered_map<VkDeviceAddress, const DeviceMemoryWrapper*> device_memory_addresses_map;
+    std::unordered_map<VkDeviceAddress, const VulkanDeviceMemoryWrapper*> device_memory_addresses_map;
 
     // Keeps track of acceleration structures' device addresses
-    std::unordered_map<VkDeviceAddress, AccelerationStructureKHRWrapper*> as_device_addresses_map;
+    std::unordered_map<VkDeviceAddress, VulkanAccelerationStructureKHRWrapper*> as_device_addresses_map;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -234,12 +234,12 @@ inline void InitializeState<VkDevice, vulkan_wrappers::EventWrapper, VkEventCrea
 }
 
 template <>
-inline void
-InitializeState<VkDevice, vulkan_wrappers::PipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
-                                                                           vulkan_wrappers::PipelineCacheWrapper* wrapper,
-                                                                           const VkPipelineCacheCreateInfo* create_info,
-                                                                           format::ApiCallId create_call_id,
-                                                                           vulkan_state_info::CreateParameters  create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::PipelineCacheWrapper, VkPipelineCacheCreateInfo>(
+    VkDevice                               parent_handle,
+    vulkan_wrappers::PipelineCacheWrapper* wrapper,
+    const VkPipelineCacheCreateInfo*       create_info,
+    format::ApiCallId                      create_call_id,
+    vulkan_state_info::CreateParameters    create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -94,11 +94,12 @@ void InitializeGroupObjectState(ParentHandle      parent_handle,
 }
 
 template <>
-inline void InitializeState<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>(VkPhysicalDevice parent_handle,
-                                                                                 DeviceWrapper*   wrapper,
-                                                                                 const VkDeviceCreateInfo* create_info,
-                                                                                 format::ApiCallId create_call_id,
-                                                                                 CreateParameters  create_parameters)
+inline void
+InitializeState<VkPhysicalDevice, VulkanDeviceWrapper, VkDeviceCreateInfo>(VkPhysicalDevice          parent_handle,
+                                                                           VulkanDeviceWrapper*      wrapper,
+                                                                           const VkDeviceCreateInfo* create_info,
+                                                                           format::ApiCallId         create_call_id,
+                                                                           CreateParameters          create_parameters)
 {
     assert(parent_handle != VK_NULL_HANDLE);
     assert(wrapper != nullptr);
@@ -109,13 +110,13 @@ inline void InitializeState<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->physical_device = GetWrapper<PhysicalDeviceWrapper>(parent_handle);
+    wrapper->physical_device = GetWrapper<VulkanPhysicalDeviceWrapper>(parent_handle);
 }
 
 template <>
-inline void InitializeState<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(
+inline void InitializeState<VkDevice, VulkanPipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(
     VkDevice                          parent_handle,
-    PipelineLayoutWrapper*            wrapper,
+    VulkanPipelineLayoutWrapper*      wrapper,
     const VkPipelineLayoutCreateInfo* create_info,
     format::ApiCallId                 create_call_id,
     CreateParameters                  create_parameters)
@@ -135,7 +136,7 @@ inline void InitializeState<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCre
     {
         if (create_info->pSetLayouts[i] != VK_NULL_HANDLE)
         {
-            auto                 layout_wrapper = GetWrapper<DescriptorSetLayoutWrapper>(create_info->pSetLayouts[i]);
+            auto layout_wrapper = GetWrapper<VulkanDescriptorSetLayoutWrapper>(create_info->pSetLayouts[i]);
             CreateDependencyInfo info;
             info.handle_id         = layout_wrapper->handle_id;
             info.create_call_id    = layout_wrapper->create_call_id;
@@ -150,11 +151,11 @@ inline void InitializeState<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCre
 
 template <>
 inline void
-InitializeState<VkDevice, CommandPoolWrapper, VkCommandPoolCreateInfo>(VkDevice                       parent_handle,
-                                                                       CommandPoolWrapper*            wrapper,
-                                                                       const VkCommandPoolCreateInfo* create_info,
-                                                                       format::ApiCallId              create_call_id,
-                                                                       CreateParameters               create_parameters)
+InitializeState<VkDevice, VulkanCommandPoolWrapper, VkCommandPoolCreateInfo>(VkDevice                  parent_handle,
+                                                                             VulkanCommandPoolWrapper* wrapper,
+                                                                             const VkCommandPoolCreateInfo* create_info,
+                                                                             format::ApiCallId create_call_id,
+                                                                             CreateParameters  create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
@@ -169,11 +170,12 @@ InitializeState<VkDevice, CommandPoolWrapper, VkCommandPoolCreateInfo>(VkDevice 
 }
 
 template <>
-inline void InitializeState<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(VkDevice          parent_handle,
-                                                                               QueryPoolWrapper* wrapper,
-                                                                               const VkQueryPoolCreateInfo* create_info,
-                                                                               format::ApiCallId create_call_id,
-                                                                               CreateParameters  create_parameters)
+inline void
+InitializeState<VkDevice, VulkanQueryPoolWrapper, VkQueryPoolCreateInfo>(VkDevice                     parent_handle,
+                                                                         VulkanQueryPoolWrapper*      wrapper,
+                                                                         const VkQueryPoolCreateInfo* create_info,
+                                                                         format::ApiCallId            create_call_id,
+                                                                         CreateParameters             create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
@@ -182,18 +184,18 @@ inline void InitializeState<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device      = GetWrapper<DeviceWrapper>(parent_handle);
+    wrapper->device      = GetWrapper<VulkanDeviceWrapper>(parent_handle);
     wrapper->query_type  = create_info->queryType;
     wrapper->query_count = create_info->queryCount;
     wrapper->pending_queries.resize(create_info->queryCount);
 }
 
 template <>
-inline void InitializeState<VkDevice, FenceWrapper, VkFenceCreateInfo>(VkDevice                 parent_handle,
-                                                                       FenceWrapper*            wrapper,
-                                                                       const VkFenceCreateInfo* create_info,
-                                                                       format::ApiCallId        create_call_id,
-                                                                       CreateParameters         create_parameters)
+inline void InitializeState<VkDevice, VulkanFenceWrapper, VkFenceCreateInfo>(VkDevice                 parent_handle,
+                                                                             VulkanFenceWrapper*      wrapper,
+                                                                             const VkFenceCreateInfo* create_info,
+                                                                             format::ApiCallId        create_call_id,
+                                                                             CreateParameters         create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -205,15 +207,15 @@ inline void InitializeState<VkDevice, FenceWrapper, VkFenceCreateInfo>(VkDevice 
     wrapper->create_parameters = std::move(create_parameters);
 
     wrapper->created_signaled = ((create_info->flags & VK_FENCE_CREATE_SIGNALED_BIT) == VK_FENCE_CREATE_SIGNALED_BIT);
-    wrapper->device           = GetWrapper<DeviceWrapper>(parent_handle);
+    wrapper->device           = GetWrapper<VulkanDeviceWrapper>(parent_handle);
 }
 
 template <>
-inline void InitializeState<VkDevice, EventWrapper, VkEventCreateInfo>(VkDevice                 parent_handle,
-                                                                       EventWrapper*            wrapper,
-                                                                       const VkEventCreateInfo* create_info,
-                                                                       format::ApiCallId        create_call_id,
-                                                                       CreateParameters         create_parameters)
+inline void InitializeState<VkDevice, VulkanEventWrapper, VkEventCreateInfo>(VkDevice                 parent_handle,
+                                                                             VulkanEventWrapper*      wrapper,
+                                                                             const VkEventCreateInfo* create_info,
+                                                                             format::ApiCallId        create_call_id,
+                                                                             CreateParameters         create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -224,13 +226,13 @@ inline void InitializeState<VkDevice, EventWrapper, VkEventCreateInfo>(VkDevice 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<DeviceWrapper>(parent_handle);
+    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
 }
 
 template <>
 inline void
-InitializeState<VkDevice, PipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
-                                                                           PipelineCacheWrapper* wrapper,
+InitializeState<VkDevice, VulkanPipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
+                                                                           VulkanPipelineCacheWrapper* wrapper,
                                                                            const VkPipelineCacheCreateInfo* create_info,
                                                                            format::ApiCallId create_call_id,
                                                                            CreateParameters  create_parameters)
@@ -242,17 +244,18 @@ InitializeState<VkDevice, PipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDev
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<DeviceWrapper>(parent_handle);
+    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
 
     wrapper->create_info = *create_info;
 }
 
 template <>
-inline void InitializeState<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(VkDevice          parent_handle,
-                                                                               SemaphoreWrapper* wrapper,
-                                                                               const VkSemaphoreCreateInfo* create_info,
-                                                                               format::ApiCallId create_call_id,
-                                                                               CreateParameters  create_parameters)
+inline void
+InitializeState<VkDevice, VulkanSemaphoreWrapper, VkSemaphoreCreateInfo>(VkDevice                     parent_handle,
+                                                                         VulkanSemaphoreWrapper*      wrapper,
+                                                                         const VkSemaphoreCreateInfo* create_info,
+                                                                         format::ApiCallId            create_call_id,
+                                                                         CreateParameters             create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -263,7 +266,7 @@ inline void InitializeState<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<DeviceWrapper>(parent_handle);
+    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
 
     auto next = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
     while (next)
@@ -279,11 +282,11 @@ inline void InitializeState<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(V
 
 template <>
 inline void
-InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice                       parent_handle,
-                                                                       FramebufferWrapper*            wrapper,
-                                                                       const VkFramebufferCreateInfo* create_info,
-                                                                       format::ApiCallId              create_call_id,
-                                                                       CreateParameters               create_parameters)
+InitializeState<VkDevice, VulkanFramebufferWrapper, VkFramebufferCreateInfo>(VkDevice                  parent_handle,
+                                                                             VulkanFramebufferWrapper* wrapper,
+                                                                             const VkFramebufferCreateInfo* create_info,
+                                                                             format::ApiCallId create_call_id,
+                                                                             CreateParameters  create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -294,7 +297,7 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto render_pass_wrapper = GetWrapper<RenderPassWrapper>(create_info->renderPass);
+    auto render_pass_wrapper = GetWrapper<VulkanRenderPassWrapper>(create_info->renderPass);
     assert(render_pass_wrapper != nullptr);
     wrapper->render_pass_id                = render_pass_wrapper->handle_id;
     wrapper->render_pass_create_call_id    = render_pass_wrapper->create_call_id;
@@ -304,7 +307,7 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
     {
         for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
         {
-            auto image_view_wrapper = GetWrapper<ImageViewWrapper>(create_info->pAttachments[i]);
+            auto image_view_wrapper = GetWrapper<VulkanImageViewWrapper>(create_info->pAttachments[i]);
             assert(image_view_wrapper != nullptr);
 
             wrapper->image_view_ids.push_back(image_view_wrapper->handle_id);
@@ -315,11 +318,11 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
 
 template <>
 inline void
-InitializeState<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo>(VkDevice                      parent_handle,
-                                                                     RenderPassWrapper*            wrapper,
-                                                                     const VkRenderPassCreateInfo* create_info,
-                                                                     format::ApiCallId             create_call_id,
-                                                                     CreateParameters              create_parameters)
+InitializeState<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo>(VkDevice                      parent_handle,
+                                                                           VulkanRenderPassWrapper*      wrapper,
+                                                                           const VkRenderPassCreateInfo* create_info,
+                                                                           format::ApiCallId             create_call_id,
+                                                                           CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -341,11 +344,11 @@ InitializeState<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo>(VkDevice   
 
 template <>
 inline void
-InitializeState<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo2>(VkDevice                       parent_handle,
-                                                                      RenderPassWrapper*             wrapper,
-                                                                      const VkRenderPassCreateInfo2* create_info,
-                                                                      format::ApiCallId              create_call_id,
-                                                                      CreateParameters               create_parameters)
+InitializeState<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo2>(VkDevice                 parent_handle,
+                                                                            VulkanRenderPassWrapper* wrapper,
+                                                                            const VkRenderPassCreateInfo2* create_info,
+                                                                            format::ApiCallId create_call_id,
+                                                                            CreateParameters  create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -366,10 +369,10 @@ InitializeState<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo2>(VkDevice  
 }
 
 template <>
-inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrapper, VkGraphicsPipelineCreateInfo>(
+inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkGraphicsPipelineCreateInfo>(
     VkDevice                            parent_handle,
     VkPipelineCache                     secondary_handle,
-    PipelineWrapper*                    wrapper,
+    VulkanPipelineWrapper*              wrapper,
     const VkGraphicsPipelineCreateInfo* create_info,
     format::ApiCallId                   create_call_id,
     CreateParameters                    create_parameters)
@@ -390,7 +393,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
     {
         if (create_info->pStages[i].module != VK_NULL_HANDLE)
         {
-            auto shader_wrapper = GetWrapper<ShaderModuleWrapper>(create_info->pStages[i].module);
+            auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->pStages[i].module);
             if (shader_wrapper)
             {
                 CreateDependencyInfo info;
@@ -403,7 +406,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         }
     }
 
-    auto render_pass_wrapper = GetWrapper<RenderPassWrapper>(create_info->renderPass);
+    auto render_pass_wrapper = GetWrapper<VulkanRenderPassWrapper>(create_info->renderPass);
     if (render_pass_wrapper)
     {
         wrapper->render_pass_dependency.handle_id         = render_pass_wrapper->handle_id;
@@ -413,7 +416,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     if (create_info->layout != VK_NULL_HANDLE)
     {
-        auto layout_wrapper = GetWrapper<PipelineLayoutWrapper>(create_info->layout);
+        auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
         assert(layout_wrapper != nullptr);
 
         wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -424,10 +427,10 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 }
 
 template <>
-inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrapper, VkComputePipelineCreateInfo>(
+inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkComputePipelineCreateInfo>(
     VkDevice                           parent_handle,
     VkPipelineCache                    secondary_handle,
-    PipelineWrapper*                   wrapper,
+    VulkanPipelineWrapper*             wrapper,
     const VkComputePipelineCreateInfo* create_info,
     format::ApiCallId                  create_call_id,
     CreateParameters                   create_parameters)
@@ -444,7 +447,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto shader_wrapper = GetWrapper<ShaderModuleWrapper>(create_info->stage.module);
+    auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->stage.module);
     if (shader_wrapper)
     {
         CreateDependencyInfo info;
@@ -454,7 +457,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
-    auto layout_wrapper = GetWrapper<PipelineLayoutWrapper>(create_info->layout);
+    auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -464,10 +467,11 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 }
 
 template <>
-inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(
+inline void
+InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkRayTracingPipelineCreateInfoNV>(
     VkDevice                                parent_handle,
     VkPipelineCache                         secondary_handle,
-    PipelineWrapper*                        wrapper,
+    VulkanPipelineWrapper*                  wrapper,
     const VkRayTracingPipelineCreateInfoNV* create_info,
     format::ApiCallId                       create_call_id,
     CreateParameters                        create_parameters)
@@ -486,7 +490,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = GetWrapper<ShaderModuleWrapper>(create_info->pStages[i].module);
+        auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->pStages[i].module);
         if (shader_wrapper)
         {
             CreateDependencyInfo info;
@@ -498,7 +502,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         }
     }
 
-    auto layout_wrapper = GetWrapper<PipelineLayoutWrapper>(create_info->layout);
+    auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -509,10 +513,10 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
 template <>
 inline void
-InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, VkRayTracingPipelineCreateInfoKHR>(
+InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, VulkanPipelineWrapper, VkRayTracingPipelineCreateInfoKHR>(
     VkDevice                                 parent_handle,
     VkDeferredOperationKHR                   secondary_handle,
-    PipelineWrapper*                         wrapper,
+    VulkanPipelineWrapper*                   wrapper,
     const VkRayTracingPipelineCreateInfoKHR* create_info,
     format::ApiCallId                        create_call_id,
     CreateParameters                         create_parameters)
@@ -531,7 +535,7 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, Vk
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = GetWrapper<ShaderModuleWrapper>(create_info->pStages[i].module);
+        auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->pStages[i].module);
         if (shader_wrapper)
         {
             CreateDependencyInfo info;
@@ -543,7 +547,7 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, Vk
         }
     }
 
-    auto layout_wrapper = GetWrapper<PipelineLayoutWrapper>(create_info->layout);
+    auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -553,11 +557,12 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, Vk
 }
 
 template <>
-inline void InitializeState<VkDevice, DeviceMemoryWrapper, VkMemoryAllocateInfo>(VkDevice             parent_handle,
-                                                                                 DeviceMemoryWrapper* wrapper,
-                                                                                 const VkMemoryAllocateInfo* alloc_info,
-                                                                                 format::ApiCallId create_call_id,
-                                                                                 CreateParameters  create_parameters)
+inline void
+InitializeState<VkDevice, VulkanDeviceMemoryWrapper, VkMemoryAllocateInfo>(VkDevice                    parent_handle,
+                                                                           VulkanDeviceMemoryWrapper*  wrapper,
+                                                                           const VkMemoryAllocateInfo* alloc_info,
+                                                                           format::ApiCallId           create_call_id,
+                                                                           CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(alloc_info != nullptr);
@@ -573,11 +578,11 @@ inline void InitializeState<VkDevice, DeviceMemoryWrapper, VkMemoryAllocateInfo>
 }
 
 template <>
-inline void InitializeState<VkDevice, BufferWrapper, VkBufferCreateInfo>(VkDevice                  parent_handle,
-                                                                         BufferWrapper*            wrapper,
-                                                                         const VkBufferCreateInfo* create_info,
-                                                                         format::ApiCallId         create_call_id,
-                                                                         CreateParameters          create_parameters)
+inline void InitializeState<VkDevice, VulkanBufferWrapper, VkBufferCreateInfo>(VkDevice                  parent_handle,
+                                                                               VulkanBufferWrapper*      wrapper,
+                                                                               const VkBufferCreateInfo* create_info,
+                                                                               format::ApiCallId         create_call_id,
+                                                                               CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -599,11 +604,11 @@ inline void InitializeState<VkDevice, BufferWrapper, VkBufferCreateInfo>(VkDevic
 
 // Images created with vkCreateImage.
 template <>
-inline void InitializeState<VkDevice, ImageWrapper, VkImageCreateInfo>(VkDevice                 parent_handle,
-                                                                       ImageWrapper*            wrapper,
-                                                                       const VkImageCreateInfo* create_info,
-                                                                       format::ApiCallId        create_call_id,
-                                                                       CreateParameters         create_parameters)
+inline void InitializeState<VkDevice, VulkanImageWrapper, VkImageCreateInfo>(VkDevice                 parent_handle,
+                                                                             VulkanImageWrapper*      wrapper,
+                                                                             const VkImageCreateInfo* create_info,
+                                                                             format::ApiCallId        create_call_id,
+                                                                             CreateParameters         create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -630,12 +635,12 @@ inline void InitializeState<VkDevice, ImageWrapper, VkImageCreateInfo>(VkDevice 
 }
 
 template <>
-inline void
-InitializeState<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(VkDevice                        parent_handle,
-                                                                         SwapchainKHRWrapper*            wrapper,
-                                                                         const VkSwapchainCreateInfoKHR* create_info,
-                                                                         format::ApiCallId               create_call_id,
-                                                                         CreateParameters create_parameters)
+inline void InitializeState<VkDevice, VulkanSwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(
+    VkDevice                        parent_handle,
+    VulkanSwapchainKHRWrapper*      wrapper,
+    const VkSwapchainCreateInfoKHR* create_info,
+    format::ApiCallId               create_call_id,
+    CreateParameters                create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -646,8 +651,8 @@ InitializeState<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(VkDevic
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device        = GetWrapper<DeviceWrapper>(parent_handle);
-    wrapper->surface       = GetWrapper<SurfaceKHRWrapper>(create_info->surface);
+    wrapper->device        = GetWrapper<VulkanDeviceWrapper>(parent_handle);
+    wrapper->surface       = GetWrapper<VulkanSurfaceKHRWrapper>(create_info->surface);
     wrapper->format        = create_info->imageFormat;
     wrapper->extent        = { create_info->imageExtent.width, create_info->imageExtent.height, 0 };
     wrapper->pre_transform = create_info->preTransform;
@@ -661,12 +666,13 @@ InitializeState<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(VkDevic
 
 // Swapchain Images retrieved with vkGetSwapchainImagesKHR.
 template <>
-inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, void>(VkDevice          parent_handle,
-                                                                                     VkSwapchainKHR    swapchain_handle,
-                                                                                     ImageWrapper*     wrapper,
-                                                                                     const void*       create_info,
-                                                                                     format::ApiCallId create_call_id,
-                                                                                     CreateParameters create_parameters)
+inline void
+InitializeGroupObjectState<VkDevice, VkSwapchainKHR, VulkanImageWrapper, void>(VkDevice            parent_handle,
+                                                                               VkSwapchainKHR      swapchain_handle,
+                                                                               VulkanImageWrapper* wrapper,
+                                                                               const void*         create_info,
+                                                                               format::ApiCallId   create_call_id,
+                                                                               CreateParameters    create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
@@ -677,7 +683,7 @@ inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, v
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto swapchain_wrapper = GetWrapper<SwapchainKHRWrapper>(swapchain_handle);
+    auto swapchain_wrapper = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain_handle);
     assert(swapchain_wrapper != nullptr);
 
     wrapper->image_type         = VK_IMAGE_TYPE_2D;
@@ -692,11 +698,11 @@ inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, v
 
 template <>
 inline void
-InitializeState<VkDevice, BufferViewWrapper, VkBufferViewCreateInfo>(VkDevice                      parent_handle,
-                                                                     BufferViewWrapper*            wrapper,
-                                                                     const VkBufferViewCreateInfo* create_info,
-                                                                     format::ApiCallId             create_call_id,
-                                                                     CreateParameters              create_parameters)
+InitializeState<VkDevice, VulkanBufferViewWrapper, VkBufferViewCreateInfo>(VkDevice                      parent_handle,
+                                                                           VulkanBufferViewWrapper*      wrapper,
+                                                                           const VkBufferViewCreateInfo* create_info,
+                                                                           format::ApiCallId             create_call_id,
+                                                                           CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -707,16 +713,17 @@ InitializeState<VkDevice, BufferViewWrapper, VkBufferViewCreateInfo>(VkDevice   
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto buffer        = GetWrapper<BufferWrapper>(create_info->buffer);
+    auto buffer        = GetWrapper<VulkanBufferWrapper>(create_info->buffer);
     wrapper->buffer_id = buffer->handle_id;
 }
 
 template <>
-inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(VkDevice          parent_handle,
-                                                                               ImageViewWrapper* wrapper,
-                                                                               const VkImageViewCreateInfo* create_info,
-                                                                               format::ApiCallId create_call_id,
-                                                                               CreateParameters  create_parameters)
+inline void
+InitializeState<VkDevice, VulkanImageViewWrapper, VkImageViewCreateInfo>(VkDevice                     parent_handle,
+                                                                         VulkanImageViewWrapper*      wrapper,
+                                                                         const VkImageViewCreateInfo* create_info,
+                                                                         format::ApiCallId            create_call_id,
+                                                                         CreateParameters             create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -727,15 +734,15 @@ inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto image        = GetWrapper<ImageWrapper>(create_info->image);
+    auto image        = GetWrapper<VulkanImageWrapper>(create_info->image);
     wrapper->image_id = image->handle_id;
     wrapper->image    = image;
 }
 
 template <>
-inline void InitializeState<VkDevice, DescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(
+inline void InitializeState<VkDevice, VulkanDescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(
     VkDevice                               parent_handle,
-    DescriptorSetLayoutWrapper*            wrapper,
+    VulkanDescriptorSetLayoutWrapper*      wrapper,
     const VkDescriptorSetLayoutCreateInfo* create_info,
     format::ApiCallId                      create_call_id,
     CreateParameters                       create_parameters)
@@ -772,7 +779,7 @@ inline void InitializeState<VkDevice, DescriptorSetLayoutWrapper, VkDescriptorSe
 }
 
 inline void InitializePoolObjectState(VkDevice                           parent_handle,
-                                      CommandBufferWrapper*              wrapper,
+                                      VulkanCommandBufferWrapper*        wrapper,
                                       uint32_t                           alloc_index,
                                       const VkCommandBufferAllocateInfo* alloc_info,
                                       format::ApiCallId                  create_call_id,
@@ -792,7 +799,7 @@ inline void InitializePoolObjectState(VkDevice                           parent_
 }
 
 inline void InitializePoolObjectState(VkDevice                           parent_handle,
-                                      DescriptorSetWrapper*              wrapper,
+                                      VulkanDescriptorSetWrapper*        wrapper,
                                       uint32_t                           alloc_index,
                                       const VkDescriptorSetAllocateInfo* alloc_info,
                                       format::ApiCallId                  create_call_id,
@@ -805,9 +812,9 @@ inline void InitializePoolObjectState(VkDevice                           parent_
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<DeviceWrapper>(parent_handle);
+    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
 
-    auto layout_wrapper = GetWrapper<DescriptorSetLayoutWrapper>(alloc_info->pSetLayouts[alloc_index]);
+    auto layout_wrapper = GetWrapper<VulkanDescriptorSetLayoutWrapper>(alloc_info->pSetLayouts[alloc_index]);
     assert(layout_wrapper != nullptr);
 
     // Add a binding entry for each binding described by the descriptor set layout.

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -235,11 +235,11 @@ inline void InitializeState<VkDevice, vulkan_wrappers::EventWrapper, VkEventCrea
 
 template <>
 inline void
-InitializeState<VkDevice, vulka_wrappers::PipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
-                                                                           vulka_wrappers::PipelineCacheWrapper* wrapper,
+InitializeState<VkDevice, vulkan_wrappers::PipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
+                                                                           vulkan_wrappers::PipelineCacheWrapper* wrapper,
                                                                            const VkPipelineCacheCreateInfo* create_info,
                                                                            format::ApiCallId create_call_id,
-                                                                           CreateParameters  create_parameters)
+                                                                           vulkan_state_info::CreateParameters  create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -248,7 +248,7 @@ InitializeState<VkDevice, vulka_wrappers::PipelineCacheWrapper, VkPipelineCacheC
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<vulka_wrappers::DeviceWrapper>(parent_handle);
+    wrapper->device = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
 
     wrapper->create_info = *create_info;
 }

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -63,11 +63,11 @@ inline const void* GetCreateInfoEntry<void>(uint32_t, const void*)
 }
 
 template <typename ParentHandle, typename Wrapper, typename CreateInfo>
-void InitializeState(ParentHandle      parent_handle,
-                     Wrapper*          wrapper,
-                     const CreateInfo* create_info,
-                     format::ApiCallId create_call_id,
-                     CreateParameters  create_parameters)
+void InitializeState(ParentHandle                        parent_handle,
+                     Wrapper*                            wrapper,
+                     const CreateInfo*                   create_info,
+                     format::ApiCallId                   create_call_id,
+                     vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
@@ -80,12 +80,12 @@ void InitializeState(ParentHandle      parent_handle,
 }
 
 template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
-void InitializeGroupObjectState(ParentHandle      parent_handle,
-                                SecondaryHandle   secondary_handle,
-                                Wrapper*          wrapper,
-                                const CreateInfo* create_info,
-                                format::ApiCallId create_call_id,
-                                CreateParameters  create_parameters)
+void InitializeGroupObjectState(ParentHandle                        parent_handle,
+                                SecondaryHandle                     secondary_handle,
+                                Wrapper*                            wrapper,
+                                const CreateInfo*                   create_info,
+                                format::ApiCallId                   create_call_id,
+                                vulkan_state_info::CreateParameters create_parameters)
 {
     // The secondary handle is only used by sepcializations.
     GFXRECON_UNREFERENCED_PARAMETER(secondary_handle);
@@ -94,12 +94,12 @@ void InitializeGroupObjectState(ParentHandle      parent_handle,
 }
 
 template <>
-inline void
-InitializeState<VkPhysicalDevice, VulkanDeviceWrapper, VkDeviceCreateInfo>(VkPhysicalDevice          parent_handle,
-                                                                           VulkanDeviceWrapper*      wrapper,
-                                                                           const VkDeviceCreateInfo* create_info,
-                                                                           format::ApiCallId         create_call_id,
-                                                                           CreateParameters          create_parameters)
+inline void InitializeState<VkPhysicalDevice, vulkan_wrappers::DeviceWrapper, VkDeviceCreateInfo>(
+    VkPhysicalDevice                    parent_handle,
+    vulkan_wrappers::DeviceWrapper*     wrapper,
+    const VkDeviceCreateInfo*           create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(parent_handle != VK_NULL_HANDLE);
     assert(wrapper != nullptr);
@@ -110,16 +110,16 @@ InitializeState<VkPhysicalDevice, VulkanDeviceWrapper, VkDeviceCreateInfo>(VkPhy
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->physical_device = GetWrapper<VulkanPhysicalDeviceWrapper>(parent_handle);
+    wrapper->physical_device = GetVulkanWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(parent_handle);
 }
 
 template <>
-inline void InitializeState<VkDevice, VulkanPipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(
-    VkDevice                          parent_handle,
-    VulkanPipelineLayoutWrapper*      wrapper,
-    const VkPipelineLayoutCreateInfo* create_info,
-    format::ApiCallId                 create_call_id,
-    CreateParameters                  create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(
+    VkDevice                                parent_handle,
+    vulkan_wrappers::PipelineLayoutWrapper* wrapper,
+    const VkPipelineLayoutCreateInfo*       create_info,
+    format::ApiCallId                       create_call_id,
+    vulkan_state_info::CreateParameters     create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -130,14 +130,16 @@ inline void InitializeState<VkDevice, VulkanPipelineLayoutWrapper, VkPipelineLay
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    std::shared_ptr<PipelineLayoutDependencies> layout_dependencies = std::make_shared<PipelineLayoutDependencies>();
+    std::shared_ptr<vulkan_state_info::PipelineLayoutDependencies> layout_dependencies =
+        std::make_shared<vulkan_state_info::PipelineLayoutDependencies>();
 
     for (uint32_t i = 0; i < create_info->setLayoutCount; ++i)
     {
         if (create_info->pSetLayouts[i] != VK_NULL_HANDLE)
         {
-            auto layout_wrapper = GetWrapper<VulkanDescriptorSetLayoutWrapper>(create_info->pSetLayouts[i]);
-            CreateDependencyInfo info;
+            auto layout_wrapper =
+                GetVulkanWrapper<vulkan_wrappers::DescriptorSetLayoutWrapper>(create_info->pSetLayouts[i]);
+            vulkan_state_info::CreateDependencyInfo info;
             info.handle_id         = layout_wrapper->handle_id;
             info.create_call_id    = layout_wrapper->create_call_id;
             info.create_parameters = layout_wrapper->create_parameters;
@@ -150,12 +152,12 @@ inline void InitializeState<VkDevice, VulkanPipelineLayoutWrapper, VkPipelineLay
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanCommandPoolWrapper, VkCommandPoolCreateInfo>(VkDevice                  parent_handle,
-                                                                             VulkanCommandPoolWrapper* wrapper,
-                                                                             const VkCommandPoolCreateInfo* create_info,
-                                                                             format::ApiCallId create_call_id,
-                                                                             CreateParameters  create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::CommandPoolWrapper, VkCommandPoolCreateInfo>(
+    VkDevice                             parent_handle,
+    vulkan_wrappers::CommandPoolWrapper* wrapper,
+    const VkCommandPoolCreateInfo*       create_info,
+    format::ApiCallId                    create_call_id,
+    vulkan_state_info::CreateParameters  create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
@@ -170,12 +172,12 @@ InitializeState<VkDevice, VulkanCommandPoolWrapper, VkCommandPoolCreateInfo>(VkD
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanQueryPoolWrapper, VkQueryPoolCreateInfo>(VkDevice                     parent_handle,
-                                                                         VulkanQueryPoolWrapper*      wrapper,
-                                                                         const VkQueryPoolCreateInfo* create_info,
-                                                                         format::ApiCallId            create_call_id,
-                                                                         CreateParameters             create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::QueryPoolWrapper, VkQueryPoolCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::QueryPoolWrapper*  wrapper,
+    const VkQueryPoolCreateInfo*        create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
@@ -184,18 +186,19 @@ InitializeState<VkDevice, VulkanQueryPoolWrapper, VkQueryPoolCreateInfo>(VkDevic
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device      = GetWrapper<VulkanDeviceWrapper>(parent_handle);
+    wrapper->device      = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
     wrapper->query_type  = create_info->queryType;
     wrapper->query_count = create_info->queryCount;
     wrapper->pending_queries.resize(create_info->queryCount);
 }
 
 template <>
-inline void InitializeState<VkDevice, VulkanFenceWrapper, VkFenceCreateInfo>(VkDevice                 parent_handle,
-                                                                             VulkanFenceWrapper*      wrapper,
-                                                                             const VkFenceCreateInfo* create_info,
-                                                                             format::ApiCallId        create_call_id,
-                                                                             CreateParameters         create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::FenceWrapper, VkFenceCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::FenceWrapper*      wrapper,
+    const VkFenceCreateInfo*            create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -207,15 +210,16 @@ inline void InitializeState<VkDevice, VulkanFenceWrapper, VkFenceCreateInfo>(VkD
     wrapper->create_parameters = std::move(create_parameters);
 
     wrapper->created_signaled = ((create_info->flags & VK_FENCE_CREATE_SIGNALED_BIT) == VK_FENCE_CREATE_SIGNALED_BIT);
-    wrapper->device           = GetWrapper<VulkanDeviceWrapper>(parent_handle);
+    wrapper->device           = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
 }
 
 template <>
-inline void InitializeState<VkDevice, VulkanEventWrapper, VkEventCreateInfo>(VkDevice                 parent_handle,
-                                                                             VulkanEventWrapper*      wrapper,
-                                                                             const VkEventCreateInfo* create_info,
-                                                                             format::ApiCallId        create_call_id,
-                                                                             CreateParameters         create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::EventWrapper, VkEventCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::EventWrapper*      wrapper,
+    const VkEventCreateInfo*            create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -226,13 +230,13 @@ inline void InitializeState<VkDevice, VulkanEventWrapper, VkEventCreateInfo>(VkD
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
+    wrapper->device = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
 }
 
 template <>
 inline void
-InitializeState<VkDevice, VulkanPipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
-                                                                           VulkanPipelineCacheWrapper* wrapper,
+InitializeState<VkDevice, vulka_wrappers::PipelineCacheWrapper, VkPipelineCacheCreateInfo>(VkDevice              parent_handle,
+                                                                           vulka_wrappers::PipelineCacheWrapper* wrapper,
                                                                            const VkPipelineCacheCreateInfo* create_info,
                                                                            format::ApiCallId create_call_id,
                                                                            CreateParameters  create_parameters)
@@ -244,18 +248,18 @@ InitializeState<VkDevice, VulkanPipelineCacheWrapper, VkPipelineCacheCreateInfo>
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
+    wrapper->device = GetWrapper<vulka_wrappers::DeviceWrapper>(parent_handle);
 
     wrapper->create_info = *create_info;
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanSemaphoreWrapper, VkSemaphoreCreateInfo>(VkDevice                     parent_handle,
-                                                                         VulkanSemaphoreWrapper*      wrapper,
-                                                                         const VkSemaphoreCreateInfo* create_info,
-                                                                         format::ApiCallId            create_call_id,
-                                                                         CreateParameters             create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::SemaphoreWrapper, VkSemaphoreCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::SemaphoreWrapper*  wrapper,
+    const VkSemaphoreCreateInfo*        create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -266,7 +270,7 @@ InitializeState<VkDevice, VulkanSemaphoreWrapper, VkSemaphoreCreateInfo>(VkDevic
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
+    wrapper->device = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
 
     auto next = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
     while (next)
@@ -281,12 +285,12 @@ InitializeState<VkDevice, VulkanSemaphoreWrapper, VkSemaphoreCreateInfo>(VkDevic
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanFramebufferWrapper, VkFramebufferCreateInfo>(VkDevice                  parent_handle,
-                                                                             VulkanFramebufferWrapper* wrapper,
-                                                                             const VkFramebufferCreateInfo* create_info,
-                                                                             format::ApiCallId create_call_id,
-                                                                             CreateParameters  create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::FramebufferWrapper, VkFramebufferCreateInfo>(
+    VkDevice                             parent_handle,
+    vulkan_wrappers::FramebufferWrapper* wrapper,
+    const VkFramebufferCreateInfo*       create_info,
+    format::ApiCallId                    create_call_id,
+    vulkan_state_info::CreateParameters  create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -297,7 +301,7 @@ InitializeState<VkDevice, VulkanFramebufferWrapper, VkFramebufferCreateInfo>(VkD
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto render_pass_wrapper = GetWrapper<VulkanRenderPassWrapper>(create_info->renderPass);
+    auto render_pass_wrapper = GetVulkanWrapper<vulkan_wrappers::RenderPassWrapper>(create_info->renderPass);
     assert(render_pass_wrapper != nullptr);
     wrapper->render_pass_id                = render_pass_wrapper->handle_id;
     wrapper->render_pass_create_call_id    = render_pass_wrapper->create_call_id;
@@ -307,7 +311,7 @@ InitializeState<VkDevice, VulkanFramebufferWrapper, VkFramebufferCreateInfo>(VkD
     {
         for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
         {
-            auto image_view_wrapper = GetWrapper<VulkanImageViewWrapper>(create_info->pAttachments[i]);
+            auto image_view_wrapper = GetVulkanWrapper<vulkan_wrappers::ImageViewWrapper>(create_info->pAttachments[i]);
             assert(image_view_wrapper != nullptr);
 
             wrapper->image_view_ids.push_back(image_view_wrapper->handle_id);
@@ -317,12 +321,38 @@ InitializeState<VkDevice, VulkanFramebufferWrapper, VkFramebufferCreateInfo>(VkD
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo>(VkDevice                      parent_handle,
-                                                                           VulkanRenderPassWrapper*      wrapper,
-                                                                           const VkRenderPassCreateInfo* create_info,
-                                                                           format::ApiCallId             create_call_id,
-                                                                           CreateParameters create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::RenderPassWrapper, VkRenderPassCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::RenderPassWrapper* wrapper,
+    const VkRenderPassCreateInfo*       create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    if (create_info->pAttachments != nullptr)
+    {
+        for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
+        {
+            wrapper->attachment_final_layouts.push_back(create_info->pAttachments[i].finalLayout);
+        }
+    }
+}
+
+template <>
+inline void InitializeState<VkDevice, vulkan_wrappers::RenderPassWrapper, VkRenderPassCreateInfo2>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::RenderPassWrapper* wrapper,
+    const VkRenderPassCreateInfo2*      create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -344,38 +374,13 @@ InitializeState<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo>(VkDev
 
 template <>
 inline void
-InitializeState<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo2>(VkDevice                 parent_handle,
-                                                                            VulkanRenderPassWrapper* wrapper,
-                                                                            const VkRenderPassCreateInfo2* create_info,
-                                                                            format::ApiCallId create_call_id,
-                                                                            CreateParameters  create_parameters)
-{
-    assert(wrapper != nullptr);
-    assert(create_info != nullptr);
-    assert(create_parameters != nullptr);
-
-    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
-
-    wrapper->create_call_id    = create_call_id;
-    wrapper->create_parameters = std::move(create_parameters);
-
-    if (create_info->pAttachments != nullptr)
-    {
-        for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
-        {
-            wrapper->attachment_final_layouts.push_back(create_info->pAttachments[i].finalLayout);
-        }
-    }
-}
-
-template <>
-inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkGraphicsPipelineCreateInfo>(
+InitializeGroupObjectState<VkDevice, VkPipelineCache, vulkan_wrappers::PipelineWrapper, VkGraphicsPipelineCreateInfo>(
     VkDevice                            parent_handle,
     VkPipelineCache                     secondary_handle,
-    VulkanPipelineWrapper*              wrapper,
+    vulkan_wrappers::PipelineWrapper*   wrapper,
     const VkGraphicsPipelineCreateInfo* create_info,
     format::ApiCallId                   create_call_id,
-    CreateParameters                    create_parameters)
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -393,10 +398,11 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipeline
     {
         if (create_info->pStages[i].module != VK_NULL_HANDLE)
         {
-            auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->pStages[i].module);
+            auto shader_wrapper =
+                GetVulkanWrapper<vulkan_wrappers::ShaderModuleWrapper>(create_info->pStages[i].module);
             if (shader_wrapper)
             {
-                CreateDependencyInfo info;
+                vulkan_state_info::CreateDependencyInfo info;
                 info.handle_id         = shader_wrapper->handle_id;
                 info.create_call_id    = shader_wrapper->create_call_id;
                 info.create_parameters = shader_wrapper->create_parameters;
@@ -406,7 +412,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipeline
         }
     }
 
-    auto render_pass_wrapper = GetWrapper<VulkanRenderPassWrapper>(create_info->renderPass);
+    auto render_pass_wrapper = GetVulkanWrapper<vulkan_wrappers::RenderPassWrapper>(create_info->renderPass);
     if (render_pass_wrapper)
     {
         wrapper->render_pass_dependency.handle_id         = render_pass_wrapper->handle_id;
@@ -416,7 +422,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipeline
 
     if (create_info->layout != VK_NULL_HANDLE)
     {
-        auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
+        auto layout_wrapper = GetVulkanWrapper<vulkan_wrappers::PipelineLayoutWrapper>(create_info->layout);
         assert(layout_wrapper != nullptr);
 
         wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -427,13 +433,14 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipeline
 }
 
 template <>
-inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkComputePipelineCreateInfo>(
-    VkDevice                           parent_handle,
-    VkPipelineCache                    secondary_handle,
-    VulkanPipelineWrapper*             wrapper,
-    const VkComputePipelineCreateInfo* create_info,
-    format::ApiCallId                  create_call_id,
-    CreateParameters                   create_parameters)
+inline void
+InitializeGroupObjectState<VkDevice, VkPipelineCache, vulkan_wrappers::PipelineWrapper, VkComputePipelineCreateInfo>(
+    VkDevice                            parent_handle,
+    VkPipelineCache                     secondary_handle,
+    vulkan_wrappers::PipelineWrapper*   wrapper,
+    const VkComputePipelineCreateInfo*  create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -447,17 +454,17 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipeline
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->stage.module);
+    auto shader_wrapper = GetVulkanWrapper<vulkan_wrappers::ShaderModuleWrapper>(create_info->stage.module);
     if (shader_wrapper)
     {
-        CreateDependencyInfo info;
+        vulkan_state_info::CreateDependencyInfo info;
         info.handle_id         = shader_wrapper->handle_id;
         info.create_call_id    = shader_wrapper->create_call_id;
         info.create_parameters = shader_wrapper->create_parameters;
 
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
-    auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
+    auto layout_wrapper = GetVulkanWrapper<vulkan_wrappers::PipelineLayoutWrapper>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -468,13 +475,15 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipeline
 
 template <>
 inline void
-InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkRayTracingPipelineCreateInfoNV>(
-    VkDevice                                parent_handle,
-    VkPipelineCache                         secondary_handle,
-    VulkanPipelineWrapper*                  wrapper,
-    const VkRayTracingPipelineCreateInfoNV* create_info,
-    format::ApiCallId                       create_call_id,
-    CreateParameters                        create_parameters)
+InitializeGroupObjectState<VkDevice,
+                           VkPipelineCache,
+                           vulkan_wrappers::PipelineWrapper,
+                           VkRayTracingPipelineCreateInfoNV>(VkDevice                                parent_handle,
+                                                             VkPipelineCache                         secondary_handle,
+                                                             vulkan_wrappers::PipelineWrapper*       wrapper,
+                                                             const VkRayTracingPipelineCreateInfoNV* create_info,
+                                                             format::ApiCallId                       create_call_id,
+                                                             vulkan_state_info::CreateParameters     create_parameters)
 {
     assert(wrapper != nullptr);
     assert((create_info != nullptr) && (create_info->pStages != nullptr));
@@ -490,10 +499,10 @@ InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkR
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->pStages[i].module);
+        auto shader_wrapper = GetVulkanWrapper<vulkan_wrappers::ShaderModuleWrapper>(create_info->pStages[i].module);
         if (shader_wrapper)
         {
-            CreateDependencyInfo info;
+            vulkan_state_info::CreateDependencyInfo info;
             info.handle_id         = shader_wrapper->handle_id;
             info.create_call_id    = shader_wrapper->create_call_id;
             info.create_parameters = shader_wrapper->create_parameters;
@@ -502,7 +511,7 @@ InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkR
         }
     }
 
-    auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
+    auto layout_wrapper = GetVulkanWrapper<vulkan_wrappers::PipelineLayoutWrapper>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -513,13 +522,15 @@ InitializeGroupObjectState<VkDevice, VkPipelineCache, VulkanPipelineWrapper, VkR
 
 template <>
 inline void
-InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, VulkanPipelineWrapper, VkRayTracingPipelineCreateInfoKHR>(
-    VkDevice                                 parent_handle,
-    VkDeferredOperationKHR                   secondary_handle,
-    VulkanPipelineWrapper*                   wrapper,
-    const VkRayTracingPipelineCreateInfoKHR* create_info,
-    format::ApiCallId                        create_call_id,
-    CreateParameters                         create_parameters)
+InitializeGroupObjectState<VkDevice,
+                           VkDeferredOperationKHR,
+                           vulkan_wrappers::PipelineWrapper,
+                           VkRayTracingPipelineCreateInfoKHR>(VkDevice                                 parent_handle,
+                                                              VkDeferredOperationKHR                   secondary_handle,
+                                                              vulkan_wrappers::PipelineWrapper*        wrapper,
+                                                              const VkRayTracingPipelineCreateInfoKHR* create_info,
+                                                              format::ApiCallId                        create_call_id,
+                                                              vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert((create_info != nullptr) && (create_info->pStages != nullptr));
@@ -535,10 +546,10 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, VulkanPipelineWrapp
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = GetWrapper<VulkanShaderModuleWrapper>(create_info->pStages[i].module);
+        auto shader_wrapper = GetVulkanWrapper<vulkan_wrappers::ShaderModuleWrapper>(create_info->pStages[i].module);
         if (shader_wrapper)
         {
-            CreateDependencyInfo info;
+            vulkan_state_info::CreateDependencyInfo info;
             info.handle_id         = shader_wrapper->handle_id;
             info.create_call_id    = shader_wrapper->create_call_id;
             info.create_parameters = shader_wrapper->create_parameters;
@@ -547,7 +558,7 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, VulkanPipelineWrapp
         }
     }
 
-    auto layout_wrapper = GetWrapper<VulkanPipelineLayoutWrapper>(create_info->layout);
+    auto layout_wrapper = GetVulkanWrapper<vulkan_wrappers::PipelineLayoutWrapper>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -557,12 +568,12 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, VulkanPipelineWrapp
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanDeviceMemoryWrapper, VkMemoryAllocateInfo>(VkDevice                    parent_handle,
-                                                                           VulkanDeviceMemoryWrapper*  wrapper,
-                                                                           const VkMemoryAllocateInfo* alloc_info,
-                                                                           format::ApiCallId           create_call_id,
-                                                                           CreateParameters create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::DeviceMemoryWrapper, VkMemoryAllocateInfo>(
+    VkDevice                              parent_handle,
+    vulkan_wrappers::DeviceMemoryWrapper* wrapper,
+    const VkMemoryAllocateInfo*           alloc_info,
+    format::ApiCallId                     create_call_id,
+    vulkan_state_info::CreateParameters   create_parameters)
 {
     assert(wrapper != nullptr);
     assert(alloc_info != nullptr);
@@ -578,11 +589,12 @@ InitializeState<VkDevice, VulkanDeviceMemoryWrapper, VkMemoryAllocateInfo>(VkDev
 }
 
 template <>
-inline void InitializeState<VkDevice, VulkanBufferWrapper, VkBufferCreateInfo>(VkDevice                  parent_handle,
-                                                                               VulkanBufferWrapper*      wrapper,
-                                                                               const VkBufferCreateInfo* create_info,
-                                                                               format::ApiCallId         create_call_id,
-                                                                               CreateParameters create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::BufferWrapper, VkBufferCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::BufferWrapper*     wrapper,
+    const VkBufferCreateInfo*           create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -604,11 +616,12 @@ inline void InitializeState<VkDevice, VulkanBufferWrapper, VkBufferCreateInfo>(V
 
 // Images created with vkCreateImage.
 template <>
-inline void InitializeState<VkDevice, VulkanImageWrapper, VkImageCreateInfo>(VkDevice                 parent_handle,
-                                                                             VulkanImageWrapper*      wrapper,
-                                                                             const VkImageCreateInfo* create_info,
-                                                                             format::ApiCallId        create_call_id,
-                                                                             CreateParameters         create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::ImageWrapper*      wrapper,
+    const VkImageCreateInfo*            create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -635,12 +648,12 @@ inline void InitializeState<VkDevice, VulkanImageWrapper, VkImageCreateInfo>(VkD
 }
 
 template <>
-inline void InitializeState<VkDevice, VulkanSwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(
-    VkDevice                        parent_handle,
-    VulkanSwapchainKHRWrapper*      wrapper,
-    const VkSwapchainCreateInfoKHR* create_info,
-    format::ApiCallId               create_call_id,
-    CreateParameters                create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(
+    VkDevice                              parent_handle,
+    vulkan_wrappers::SwapchainKHRWrapper* wrapper,
+    const VkSwapchainCreateInfoKHR*       create_info,
+    format::ApiCallId                     create_call_id,
+    vulkan_state_info::CreateParameters   create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -651,8 +664,8 @@ inline void InitializeState<VkDevice, VulkanSwapchainKHRWrapper, VkSwapchainCrea
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device        = GetWrapper<VulkanDeviceWrapper>(parent_handle);
-    wrapper->surface       = GetWrapper<VulkanSurfaceKHRWrapper>(create_info->surface);
+    wrapper->device        = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
+    wrapper->surface       = GetVulkanWrapper<vulkan_wrappers::SurfaceKHRWrapper>(create_info->surface);
     wrapper->format        = create_info->imageFormat;
     wrapper->extent        = { create_info->imageExtent.width, create_info->imageExtent.height, 0 };
     wrapper->pre_transform = create_info->preTransform;
@@ -666,13 +679,13 @@ inline void InitializeState<VkDevice, VulkanSwapchainKHRWrapper, VkSwapchainCrea
 
 // Swapchain Images retrieved with vkGetSwapchainImagesKHR.
 template <>
-inline void
-InitializeGroupObjectState<VkDevice, VkSwapchainKHR, VulkanImageWrapper, void>(VkDevice            parent_handle,
-                                                                               VkSwapchainKHR      swapchain_handle,
-                                                                               VulkanImageWrapper* wrapper,
-                                                                               const void*         create_info,
-                                                                               format::ApiCallId   create_call_id,
-                                                                               CreateParameters    create_parameters)
+inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, vulkan_wrappers::ImageWrapper, void>(
+    VkDevice                            parent_handle,
+    VkSwapchainKHR                      swapchain_handle,
+    vulkan_wrappers::ImageWrapper*      wrapper,
+    const void*                         create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
@@ -683,7 +696,7 @@ InitializeGroupObjectState<VkDevice, VkSwapchainKHR, VulkanImageWrapper, void>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto swapchain_wrapper = GetWrapper<VulkanSwapchainKHRWrapper>(swapchain_handle);
+    auto swapchain_wrapper = GetVulkanWrapper<vulkan_wrappers::SwapchainKHRWrapper>(swapchain_handle);
     assert(swapchain_wrapper != nullptr);
 
     wrapper->image_type         = VK_IMAGE_TYPE_2D;
@@ -697,12 +710,12 @@ InitializeGroupObjectState<VkDevice, VkSwapchainKHR, VulkanImageWrapper, void>(V
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanBufferViewWrapper, VkBufferViewCreateInfo>(VkDevice                      parent_handle,
-                                                                           VulkanBufferViewWrapper*      wrapper,
-                                                                           const VkBufferViewCreateInfo* create_info,
-                                                                           format::ApiCallId             create_call_id,
-                                                                           CreateParameters create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::BufferViewWrapper, VkBufferViewCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::BufferViewWrapper* wrapper,
+    const VkBufferViewCreateInfo*       create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -713,17 +726,17 @@ InitializeState<VkDevice, VulkanBufferViewWrapper, VkBufferViewCreateInfo>(VkDev
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto buffer        = GetWrapper<VulkanBufferWrapper>(create_info->buffer);
+    auto buffer        = GetVulkanWrapper<vulkan_wrappers::BufferWrapper>(create_info->buffer);
     wrapper->buffer_id = buffer->handle_id;
 }
 
 template <>
-inline void
-InitializeState<VkDevice, VulkanImageViewWrapper, VkImageViewCreateInfo>(VkDevice                     parent_handle,
-                                                                         VulkanImageViewWrapper*      wrapper,
-                                                                         const VkImageViewCreateInfo* create_info,
-                                                                         format::ApiCallId            create_call_id,
-                                                                         CreateParameters             create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::ImageViewWrapper, VkImageViewCreateInfo>(
+    VkDevice                            parent_handle,
+    vulkan_wrappers::ImageViewWrapper*  wrapper,
+    const VkImageViewCreateInfo*        create_info,
+    format::ApiCallId                   create_call_id,
+    vulkan_state_info::CreateParameters create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -734,18 +747,18 @@ InitializeState<VkDevice, VulkanImageViewWrapper, VkImageViewCreateInfo>(VkDevic
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto image        = GetWrapper<VulkanImageWrapper>(create_info->image);
+    auto image        = GetVulkanWrapper<vulkan_wrappers::ImageWrapper>(create_info->image);
     wrapper->image_id = image->handle_id;
     wrapper->image    = image;
 }
 
 template <>
-inline void InitializeState<VkDevice, VulkanDescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(
-    VkDevice                               parent_handle,
-    VulkanDescriptorSetLayoutWrapper*      wrapper,
-    const VkDescriptorSetLayoutCreateInfo* create_info,
-    format::ApiCallId                      create_call_id,
-    CreateParameters                       create_parameters)
+inline void InitializeState<VkDevice, vulkan_wrappers::DescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(
+    VkDevice                                     parent_handle,
+    vulkan_wrappers::DescriptorSetLayoutWrapper* wrapper,
+    const VkDescriptorSetLayoutCreateInfo*       create_info,
+    format::ApiCallId                            create_call_id,
+    vulkan_state_info::CreateParameters          create_parameters)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -763,7 +776,7 @@ inline void InitializeState<VkDevice, VulkanDescriptorSetLayoutWrapper, VkDescri
         {
             const VkDescriptorSetLayoutBinding* binding = &create_info->pBindings[i];
 
-            DescriptorBindingInfo binding_info;
+            vulkan_state_info::DescriptorBindingInfo binding_info;
             binding_info.binding_index = binding->binding;
             binding_info.count         = binding->descriptorCount;
             binding_info.type          = binding->descriptorType;
@@ -778,12 +791,12 @@ inline void InitializeState<VkDevice, VulkanDescriptorSetLayoutWrapper, VkDescri
     }
 }
 
-inline void InitializePoolObjectState(VkDevice                           parent_handle,
-                                      VulkanCommandBufferWrapper*        wrapper,
-                                      uint32_t                           alloc_index,
-                                      const VkCommandBufferAllocateInfo* alloc_info,
-                                      format::ApiCallId                  create_call_id,
-                                      CreateParameters                   create_parameters)
+inline void InitializePoolObjectState(VkDevice                               parent_handle,
+                                      vulkan_wrappers::CommandBufferWrapper* wrapper,
+                                      uint32_t                               alloc_index,
+                                      const VkCommandBufferAllocateInfo*     alloc_info,
+                                      format::ApiCallId                      create_call_id,
+                                      vulkan_state_info::CreateParameters    create_parameters)
 {
     assert(wrapper != nullptr);
     assert(alloc_info != nullptr);
@@ -798,12 +811,12 @@ inline void InitializePoolObjectState(VkDevice                           parent_
     wrapper->level = alloc_info->level;
 }
 
-inline void InitializePoolObjectState(VkDevice                           parent_handle,
-                                      VulkanDescriptorSetWrapper*        wrapper,
-                                      uint32_t                           alloc_index,
-                                      const VkDescriptorSetAllocateInfo* alloc_info,
-                                      format::ApiCallId                  create_call_id,
-                                      CreateParameters                   create_parameters)
+inline void InitializePoolObjectState(VkDevice                               parent_handle,
+                                      vulkan_wrappers::DescriptorSetWrapper* wrapper,
+                                      uint32_t                               alloc_index,
+                                      const VkDescriptorSetAllocateInfo*     alloc_info,
+                                      format::ApiCallId                      create_call_id,
+                                      vulkan_state_info::CreateParameters    create_parameters)
 {
     assert(wrapper != nullptr);
     assert(alloc_info != nullptr);
@@ -812,15 +825,16 @@ inline void InitializePoolObjectState(VkDevice                           parent_
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = GetWrapper<VulkanDeviceWrapper>(parent_handle);
+    wrapper->device = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(parent_handle);
 
-    auto layout_wrapper = GetWrapper<VulkanDescriptorSetLayoutWrapper>(alloc_info->pSetLayouts[alloc_index]);
+    auto layout_wrapper =
+        GetVulkanWrapper<vulkan_wrappers::DescriptorSetLayoutWrapper>(alloc_info->pSetLayouts[alloc_index]);
     assert(layout_wrapper != nullptr);
 
     // Add a binding entry for each binding described by the descriptor set layout.
     for (const auto& binding_info : layout_wrapper->binding_info)
     {
-        DescriptorInfo descriptor_info;
+        vulkan_state_info::DescriptorInfo descriptor_info;
         descriptor_info.type               = binding_info.type;
         descriptor_info.count              = binding_info.count;
         descriptor_info.immutable_samplers = binding_info.immutable_samplers;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1267,7 +1267,7 @@ void VulkanStateWriter::ProcessBufferMemory(const DeviceWrapper*                
 {
     assert(device_wrapper != nullptr);
 
-    const DeviceTable* device_table = &device_wrapper->layer_table;
+    const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
     for (const auto& snapshot_entry : buffer_snapshot_info)
     {
@@ -1375,7 +1375,7 @@ void VulkanStateWriter::ProcessImageMemory(const DeviceWrapper*                 
 {
     assert(device_wrapper != nullptr);
 
-    const DeviceTable* device_table = &device_wrapper->layer_table;
+    const VulkanDeviceTable* device_table = &device_wrapper->layer_table;
 
     for (const auto& snapshot_entry : image_snapshot_info)
     {
@@ -1530,8 +1530,8 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
 
         if (memory_wrapper != nullptr)
         {
-            const DeviceWrapper* device_wrapper = wrapper->bind_device;
-            const DeviceTable*   device_table   = &device_wrapper->layer_table;
+            const DeviceWrapper*     device_wrapper = wrapper->bind_device;
+            const VulkanDeviceTable* device_table   = &device_wrapper->layer_table;
 
             assert((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -1617,8 +1617,8 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
         if ((wrapper->is_swapchain_image && memory_wrapper == nullptr && wrapper->bind_device != nullptr) ||
             (!wrapper->is_swapchain_image && memory_wrapper != nullptr))
         {
-            const DeviceWrapper* device_wrapper = wrapper->bind_device;
-            const DeviceTable*   device_table   = &device_wrapper->layer_table;
+            const DeviceWrapper*     device_wrapper = wrapper->bind_device;
+            const VulkanDeviceTable* device_table   = &device_wrapper->layer_table;
 
             assert((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -1757,8 +1757,8 @@ void VulkanStateWriter::WriteImageSubresourceLayouts(const ImageWrapper* image_w
 {
     assert((image_wrapper != nullptr) && (aspect_flags != 0));
 
-    const DeviceWrapper* device_wrapper = image_wrapper->bind_device;
-    const DeviceTable*   device_table   = &device_wrapper->layer_table;
+    const DeviceWrapper*     device_wrapper = image_wrapper->bind_device;
+    const VulkanDeviceTable* device_table   = &device_wrapper->layer_table;
 
     assert((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -1969,7 +1969,7 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 void VulkanStateWriter::WritePhysicalDevicePropertiesMetaData(const PhysicalDeviceWrapper* physical_device_wrapper)
 {
     // Write the meta-data commands to set physical device properties.
-    const InstanceTable* instance_table = physical_device_wrapper->layer_table_ref;
+    const VulkanInstanceTable* instance_table = physical_device_wrapper->layer_table_ref;
     assert(instance_table != nullptr);
 
     format::HandleId           physical_device_id     = physical_device_wrapper->handle_id;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1,25 +1,25 @@
 /*
-** Copyright (c) 2019-2020 LunarG, Inc.
-** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and associated documentation files (the "Software"),
-** to deal in the Software without restriction, including without limitation
-** the rights to use, copy, modify, merge, publish, distribute, sublicense,
-** and/or sell copies of the Software, and to permit persons to whom the
-** Software is furnished to do so, subject to the following conditions:
-**
-** The above copyright notice and this permission notice shall be included in
-** all copies or substantial portions of the Software.
-**
-** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-** DEALINGS IN THE SOFTWARE.
-*/
+ ** Copyright (c) 2019-2020 LunarG, Inc.
+ ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
 
 #include "encode/vulkan_state_writer.h"
 
@@ -1534,7 +1534,7 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
         if (memory_wrapper != nullptr)
         {
             const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
-            const VulkanDeviceTable*   device_table   = &device_wrapper->layer_table;
+            const VulkanDeviceTable*              device_table   = &device_wrapper->layer_table;
 
             assert((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -1622,7 +1622,7 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
             (!wrapper->is_swapchain_image && memory_wrapper != nullptr))
         {
             const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
-            const VulkanDeviceTable*   device_table   = &device_wrapper->layer_table;
+            const VulkanDeviceTable*              device_table   = &device_wrapper->layer_table;
 
             assert((device_wrapper != nullptr) && (device_table != nullptr));
 
@@ -1763,7 +1763,7 @@ void VulkanStateWriter::WriteImageSubresourceLayouts(const vulkan_wrappers::Imag
     assert((image_wrapper != nullptr) && (aspect_flags != 0));
 
     const vulkan_wrappers::DeviceWrapper* device_wrapper = image_wrapper->bind_device;
-    const VulkanDeviceTable*   device_table   = &device_wrapper->layer_table;
+    const VulkanDeviceTable*              device_table   = &device_wrapper->layer_table;
 
     assert((device_wrapper != nullptr) && (device_table != nullptr));
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -53,7 +53,8 @@ static bool IsMemoryReadable(VkMemoryPropertyFlags property_flags)
             (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT));
 }
 
-static bool IsBufferReadable(VkMemoryPropertyFlags property_flags, const VulkanDeviceMemoryWrapper* memory_wrapper)
+static bool IsBufferReadable(VkMemoryPropertyFlags                       property_flags,
+                             const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper)
 {
     // If a sub-range of host visible memory is mapped, a staging copy will be used to ensure that the entire allocation
     // is accessible for read.
@@ -63,9 +64,9 @@ static bool IsBufferReadable(VkMemoryPropertyFlags property_flags, const VulkanD
                                                    (memory_wrapper->mapped_size == VK_WHOLE_SIZE)))));
 }
 
-static bool IsImageReadable(VkMemoryPropertyFlags            property_flags,
-                            const VulkanDeviceMemoryWrapper* memory_wrapper,
-                            const VulkanImageWrapper*        image_wrapper)
+static bool IsImageReadable(VkMemoryPropertyFlags                       property_flags,
+                            const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper,
+                            const vulkan_wrappers::ImageWrapper*        image_wrapper)
 {
     // If a sub-range of host visible memory is mapped, a staging copy will be used to ensure that the entire allocation
     // is accessible for read.
@@ -100,16 +101,16 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
     output_stream_->Write(&marker, sizeof(marker));
 
     // Instance, device, and queue creation.
-    StandardCreateWrite<VulkanInstanceWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::InstanceWrapper>(state_table);
     WritePhysicalDeviceState(state_table);
     WriteDeviceState(state_table);
-    StandardCreateWrite<VulkanQueueWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::QueueWrapper>(state_table);
 
     // Utility object creation.
-    StandardCreateWrite<VulkanDebugReportCallbackEXTWrapper>(state_table);
-    StandardCreateWrite<VulkanDebugUtilsMessengerEXTWrapper>(state_table);
-    StandardCreateWrite<VulkanValidationCacheEXTWrapper>(state_table);
-    StandardCreateWrite<VulkanDeferredOperationKHRWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DebugReportCallbackEXTWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::ValidationCacheEXTWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DeferredOperationKHRWrapper>(state_table);
     WritePrivateDataSlotState(state_table);
 
     // Synchronization primitive creation.
@@ -118,14 +119,14 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
     WriteSemaphoreState(state_table);
 
     // WSI object creation.
-    StandardCreateWrite<VulkanDisplayKHRWrapper>(state_table);
-    StandardCreateWrite<VulkanDisplayModeKHRWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DisplayKHRWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DisplayModeKHRWrapper>(state_table);
     WriteSurfaceKhrState(state_table);
     WriteSwapchainKhrState(state_table);
 
     // Resource creation.
     WriteBufferState(state_table);
-    StandardCreateWrite<VulkanImageWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::ImageWrapper>(state_table);
     WriteDeviceMemoryState(state_table);
 
     // Bind memory after buffer/image creation and memory allocation. The buffer/image needs to be created before memory
@@ -137,39 +138,39 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
 
     WriteBufferViewState(state_table);
     WriteImageViewState(state_table);
-    StandardCreateWrite<VulkanSamplerWrapper>(state_table);
-    StandardCreateWrite<VulkanSamplerYcbcrConversionWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::SamplerWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::SamplerYcbcrConversionWrapper>(state_table);
 
     // Render object creation.
-    StandardCreateWrite<VulkanRenderPassWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::RenderPassWrapper>(state_table);
     WriteFramebufferState(state_table);
-    StandardCreateWrite<VulkanShaderModuleWrapper>(state_table);
-    StandardCreateWrite<VulkanDescriptorSetLayoutWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::ShaderModuleWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DescriptorSetLayoutWrapper>(state_table);
     WritePipelineLayoutState(state_table);
     WritePipelineCacheState(state_table);
     WritePipelineState(state_table);
     WriteAccelerationStructureKHRState(state_table);
     WriteTlasToBlasDependenciesMetadata(state_table);
-    StandardCreateWrite<VulkanAccelerationStructureNVWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::AccelerationStructureNVWrapper>(state_table);
 
     // Descriptor creation.
-    StandardCreateWrite<VulkanDescriptorPoolWrapper>(state_table);
-    StandardCreateWrite<VulkanDescriptorUpdateTemplateWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DescriptorPoolWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(state_table);
     WriteDescriptorSetState(state_table);
 
     // Query object creation.
     WriteQueryPoolState(state_table);
-    StandardCreateWrite<VulkanPerformanceConfigurationINTELWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(state_table);
 
-    StandardCreateWrite<VulkanMicromapEXTWrapper>(state_table);
-    StandardCreateWrite<VulkanOpticalFlowSessionNVWrapper>(state_table);
-    StandardCreateWrite<VulkanVideoSessionKHRWrapper>(state_table);
-    StandardCreateWrite<VulkanVideoSessionParametersKHRWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::MicromapEXTWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::OpticalFlowSessionNVWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::VideoSessionKHRWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::VideoSessionParametersKHRWrapper>(state_table);
 
     // Command creation.
-    StandardCreateWrite<VulkanCommandPoolWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::CommandPoolWrapper>(state_table);
     WriteCommandBufferState(state_table);
-    StandardCreateWrite<VulkanIndirectCommandsLayoutNVWrapper>(state_table);  // TODO: If we intend to support this, we need to reserve command space after creation.
+    StandardCreateWrite<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(state_table);  // TODO: If we intend to support this, we need to reserve command space after creation.
     WriteTrimCommandPool(state_table);
 
     // Process swapchain image acquire.
@@ -186,7 +187,7 @@ void VulkanStateWriter::WritePhysicalDeviceState(const VulkanStateTable& state_t
 {
     std::set<util::MemoryOutputStream*> processed;
 
-    state_table.VisitWrappers([&](const VulkanPhysicalDeviceWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::PhysicalDeviceWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Filter duplicate calls to vkEnumeratePhysicalDevice for phsyical devices that were retrieved by the same API
@@ -229,7 +230,7 @@ void VulkanStateWriter::WritePhysicalDeviceState(const VulkanStateTable& state_t
 
 void VulkanStateWriter::WriteDeviceState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanDeviceWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::DeviceWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Write device creation call.
@@ -246,10 +247,10 @@ void VulkanStateWriter::WriteDeviceState(const VulkanStateTable& state_table)
 
 void VulkanStateWriter::WriteCommandBufferState(const VulkanStateTable& state_table)
 {
-    std::set<util::MemoryOutputStream*>            processed;
-    std::vector<const VulkanCommandBufferWrapper*> primary;
+    std::set<util::MemoryOutputStream*>                       processed;
+    std::vector<const vulkan_wrappers::CommandBufferWrapper*> primary;
 
-    state_table.VisitWrappers([&](const VulkanCommandBufferWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::CommandBufferWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Filter duplicate calls to vkAllocateCommandBuffers for command buffers that were allocated by the same API
@@ -285,11 +286,11 @@ void VulkanStateWriter::WriteCommandBufferState(const VulkanStateTable& state_ta
 void VulkanStateWriter::WriteTrimCommandPool(const VulkanStateTable& state_table)
 {
     // vkTrimCommandPool shouldn't affect rendering. It's not necessary to replay. But it could help as debug info.
-    state_table.VisitWrappers([&](const VulkanCommandPoolWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::CommandPoolWrapper* wrapper) {
         assert(wrapper != nullptr);
         if (wrapper->trim_command_pool)
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             encoder_.EncodeHandleIdValue(device_wrapper->handle_id);
@@ -306,7 +307,7 @@ void VulkanStateWriter::WritePrivateDataSlotState(const VulkanStateTable& state_
 {
     std::set<util::MemoryOutputStream*> processed;
 
-    state_table.VisitWrappers([&](const VulkanPrivateDataSlotWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::PrivateDataSlotWrapper* wrapper) {
         assert(wrapper != nullptr);
         if (processed.find(wrapper->create_parameters.get()) == processed.end())
         {
@@ -317,7 +318,7 @@ void VulkanStateWriter::WritePrivateDataSlotState(const VulkanStateTable& state_
             // info.
             if (wrapper->data != 0)
             {
-                const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+                const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
                 assert(device_wrapper != nullptr);
 
                 encoder_.EncodeHandleIdValue(device_wrapper->handle_id);
@@ -336,12 +337,12 @@ void VulkanStateWriter::WritePrivateDataSlotState(const VulkanStateTable& state_
 
 void VulkanStateWriter::WriteFenceState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanFenceWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::FenceWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Check fence signaled state against create info signaled state.
-        const VulkanDeviceWrapper* device_wrapper = wrapper->device;
-        bool                       signaled       = wrapper->created_signaled;
+        const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
+        bool                                  signaled       = wrapper->created_signaled;
 
         GetFenceStatus(device_wrapper, wrapper->handle, &signaled);
 
@@ -361,14 +362,14 @@ void VulkanStateWriter::WriteFenceState(const VulkanStateTable& state_table)
 
 void VulkanStateWriter::WriteEventState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanEventWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::EventWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Write event creation call.
         WriteFunctionCall(wrapper->create_call_id, wrapper->create_parameters.get());
 
         // Check and set signaled state if necessary.
-        const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+        const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
         assert(device_wrapper != nullptr);
 
         VkResult result = device_wrapper->layer_table.GetEventStatus(device_wrapper->handle, wrapper->handle);
@@ -382,9 +383,9 @@ void VulkanStateWriter::WriteEventState(const VulkanStateTable& state_table)
 
 void VulkanStateWriter::WriteSemaphoreState(const VulkanStateTable& state_table)
 {
-    std::unordered_map<const VulkanDeviceWrapper*, std::vector<format::HandleId>> signaled;
+    std::unordered_map<const vulkan_wrappers::DeviceWrapper*, std::vector<format::HandleId>> signaled;
 
-    state_table.VisitWrappers([&](const VulkanSemaphoreWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::SemaphoreWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Write semaphore creation call.
@@ -392,7 +393,7 @@ void VulkanStateWriter::WriteSemaphoreState(const VulkanStateTable& state_table)
 
         if (wrapper->type == VK_SEMAPHORE_TYPE_TIMELINE)
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             // Query current semaphore value
@@ -430,7 +431,7 @@ void VulkanStateWriter::WriteSemaphoreState(const VulkanStateTable& state_table)
         {
             // Any queue should be sufficient for signaling the semaphores; queue submit will not include any
             // command buffers.
-            const VulkanQueueWrapper* queue_wrapper = entry.first->child_queues.front();
+            const vulkan_wrappers::QueueWrapper* queue_wrapper = entry.first->child_queues.front();
             WriteCommandExecution(queue_wrapper->handle_id,
                                   0,
                                   nullptr,
@@ -445,7 +446,7 @@ void VulkanStateWriter::WriteSemaphoreState(const VulkanStateTable& state_table)
 
 void VulkanStateWriter::WriteBufferViewState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanBufferViewWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::BufferViewWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Omit the current buffer view object if the buffer used to create it no longer exists.
@@ -459,7 +460,7 @@ void VulkanStateWriter::WriteBufferViewState(const VulkanStateTable& state_table
 
 void VulkanStateWriter::WriteImageViewState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanImageViewWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::ImageViewWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Omit the current image view object if the image used to create it no longer exists.
@@ -475,12 +476,12 @@ void VulkanStateWriter::WriteFramebufferState(const VulkanStateTable& state_tabl
 {
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_render_passes;
 
-    state_table.VisitWrappers([&](const VulkanFramebufferWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::FramebufferWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         if (IsFramebufferValid(wrapper, state_table))
         {
-            auto render_pass_wrapper = state_table.GetVulkanRenderPassWrapper(wrapper->render_pass_id);
+            auto render_pass_wrapper = state_table.GetRenderPassWrapper(wrapper->render_pass_id);
             if (render_pass_wrapper == nullptr)
             {
                 // The object no longer exists, so a temporary object must be created.
@@ -514,14 +515,14 @@ void VulkanStateWriter::WritePipelineLayoutState(const VulkanStateTable& state_t
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_ds_layouts;
 
     // Perform temporary creations for dependencies that are no longer live, and create the pipeline layout.
-    state_table.VisitWrappers([&](const VulkanPipelineLayoutWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::PipelineLayoutWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Check descriptor set layout dependencies.
         auto deps = wrapper->layout_dependencies;
         for (const auto& entry : deps->layouts)
         {
-            auto ds_layout_wrapper = state_table.GetVulkanDescriptorSetLayoutWrapper(entry.handle_id);
+            auto ds_layout_wrapper = state_table.GetDescriptorSetLayoutWrapper(entry.handle_id);
             if (ds_layout_wrapper == nullptr)
             {
                 // The layout object has been destroyed, so a temporary object must be created.
@@ -613,7 +614,7 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
 
     // First pass over pipeline table to sort pipelines by type and determine which dependencies need to be created
     // temporarily.
-    state_table.VisitWrappers([&](const VulkanPipelineWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::PipelineWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Determine type of pipeline.
@@ -628,8 +629,7 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
             if (wrapper->render_pass_dependency.create_call_id != format::ApiCallId::ApiCall_Unknown)
             {
                 // Check for graphics-specific creation dependencies that no longer exist.
-                auto render_pass_wrapper =
-                    state_table.GetVulkanRenderPassWrapper(wrapper->render_pass_dependency.handle_id);
+                auto render_pass_wrapper = state_table.GetRenderPassWrapper(wrapper->render_pass_dependency.handle_id);
                 if (render_pass_wrapper == nullptr)
                 {
                     // The object no longer exists, so a temporary object must be created.
@@ -705,7 +705,7 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
         // Check for creation dependencies that no longer exist.
         for (const auto& entry : wrapper->shader_module_dependencies)
         {
-            auto shader_wrapper = state_table.GetVulkanShaderModuleWrapper(entry.handle_id);
+            auto shader_wrapper = state_table.GetShaderModuleWrapper(entry.handle_id);
             if (shader_wrapper == nullptr)
             {
                 // The object no longer exists, so a temporary object must be created.
@@ -722,7 +722,7 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
 
         if (wrapper->layout_dependency.handle_id != format::kNullHandleId)
         {
-            auto layout_wrapper = state_table.GetVulkanPipelineLayoutWrapper(wrapper->layout_dependency.handle_id);
+            auto layout_wrapper = state_table.GetPipelineLayoutWrapper(wrapper->layout_dependency.handle_id);
             if (layout_wrapper == nullptr)
             {
                 // The object no longer exists, so a temporary object must be created.
@@ -737,7 +737,7 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
                     auto deps = wrapper->layout_dependencies;
                     for (const auto& entry : deps->layouts)
                     {
-                        auto ds_layout_wrapper = state_table.GetVulkanDescriptorSetLayoutWrapper(entry.handle_id);
+                        auto ds_layout_wrapper = state_table.GetDescriptorSetLayoutWrapper(entry.handle_id);
                         if (ds_layout_wrapper == nullptr)
                         {
                             // The object no longer exists, so a temporary object must be created.
@@ -814,11 +814,10 @@ void VulkanStateWriter::WriteDescriptorSetState(const VulkanStateTable& state_ta
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_ds_layouts;
 
     // First pass over descriptor set table to determine which dependencies need to be created temporarily.
-    state_table.VisitWrappers([&](const VulkanDescriptorSetWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::DescriptorSetWrapper* wrapper) {
         assert(wrapper != nullptr);
 
-        auto ds_layout_wrapper =
-            state_table.GetVulkanDescriptorSetLayoutWrapper(wrapper->set_layout_dependency.handle_id);
+        auto ds_layout_wrapper = state_table.GetDescriptorSetLayoutWrapper(wrapper->set_layout_dependency.handle_id);
         if (ds_layout_wrapper == nullptr)
         {
             // The object no longer exists, so a temporary object must be created.
@@ -834,7 +833,7 @@ void VulkanStateWriter::WriteDescriptorSetState(const VulkanStateTable& state_ta
         }
     });
 
-    state_table.VisitWrappers([&](const VulkanDescriptorSetWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::DescriptorSetWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Filter duplicate calls to vkAllocateDescriptorSets for descriptor sets that were allocated by the same API
@@ -851,8 +850,8 @@ void VulkanStateWriter::WriteDescriptorSetState(const VulkanStateTable& state_ta
 
         for (const auto& binding_entry : wrapper->bindings)
         {
-            const DescriptorInfo* binding = &binding_entry.second;
-            bool                  active  = false;
+            const vulkan_state_info::DescriptorInfo* binding = &binding_entry.second;
+            bool                                     active  = false;
 
             write.pNext      = binding->write_pnext;
             write.dstBinding = binding_entry.first;
@@ -909,10 +908,11 @@ void VulkanStateWriter::WriteDescriptorSetState(const VulkanStateTable& state_ta
 
 void VulkanStateWriter::WriteQueryPoolState(const VulkanStateTable& state_table)
 {
-    std::unordered_map<const VulkanDeviceWrapper*, std::vector<const VulkanQueryPoolWrapper*>> device_query_pools;
-    std::unordered_map<const VulkanDeviceWrapper*, QueryActivationQueueFamilyTable>            device_queries;
+    std::unordered_map<const vulkan_wrappers::DeviceWrapper*, std::vector<const vulkan_wrappers::QueryPoolWrapper*>>
+                                                                                               device_query_pools;
+    std::unordered_map<const vulkan_wrappers::DeviceWrapper*, QueryActivationQueueFamilyTable> device_queries;
 
-    state_table.VisitWrappers([&](const VulkanQueryPoolWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::QueryPoolWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Write query pool creation call.
@@ -960,7 +960,7 @@ void VulkanStateWriter::WriteQueryPoolState(const VulkanStateTable& state_table)
 
 void VulkanStateWriter::WriteSurfaceKhrState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanSurfaceKHRWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::SurfaceKHRWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Write surface creation call.
@@ -1002,10 +1002,10 @@ void VulkanStateWriter::WriteSurfaceKhrState(const VulkanStateTable& state_table
 
 void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanSwapchainKHRWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::SwapchainKHRWrapper* wrapper) {
         assert(wrapper != nullptr);
 
-        const VulkanSurfaceKHRWrapper* surface_wrapper = wrapper->surface;
+        const vulkan_wrappers::SurfaceKHRWrapper* surface_wrapper = wrapper->surface;
         assert(surface_wrapper != nullptr);
 
         WriteResizeWindowCmd2(
@@ -1019,7 +1019,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
 
         if (image_count > 0)
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             const VkResult result = VK_SUCCESS;
@@ -1035,7 +1035,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
 
         if (wrapper->acquire_full_screen_exclusive_mode)
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             const VkResult result = VK_SUCCESS;
@@ -1049,7 +1049,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
 
         if (wrapper->release_full_screen_exclusive_mode)
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             const VkResult result = VK_SUCCESS;
@@ -1063,7 +1063,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
 
         if (wrapper->using_local_dimming_AMD)
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
             assert(device_wrapper != nullptr);
 
             const VkResult result = VK_SUCCESS;
@@ -1080,10 +1080,10 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
 void VulkanStateWriter::WriteDeviceMemoryState(const VulkanStateTable& state_table)
 {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    std::unordered_map<AHardwareBuffer*, const VulkanDeviceMemoryWrapper*> hardware_buffers;
+    std::unordered_map<AHardwareBuffer*, const vulkan_wrappers::DeviceMemoryWrapper*> hardware_buffers;
 
     // Before writing the device memory allocation calls, generate a list of external memory objects to create.
-    state_table.VisitWrappers([&](const VulkanDeviceMemoryWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::DeviceMemoryWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         if (wrapper->hardware_buffer != nullptr)
@@ -1095,13 +1095,13 @@ void VulkanStateWriter::WriteDeviceMemoryState(const VulkanStateTable& state_tab
     // Write AHB creation commands.
     for (auto hardware_buffer : hardware_buffers)
     {
-        const VulkanDeviceMemoryWrapper* wrapper = hardware_buffer.second;
+        const vulkan_wrappers::DeviceMemoryWrapper* wrapper = hardware_buffer.second;
         ProcessHardwareBuffer(wrapper->hardware_buffer_memory_id, wrapper->hardware_buffer, wrapper->allocation_size);
     }
 #endif
 
     // Write device memory allocation calls.
-    state_table.VisitWrappers([&](const VulkanDeviceMemoryWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::DeviceMemoryWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         if (wrapper->device_id != format::kNullHandleId)
@@ -1115,7 +1115,7 @@ void VulkanStateWriter::WriteDeviceMemoryState(const VulkanStateTable& state_tab
 
 void VulkanStateWriter::WriteBufferState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanBufferWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::BufferWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         if ((wrapper->device_id != format::kNullHandleId) && (wrapper->address != 0))
@@ -1132,7 +1132,7 @@ void VulkanStateWriter::WriteBufferState(const VulkanStateTable& state_table)
 
 void VulkanStateWriter::WriteTlasToBlasDependenciesMetadata(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanAccelerationStructureKHRWrapper* tlas) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::AccelerationStructureKHRWrapper* tlas) {
         assert(tlas != nullptr);
 
         if (tlas->blas.size())
@@ -1164,7 +1164,7 @@ void VulkanStateWriter::WriteTlasToBlasDependenciesMetadata(const VulkanStateTab
 
 void VulkanStateWriter::WriteAccelerationStructureKHRState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanAccelerationStructureKHRWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         if ((wrapper->device_id != format::kNullHandleId) && (wrapper->address != 0))
@@ -1263,7 +1263,7 @@ void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
 #endif
 }
 
-void VulkanStateWriter::ProcessBufferMemory(const VulkanDeviceWrapper*             device_wrapper,
+void VulkanStateWriter::ProcessBufferMemory(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
                                             const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
                                             graphics::VulkanResourcesUtil&         resource_util)
 {
@@ -1273,10 +1273,10 @@ void VulkanStateWriter::ProcessBufferMemory(const VulkanDeviceWrapper*          
 
     for (const auto& snapshot_entry : buffer_snapshot_info)
     {
-        const VulkanBufferWrapper*       buffer_wrapper = snapshot_entry.buffer_wrapper;
-        const VulkanDeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
-        const uint8_t*                   bytes          = nullptr;
-        std::vector<uint8_t>             data;
+        const vulkan_wrappers::BufferWrapper*       buffer_wrapper = snapshot_entry.buffer_wrapper;
+        const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
+        const uint8_t*                              bytes          = nullptr;
+        std::vector<uint8_t>                        data;
 
         assert((buffer_wrapper != nullptr) && (memory_wrapper != nullptr));
 
@@ -1371,7 +1371,7 @@ void VulkanStateWriter::ProcessBufferMemory(const VulkanDeviceWrapper*          
     }
 }
 
-void VulkanStateWriter::ProcessImageMemory(const VulkanDeviceWrapper*            device_wrapper,
+void VulkanStateWriter::ProcessImageMemory(const vulkan_wrappers::DeviceWrapper* device_wrapper,
                                            const std::vector<ImageSnapshotInfo>& image_snapshot_info,
                                            graphics::VulkanResourcesUtil&        resource_util)
 {
@@ -1381,10 +1381,10 @@ void VulkanStateWriter::ProcessImageMemory(const VulkanDeviceWrapper*           
 
     for (const auto& snapshot_entry : image_snapshot_info)
     {
-        const VulkanImageWrapper*        image_wrapper  = snapshot_entry.image_wrapper;
-        const VulkanDeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
-        const uint8_t*                   bytes          = nullptr;
-        std::vector<uint8_t>             data;
+        const vulkan_wrappers::ImageWrapper*        image_wrapper  = snapshot_entry.image_wrapper;
+        const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper = snapshot_entry.memory_wrapper;
+        const uint8_t*                              bytes          = nullptr;
+        std::vector<uint8_t>                        data;
 
         assert((image_wrapper != nullptr) && ((image_wrapper->is_swapchain_image && memory_wrapper == nullptr) ||
                                               (!image_wrapper->is_swapchain_image && memory_wrapper != nullptr)));
@@ -1524,16 +1524,16 @@ void VulkanStateWriter::WriteBufferMemoryState(const VulkanStateTable& state_tab
 {
     assert((resources != nullptr) && (max_resource_size != nullptr) && (max_staging_copy_size != nullptr));
 
-    state_table.VisitWrappers([&](const VulkanBufferWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::BufferWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Perform memory binding.
-        const VulkanDeviceMemoryWrapper* memory_wrapper =
-            state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
+        const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
+            state_table.GetDeviceMemoryWrapper(wrapper->bind_memory_id);
 
         if (memory_wrapper != nullptr)
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
             const VulkanDeviceTable*   device_table   = &device_wrapper->layer_table;
 
             assert((device_wrapper != nullptr) && (device_table != nullptr));
@@ -1611,17 +1611,17 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
 {
     assert((resources != nullptr) && (max_resource_size != nullptr) && (max_staging_copy_size != nullptr));
 
-    state_table.VisitWrappers([&](const VulkanImageWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::ImageWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         // Perform memory binding.
-        const VulkanDeviceMemoryWrapper* memory_wrapper =
-            state_table.GetVulkanDeviceMemoryWrapper(wrapper->bind_memory_id);
+        const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper =
+            state_table.GetDeviceMemoryWrapper(wrapper->bind_memory_id);
 
         if ((wrapper->is_swapchain_image && memory_wrapper == nullptr && wrapper->bind_device != nullptr) ||
             (!wrapper->is_swapchain_image && memory_wrapper != nullptr))
         {
-            const VulkanDeviceWrapper* device_wrapper = wrapper->bind_device;
+            const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->bind_device;
             const VulkanDeviceTable*   device_table   = &device_wrapper->layer_table;
 
             assert((device_wrapper != nullptr) && (device_table != nullptr));
@@ -1757,12 +1757,12 @@ void VulkanStateWriter::WriteImageMemoryState(const VulkanStateTable& state_tabl
     });
 }
 
-void VulkanStateWriter::WriteImageSubresourceLayouts(const VulkanImageWrapper* image_wrapper,
-                                                     VkImageAspectFlags        aspect_flags)
+void VulkanStateWriter::WriteImageSubresourceLayouts(const vulkan_wrappers::ImageWrapper* image_wrapper,
+                                                     VkImageAspectFlags                   aspect_flags)
 {
     assert((image_wrapper != nullptr) && (aspect_flags != 0));
 
-    const VulkanDeviceWrapper* device_wrapper = image_wrapper->bind_device;
+    const vulkan_wrappers::DeviceWrapper* device_wrapper = image_wrapper->bind_device;
     const VulkanDeviceTable*   device_table   = &device_wrapper->layer_table;
 
     assert((device_wrapper != nullptr) && (device_table != nullptr));
@@ -1803,8 +1803,8 @@ void VulkanStateWriter::WriteResourceMemoryState(const VulkanStateTable& state_t
     // Write resource memory content.
     for (const auto& resource_entry : resources)
     {
-        const VulkanDeviceWrapper* device_wrapper = resource_entry.first;
-        VkResult                   result         = VK_SUCCESS;
+        const vulkan_wrappers::DeviceWrapper* device_wrapper = resource_entry.first;
+        VkResult                              result         = VK_SUCCESS;
 
         graphics::VulkanResourcesUtil resource_util(
             device_wrapper->handle, device_wrapper->layer_table, device_wrapper->physical_device->memory_properties);
@@ -1857,7 +1857,7 @@ void VulkanStateWriter::WriteResourceMemoryState(const VulkanStateTable& state_t
 
 void VulkanStateWriter::WriteMappedMemoryState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanDeviceMemoryWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::DeviceMemoryWrapper* wrapper) {
         assert(wrapper != nullptr);
 
         if (wrapper->mapped_data != nullptr)
@@ -1883,13 +1883,13 @@ void VulkanStateWriter::WriteMappedMemoryState(const VulkanStateTable& state_tab
 
 void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const VulkanSwapchainKHRWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::SwapchainKHRWrapper* wrapper) {
         assert(wrapper != nullptr && wrapper->device != nullptr);
 
-        const VulkanDeviceWrapper* device_wrapper = wrapper->device;
-        size_t                     image_count    = wrapper->child_images.size() > wrapper->image_acquired_info.size()
-                                                        ? wrapper->image_acquired_info.size()
-                                                        : wrapper->child_images.size();
+        const vulkan_wrappers::DeviceWrapper* device_wrapper = wrapper->device;
+        size_t image_count = wrapper->child_images.size() > wrapper->image_acquired_info.size()
+                                 ? wrapper->image_acquired_info.size()
+                                 : wrapper->child_images.size();
 
         format::SetSwapchainImageStateCommandHeader header;
         format::SwapchainImageStateInfo             info;
@@ -1912,7 +1912,7 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 
         for (size_t i = 0; i < image_count; ++i)
         {
-            VulkanImageWrapper* image_wrapper = wrapper->child_images[i];
+            vulkan_wrappers::ImageWrapper* image_wrapper = wrapper->child_images[i];
 
             info.image_index  = static_cast<uint32_t>(i);
             info.image_id     = image_wrapper->handle_id;
@@ -1920,8 +1920,8 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 
             if (wrapper->image_acquired_info[i].last_presented_queue != VK_NULL_HANDLE)
             {
-                auto queue_wrapper =
-                    GetWrapper<VulkanQueueWrapper>(wrapper->image_acquired_info[i].last_presented_queue);
+                auto queue_wrapper = GetVulkanWrapper<vulkan_wrappers::QueueWrapper>(
+                    wrapper->image_acquired_info[i].last_presented_queue);
                 info.last_presented_queue_id = queue_wrapper->handle_id;
             }
             else
@@ -1937,8 +1937,8 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 
                 // Only provide sync object IDs if the objects have not been destroyed between now and image
                 // acquire.
-                const VulkanSemaphoreWrapper* semaphore_wrapper =
-                    state_table.GetVulkanSemaphoreWrapper(wrapper->image_acquired_info[i].acquired_semaphore_id);
+                const vulkan_wrappers::SemaphoreWrapper* semaphore_wrapper =
+                    state_table.GetSemaphoreWrapper(wrapper->image_acquired_info[i].acquired_semaphore_id);
                 if (semaphore_wrapper != nullptr)
                 {
                     info.acquire_semaphore_id = wrapper->image_acquired_info[i].acquired_semaphore_id;
@@ -1948,8 +1948,8 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
                     info.acquire_semaphore_id = 0;
                 }
 
-                const VulkanFenceWrapper* fence_wrapper =
-                    state_table.GetVulkanFenceWrapper(wrapper->image_acquired_info[i].acquired_fence_id);
+                const vulkan_wrappers::FenceWrapper* fence_wrapper =
+                    state_table.GetFenceWrapper(wrapper->image_acquired_info[i].acquired_fence_id);
                 if (fence_wrapper != nullptr)
                 {
                     info.acquire_fence_id = wrapper->image_acquired_info[i].acquired_fence_id;
@@ -1973,7 +1973,7 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 }
 
 void VulkanStateWriter::WritePhysicalDevicePropertiesMetaData(
-    const VulkanPhysicalDeviceWrapper* physical_device_wrapper)
+    const vulkan_wrappers::PhysicalDeviceWrapper* physical_device_wrapper)
 {
     // Write the meta-data commands to set physical device properties.
     const VulkanInstanceTable* instance_table = physical_device_wrapper->layer_table_ref;
@@ -2030,10 +2030,11 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceSupport(format::HandleId ph
     parameter_stream_.Reset();
 }
 
-void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceCapabilities(format::HandleId                 physical_device_id,
-                                                                  format::HandleId                 surface_id,
-                                                                  const VulkanSurfaceCapabilities& capabilities,
-                                                                  const VulkanStateTable&          state_table)
+void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceCapabilities(
+    format::HandleId                            physical_device_id,
+    format::HandleId                            surface_id,
+    const vulkan_wrappers::SurfaceCapabilities& capabilities,
+    const VulkanStateTable&                     state_table)
 {
     const VkResult result = VK_SUCCESS;
 
@@ -2046,10 +2047,10 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceCapabilities(format::Handle
     parameter_stream_.Reset();
 }
 
-void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceFormats(format::HandleId            physical_device_id,
-                                                             format::HandleId            surface_id,
-                                                             const VulkanSurfaceFormats& formats,
-                                                             const VulkanStateTable&     state_table)
+void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceFormats(format::HandleId                       physical_device_id,
+                                                             format::HandleId                       surface_id,
+                                                             const vulkan_wrappers::SurfaceFormats& formats,
+                                                             const VulkanStateTable&                state_table)
 {
     const VkResult result = VK_SUCCESS;
 
@@ -2076,10 +2077,11 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfaceFormats(format::HandleId   
     parameter_stream_.Reset();
 }
 
-void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::HandleId                 physical_device_id,
-                                                                  format::HandleId                 surface_id,
-                                                                  const VulkanSurfacePresentModes& present_modes,
-                                                                  const VulkanStateTable&          state_table)
+void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(
+    format::HandleId                            physical_device_id,
+    format::HandleId                            surface_id,
+    const vulkan_wrappers::SurfacePresentModes& present_modes,
+    const VulkanStateTable&                     state_table)
 {
     const VkResult          result        = VK_SUCCESS;
     uint32_t                mode_count    = static_cast<uint32_t>(present_modes.present_modes.size());
@@ -2112,7 +2114,7 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::Handle
         VkPhysicalDeviceSurfaceInfo2KHR surface_info2;
         surface_info2.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
         surface_info2.pNext   = present_modes.surface_info_pnext;
-        auto surface_wrapper  = state_table.GetVulkanSurfaceKHRWrapper(surface_id);
+        auto surface_wrapper  = state_table.GetSurfaceKHRWrapper(surface_id);
         surface_info2.surface = surface_wrapper->handle;
 
         // First write the call to retrieve the size.
@@ -2137,10 +2139,11 @@ void VulkanStateWriter::WriteGetPhysicalDeviceSurfacePresentModes(format::Handle
     }
 }
 
-void VulkanStateWriter::WriteGetDeviceGroupSurfacePresentModes(format::HandleId                      device_id,
-                                                               format::HandleId                      surface_id,
-                                                               const VulkanGroupSurfacePresentModes& present_modes,
-                                                               const VulkanStateTable&               state_table)
+void VulkanStateWriter::WriteGetDeviceGroupSurfacePresentModes(
+    format::HandleId                                 device_id,
+    format::HandleId                                 surface_id,
+    const vulkan_wrappers::GroupSurfacePresentModes& present_modes,
+    const VulkanStateTable&                          state_table)
 {
     const VkResult result = VK_SUCCESS;
 
@@ -2159,7 +2162,7 @@ void VulkanStateWriter::WriteGetDeviceGroupSurfacePresentModes(format::HandleId 
         VkPhysicalDeviceSurfaceInfo2KHR surface_info2;
         surface_info2.sType   = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
         surface_info2.pNext   = present_modes.surface_info_pnext;
-        auto surface_wrapper  = state_table.GetVulkanSurfaceKHRWrapper(surface_id);
+        auto surface_wrapper  = state_table.GetSurfaceKHRWrapper(surface_id);
         surface_info2.surface = surface_wrapper->handle;
 
         encoder_.EncodeHandleIdValue(device_id);
@@ -2199,7 +2202,7 @@ void VulkanStateWriter::WriteCommandProcessingCreateCommands(format::HandleId de
     encoder_.EncodeHandleIdValue(device_id);
     EncodeStructPtr(&encoder_, &create_info);
     EncodeStructPtr(&encoder_, allocator);
-    encoder_.EncodeHandlePtr<VulkanCommandPoolWrapper>(&command_pool);
+    encoder_.EncodeHandlePtr<vulkan_wrappers::CommandPoolWrapper>(&command_pool);
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkCreateCommandPool, &parameter_stream_);
@@ -2277,7 +2280,7 @@ void VulkanStateWriter::WriteCommandExecution(format::HandleId            queue_
     encoder_.EncodeUInt32Value(signal_semaphore_count);
     encoder_.EncodeHandleIdArray(signal_semaphore_ids, signal_semaphore_count);
 
-    encoder_.EncodeHandleValue<VulkanFenceWrapper>(fence);
+    encoder_.EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkQueueSubmit, &parameter_stream_);
@@ -2291,8 +2294,8 @@ void VulkanStateWriter::WriteCommandExecution(format::HandleId            queue_
     parameter_stream_.Reset();
 }
 
-void VulkanStateWriter::WriteCommandBufferCommands(const VulkanCommandBufferWrapper* wrapper,
-                                                   const VulkanStateTable&           state_table)
+void VulkanStateWriter::WriteCommandBufferCommands(const vulkan_wrappers::CommandBufferWrapper* wrapper,
+                                                   const VulkanStateTable&                      state_table)
 {
     assert(wrapper != nullptr);
 
@@ -2321,9 +2324,9 @@ void VulkanStateWriter::WriteCommandBufferCommands(const VulkanCommandBufferWrap
     }
 }
 
-void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      device_id,
-                                                     const DescriptorInfo* binding,
-                                                     VkWriteDescriptorSet* write)
+void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId                         device_id,
+                                                     const vulkan_state_info::DescriptorInfo* binding,
+                                                     VkWriteDescriptorSet*                    write)
 {
     assert((binding != nullptr) && (write != nullptr));
 
@@ -2382,8 +2385,8 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      devic
     parameter_stream_.Reset();
 }
 
-void VulkanStateWriter::WriteQueryPoolReset(format::HandleId                                  device_id,
-                                            const std::vector<const VulkanQueryPoolWrapper*>& query_pool_wrappers)
+void VulkanStateWriter::WriteQueryPoolReset(
+    format::HandleId device_id, const std::vector<const vulkan_wrappers::QueryPoolWrapper*>& query_pool_wrappers)
 {
     // Retrieve a queue and create a command buffer for query pool reset.
     WriteCommandProcessingCreateCommands(
@@ -2945,14 +2948,14 @@ void VulkanStateWriter::WriteSetRayTracingShaderGroupHandlesCommand(format::Hand
     ++blocks_written_;
 }
 
-VkMemoryPropertyFlags VulkanStateWriter::GetMemoryProperties(const VulkanDeviceWrapper*       device_wrapper,
-                                                             const VulkanDeviceMemoryWrapper* memory_wrapper)
+VkMemoryPropertyFlags VulkanStateWriter::GetMemoryProperties(const vulkan_wrappers::DeviceWrapper*       device_wrapper,
+                                                             const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper)
 {
     assert((device_wrapper != nullptr) && (memory_wrapper != nullptr));
 
     VkMemoryPropertyFlags flags = 0;
 
-    const VulkanPhysicalDeviceWrapper* physical_device_wrapper = device_wrapper->physical_device;
+    const vulkan_wrappers::PhysicalDeviceWrapper* physical_device_wrapper = device_wrapper->physical_device;
     assert(physical_device_wrapper != nullptr);
 
     const VkPhysicalDeviceMemoryProperties* memory_properties = &physical_device_wrapper->memory_properties;
@@ -2964,10 +2967,10 @@ VkMemoryPropertyFlags VulkanStateWriter::GetMemoryProperties(const VulkanDeviceW
     return flags;
 }
 
-void VulkanStateWriter::InvalidateMappedMemoryRange(const VulkanDeviceWrapper* device_wrapper,
-                                                    VkDeviceMemory             memory,
-                                                    VkDeviceSize               offset,
-                                                    VkDeviceSize               size)
+void VulkanStateWriter::InvalidateMappedMemoryRange(const vulkan_wrappers::DeviceWrapper* device_wrapper,
+                                                    VkDeviceMemory                        memory,
+                                                    VkDeviceSize                          offset,
+                                                    VkDeviceSize                          size)
 {
     assert(device_wrapper != nullptr);
 
@@ -2980,7 +2983,9 @@ void VulkanStateWriter::InvalidateMappedMemoryRange(const VulkanDeviceWrapper* d
     device_wrapper->layer_table.InvalidateMappedMemoryRanges(device_wrapper->handle, 1, &invalidate_range);
 }
 
-void VulkanStateWriter::GetFenceStatus(const VulkanDeviceWrapper* device_wrapper, VkFence fence, bool* status)
+void VulkanStateWriter::GetFenceStatus(const vulkan_wrappers::DeviceWrapper* device_wrapper,
+                                       VkFence                               fence,
+                                       bool*                                 status)
 {
     assert(device_wrapper != nullptr);
 
@@ -2988,15 +2993,15 @@ void VulkanStateWriter::GetFenceStatus(const VulkanDeviceWrapper* device_wrapper
     (*status)       = (result == VK_SUCCESS);
 }
 
-bool VulkanStateWriter::CheckCommandHandles(const VulkanCommandBufferWrapper* wrapper,
-                                            const VulkanStateTable&           state_table)
+bool VulkanStateWriter::CheckCommandHandles(const vulkan_wrappers::CommandBufferWrapper* wrapper,
+                                            const VulkanStateTable&                      state_table)
 {
     // Ignore commands that reference destroyed objects.
-    for (uint32_t i = 0; i < CommandHandleType::NumHandleTypes; ++i)
+    for (uint32_t i = 0; i < vulkan_state_info::CommandHandleType::NumHandleTypes; ++i)
     {
         for (auto id : wrapper->command_handles[i])
         {
-            if (!CheckCommandHandle(static_cast<CommandHandleType>(i), id, state_table))
+            if (!CheckCommandHandle(static_cast<vulkan_state_info::CommandHandleType>(i), id, state_table))
             {
                 return false;
             }
@@ -3006,56 +3011,56 @@ bool VulkanStateWriter::CheckCommandHandles(const VulkanCommandBufferWrapper* wr
     return true;
 }
 
-bool VulkanStateWriter::CheckCommandHandle(CommandHandleType       handle_type,
-                                           format::HandleId        handle_id,
-                                           const VulkanStateTable& state_table)
+bool VulkanStateWriter::CheckCommandHandle(vulkan_state_info::CommandHandleType handle_type,
+                                           format::HandleId                     handle_id,
+                                           const VulkanStateTable&              state_table)
 {
     switch (handle_type)
     {
-        case CommandHandleType::BufferHandle:
+        case vulkan_state_info::CommandHandleType::BufferHandle:
             return IsBufferValid(handle_id, state_table);
-        case CommandHandleType::BufferViewHandle:
+        case vulkan_state_info::CommandHandleType::BufferViewHandle:
             return IsBufferViewValid(handle_id, state_table);
-        case CommandHandleType::CommandBufferHandle:
-            return (state_table.GetVulkanCommandBufferWrapper(handle_id) != nullptr);
-        case CommandHandleType::DescriptorSetHandle:
-            return (state_table.GetVulkanDescriptorSetWrapper(handle_id) != nullptr);
-        case CommandHandleType::EventHandle:
-            return (state_table.GetVulkanEventWrapper(handle_id) != nullptr);
-        case CommandHandleType::FramebufferHandle:
+        case vulkan_state_info::CommandHandleType::CommandBufferHandle:
+            return (state_table.GetCommandBufferWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::DescriptorSetHandle:
+            return (state_table.GetDescriptorSetWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::EventHandle:
+            return (state_table.GetEventWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::FramebufferHandle:
             return IsFramebufferValid(handle_id, state_table);
-        case CommandHandleType::ImageHandle:
+        case vulkan_state_info::CommandHandleType::ImageHandle:
             return IsImageValid(handle_id, state_table);
-        case CommandHandleType::ImageViewHandle:
+        case vulkan_state_info::CommandHandleType::ImageViewHandle:
             return IsImageViewValid(handle_id, state_table);
-        case CommandHandleType::PipelineHandle:
-            return (state_table.GetVulkanPipelineWrapper(handle_id) != nullptr);
-        case CommandHandleType::PipelineLayoutHandle:
-            return (state_table.GetVulkanPipelineLayoutWrapper(handle_id) != nullptr);
-        case CommandHandleType::QueryPoolHandle:
-            return (state_table.GetVulkanQueryPoolWrapper(handle_id) != nullptr);
-        case CommandHandleType::RenderPassHandle:
-            return (state_table.GetVulkanRenderPassWrapper(handle_id) != nullptr);
-        case CommandHandleType::SamplerHandle:
-            return (state_table.GetVulkanSamplerWrapper(handle_id) != nullptr);
-        case CommandHandleType::AccelerationStructureNVHandle:
-            return (state_table.GetVulkanAccelerationStructureNVWrapper(handle_id) != nullptr);
-        case CommandHandleType::AccelerationStructureKHRHandle:
-            return (state_table.GetVulkanAccelerationStructureKHRWrapper(handle_id) != nullptr);
-        case CommandHandleType::IndirectCommandsLayoutNVHandle:
-            return (state_table.GetVulkanIndirectCommandsLayoutNVWrapper(handle_id) != nullptr);
-        case CommandHandleType::DeferredOperationKHRHandle:
-            return (state_table.GetVulkanDeferredOperationKHRWrapper(handle_id) != nullptr);
-        case CommandHandleType::MicromapEXTHandle:
-            return (state_table.GetVulkanMicromapEXTWrapper(handle_id) != nullptr);
-        case CommandHandleType::OpticalFlowSessionNVHandle:
-            return (state_table.GetVulkanOpticalFlowSessionNVWrapper(handle_id) != nullptr);
-        case CommandHandleType::VideoSessionKHRHandle:
-            return (state_table.GetVulkanVideoSessionKHRWrapper(handle_id) != nullptr);
-        case CommandHandleType::VideoSessionParametersKHRHandle:
-            return (state_table.GetVulkanVideoSessionParametersKHRWrapper(handle_id) != nullptr);
-        case CommandHandleType::ShaderEXTHandle:
-            return (state_table.GetVulkanShaderEXTWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::PipelineHandle:
+            return (state_table.GetPipelineWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::PipelineLayoutHandle:
+            return (state_table.GetPipelineLayoutWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::QueryPoolHandle:
+            return (state_table.GetQueryPoolWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::RenderPassHandle:
+            return (state_table.GetRenderPassWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::SamplerHandle:
+            return (state_table.GetSamplerWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle:
+            return (state_table.GetAccelerationStructureNVWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle:
+            return (state_table.GetAccelerationStructureKHRWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::IndirectCommandsLayoutNVHandle:
+            return (state_table.GetIndirectCommandsLayoutNVWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::DeferredOperationKHRHandle:
+            return (state_table.GetDeferredOperationKHRWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::MicromapEXTHandle:
+            return (state_table.GetMicromapEXTWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::OpticalFlowSessionNVHandle:
+            return (state_table.GetOpticalFlowSessionNVWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::VideoSessionKHRHandle:
+            return (state_table.GetVideoSessionKHRWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::VideoSessionParametersKHRHandle:
+            return (state_table.GetVideoSessionParametersKHRWrapper(handle_id) != nullptr);
+        case vulkan_state_info::CommandHandleType::ShaderEXTHandle:
+            return (state_table.GetShaderEXTWrapper(handle_id) != nullptr);
         default:
             GFXRECON_LOG_ERROR("State write is skipping unrecognized handle type when checking handles "
                                "referenced by command buffers");
@@ -3064,10 +3069,10 @@ bool VulkanStateWriter::CheckCommandHandle(CommandHandleType       handle_type,
     }
 }
 
-bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor,
-                                              uint32_t                index,
-                                              const VulkanStateTable& state_table,
-                                              VkDescriptorType*       descriptor_type)
+bool VulkanStateWriter::CheckDescriptorStatus(const vulkan_state_info::DescriptorInfo* descriptor,
+                                              uint32_t                                 index,
+                                              const VulkanStateTable&                  state_table,
+                                              VkDescriptorType*                        descriptor_type)
 {
     bool valid = false;
 
@@ -3087,14 +3092,14 @@ bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor
         switch (*descriptor_type)
         {
             case VK_DESCRIPTOR_TYPE_SAMPLER:
-                if (state_table.GetVulkanSamplerWrapper(descriptor->sampler_ids[index]) != nullptr)
+                if (state_table.GetSamplerWrapper(descriptor->sampler_ids[index]) != nullptr)
                 {
                     valid = true;
                 }
                 break;
             case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
                 if ((descriptor->immutable_samplers ||
-                     (state_table.GetVulkanSamplerWrapper(descriptor->sampler_ids[index]) != nullptr)) &&
+                     (state_table.GetSamplerWrapper(descriptor->sampler_ids[index]) != nullptr)) &&
                     IsImageViewValid(descriptor->handle_ids[index], state_table))
                 {
                     valid = true;
@@ -3133,7 +3138,7 @@ bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor
                 GFXRECON_LOG_WARNING("Descriptor type acceleration structure NV is not currently supported");
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-                if (state_table.GetVulkanAccelerationStructureKHRWrapper(descriptor->handle_ids[index]) != nullptr)
+                if (state_table.GetAccelerationStructureKHRWrapper(descriptor->handle_ids[index]) != nullptr)
                 {
                     valid = true;
                 }
@@ -3153,13 +3158,13 @@ bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor
 bool VulkanStateWriter::IsBufferValid(format::HandleId buffer_id, const VulkanStateTable& state_table)
 {
     bool valid          = false;
-    auto buffer_wrapper = state_table.GetVulkanBufferWrapper(buffer_id);
+    auto buffer_wrapper = state_table.GetBufferWrapper(buffer_id);
 
     if (buffer_wrapper != nullptr)
     {
         format::HandleId memory_id = buffer_wrapper->bind_memory_id;
 
-        if ((memory_id == 0) || (state_table.GetVulkanDeviceMemoryWrapper(memory_id) != nullptr))
+        if ((memory_id == 0) || (state_table.GetDeviceMemoryWrapper(memory_id) != nullptr))
         {
             valid = true;
         }
@@ -3171,7 +3176,7 @@ bool VulkanStateWriter::IsBufferValid(format::HandleId buffer_id, const VulkanSt
 bool VulkanStateWriter::IsBufferViewValid(format::HandleId view_id, const VulkanStateTable& state_table)
 {
     bool valid               = false;
-    auto buffer_view_wrapper = state_table.GetVulkanBufferViewWrapper(view_id);
+    auto buffer_view_wrapper = state_table.GetBufferViewWrapper(view_id);
 
     if (buffer_view_wrapper != nullptr)
     {
@@ -3184,13 +3189,13 @@ bool VulkanStateWriter::IsBufferViewValid(format::HandleId view_id, const Vulkan
 bool VulkanStateWriter::IsImageValid(format::HandleId image_id, const VulkanStateTable& state_table)
 {
     bool valid         = false;
-    auto image_wrapper = state_table.GetVulkanImageWrapper(image_id);
+    auto image_wrapper = state_table.GetImageWrapper(image_id);
 
     if (image_wrapper != nullptr)
     {
         format::HandleId memory_id = image_wrapper->bind_memory_id;
 
-        if ((memory_id == 0) || (state_table.GetVulkanDeviceMemoryWrapper(memory_id) != nullptr))
+        if ((memory_id == 0) || (state_table.GetDeviceMemoryWrapper(memory_id) != nullptr))
         {
             valid = true;
         }
@@ -3202,7 +3207,7 @@ bool VulkanStateWriter::IsImageValid(format::HandleId image_id, const VulkanStat
 bool VulkanStateWriter::IsImageViewValid(format::HandleId view_id, const VulkanStateTable& state_table)
 {
     bool valid              = false;
-    auto image_view_wrapper = state_table.GetVulkanImageViewWrapper(view_id);
+    auto image_view_wrapper = state_table.GetImageViewWrapper(view_id);
 
     if (image_view_wrapper != nullptr)
     {
@@ -3215,7 +3220,7 @@ bool VulkanStateWriter::IsImageViewValid(format::HandleId view_id, const VulkanS
 bool VulkanStateWriter::IsFramebufferValid(format::HandleId framebuffer_id, const VulkanStateTable& state_table)
 {
     bool valid               = false;
-    auto framebuffer_wrapper = state_table.GetVulkanFramebufferWrapper(framebuffer_id);
+    auto framebuffer_wrapper = state_table.GetFramebufferWrapper(framebuffer_id);
 
     if (framebuffer_wrapper != nullptr)
     {
@@ -3225,8 +3230,8 @@ bool VulkanStateWriter::IsFramebufferValid(format::HandleId framebuffer_id, cons
     return valid;
 }
 
-bool VulkanStateWriter::IsFramebufferValid(const VulkanFramebufferWrapper* framebuffer_wrapper,
-                                           const VulkanStateTable&         state_table)
+bool VulkanStateWriter::IsFramebufferValid(const vulkan_wrappers::FramebufferWrapper* framebuffer_wrapper,
+                                           const VulkanStateTable&                    state_table)
 {
     bool valid = true;
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -549,7 +549,7 @@ void VulkanStateWriter::WritePipelineLayoutState(const VulkanStateTable& state_t
 
 void VulkanStateWriter::WritePipelineCacheState(const VulkanStateTable& state_table)
 {
-    state_table.VisitWrappers([&](const PipelineCacheWrapper* wrapper) {
+    state_table.VisitWrappers([&](const vulkan_wrappers::PipelineCacheWrapper* wrapper) {
         GFXRECON_ASSERT(wrapper != nullptr);
 
         // Pipeline cache data can be indirectly changed by pipeline creation command or directly changed by calls like
@@ -562,23 +562,24 @@ void VulkanStateWriter::WritePipelineCacheState(const VulkanStateTable& state_ta
 
         if (data_size != 0)
         {
-            const_cast<PipelineCacheWrapper*>(wrapper)->cache_data.resize(data_size);
+            const_cast<vulkan_wrappers::PipelineCacheWrapper*>(wrapper)->cache_data.resize(data_size);
 
             result = wrapper->device->layer_table.GetPipelineCacheData(
                 wrapper->device->handle,
                 wrapper->handle,
                 &data_size,
-                const_cast<PipelineCacheWrapper*>(wrapper)->cache_data.data());
+                const_cast<vulkan_wrappers::PipelineCacheWrapper*>(wrapper)->cache_data.data());
 
             GFXRECON_ASSERT(result == VK_SUCCESS);
 
-            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.initialDataSize = data_size;
-            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.pInitialData    = wrapper->cache_data.data();
+            const_cast<vulkan_wrappers::PipelineCacheWrapper*>(wrapper)->create_info.initialDataSize = data_size;
+            const_cast<vulkan_wrappers::PipelineCacheWrapper*>(wrapper)->create_info.pInitialData =
+                wrapper->cache_data.data();
         }
         else
         {
-            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.initialDataSize = 0;
-            const_cast<PipelineCacheWrapper*>(wrapper)->create_info.pInitialData    = nullptr;
+            const_cast<vulkan_wrappers::PipelineCacheWrapper*>(wrapper)->create_info.initialDataSize = 0;
+            const_cast<vulkan_wrappers::PipelineCacheWrapper*>(wrapper)->create_info.pInitialData    = nullptr;
         }
 
         WriteCreatePipelineCache(wrapper->device->handle_id,
@@ -2581,7 +2582,7 @@ void VulkanStateWriter::WriteCreatePipelineCache(format::HandleId               
     {
         omit_output_data = true;
     }
-    encoder_.EncodeHandlePtr<PipelineCacheWrapper>(pPipelineCache, omit_output_data);
+    encoder_.EncodeHandlePtr<vulkan_wrappers::PipelineCacheWrapper>(pPipelineCache, omit_output_data);
     encoder_.EncodeEnumValue(result);
     WriteFunctionCall(call_id, &parameter_stream_);
     parameter_stream_.Reset();

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -58,16 +58,16 @@ class VulkanStateWriter
     // Data structures for processing resource memory snapshots.
     struct BufferSnapshotInfo
     {
-        const VulkanBufferWrapper*       buffer_wrapper{ nullptr };
-        const VulkanDeviceMemoryWrapper* memory_wrapper{ nullptr };
+        const vulkan_wrappers::BufferWrapper*       buffer_wrapper{ nullptr };
+        const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper{ nullptr };
         VkMemoryPropertyFlags            memory_properties{};
         bool                             need_staging_copy{ false };
     };
 
     struct ImageSnapshotInfo
     {
-        const VulkanImageWrapper*        image_wrapper{ nullptr };
-        const VulkanDeviceMemoryWrapper* memory_wrapper{ nullptr };
+        const vulkan_wrappers::ImageWrapper*        image_wrapper{ nullptr };
+        const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper{ nullptr };
         VkMemoryPropertyFlags            memory_properties{};
         bool                             need_staging_copy{ false };
         VkImageAspectFlagBits            aspect{};
@@ -82,7 +82,8 @@ class VulkanStateWriter
     };
 
     typedef std::unordered_map<uint32_t, ResourceSnapshotInfo> ResourceSnapshotQueueFamilyTable;
-    typedef std::unordered_map<const VulkanDeviceWrapper*, ResourceSnapshotQueueFamilyTable> DeviceResourceTables;
+    typedef std::unordered_map<const vulkan_wrappers::DeviceWrapper*, ResourceSnapshotQueueFamilyTable>
+        DeviceResourceTables;
 
     struct QueryActivationData
     {
@@ -144,11 +145,11 @@ class VulkanStateWriter
     void
     ProcessHardwareBuffer(format::HandleId memory_id, AHardwareBuffer* hardware_buffer, VkDeviceSize allocation_size);
 
-    void ProcessBufferMemory(const VulkanDeviceWrapper*             device_wrapper,
+    void ProcessBufferMemory(const vulkan_wrappers::DeviceWrapper*  device_wrapper,
                              const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
                              graphics::VulkanResourcesUtil&         resource_util);
 
-    void ProcessImageMemory(const VulkanDeviceWrapper*            device_wrapper,
+    void ProcessImageMemory(const vulkan_wrappers::DeviceWrapper* device_wrapper,
                             const std::vector<ImageSnapshotInfo>& image_snapshot_info,
                             graphics::VulkanResourcesUtil&        resource_util);
 
@@ -162,7 +163,8 @@ class VulkanStateWriter
                                VkDeviceSize*           max_resource_size,
                                VkDeviceSize*           max_staging_copy_size);
 
-    void WriteImageSubresourceLayouts(const VulkanImageWrapper* image_wrapper, VkImageAspectFlags aspect_flags);
+    void WriteImageSubresourceLayouts(const vulkan_wrappers::ImageWrapper* image_wrapper,
+                                      VkImageAspectFlags                   aspect_flags);
 
     void WriteResourceMemoryState(const VulkanStateTable& state_table);
 
@@ -170,7 +172,7 @@ class VulkanStateWriter
 
     void WriteSwapchainImageState(const VulkanStateTable& state_table);
 
-    void WritePhysicalDevicePropertiesMetaData(const VulkanPhysicalDeviceWrapper* physical_device_wrapper);
+    void WritePhysicalDevicePropertiesMetaData(const vulkan_wrappers::PhysicalDeviceWrapper* physical_device_wrapper);
 
     template <typename T>
     void WriteGetPhysicalDeviceQueueFamilyProperties(format::ApiCallId call_id,
@@ -183,25 +185,25 @@ class VulkanStateWriter
                                               format::HandleId surface_id,
                                               VkBool32         supported);
 
-    void WriteGetPhysicalDeviceSurfaceCapabilities(format::HandleId                 physical_device_id,
-                                                   format::HandleId                 surface_id,
-                                                   const VulkanSurfaceCapabilities& capabilities,
-                                                   const VulkanStateTable&          state_table);
+    void WriteGetPhysicalDeviceSurfaceCapabilities(format::HandleId                            physical_device_id,
+                                                   format::HandleId                            surface_id,
+                                                   const vulkan_wrappers::SurfaceCapabilities& capabilities,
+                                                   const VulkanStateTable&                     state_table);
 
-    void WriteGetPhysicalDeviceSurfaceFormats(format::HandleId            physical_device_id,
-                                              format::HandleId            surface_id,
-                                              const VulkanSurfaceFormats& formats,
-                                              const VulkanStateTable&     state_table);
+    void WriteGetPhysicalDeviceSurfaceFormats(format::HandleId                       physical_device_id,
+                                              format::HandleId                       surface_id,
+                                              const vulkan_wrappers::SurfaceFormats& formats,
+                                              const VulkanStateTable&                state_table);
 
-    void WriteGetPhysicalDeviceSurfacePresentModes(format::HandleId                 physical_device_id,
-                                                   format::HandleId                 surface_id,
-                                                   const VulkanSurfacePresentModes& present_modes,
-                                                   const VulkanStateTable&          state_table);
+    void WriteGetPhysicalDeviceSurfacePresentModes(format::HandleId                            physical_device_id,
+                                                   format::HandleId                            surface_id,
+                                                   const vulkan_wrappers::SurfacePresentModes& present_modes,
+                                                   const VulkanStateTable&                     state_table);
 
-    void WriteGetDeviceGroupSurfacePresentModes(format::HandleId                      device_id,
-                                                format::HandleId                      surface_id,
-                                                const VulkanGroupSurfacePresentModes& present_modes,
-                                                const VulkanStateTable&               state_table);
+    void WriteGetDeviceGroupSurfacePresentModes(format::HandleId                                 device_id,
+                                                format::HandleId                                 surface_id,
+                                                const vulkan_wrappers::GroupSurfacePresentModes& present_modes,
+                                                const VulkanStateTable&                          state_table);
 
     void WriteCommandProcessingCreateCommands(format::HandleId device_id,
                                               uint32_t         queue_family_index,
@@ -227,14 +229,15 @@ class VulkanStateWriter
         WriteCommandExecution(queue_id, 1, &command_buffer_id, 0, nullptr, 0, nullptr, nullptr);
     }
 
-    void WriteCommandBufferCommands(const VulkanCommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
+    void WriteCommandBufferCommands(const vulkan_wrappers::CommandBufferWrapper* wrapper,
+                                    const VulkanStateTable&                      state_table);
 
-    void WriteDescriptorUpdateCommand(format::HandleId      device_id,
-                                      const DescriptorInfo* binding,
-                                      VkWriteDescriptorSet* write);
+    void WriteDescriptorUpdateCommand(format::HandleId                         device_id,
+                                      const vulkan_state_info::DescriptorInfo* binding,
+                                      VkWriteDescriptorSet*                    write);
 
-    void WriteQueryPoolReset(format::HandleId                                  device_id,
-                             const std::vector<const VulkanQueryPoolWrapper*>& query_pool_wrappers);
+    void WriteQueryPoolReset(format::HandleId                                             device_id,
+                             const std::vector<const vulkan_wrappers::QueryPoolWrapper*>& query_pool_wrappers);
 
     void WriteQueryActivation(format::HandleId           device_id,
                               uint32_t                   queue_family_index,
@@ -307,25 +310,26 @@ class VulkanStateWriter
         });
     }
 
-    VkMemoryPropertyFlags GetMemoryProperties(const VulkanDeviceWrapper*       device_wrapper,
-                                              const VulkanDeviceMemoryWrapper* memory_wrapper);
+    VkMemoryPropertyFlags GetMemoryProperties(const vulkan_wrappers::DeviceWrapper*       device_wrapper,
+                                              const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper);
 
-    void InvalidateMappedMemoryRange(const VulkanDeviceWrapper* device_wrapper,
-                                     VkDeviceMemory             memory,
-                                     VkDeviceSize               offset,
-                                     VkDeviceSize               size);
+    void InvalidateMappedMemoryRange(const vulkan_wrappers::DeviceWrapper* device_wrapper,
+                                     VkDeviceMemory                        memory,
+                                     VkDeviceSize                          offset,
+                                     VkDeviceSize                          size);
 
-    void GetFenceStatus(const VulkanDeviceWrapper* device_wrapper, VkFence fence, bool* result);
+    void GetFenceStatus(const vulkan_wrappers::DeviceWrapper* device_wrapper, VkFence fence, bool* result);
 
-    bool CheckCommandHandles(const VulkanCommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
+    bool CheckCommandHandles(const vulkan_wrappers::CommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
 
-    bool
-    CheckCommandHandle(CommandHandleType handle_type, format::HandleId handle, const VulkanStateTable& state_table);
+    bool CheckCommandHandle(vulkan_state_info::CommandHandleType handle_type,
+                            format::HandleId                     handle,
+                            const VulkanStateTable&              state_table);
 
-    bool CheckDescriptorStatus(const DescriptorInfo*   descriptor,
-                               uint32_t                index,
-                               const VulkanStateTable& state_table,
-                               VkDescriptorType*       descriptor_type);
+    bool CheckDescriptorStatus(const vulkan_state_info::DescriptorInfo* descriptor,
+                               uint32_t                                 index,
+                               const VulkanStateTable&                  state_table,
+                               VkDescriptorType*                        descriptor_type);
 
     bool IsBufferValid(format::HandleId buffer_id, const VulkanStateTable& state_table);
 
@@ -337,7 +341,8 @@ class VulkanStateWriter
 
     bool IsFramebufferValid(format::HandleId framebuffer_id, const VulkanStateTable& state_table);
 
-    bool IsFramebufferValid(const VulkanFramebufferWrapper* framebuffer_wrapper, const VulkanStateTable& state_table);
+    bool IsFramebufferValid(const vulkan_wrappers::FramebufferWrapper* framebuffer_wrapper,
+                            const VulkanStateTable&                    state_table);
 
     void WriteTlasToBlasDependenciesMetadata(const VulkanStateTable& state_table);
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -58,21 +58,21 @@ class VulkanStateWriter
     // Data structures for processing resource memory snapshots.
     struct BufferSnapshotInfo
     {
-        const BufferWrapper*       buffer_wrapper{ nullptr };
-        const DeviceMemoryWrapper* memory_wrapper{ nullptr };
-        VkMemoryPropertyFlags      memory_properties{};
-        bool                       need_staging_copy{ false };
+        const VulkanBufferWrapper*       buffer_wrapper{ nullptr };
+        const VulkanDeviceMemoryWrapper* memory_wrapper{ nullptr };
+        VkMemoryPropertyFlags            memory_properties{};
+        bool                             need_staging_copy{ false };
     };
 
     struct ImageSnapshotInfo
     {
-        const ImageWrapper*        image_wrapper{ nullptr };
-        const DeviceMemoryWrapper* memory_wrapper{ nullptr };
-        VkMemoryPropertyFlags      memory_properties{};
-        bool                       need_staging_copy{ false };
-        VkImageAspectFlagBits      aspect{};
-        VkDeviceSize               resource_size{ 0 }; // Combined size of all sub-resources.
-        std::vector<uint64_t>      level_sizes;        // Combined size of all layers in a mip level.
+        const VulkanImageWrapper*        image_wrapper{ nullptr };
+        const VulkanDeviceMemoryWrapper* memory_wrapper{ nullptr };
+        VkMemoryPropertyFlags            memory_properties{};
+        bool                             need_staging_copy{ false };
+        VkImageAspectFlagBits            aspect{};
+        VkDeviceSize                     resource_size{ 0 }; // Combined size of all sub-resources.
+        std::vector<uint64_t>            level_sizes;        // Combined size of all layers in a mip level.
     };
 
     struct ResourceSnapshotInfo
@@ -81,8 +81,8 @@ class VulkanStateWriter
         std::vector<ImageSnapshotInfo>  images;
     };
 
-    typedef std::unordered_map<uint32_t, ResourceSnapshotInfo>                         ResourceSnapshotQueueFamilyTable;
-    typedef std::unordered_map<const DeviceWrapper*, ResourceSnapshotQueueFamilyTable> DeviceResourceTables;
+    typedef std::unordered_map<uint32_t, ResourceSnapshotInfo> ResourceSnapshotQueueFamilyTable;
+    typedef std::unordered_map<const VulkanDeviceWrapper*, ResourceSnapshotQueueFamilyTable> DeviceResourceTables;
 
     struct QueryActivationData
     {
@@ -144,11 +144,11 @@ class VulkanStateWriter
     void
     ProcessHardwareBuffer(format::HandleId memory_id, AHardwareBuffer* hardware_buffer, VkDeviceSize allocation_size);
 
-    void ProcessBufferMemory(const DeviceWrapper*                   device_wrapper,
+    void ProcessBufferMemory(const VulkanDeviceWrapper*             device_wrapper,
                              const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
                              graphics::VulkanResourcesUtil&         resource_util);
 
-    void ProcessImageMemory(const DeviceWrapper*                  device_wrapper,
+    void ProcessImageMemory(const VulkanDeviceWrapper*            device_wrapper,
                             const std::vector<ImageSnapshotInfo>& image_snapshot_info,
                             graphics::VulkanResourcesUtil&        resource_util);
 
@@ -162,7 +162,7 @@ class VulkanStateWriter
                                VkDeviceSize*           max_resource_size,
                                VkDeviceSize*           max_staging_copy_size);
 
-    void WriteImageSubresourceLayouts(const ImageWrapper* image_wrapper, VkImageAspectFlags aspect_flags);
+    void WriteImageSubresourceLayouts(const VulkanImageWrapper* image_wrapper, VkImageAspectFlags aspect_flags);
 
     void WriteResourceMemoryState(const VulkanStateTable& state_table);
 
@@ -170,7 +170,7 @@ class VulkanStateWriter
 
     void WriteSwapchainImageState(const VulkanStateTable& state_table);
 
-    void WritePhysicalDevicePropertiesMetaData(const PhysicalDeviceWrapper* physical_device_wrapper);
+    void WritePhysicalDevicePropertiesMetaData(const VulkanPhysicalDeviceWrapper* physical_device_wrapper);
 
     template <typename T>
     void WriteGetPhysicalDeviceQueueFamilyProperties(format::ApiCallId call_id,
@@ -183,25 +183,25 @@ class VulkanStateWriter
                                               format::HandleId surface_id,
                                               VkBool32         supported);
 
-    void WriteGetPhysicalDeviceSurfaceCapabilities(format::HandleId           physical_device_id,
-                                                   format::HandleId           surface_id,
-                                                   const SurfaceCapabilities& capabilities,
-                                                   const VulkanStateTable&    state_table);
+    void WriteGetPhysicalDeviceSurfaceCapabilities(format::HandleId                 physical_device_id,
+                                                   format::HandleId                 surface_id,
+                                                   const VulkanSurfaceCapabilities& capabilities,
+                                                   const VulkanStateTable&          state_table);
 
-    void WriteGetPhysicalDeviceSurfaceFormats(format::HandleId        physical_device_id,
-                                              format::HandleId        surface_id,
-                                              const SurfaceFormats&   formats,
-                                              const VulkanStateTable& state_table);
+    void WriteGetPhysicalDeviceSurfaceFormats(format::HandleId            physical_device_id,
+                                              format::HandleId            surface_id,
+                                              const VulkanSurfaceFormats& formats,
+                                              const VulkanStateTable&     state_table);
 
-    void WriteGetPhysicalDeviceSurfacePresentModes(format::HandleId           physical_device_id,
-                                                   format::HandleId           surface_id,
-                                                   const SurfacePresentModes& present_modes,
-                                                   const VulkanStateTable&    state_table);
+    void WriteGetPhysicalDeviceSurfacePresentModes(format::HandleId                 physical_device_id,
+                                                   format::HandleId                 surface_id,
+                                                   const VulkanSurfacePresentModes& present_modes,
+                                                   const VulkanStateTable&          state_table);
 
-    void WriteGetDeviceGroupSurfacePresentModes(format::HandleId                device_id,
-                                                format::HandleId                surface_id,
-                                                const GroupSurfacePresentModes& present_modes,
-                                                const VulkanStateTable&         state_table);
+    void WriteGetDeviceGroupSurfacePresentModes(format::HandleId                      device_id,
+                                                format::HandleId                      surface_id,
+                                                const VulkanGroupSurfacePresentModes& present_modes,
+                                                const VulkanStateTable&               state_table);
 
     void WriteCommandProcessingCreateCommands(format::HandleId device_id,
                                               uint32_t         queue_family_index,
@@ -227,14 +227,14 @@ class VulkanStateWriter
         WriteCommandExecution(queue_id, 1, &command_buffer_id, 0, nullptr, 0, nullptr, nullptr);
     }
 
-    void WriteCommandBufferCommands(const CommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
+    void WriteCommandBufferCommands(const VulkanCommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
 
     void WriteDescriptorUpdateCommand(format::HandleId      device_id,
                                       const DescriptorInfo* binding,
                                       VkWriteDescriptorSet* write);
 
-    void WriteQueryPoolReset(format::HandleId                            device_id,
-                             const std::vector<const QueryPoolWrapper*>& query_pool_wrappers);
+    void WriteQueryPoolReset(format::HandleId                                  device_id,
+                             const std::vector<const VulkanQueryPoolWrapper*>& query_pool_wrappers);
 
     void WriteQueryActivation(format::HandleId           device_id,
                               uint32_t                   queue_family_index,
@@ -307,17 +307,17 @@ class VulkanStateWriter
         });
     }
 
-    VkMemoryPropertyFlags GetMemoryProperties(const DeviceWrapper*       device_wrapper,
-                                              const DeviceMemoryWrapper* memory_wrapper);
+    VkMemoryPropertyFlags GetMemoryProperties(const VulkanDeviceWrapper*       device_wrapper,
+                                              const VulkanDeviceMemoryWrapper* memory_wrapper);
 
-    void InvalidateMappedMemoryRange(const DeviceWrapper* device_wrapper,
-                                     VkDeviceMemory       memory,
-                                     VkDeviceSize         offset,
-                                     VkDeviceSize         size);
+    void InvalidateMappedMemoryRange(const VulkanDeviceWrapper* device_wrapper,
+                                     VkDeviceMemory             memory,
+                                     VkDeviceSize               offset,
+                                     VkDeviceSize               size);
 
-    void GetFenceStatus(const DeviceWrapper* device_wrapper, VkFence fence, bool* result);
+    void GetFenceStatus(const VulkanDeviceWrapper* device_wrapper, VkFence fence, bool* result);
 
-    bool CheckCommandHandles(const CommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
+    bool CheckCommandHandles(const VulkanCommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
 
     bool
     CheckCommandHandle(CommandHandleType handle_type, format::HandleId handle, const VulkanStateTable& state_table);
@@ -337,7 +337,7 @@ class VulkanStateWriter
 
     bool IsFramebufferValid(format::HandleId framebuffer_id, const VulkanStateTable& state_table);
 
-    bool IsFramebufferValid(const FramebufferWrapper* framebuffer_wrapper, const VulkanStateTable& state_table);
+    bool IsFramebufferValid(const VulkanFramebufferWrapper* framebuffer_wrapper, const VulkanStateTable& state_table);
 
     void WriteTlasToBlasDependenciesMetadata(const VulkanStateTable& state_table);
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -1,25 +1,25 @@
 /*
-** Copyright (c) 2019-2021 LunarG, Inc.
-** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and associated documentation files (the "Software"),
-** to deal in the Software without restriction, including without limitation
-** the rights to use, copy, modify, merge, publish, distribute, sublicense,
-** and/or sell copies of the Software, and to permit persons to whom the
-** Software is furnished to do so, subject to the following conditions:
-**
-** The above copyright notice and this permission notice shall be included in
-** all copies or substantial portions of the Software.
-**
-** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-** DEALINGS IN THE SOFTWARE.
-*/
+ ** Copyright (c) 2019-2021 LunarG, Inc.
+ ** Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ **
+ ** Permission is hereby granted, free of charge, to any person obtaining a
+ ** copy of this software and associated documentation files (the "Software"),
+ ** to deal in the Software without restriction, including without limitation
+ ** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ ** and/or sell copies of the Software, and to permit persons to whom the
+ ** Software is furnished to do so, subject to the following conditions:
+ **
+ ** The above copyright notice and this permission notice shall be included in
+ ** all copies or substantial portions of the Software.
+ **
+ ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ ** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ ** DEALINGS IN THE SOFTWARE.
+ */
 
 #ifndef GFXRECON_ENCODE_VULKAN_STATE_WRITER_H
 #define GFXRECON_ENCODE_VULKAN_STATE_WRITER_H
@@ -60,19 +60,19 @@ class VulkanStateWriter
     {
         const vulkan_wrappers::BufferWrapper*       buffer_wrapper{ nullptr };
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper{ nullptr };
-        VkMemoryPropertyFlags            memory_properties{};
-        bool                             need_staging_copy{ false };
+        VkMemoryPropertyFlags                       memory_properties{};
+        bool                                        need_staging_copy{ false };
     };
 
     struct ImageSnapshotInfo
     {
         const vulkan_wrappers::ImageWrapper*        image_wrapper{ nullptr };
         const vulkan_wrappers::DeviceMemoryWrapper* memory_wrapper{ nullptr };
-        VkMemoryPropertyFlags            memory_properties{};
-        bool                             need_staging_copy{ false };
-        VkImageAspectFlagBits            aspect{};
-        VkDeviceSize                     resource_size{ 0 }; // Combined size of all sub-resources.
-        std::vector<uint64_t>            level_sizes;        // Combined size of all layers in a mip level.
+        VkMemoryPropertyFlags                       memory_properties{};
+        bool                                        need_staging_copy{ false };
+        VkImageAspectFlagBits                       aspect{};
+        VkDeviceSize                                resource_size{ 0 }; // Combined size of all sub-resources.
+        std::vector<uint64_t>                       level_sizes;        // Combined size of all layers in a mip level.
     };
 
     struct ResourceSnapshotInfo

--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -48,7 +48,7 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 
-const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
+const std::unordered_map<std::string, PFN_vkVoidFunction> vulkan_func_table = {
     { "vkCreateInstance",                                                                                    reinterpret_cast<PFN_vkVoidFunction>(encode::CreateInstance) },
     { "vkDestroyInstance",                                                                                   reinterpret_cast<PFN_vkVoidFunction>(encode::DestroyInstance) },
     { "vkEnumeratePhysicalDevices",                                                                          reinterpret_cast<PFN_vkVoidFunction>(encode::EnumeratePhysicalDevices) },

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -23879,13 +23879,13 @@ VKAPI_ATTR VkResult VKAPI_CALL SetLatencySleepModeNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetLatencySleepModeNV>::Dispatch(manager, device, swapchain, pSleepModeInfo);
 
-    VkResult result = GetDeviceTable(device)->SetLatencySleepModeNV(device, swapchain, pSleepModeInfo);
+    VkResult result = GetVulkanDeviceTable(device)->SetLatencySleepModeNV(device, swapchain, pSleepModeInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetLatencySleepModeNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pSleepModeInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -23920,13 +23920,13 @@ VKAPI_ATTR VkResult VKAPI_CALL LatencySleepNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkLatencySleepInfoNV* pSleepInfo_unwrapped = UnwrapStructPtrHandles(pSleepInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->LatencySleepNV(device, swapchain, pSleepInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->LatencySleepNV(device, swapchain, pSleepInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkLatencySleepNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pSleepInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -23961,13 +23961,13 @@ VKAPI_ATTR void VKAPI_CALL SetLatencyMarkerNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetLatencyMarkerNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pLatencyMarkerInfo);
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->SetLatencyMarkerNV(device, swapchain, pLatencyMarkerInfo);
+    GetVulkanDeviceTable(device)->SetLatencyMarkerNV(device, swapchain, pLatencyMarkerInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetLatencyMarkerNV>::Dispatch(manager, device, swapchain, pLatencyMarkerInfo);
 }
@@ -23993,13 +23993,13 @@ VKAPI_ATTR void VKAPI_CALL GetLatencyTimingsNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetLatencyTimingsNV>::Dispatch(manager, device, swapchain, pLatencyMarkerInfo);
 
-    GetDeviceTable(device)->GetLatencyTimingsNV(device, swapchain, pLatencyMarkerInfo);
+    GetVulkanDeviceTable(device)->GetLatencyTimingsNV(device, swapchain, pLatencyMarkerInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetLatencyTimingsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pLatencyMarkerInfo);
         manager->EndApiCallCapture();
     }
@@ -24030,12 +24030,12 @@ VKAPI_ATTR void VKAPI_CALL QueueNotifyOutOfBandNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueNotifyOutOfBandNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         EncodeStructPtr(encoder, pQueueTypeInfo);
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(queue)->QueueNotifyOutOfBandNV(queue, pQueueTypeInfo);
+    GetVulkanDeviceTable(queue)->QueueNotifyOutOfBandNV(queue, pQueueTypeInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueNotifyOutOfBandNV>::Dispatch(manager, queue, pQueueTypeInfo);
 }

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -75,9 +75,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
     {
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanInstanceWrapper>(pInstance, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::InstanceWrapper>(pInstance, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndCreateApiCallCapture<const void*, VulkanInstanceWrapper, VkInstanceCreateInfo>(result, nullptr, pInstance, pCreateInfo);
+        VulkanCaptureManager::Get()->EndCreateApiCallCapture<const void*, vulkan_wrappers::InstanceWrapper, VkInstanceCreateInfo>(result, nullptr, pInstance, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateInstance>::Dispatch(VulkanCaptureManager::Get(), result, pCreateInfo, pAllocator, pInstance);
@@ -108,9 +108,9 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyInstance);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanInstanceWrapper>(instance);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::InstanceWrapper>(instance);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -118,7 +118,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(manager, instance, pAllocator);
 
-    DestroyWrappedHandle<VulkanInstanceWrapper>(instance);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper>(instance);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
@@ -148,7 +148,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanPhysicalDeviceWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandles<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::PhysicalDeviceWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -158,11 +158,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceCount, omit_output_data);
-        encoder->EncodeHandleArray<VulkanPhysicalDeviceWrapper>(pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::PhysicalDeviceWrapper>(pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkInstance, void*, VulkanPhysicalDeviceWrapper, void>(result, instance, nullptr, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr);
+        manager->EndGroupCreateApiCallCapture<VkInstance, void*, vulkan_wrappers::PhysicalDeviceWrapper, void>(result, instance, nullptr, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices>::Dispatch(manager, result, instance, pPhysicalDeviceCount, pPhysicalDevices);
@@ -195,7 +195,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFeatures);
         manager->EndApiCallCapture();
     }
@@ -229,7 +229,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         EncodeStructPtr(encoder, pFormatProperties);
         manager->EndApiCallCapture();
@@ -274,7 +274,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         encoder->EncodeEnumValue(type);
         encoder->EncodeEnumValue(tiling);
@@ -315,7 +315,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pProperties);
         manager->EndApiCallCapture();
     }
@@ -349,7 +349,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
         EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         manager->EndApiCallCapture();
@@ -383,7 +383,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pMemoryProperties);
         manager->EndApiCallCapture();
     }
@@ -424,12 +424,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDevice);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDeviceWrapper>(pDevice, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DeviceWrapper>(pDevice, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDeviceWrapper, VkDeviceCreateInfo>(result, physicalDevice, pDevice, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DeviceWrapper, VkDeviceCreateInfo>(result, physicalDevice, pDevice, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDevice>::Dispatch(manager, result, physicalDevice, pCreateInfo, pAllocator, pDevice);
@@ -460,9 +460,9 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDevice);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDeviceWrapper>(device);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DeviceWrapper>(device);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -470,7 +470,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(manager, device, pAllocator);
 
-    DestroyWrappedHandle<VulkanDeviceWrapper>(device);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper>(device);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
@@ -497,16 +497,16 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
 
     GetVulkanDeviceTable(device)->GetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue);
 
-    CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanQueueWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
+    CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::QueueWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceQueue);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeUInt32Value(queueIndex);
-        encoder->EncodeHandlePtr<VulkanQueueWrapper>(pQueue);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanQueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
+        encoder->EncodeHandlePtr<vulkan_wrappers::QueueWrapper>(pQueue);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::QueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDeviceQueue>::Dispatch(manager, device, queueFamilyIndex, queueIndex, pQueue);
@@ -542,10 +542,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         encoder->EncodeUInt32Value(submitCount);
         EncodeStructArray(encoder, pSubmits, submitCount);
-        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
+        encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -579,7 +579,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueWaitIdle(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueWaitIdle);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -613,7 +613,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DeviceWaitIdle(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDeviceWaitIdle);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -656,12 +656,12 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAllocateMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDeviceMemoryWrapper>(pMemory, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DeviceMemoryWrapper>(pMemory, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanDeviceMemoryWrapper, VkMemoryAllocateInfo>(result, device, pMemory, pAllocateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::DeviceMemoryWrapper, VkMemoryAllocateInfo>(result, device, pMemory, pAllocateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateMemory>::Dispatch(manager, result, device, pAllocateInfo, pAllocator, pMemory);
@@ -693,10 +693,10 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDeviceMemoryWrapper>(memory);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DeviceMemoryWrapper>(memory);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -704,7 +704,7 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(manager, device, memory, pAllocator);
 
-    DestroyWrappedHandle<VulkanDeviceMemoryWrapper>(memory);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DeviceMemoryWrapper>(memory);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
@@ -742,8 +742,8 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMapMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeVkDeviceSizeValue(size);
         encoder->EncodeFlagsValue(flags);
@@ -780,8 +780,8 @@ VKAPI_ATTR void VKAPI_CALL UnmapMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUnmapMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         manager->EndApiCallCapture();
     }
 
@@ -819,7 +819,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FlushMappedMemoryRanges(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkFlushMappedMemoryRanges);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(memoryRangeCount);
         EncodeStructArray(encoder, pMemoryRanges, memoryRangeCount);
         encoder->EncodeEnumValue(result);
@@ -860,7 +860,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkInvalidateMappedMemoryRanges);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(memoryRangeCount);
         EncodeStructArray(encoder, pMemoryRanges, memoryRangeCount);
         encoder->EncodeEnumValue(result);
@@ -898,8 +898,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMemoryCommitment(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryCommitment);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizePtr(pCommittedMemoryInBytes);
         manager->EndApiCallCapture();
     }
@@ -934,9 +934,9 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizeValue(memoryOffset);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -974,9 +974,9 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizeValue(memoryOffset);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -1013,8 +1013,8 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
     }
@@ -1048,8 +1048,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
     }
@@ -1084,8 +1084,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
         manager->EndApiCallCapture();
@@ -1125,7 +1125,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         encoder->EncodeEnumValue(type);
         encoder->EncodeEnumValue(samples);
@@ -1169,10 +1169,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueBindSparse);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfo, bindInfoCount);
-        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
+        encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1210,7 +1210,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanFenceWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::FenceWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1220,12 +1220,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateFence);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanFenceWrapper>(pFence, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::FenceWrapper>(pFence, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanFenceWrapper, VkFenceCreateInfo>(result, device, pFence, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::FenceWrapper, VkFenceCreateInfo>(result, device, pFence, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFence>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pFence);
@@ -1257,10 +1257,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyFence);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanFenceWrapper>(fence);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::FenceWrapper>(fence);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1268,7 +1268,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(manager, device, fence, pAllocator);
 
-    DestroyWrappedHandle<VulkanFenceWrapper>(fence);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::FenceWrapper>(fence);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
@@ -1297,9 +1297,9 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetFences);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(fenceCount);
-        encoder->EncodeHandleArray<VulkanFenceWrapper>(pFences, fenceCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::FenceWrapper>(pFences, fenceCount);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1334,8 +1334,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceStatus(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFenceStatus);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1373,9 +1373,9 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForFences(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitForFences);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(fenceCount);
-        encoder->EncodeHandleArray<VulkanFenceWrapper>(pFences, fenceCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::FenceWrapper>(pFences, fenceCount);
         encoder->EncodeVkBool32Value(waitAll);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -1415,7 +1415,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSemaphoreWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSemaphore, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SemaphoreWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSemaphore, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1425,12 +1425,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSemaphore);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSemaphoreWrapper>(pSemaphore, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SemaphoreWrapper>(pSemaphore, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanSemaphoreWrapper, VkSemaphoreCreateInfo>(result, device, pSemaphore, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::SemaphoreWrapper, VkSemaphoreCreateInfo>(result, device, pSemaphore, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSemaphore>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSemaphore);
@@ -1462,10 +1462,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySemaphore);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(semaphore);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanSemaphoreWrapper>(semaphore);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::SemaphoreWrapper>(semaphore);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1473,7 +1473,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(manager, device, semaphore, pAllocator);
 
-    DestroyWrappedHandle<VulkanSemaphoreWrapper>(semaphore);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::SemaphoreWrapper>(semaphore);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
@@ -1504,7 +1504,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanEventWrapper>(device, VulkanNoParentWrapper::kHandleValue, pEvent, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::EventWrapper>(device, VulkanNoParentWrapper::kHandleValue, pEvent, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1514,12 +1514,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanEventWrapper>(pEvent, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::EventWrapper>(pEvent, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanEventWrapper, VkEventCreateInfo>(result, device, pEvent, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::EventWrapper, VkEventCreateInfo>(result, device, pEvent, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateEvent>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pEvent);
@@ -1551,10 +1551,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanEventWrapper>(event);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::EventWrapper>(event);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1562,7 +1562,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(manager, device, event, pAllocator);
 
-    DestroyWrappedHandle<VulkanEventWrapper>(event);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::EventWrapper>(event);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
@@ -1590,8 +1590,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetEventStatus);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1626,8 +1626,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetEvent(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1662,8 +1662,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetEvent(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1701,7 +1701,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanQueryPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueryPool, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::QueryPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueryPool, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1711,12 +1711,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanQueryPoolWrapper>(pQueryPool, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::QueryPoolWrapper>(pQueryPool, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanQueryPoolWrapper, VkQueryPoolCreateInfo>(result, device, pQueryPool, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::QueryPoolWrapper, VkQueryPoolCreateInfo>(result, device, pQueryPool, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateQueryPool>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pQueryPool);
@@ -1748,10 +1748,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanQueryPoolWrapper>(queryPool);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::QueryPoolWrapper>(queryPool);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1759,7 +1759,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(manager, device, queryPool, pAllocator);
 
-    DestroyWrappedHandle<VulkanQueryPoolWrapper>(queryPool);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::QueryPoolWrapper>(queryPool);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
@@ -1799,8 +1799,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueryPoolResults);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -1849,12 +1849,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanBufferWrapper>(pBuffer, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::BufferWrapper>(pBuffer, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanBufferWrapper, VkBufferCreateInfo>(result, device, pBuffer, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::BufferWrapper, VkBufferCreateInfo>(result, device, pBuffer, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBuffer>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pBuffer);
@@ -1886,10 +1886,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanBufferWrapper>(buffer);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::BufferWrapper>(buffer);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1897,7 +1897,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(manager, device, buffer, pAllocator);
 
-    DestroyWrappedHandle<VulkanBufferWrapper>(buffer);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::BufferWrapper>(buffer);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
@@ -1931,7 +1931,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanBufferViewWrapper>(device, VulkanNoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::BufferViewWrapper>(device, VulkanNoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1941,12 +1941,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateBufferView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanBufferViewWrapper>(pView, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::BufferViewWrapper>(pView, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanBufferViewWrapper, VkBufferViewCreateInfo>(result, device, pView, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::BufferViewWrapper, VkBufferViewCreateInfo>(result, device, pView, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBufferView>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pView);
@@ -1978,10 +1978,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyBufferView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanBufferViewWrapper>(bufferView);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferViewWrapper>(bufferView);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanBufferViewWrapper>(bufferView);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::BufferViewWrapper>(bufferView);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1989,7 +1989,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(manager, device, bufferView, pAllocator);
 
-    DestroyWrappedHandle<VulkanBufferViewWrapper>(bufferView);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::BufferViewWrapper>(bufferView);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
@@ -2025,12 +2025,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanImageWrapper>(pImage, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::ImageWrapper>(pImage, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanImageWrapper, VkImageCreateInfo>(result, device, pImage, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::ImageWrapper, VkImageCreateInfo>(result, device, pImage, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImage>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pImage);
@@ -2062,10 +2062,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanImageWrapper>(image);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::ImageWrapper>(image);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2073,7 +2073,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(manager, device, image, pAllocator);
 
-    DestroyWrappedHandle<VulkanImageWrapper>(image);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::ImageWrapper>(image);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
@@ -2103,8 +2103,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         EncodeStructPtr(encoder, pSubresource);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -2144,7 +2144,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanImageViewWrapper>(device, VulkanNoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::ImageViewWrapper>(device, VulkanNoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2154,12 +2154,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateImageView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanImageViewWrapper>(pView, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::ImageViewWrapper>(pView, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanImageViewWrapper, VkImageViewCreateInfo>(result, device, pView, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::ImageViewWrapper, VkImageViewCreateInfo>(result, device, pView, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImageView>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pView);
@@ -2191,10 +2191,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyImageView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(imageView);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanImageViewWrapper>(imageView);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::ImageViewWrapper>(imageView);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2202,7 +2202,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(manager, device, imageView, pAllocator);
 
-    DestroyWrappedHandle<VulkanImageViewWrapper>(imageView);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::ImageViewWrapper>(imageView);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
@@ -2236,7 +2236,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanShaderModuleWrapper>(device, VulkanNoParentWrapper::kHandleValue, pShaderModule, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::ShaderModuleWrapper>(device, VulkanNoParentWrapper::kHandleValue, pShaderModule, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2246,12 +2246,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateShaderModule);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanShaderModuleWrapper>(pShaderModule, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::ShaderModuleWrapper>(pShaderModule, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanShaderModuleWrapper, VkShaderModuleCreateInfo>(result, device, pShaderModule, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::ShaderModuleWrapper, VkShaderModuleCreateInfo>(result, device, pShaderModule, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateShaderModule>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pShaderModule);
@@ -2283,10 +2283,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyShaderModule);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanShaderModuleWrapper>(shaderModule);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ShaderModuleWrapper>(shaderModule);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanShaderModuleWrapper>(shaderModule);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::ShaderModuleWrapper>(shaderModule);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2294,7 +2294,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(manager, device, shaderModule, pAllocator);
 
-    DestroyWrappedHandle<VulkanShaderModuleWrapper>(shaderModule);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::ShaderModuleWrapper>(shaderModule);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
@@ -2325,7 +2325,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPipelineCacheWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPipelineCache, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::PipelineCacheWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPipelineCache, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2335,12 +2335,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePipelineCache);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanPipelineCacheWrapper>(pPipelineCache, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::PipelineCacheWrapper>(pPipelineCache, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanPipelineCacheWrapper, VkPipelineCacheCreateInfo>(result, device, pPipelineCache, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::PipelineCacheWrapper, VkPipelineCacheCreateInfo>(result, device, pPipelineCache, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineCache>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPipelineCache);
@@ -2372,10 +2372,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPipelineCache);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanPipelineCacheWrapper>(pipelineCache);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2383,7 +2383,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(manager, device, pipelineCache, pAllocator);
 
-    DestroyWrappedHandle<VulkanPipelineCacheWrapper>(pipelineCache);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
@@ -2419,8 +2419,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineCacheData);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineCacheWrapper>(pipelineCache);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? (*pDataSize) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -2459,10 +2459,10 @@ VKAPI_ATTR VkResult VKAPI_CALL MergePipelineCaches(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMergePipelineCaches);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(dstCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineCacheWrapper>(dstCache);
         encoder->EncodeUInt32Value(srcCacheCount);
-        encoder->EncodeHandleArray<VulkanPipelineCacheWrapper>(pSrcCaches, srcCacheCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::PipelineCacheWrapper>(pSrcCaches, srcCacheCount);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -2496,10 +2496,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPipeline);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanPipelineWrapper>(pipeline);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::PipelineWrapper>(pipeline);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2507,7 +2507,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(manager, device, pipeline, pAllocator);
 
-    DestroyWrappedHandle<VulkanPipelineWrapper>(pipeline);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::PipelineWrapper>(pipeline);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
@@ -2541,7 +2541,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPipelineLayoutWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPipelineLayout, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::PipelineLayoutWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPipelineLayout, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2551,12 +2551,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePipelineLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanPipelineLayoutWrapper>(pPipelineLayout, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::PipelineLayoutWrapper>(pPipelineLayout, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanPipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(result, device, pPipelineLayout, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(result, device, pPipelineLayout, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineLayout>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPipelineLayout);
@@ -2588,10 +2588,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPipelineLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(pipelineLayout);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(pipelineLayout);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanPipelineLayoutWrapper>(pipelineLayout);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::PipelineLayoutWrapper>(pipelineLayout);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2599,7 +2599,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(manager, device, pipelineLayout, pAllocator);
 
-    DestroyWrappedHandle<VulkanPipelineLayoutWrapper>(pipelineLayout);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::PipelineLayoutWrapper>(pipelineLayout);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
@@ -2633,7 +2633,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSamplerWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSampler, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SamplerWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSampler, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2643,12 +2643,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSampler);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSamplerWrapper>(pSampler, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SamplerWrapper>(pSampler, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanSamplerWrapper, VkSamplerCreateInfo>(result, device, pSampler, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::SamplerWrapper, VkSamplerCreateInfo>(result, device, pSampler, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSampler>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSampler);
@@ -2680,10 +2680,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySampler);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSamplerWrapper>(sampler);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SamplerWrapper>(sampler);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanSamplerWrapper>(sampler);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::SamplerWrapper>(sampler);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2691,7 +2691,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(manager, device, sampler, pAllocator);
 
-    DestroyWrappedHandle<VulkanSamplerWrapper>(sampler);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::SamplerWrapper>(sampler);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
@@ -2725,7 +2725,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorSetLayoutWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSetLayout, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DescriptorSetLayoutWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSetLayout, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2735,12 +2735,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDescriptorSetLayoutWrapper>(pSetLayout, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DescriptorSetLayoutWrapper>(pSetLayout, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(result, device, pSetLayout, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::DescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(result, device, pSetLayout, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSetLayout);
@@ -2772,10 +2772,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorSetLayoutWrapper>(descriptorSetLayout);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetLayoutWrapper>(descriptorSetLayout);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDescriptorSetLayoutWrapper>(descriptorSetLayout);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DescriptorSetLayoutWrapper>(descriptorSetLayout);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2783,7 +2783,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(manager, device, descriptorSetLayout, pAllocator);
 
-    DestroyWrappedHandle<VulkanDescriptorSetLayoutWrapper>(descriptorSetLayout);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DescriptorSetLayoutWrapper>(descriptorSetLayout);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
@@ -2814,7 +2814,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorPool, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DescriptorPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorPool, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2824,12 +2824,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDescriptorPoolWrapper>(pDescriptorPool, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DescriptorPoolWrapper>(pDescriptorPool, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorPoolWrapper, VkDescriptorPoolCreateInfo>(result, device, pDescriptorPool, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::DescriptorPoolWrapper, VkDescriptorPoolCreateInfo>(result, device, pDescriptorPool, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorPool>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pDescriptorPool);
@@ -2861,10 +2861,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(descriptorPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorPoolWrapper>(descriptorPool);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDescriptorPoolWrapper>(descriptorPool);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DescriptorPoolWrapper>(descriptorPool);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2872,7 +2872,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(manager, device, descriptorPool, pAllocator);
 
-    DestroyWrappedHandle<VulkanDescriptorPoolWrapper>(descriptorPool);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DescriptorPoolWrapper>(descriptorPool);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
@@ -2902,8 +2902,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetDescriptorPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(descriptorPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorPoolWrapper>(descriptorPool);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -2944,7 +2944,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanDescriptorPoolWrapper, VulkanDescriptorSetWrapper>(device, pAllocateInfo->descriptorPool, pDescriptorSets, pAllocateInfo->descriptorSetCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper, vulkan_wrappers::DescriptorPoolWrapper, vulkan_wrappers::DescriptorSetWrapper>(device, pAllocateInfo->descriptorPool, pDescriptorSets, pAllocateInfo->descriptorSetCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2954,11 +2954,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAllocateDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocateInfo);
-        encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(pDescriptorSets, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::DescriptorSetWrapper>(pDescriptorSets, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndPoolCreateApiCallCapture<VkDevice, VulkanDescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, pDescriptorSets, pAllocateInfo);
+        manager->EndPoolCreateApiCallCapture<VkDevice, vulkan_wrappers::DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, pDescriptorSets, pAllocateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateDescriptorSets>::Dispatch(manager, result, device, pAllocateInfo, pDescriptorSets);
@@ -2994,17 +2994,17 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(descriptorPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorPoolWrapper>(descriptorPool);
         encoder->EncodeUInt32Value(descriptorSetCount);
-        encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
         encoder->EncodeEnumValue(result);
-        manager->EndDestroyApiCallCapture<VulkanDescriptorSetWrapper>(descriptorSetCount, pDescriptorSets);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DescriptorSetWrapper>(descriptorSetCount, pDescriptorSets);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, result, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
-    DestroyWrappedHandles<VulkanDescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
+    DestroyWrappedVulkanHandles<vulkan_wrappers::DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
 
     return result;
 }
@@ -3035,7 +3035,7 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(descriptorWriteCount);
         EncodeStructArray(encoder, pDescriptorWrites, descriptorWriteCount);
         encoder->EncodeUInt32Value(descriptorCopyCount);
@@ -3083,7 +3083,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanFramebufferWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFramebuffer, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::FramebufferWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFramebuffer, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3093,12 +3093,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateFramebuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanFramebufferWrapper>(pFramebuffer, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::FramebufferWrapper>(pFramebuffer, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanFramebufferWrapper, VkFramebufferCreateInfo>(result, device, pFramebuffer, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::FramebufferWrapper, VkFramebufferCreateInfo>(result, device, pFramebuffer, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFramebuffer>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pFramebuffer);
@@ -3130,10 +3130,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyFramebuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanFramebufferWrapper>(framebuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::FramebufferWrapper>(framebuffer);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanFramebufferWrapper>(framebuffer);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::FramebufferWrapper>(framebuffer);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3141,7 +3141,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(manager, device, framebuffer, pAllocator);
 
-    DestroyWrappedHandle<VulkanFramebufferWrapper>(framebuffer);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::FramebufferWrapper>(framebuffer);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
@@ -3172,7 +3172,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanRenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::RenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3182,12 +3182,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanRenderPassWrapper>(pRenderPass, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::RenderPassWrapper>(pRenderPass, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo>(result, device, pRenderPass, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::RenderPassWrapper, VkRenderPassCreateInfo>(result, device, pRenderPass, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -3219,10 +3219,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanRenderPassWrapper>(renderPass);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::RenderPassWrapper>(renderPass);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanRenderPassWrapper>(renderPass);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::RenderPassWrapper>(renderPass);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3230,7 +3230,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(manager, device, renderPass, pAllocator);
 
-    DestroyWrappedHandle<VulkanRenderPassWrapper>(renderPass);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::RenderPassWrapper>(renderPass);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
@@ -3259,8 +3259,8 @@ VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRenderAreaGranularity);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanRenderPassWrapper>(renderPass);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::RenderPassWrapper>(renderPass);
         EncodeStructPtr(encoder, pGranularity);
         manager->EndApiCallCapture();
     }
@@ -3296,7 +3296,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanCommandPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pCommandPool, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::CommandPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pCommandPool, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3306,12 +3306,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanCommandPoolWrapper>(pCommandPool, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::CommandPoolWrapper>(pCommandPool, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanCommandPoolWrapper, VkCommandPoolCreateInfo>(result, device, pCommandPool, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::CommandPoolWrapper, VkCommandPoolCreateInfo>(result, device, pCommandPool, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateCommandPool>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pCommandPool);
@@ -3343,10 +3343,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandPoolWrapper>(commandPool);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanCommandPoolWrapper>(commandPool);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::CommandPoolWrapper>(commandPool);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3354,7 +3354,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(manager, device, commandPool, pAllocator);
 
-    DestroyWrappedHandle<VulkanCommandPoolWrapper>(commandPool);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::CommandPoolWrapper>(commandPool);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
@@ -3383,8 +3383,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandPoolWrapper>(commandPool);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -3425,7 +3425,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanCommandPoolWrapper, VulkanCommandBufferWrapper>(device, pAllocateInfo->commandPool, pCommandBuffers, pAllocateInfo->commandBufferCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper, vulkan_wrappers::CommandPoolWrapper, vulkan_wrappers::CommandBufferWrapper>(device, pAllocateInfo->commandPool, pCommandBuffers, pAllocateInfo->commandBufferCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3435,11 +3435,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAllocateCommandBuffers);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocateInfo);
-        encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(pCommandBuffers, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::CommandBufferWrapper>(pCommandBuffers, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndPoolCreateApiCallCapture<VkDevice, VulkanCommandBufferWrapper, VkCommandBufferAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, pCommandBuffers, pAllocateInfo);
+        manager->EndPoolCreateApiCallCapture<VkDevice, vulkan_wrappers::CommandBufferWrapper, VkCommandBufferAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, pCommandBuffers, pAllocateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>::Dispatch(manager, result, device, pAllocateInfo, pCommandBuffers);
@@ -3472,11 +3472,11 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeCommandBuffers);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandPoolWrapper>(commandPool);
         encoder->EncodeUInt32Value(commandBufferCount);
-        encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(pCommandBuffers, commandBufferCount);
-        manager->EndDestroyApiCallCapture<VulkanCommandBufferWrapper>(commandBufferCount, pCommandBuffers);
+        encoder->EncodeHandleArray<vulkan_wrappers::CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::CommandBufferWrapper>(commandBufferCount, pCommandBuffers);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3484,7 +3484,7 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(manager, device, commandPool, commandBufferCount, pCommandBuffers);
 
-    DestroyWrappedHandles<VulkanCommandBufferWrapper>(pCommandBuffers, commandBufferCount);
+    DestroyWrappedVulkanHandles<vulkan_wrappers::CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
@@ -3515,7 +3515,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkBeginCommandBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBeginInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer, TrackBeginCommandBufferHandles, pBeginInfo);
@@ -3550,7 +3550,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EndCommandBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEndCommandBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -3585,7 +3585,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkResetCommandBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3620,9 +3620,9 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindPipeline);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindPipelineHandles, pipeline);
     }
 
@@ -3656,7 +3656,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewport(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewport);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewports, viewportCount);
@@ -3693,7 +3693,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissor(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetScissor);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstScissor);
         encoder->EncodeUInt32Value(scissorCount);
         EncodeStructArray(encoder, pScissors, scissorCount);
@@ -3728,7 +3728,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineWidth(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineWidth);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(lineWidth);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -3763,7 +3763,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBias);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(depthBiasConstantFactor);
         encoder->EncodeFloatValue(depthBiasClamp);
         encoder->EncodeFloatValue(depthBiasSlopeFactor);
@@ -3798,7 +3798,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetBlendConstants(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetBlendConstants);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatArray(blendConstants, 4);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -3832,7 +3832,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBounds(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBounds);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(minDepthBounds);
         encoder->EncodeFloatValue(maxDepthBounds);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3867,7 +3867,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilCompareMask(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilCompareMask);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeUInt32Value(compareMask);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3902,7 +3902,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilWriteMask(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilWriteMask);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeUInt32Value(writeMask);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3937,7 +3937,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilReference(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilReference);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeUInt32Value(reference);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3977,12 +3977,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(layout);
         encoder->EncodeUInt32Value(firstSet);
         encoder->EncodeUInt32Value(descriptorSetCount);
-        encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
         encoder->EncodeUInt32Value(dynamicOffsetCount);
         encoder->EncodeUInt32Array(pDynamicOffsets, dynamicOffsetCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindDescriptorSetsHandles, layout, descriptorSetCount, pDescriptorSets);
@@ -4018,8 +4018,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindIndexBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeEnumValue(indexType);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindIndexBufferHandles, buffer);
@@ -4056,10 +4056,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindVertexBuffers);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::BufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindVertexBuffersHandles, bindingCount, pBuffers);
     }
@@ -4095,7 +4095,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDraw(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDraw);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(vertexCount);
         encoder->EncodeUInt32Value(instanceCount);
         encoder->EncodeUInt32Value(firstVertex);
@@ -4135,7 +4135,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexed(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexed);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(indexCount);
         encoder->EncodeUInt32Value(instanceCount);
         encoder->EncodeUInt32Value(firstIndex);
@@ -4175,8 +4175,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirect);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -4214,8 +4214,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -4252,7 +4252,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatch(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatch);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(groupCountX);
         encoder->EncodeUInt32Value(groupCountY);
         encoder->EncodeUInt32Value(groupCountZ);
@@ -4288,8 +4288,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatchIndirect);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDispatchIndirectHandles, buffer);
     }
@@ -4325,9 +4325,9 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(srcBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(srcBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferHandles, srcBuffer, dstBuffer);
@@ -4366,10 +4366,10 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4410,10 +4410,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBlitImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4453,9 +4453,9 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBufferToImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(srcBuffer);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(srcBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4494,10 +4494,10 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageToBufferHandles, srcImage, dstBuffer);
@@ -4534,8 +4534,8 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdUpdateBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(dataSize);
         encoder->EncodeVoidArray(pData, static_cast<size_t>(dataSize));
@@ -4573,8 +4573,8 @@ VKAPI_ATTR void VKAPI_CALL CmdFillBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdFillBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(size);
         encoder->EncodeUInt32Value(data);
@@ -4613,8 +4613,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdClearColorImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         encoder->EncodeEnumValue(imageLayout);
         EncodeStructPtr(encoder, pColor);
         encoder->EncodeUInt32Value(rangeCount);
@@ -4654,8 +4654,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdClearDepthStencilImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         encoder->EncodeEnumValue(imageLayout);
         EncodeStructPtr(encoder, pDepthStencil);
         encoder->EncodeUInt32Value(rangeCount);
@@ -4694,7 +4694,7 @@ VKAPI_ATTR void VKAPI_CALL CmdClearAttachments(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdClearAttachments);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(attachmentCount);
         EncodeStructArray(encoder, pAttachments, attachmentCount);
         encoder->EncodeUInt32Value(rectCount);
@@ -4735,10 +4735,10 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResolveImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4774,8 +4774,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         encoder->EncodeFlagsValue(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetEventHandles, event);
     }
@@ -4809,8 +4809,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         encoder->EncodeFlagsValue(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEventHandles, event);
     }
@@ -4852,9 +4852,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWaitEvents);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(eventCount);
-        encoder->EncodeHandleArray<VulkanEventWrapper>(pEvents, eventCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::EventWrapper>(pEvents, eventCount);
         encoder->EncodeFlagsValue(srcStageMask);
         encoder->EncodeFlagsValue(dstStageMask);
         encoder->EncodeUInt32Value(memoryBarrierCount);
@@ -4906,7 +4906,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPipelineBarrier);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(srcStageMask);
         encoder->EncodeFlagsValue(dstStageMask);
         encoder->EncodeFlagsValue(dependencyFlags);
@@ -4953,8 +4953,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQuery(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginQuery);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeFlagsValue(flags);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginQueryHandles, queryPool);
@@ -4989,8 +4989,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQuery(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndQuery);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndQueryHandles, queryPool);
     }
@@ -5025,8 +5025,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetQueryPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetQueryPoolHandles, queryPool);
@@ -5062,9 +5062,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteTimestamp);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineStage);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestampHandles, queryPool);
     }
@@ -5103,11 +5103,11 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyQueryPoolResults(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyQueryPoolResults);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(stride);
         encoder->EncodeFlagsValue(flags);
@@ -5146,8 +5146,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushConstants);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(layout);
         encoder->EncodeFlagsValue(stageFlags);
         encoder->EncodeUInt32Value(offset);
         encoder->EncodeUInt32Value(size);
@@ -5184,7 +5184,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         encoder->EncodeEnumValue(contents);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderPassHandles, pRenderPassBegin);
@@ -5221,7 +5221,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdNextSubpass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(contents);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -5253,7 +5253,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -5286,9 +5286,9 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdExecuteCommands);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(commandBufferCount);
-        encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(pCommandBuffers, commandBufferCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdExecuteCommandsHandles, commandBufferCount, pCommandBuffers);
     }
 
@@ -5326,7 +5326,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -5367,7 +5367,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -5407,7 +5407,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeatures(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeatures);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(heapIndex);
         encoder->EncodeUInt32Value(localDeviceIndex);
         encoder->EncodeUInt32Value(remoteDeviceIndex);
@@ -5441,7 +5441,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMask(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDeviceMask);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(deviceMask);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -5479,7 +5479,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBase(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatchBase);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(baseGroupX);
         encoder->EncodeUInt32Value(baseGroupY);
         encoder->EncodeUInt32Value(baseGroupZ);
@@ -5521,7 +5521,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanInstanceWrapper, VulkanNoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -5531,11 +5531,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroups);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceGroupCount, omit_output_data);
         EncodeStructArray(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkInstance, VulkanPhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
+        manager->EndStructGroupCreateApiCallCapture<VkInstance, vulkan_wrappers::PhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroups>::Dispatch(manager, result, instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
@@ -5572,7 +5572,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -5610,7 +5610,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -5649,7 +5649,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -5684,7 +5684,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFeatures);
         manager->EndApiCallCapture();
     }
@@ -5717,7 +5717,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pProperties);
         manager->EndApiCallCapture();
     }
@@ -5751,7 +5751,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         EncodeStructPtr(encoder, pFormatProperties);
         manager->EndApiCallCapture();
@@ -5792,7 +5792,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pImageFormatInfo);
         EncodeStructPtr(encoder, pImageFormatProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -5830,7 +5830,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
         EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         manager->EndApiCallCapture();
@@ -5864,7 +5864,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pMemoryProperties);
         manager->EndApiCallCapture();
     }
@@ -5899,7 +5899,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFormatInfo);
         encoder->EncodeUInt32Ptr(pPropertyCount);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
@@ -5933,8 +5933,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkTrimCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandPoolWrapper>(commandPool);
         encoder->EncodeFlagsValue(flags);
         manager->EndApiCallCapture();
     }
@@ -5967,15 +5967,15 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue2(
 
     GetVulkanDeviceTable(device)->GetDeviceQueue2(device, pQueueInfo, pQueue);
 
-    CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanQueueWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
+    CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::QueueWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceQueue2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pQueueInfo);
-        encoder->EncodeHandlePtr<VulkanQueueWrapper>(pQueue);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanQueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
+        encoder->EncodeHandlePtr<vulkan_wrappers::QueueWrapper>(pQueue);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::QueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDeviceQueue2>::Dispatch(manager, device, pQueueInfo, pQueue);
@@ -6009,7 +6009,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSamplerYcbcrConversionWrapper>(device, VulkanNoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SamplerYcbcrConversionWrapper>(device, VulkanNoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6019,12 +6019,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanSamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -6056,10 +6056,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SamplerYcbcrConversionWrapper>(ycbcrConversion);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -6067,7 +6067,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
-    DestroyWrappedHandle<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::SamplerYcbcrConversionWrapper>(ycbcrConversion);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
@@ -6101,7 +6101,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorUpdateTemplateWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DescriptorUpdateTemplateWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6111,12 +6111,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -6148,10 +6148,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -6159,7 +6159,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
-    DestroyWrappedHandle<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
@@ -6188,7 +6188,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalBufferInfo);
         EncodeStructPtr(encoder, pExternalBufferProperties);
         manager->EndApiCallCapture();
@@ -6223,7 +6223,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFenceProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFenceProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalFenceInfo);
         EncodeStructPtr(encoder, pExternalFenceProperties);
         manager->EndApiCallCapture();
@@ -6258,7 +6258,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphoreProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphoreProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalSemaphoreInfo);
         EncodeStructPtr(encoder, pExternalSemaphoreProperties);
         manager->EndApiCallCapture();
@@ -6296,7 +6296,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupport(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupport);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pSupport);
         manager->EndApiCallCapture();
@@ -6333,10 +6333,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -6376,10 +6376,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -6419,7 +6419,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanRenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::RenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6429,12 +6429,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateRenderPass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanRenderPassWrapper>(pRenderPass, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::RenderPassWrapper>(pRenderPass, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::RenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass2>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -6466,7 +6466,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderPass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderPass2Handles, pRenderPassBegin);
@@ -6504,7 +6504,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdNextSubpass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -6538,7 +6538,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderPass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -6573,8 +6573,8 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         manager->EndApiCallCapture();
@@ -6617,8 +6617,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValue(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreCounterValue);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(semaphore);
         encoder->EncodeUInt64Ptr(pValue, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -6658,7 +6658,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphores(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitSemaphores);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pWaitInfo);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -6698,7 +6698,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphore(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSignalSemaphore);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pSignalInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -6737,7 +6737,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddress(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddress);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -6776,7 +6776,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddress(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddress);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -6815,7 +6815,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddress(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddress);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -6858,7 +6858,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pToolCount, omit_output_data);
         EncodeStructArray(encoder, pToolProperties, (pToolCount != nullptr) ? (*pToolCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -6898,7 +6898,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlot(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPrivateDataSlotWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::PrivateDataSlotWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6908,12 +6908,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlot(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePrivateDataSlot);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanPrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::PrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanPrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::PrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePrivateDataSlot>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPrivateDataSlot);
@@ -6945,10 +6945,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -6956,7 +6956,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
-    DestroyWrappedHandle<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
@@ -6987,10 +6987,10 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetPrivateData);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeUInt64Value(GetVulkanWrappedId(objectHandle, objectType));
+        encoder->EncodeHandleValue<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Value(data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -7029,10 +7029,10 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateData(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPrivateData);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeUInt64Value(GetVulkanWrappedId(objectHandle, objectType));
+        encoder->EncodeHandleValue<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Ptr(pData);
         manager->EndApiCallCapture();
     }
@@ -7064,8 +7064,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetEvent2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetEvent2Handles, event, pDependencyInfo);
     }
@@ -7102,8 +7102,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetEvent2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         encoder->EncodeFlags64Value(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEvent2Handles, event);
     }
@@ -7138,9 +7138,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWaitEvents2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(eventCount);
-        encoder->EncodeHandleArray<VulkanEventWrapper>(pEvents, eventCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::EventWrapper>(pEvents, eventCount);
         EncodeStructArray(encoder, pDependencyInfos, eventCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWaitEvents2Handles, eventCount, pEvents, pDependencyInfos);
     }
@@ -7176,7 +7176,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPipelineBarrier2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPipelineBarrier2Handles, pDependencyInfo);
     }
@@ -7214,9 +7214,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteTimestamp2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlags64Value(stage);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestamp2Handles, queryPool);
     }
@@ -7256,10 +7256,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         encoder->EncodeUInt32Value(submitCount);
         EncodeStructArray(encoder, pSubmits, submitCount);
-        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
+        encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -7292,7 +7292,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBuffer2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBuffer2Handles, pCopyBufferInfo);
     }
@@ -7328,7 +7328,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImage2Handles, pCopyImageInfo);
     }
@@ -7364,7 +7364,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferToImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferToImage2Handles, pCopyBufferToImageInfo);
     }
@@ -7400,7 +7400,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageToBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageToBuffer2Handles, pCopyImageToBufferInfo);
     }
@@ -7436,7 +7436,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBlitImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBlitImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBlitImage2Handles, pBlitImageInfo);
     }
@@ -7472,7 +7472,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResolveImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pResolveImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResolveImage2Handles, pResolveImageInfo);
     }
@@ -7508,7 +7508,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRendering(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRendering);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderingInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderingHandles, pRenderingInfo);
     }
@@ -7543,7 +7543,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRendering(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRendering);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -7575,7 +7575,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullMode(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCullMode);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(cullMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7608,7 +7608,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFace(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFrontFace);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(frontFace);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7641,7 +7641,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopology(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopology);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(primitiveTopology);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7675,7 +7675,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWithCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewports, viewportCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -7710,7 +7710,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetScissorWithCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(scissorCount);
         EncodeStructArray(encoder, pScissors, scissorCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -7749,10 +7749,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::BufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pSizes, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pStrides, bindingCount);
@@ -7787,7 +7787,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthTestEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7820,7 +7820,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthWriteEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7853,7 +7853,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOp(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthCompareOp);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(depthCompareOp);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7886,7 +7886,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBoundsTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7919,7 +7919,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilTestEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(stencilTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7956,7 +7956,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOp(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilOp);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeEnumValue(failOp);
         encoder->EncodeEnumValue(passOp);
@@ -7993,7 +7993,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(rasterizerDiscardEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -8026,7 +8026,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBiasEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -8059,7 +8059,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(primitiveRestartEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -8095,7 +8095,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -8133,7 +8133,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -8172,7 +8172,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -8206,10 +8206,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanSurfaceKHRWrapper>(surface);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::SurfaceKHRWrapper>(surface);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -8217,7 +8217,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(manager, instance, surface, pAllocator);
 
-    DestroyWrappedHandle<VulkanSurfaceKHRWrapper>(surface);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::SurfaceKHRWrapper>(surface);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
@@ -8253,9 +8253,9 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         encoder->EncodeVkBool32Ptr(pSupported, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8298,8 +8298,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         EncodeStructPtr(encoder, pSurfaceCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8343,8 +8343,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormatsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormatsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         encoder->EncodeUInt32Ptr(pSurfaceFormatCount, omit_output_data);
         EncodeStructArray(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8389,8 +8389,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         encoder->EncodeUInt32Ptr(pPresentModeCount, omit_output_data);
         encoder->EncodeEnumArray(pPresentModes, (pPresentModeCount != nullptr) ? (*pPresentModeCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8433,7 +8433,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSwapchainKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSwapchain, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SwapchainKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSwapchain, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8443,12 +8443,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSwapchainKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSwapchainKHRWrapper>(pSwapchain, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SwapchainKHRWrapper>(pSwapchain, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanSwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, pSwapchain, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, pSwapchain, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSwapchain);
@@ -8480,10 +8480,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySwapchainKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanSwapchainKHRWrapper>(swapchain);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -8491,7 +8491,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(manager, device, swapchain, pAllocator);
 
-    DestroyWrappedHandle<VulkanSwapchainKHRWrapper>(swapchain);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
@@ -8522,7 +8522,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanSwapchainKHRWrapper, VulkanImageWrapper>(device, swapchain, pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper, vulkan_wrappers::SwapchainKHRWrapper, vulkan_wrappers::ImageWrapper>(device, swapchain, pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8532,12 +8532,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt32Ptr(pSwapchainImageCount, omit_output_data);
-        encoder->EncodeHandleArray<VulkanImageWrapper>(pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::ImageWrapper>(pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkDevice, VkSwapchainKHR, VulkanImageWrapper, void>(result, device, swapchain, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr);
+        manager->EndGroupCreateApiCallCapture<VkDevice, VkSwapchainKHR, vulkan_wrappers::ImageWrapper, void>(result, device, swapchain, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR>::Dispatch(manager, result, device, swapchain, pSwapchainImageCount, pSwapchainImages);
@@ -8580,11 +8580,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireNextImageKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt64Value(timeout);
-        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
-        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
+        encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
         encoder->EncodeUInt32Ptr(pImageIndex, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8613,7 +8613,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueuePresentKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         EncodeStructPtr(encoder, pPresentInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8655,7 +8655,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupPresentCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPresentCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pDeviceGroupPresentCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8698,8 +8698,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         encoder->EncodeFlagsPtr(pModes, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8743,8 +8743,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDevicePresentRectanglesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDevicePresentRectanglesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         encoder->EncodeUInt32Ptr(pRectCount, omit_output_data);
         EncodeStructArray(encoder, pRects, (pRectCount != nullptr) ? (*pRectCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8791,7 +8791,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireNextImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pAcquireInfo);
         encoder->EncodeUInt32Ptr(pImageIndex, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8830,7 +8830,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPropertiesKHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPropertiesKHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8840,11 +8840,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->display); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->vulkan_wrappers::DisplayKHRWrapper* { return GetVulkanWrapper<vulkan_wrappers::DisplayKHRWrapper>(handle_struct->display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -8879,7 +8879,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPlanePropertiesKHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPlanePropertiesKHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8889,11 +8889,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->currentDisplay); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->vulkan_wrappers::DisplayKHRWrapper* { return GetVulkanWrapper<vulkan_wrappers::DisplayKHRWrapper>(handle_struct->currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -8929,7 +8929,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandles<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8939,12 +8939,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(planeIndex);
         encoder->EncodeUInt32Ptr(pDisplayCount, omit_output_data);
-        encoder->EncodeHandleArray<VulkanDisplayKHRWrapper>(pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::DisplayKHRWrapper>(pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkPhysicalDevice, void*, VulkanDisplayKHRWrapper, void>(result, physicalDevice, nullptr, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr);
+        manager->EndGroupCreateApiCallCapture<VkPhysicalDevice, void*, vulkan_wrappers::DisplayKHRWrapper, void>(result, physicalDevice, nullptr, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR>::Dispatch(manager, result, physicalDevice, planeIndex, pDisplayCount, pDisplays);
@@ -8980,7 +8980,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanDisplayKHRWrapper, VkDisplayModePropertiesKHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::PhysicalDeviceWrapper, vulkan_wrappers::DisplayKHRWrapper, VkDisplayModePropertiesKHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8990,12 +8990,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->VulkanDisplayModeKHRWrapper* { return GetWrapper<VulkanDisplayModeKHRWrapper>(handle_struct->displayMode); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->vulkan_wrappers::DisplayModeKHRWrapper* { return GetVulkanWrapper<vulkan_wrappers::DisplayModeKHRWrapper>(handle_struct->displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR>::Dispatch(manager, result, physicalDevice, display, pPropertyCount, pProperties);
@@ -9032,7 +9032,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanDisplayKHRWrapper, VulkanDisplayModeKHRWrapper>(physicalDevice, display, pMode, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::PhysicalDeviceWrapper, vulkan_wrappers::DisplayKHRWrapper, vulkan_wrappers::DisplayModeKHRWrapper>(physicalDevice, display, pMode, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9042,13 +9042,13 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDisplayModeKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDisplayModeKHRWrapper>(pMode, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DisplayModeKHRWrapper>(pMode, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayModeKHRWrapper, VkDisplayModeCreateInfoKHR>(result, physicalDevice, pMode, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayModeKHRWrapper, VkDisplayModeCreateInfoKHR>(result, physicalDevice, pMode, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayModeKHR>::Dispatch(manager, result, physicalDevice, display, pCreateInfo, pAllocator, pMode);
@@ -9089,8 +9089,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayPlaneCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(mode);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayModeKHRWrapper>(mode);
         encoder->EncodeUInt32Value(planeIndex);
         EncodeStructPtr(encoder, pCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -9133,7 +9133,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9143,12 +9143,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkDisplaySurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkDisplaySurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9188,7 +9188,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSwapchainKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSwapchains, swapchainCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SwapchainKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSwapchains, swapchainCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9198,13 +9198,13 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(swapchainCount);
         EncodeStructArray(encoder, pCreateInfos, swapchainCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<VulkanSwapchainKHRWrapper>(pSwapchains, swapchainCount, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::SwapchainKHRWrapper>(pSwapchains, swapchainCount, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkDevice, void*, VulkanSwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, nullptr, swapchainCount, pSwapchains, pCreateInfos);
+        manager->EndGroupCreateApiCallCapture<VkDevice, void*, vulkan_wrappers::SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, nullptr, swapchainCount, pSwapchains, pCreateInfos);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR>::Dispatch(manager, result, device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
@@ -9240,7 +9240,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9250,12 +9250,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkXlibSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkXlibSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9290,7 +9290,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXlibPresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceXlibPresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(dpy);
         encoder->EncodeSizeTValue(visualID);
@@ -9331,7 +9331,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9341,12 +9341,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkXcbSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkXcbSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9381,7 +9381,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXcbPresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceXcbPresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(connection);
         encoder->EncodeUInt32Value(visual_id);
@@ -9422,7 +9422,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9432,12 +9432,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkWaylandSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkWaylandSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9471,7 +9471,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWaylandPresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(display);
         encoder->EncodeVkBool32Value(result);
@@ -9511,7 +9511,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9521,12 +9521,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkAndroidSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkAndroidSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9562,7 +9562,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9572,12 +9572,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkWin32SurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkWin32SurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9610,7 +9610,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWin32PresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceWin32PresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVkBool32Value(result);
         manager->EndApiCallCapture();
@@ -9653,7 +9653,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pVideoProfile);
         EncodeStructPtr(encoder, pCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -9698,7 +9698,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoFormatPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoFormatPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pVideoFormatInfo);
         encoder->EncodeUInt32Ptr(pVideoFormatPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pVideoFormatProperties, (pVideoFormatPropertyCount != nullptr) ? (*pVideoFormatPropertyCount) : 0, omit_output_data);
@@ -9739,7 +9739,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanVideoSessionKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pVideoSession, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::VideoSessionKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pVideoSession, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9749,12 +9749,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateVideoSessionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanVideoSessionKHRWrapper>(pVideoSession, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::VideoSessionKHRWrapper>(pVideoSession, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanVideoSessionKHRWrapper, VkVideoSessionCreateInfoKHR>(result, device, pVideoSession, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::VideoSessionKHRWrapper, VkVideoSessionCreateInfoKHR>(result, device, pVideoSession, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateVideoSessionKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pVideoSession);
@@ -9786,10 +9786,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(videoSession);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionKHRWrapper>(videoSession);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanVideoSessionKHRWrapper>(videoSession);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::VideoSessionKHRWrapper>(videoSession);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -9797,7 +9797,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR>::Dispatch(manager, device, videoSession, pAllocator);
 
-    DestroyWrappedHandle<VulkanVideoSessionKHRWrapper>(videoSession);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::VideoSessionKHRWrapper>(videoSession);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
@@ -9833,8 +9833,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetVideoSessionMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(videoSession);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionKHRWrapper>(videoSession);
         encoder->EncodeUInt32Ptr(pMemoryRequirementsCount, omit_output_data);
         EncodeStructArray(encoder, pMemoryRequirements, (pMemoryRequirementsCount != nullptr) ? (*pMemoryRequirementsCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -9876,8 +9876,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindVideoSessionMemoryKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindVideoSessionMemoryKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(videoSession);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionKHRWrapper>(videoSession);
         encoder->EncodeUInt32Value(bindSessionMemoryInfoCount);
         EncodeStructArray(encoder, pBindSessionMemoryInfos, bindSessionMemoryInfoCount);
         encoder->EncodeEnumValue(result);
@@ -9920,7 +9920,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanVideoSessionParametersKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pVideoSessionParameters, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::VideoSessionParametersKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pVideoSessionParameters, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9930,12 +9930,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanVideoSessionParametersKHRWrapper>(pVideoSessionParameters, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::VideoSessionParametersKHRWrapper>(pVideoSessionParameters, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanVideoSessionParametersKHRWrapper, VkVideoSessionParametersCreateInfoKHR>(result, device, pVideoSessionParameters, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::VideoSessionParametersKHRWrapper, VkVideoSessionParametersCreateInfoKHR>(result, device, pVideoSessionParameters, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateVideoSessionParametersKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pVideoSessionParameters);
@@ -9969,8 +9969,8 @@ VKAPI_ATTR VkResult VKAPI_CALL UpdateVideoSessionParametersKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionParametersKHRWrapper>(videoSessionParameters);
         EncodeStructPtr(encoder, pUpdateInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -10005,10 +10005,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionParametersKHRWrapper>(videoSessionParameters);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::VideoSessionParametersKHRWrapper>(videoSessionParameters);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -10016,7 +10016,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR>::Dispatch(manager, device, videoSessionParameters, pAllocator);
 
-    DestroyWrappedHandle<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::VideoSessionParametersKHRWrapper>(videoSessionParameters);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
@@ -10042,7 +10042,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginVideoCodingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBeginInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginVideoCodingKHRHandles, pBeginInfo);
     }
@@ -10078,7 +10078,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndVideoCodingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndVideoCodingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pEndCodingInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -10111,7 +10111,7 @@ VKAPI_ATTR void VKAPI_CALL CmdControlVideoCodingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdControlVideoCodingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCodingControlInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -10144,7 +10144,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDecodeVideoKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDecodeVideoKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDecodeInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDecodeVideoKHRHandles, pDecodeInfo);
     }
@@ -10180,7 +10180,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderingInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderingKHRHandles, pRenderingInfo);
     }
@@ -10215,7 +10215,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -10249,7 +10249,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFeatures);
         manager->EndApiCallCapture();
     }
@@ -10282,7 +10282,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pProperties);
         manager->EndApiCallCapture();
     }
@@ -10316,7 +10316,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         EncodeStructPtr(encoder, pFormatProperties);
         manager->EndApiCallCapture();
@@ -10357,7 +10357,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pImageFormatInfo);
         EncodeStructPtr(encoder, pImageFormatProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -10395,7 +10395,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
         EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         manager->EndApiCallCapture();
@@ -10429,7 +10429,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pMemoryProperties);
         manager->EndApiCallCapture();
     }
@@ -10464,7 +10464,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFormatInfo);
         encoder->EncodeUInt32Ptr(pPropertyCount);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
@@ -10502,7 +10502,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeaturesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeaturesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(heapIndex);
         encoder->EncodeUInt32Value(localDeviceIndex);
         encoder->EncodeUInt32Value(remoteDeviceIndex);
@@ -10536,7 +10536,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDeviceMaskKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(deviceMask);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -10574,7 +10574,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatchBaseKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(baseGroupX);
         encoder->EncodeUInt32Value(baseGroupY);
         encoder->EncodeUInt32Value(baseGroupZ);
@@ -10613,8 +10613,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkTrimCommandPoolKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandPoolWrapper>(commandPool);
         encoder->EncodeFlagsValue(flags);
         manager->EndApiCallCapture();
     }
@@ -10651,7 +10651,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanInstanceWrapper, VulkanNoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -10661,11 +10661,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroupsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceGroupCount, omit_output_data);
         EncodeStructArray(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkInstance, VulkanPhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
+        manager->EndStructGroupCreateApiCallCapture<VkInstance, vulkan_wrappers::PhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroupsKHR>::Dispatch(manager, result, instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
@@ -10699,7 +10699,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalBufferInfo);
         EncodeStructPtr(encoder, pExternalBufferProperties);
         manager->EndApiCallCapture();
@@ -10743,7 +10743,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -10788,7 +10788,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryWin32HandlePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeVoidPtr(handle);
         EncodeStructPtr(encoder, pMemoryWin32HandleProperties, omit_output_data);
@@ -10836,7 +10836,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -10881,7 +10881,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryFdPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeInt32Value(fd);
         EncodeStructPtr(encoder, pMemoryFdProperties, omit_output_data);
@@ -10920,7 +10920,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphorePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalSemaphoreInfo);
         EncodeStructPtr(encoder, pExternalSemaphoreProperties);
         manager->EndApiCallCapture();
@@ -10957,7 +10957,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportSemaphoreWin32HandleInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11003,7 +11003,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11043,7 +11043,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportSemaphoreFdInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11089,7 +11089,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11128,9 +11128,9 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(layout);
         encoder->EncodeUInt32Value(set);
         encoder->EncodeUInt32Value(descriptorWriteCount);
         EncodeStructArray(encoder, pDescriptorWrites, descriptorWriteCount);
@@ -11176,7 +11176,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorUpdateTemplateWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DescriptorUpdateTemplateWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11186,12 +11186,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -11223,10 +11223,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -11234,7 +11234,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
-    DestroyWrappedHandle<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
@@ -11265,7 +11265,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanRenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::RenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11275,12 +11275,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateRenderPass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanRenderPassWrapper>(pRenderPass, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::RenderPassWrapper>(pRenderPass, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::RenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass2KHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -11312,7 +11312,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderPass2KHRHandles, pRenderPassBegin);
@@ -11350,7 +11350,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -11384,7 +11384,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -11419,8 +11419,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainStatusKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSwapchainStatusKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -11456,7 +11456,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFencePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFencePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalFenceInfo);
         EncodeStructPtr(encoder, pExternalFenceProperties);
         manager->EndApiCallCapture();
@@ -11493,7 +11493,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportFenceWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportFenceWin32HandleInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11539,7 +11539,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFenceWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11579,7 +11579,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportFenceFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportFenceFdInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11625,7 +11625,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFenceFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11671,7 +11671,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceQueueFamilyPerformanceQuer
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeUInt32Ptr(pCounterCount, omit_output_data);
         EncodeStructArray(encoder, pCounters, (pCounterCount != nullptr) ? (*pCounterCount) : 0, omit_output_data);
@@ -11711,7 +11711,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pPerformanceQueryCreateInfo);
         encoder->EncodeUInt32Ptr(pNumPasses);
         manager->EndApiCallCapture();
@@ -11745,7 +11745,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireProfilingLockKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireProfilingLockKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11778,7 +11778,7 @@ VKAPI_ATTR void VKAPI_CALL ReleaseProfilingLockKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseProfilingLockKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         manager->EndApiCallCapture();
     }
 
@@ -11822,7 +11822,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pSurfaceInfo);
         EncodeStructPtr(encoder, pSurfaceCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11870,7 +11870,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormats2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pSurfaceInfo);
         encoder->EncodeUInt32Ptr(pSurfaceFormatCount, omit_output_data);
         EncodeStructArray(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0, omit_output_data);
@@ -11910,7 +11910,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayProperties2KHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayProperties2KHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11920,11 +11920,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->displayProperties.display); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->vulkan_wrappers::DisplayKHRWrapper* { return GetVulkanWrapper<vulkan_wrappers::DisplayKHRWrapper>(handle_struct->displayProperties.display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -11959,7 +11959,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPlaneProperties2KHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPlaneProperties2KHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11969,11 +11969,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->displayPlaneProperties.currentDisplay); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->vulkan_wrappers::DisplayKHRWrapper* { return GetVulkanWrapper<vulkan_wrappers::DisplayKHRWrapper>(handle_struct->displayPlaneProperties.currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -12009,7 +12009,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanDisplayKHRWrapper, VkDisplayModeProperties2KHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<vulkan_wrappers::PhysicalDeviceWrapper, vulkan_wrappers::DisplayKHRWrapper, VkDisplayModeProperties2KHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -12019,12 +12019,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->VulkanDisplayModeKHRWrapper* { return GetWrapper<VulkanDisplayModeKHRWrapper>(handle_struct->displayModeProperties.displayMode); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->vulkan_wrappers::DisplayModeKHRWrapper* { return GetVulkanWrapper<vulkan_wrappers::DisplayModeKHRWrapper>(handle_struct->displayModeProperties.displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR>::Dispatch(manager, result, physicalDevice, display, pPropertyCount, pProperties);
@@ -12067,7 +12067,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilities2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayPlaneCapabilities2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pDisplayPlaneInfo);
         EncodeStructPtr(encoder, pCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -12108,7 +12108,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -12146,7 +12146,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -12185,7 +12185,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -12223,7 +12223,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSamplerYcbcrConversionWrapper>(device, VulkanNoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SamplerYcbcrConversionWrapper>(device, VulkanNoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -12233,12 +12233,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanSamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -12270,10 +12270,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SamplerYcbcrConversionWrapper>(ycbcrConversion);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::SamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -12281,7 +12281,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
-    DestroyWrappedHandle<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::SamplerYcbcrConversionWrapper>(ycbcrConversion);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
@@ -12313,7 +12313,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -12354,7 +12354,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -12395,7 +12395,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pSupport);
         manager->EndApiCallCapture();
@@ -12432,10 +12432,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectCountKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -12475,10 +12475,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -12522,8 +12522,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreCounterValueKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(semaphore);
         encoder->EncodeUInt64Ptr(pValue, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -12563,7 +12563,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitSemaphoresKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pWaitInfo);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -12603,7 +12603,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphoreKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSignalSemaphoreKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pSignalInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -12646,7 +12646,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceFragmentShadingRatesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFragmentShadingRatesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pFragmentShadingRateCount, omit_output_data);
         EncodeStructArray(encoder, pFragmentShadingRates, (pFragmentShadingRateCount != nullptr) ? (*pFragmentShadingRateCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -12682,7 +12682,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pFragmentSize);
         encoder->EncodeEnumArray(combinerOps, 2);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -12716,7 +12716,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingAttachmentLocationsKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRenderingAttachmentLocationsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLocationInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -12749,7 +12749,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingInputAttachmentIndicesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRenderingInputAttachmentIndicesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLocationInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -12786,8 +12786,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForPresentKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitForPresentKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt64Value(presentId);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -12827,7 +12827,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -12866,7 +12866,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -12905,7 +12905,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -12943,7 +12943,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDeferredOperationKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDeferredOperation, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DeferredOperationKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDeferredOperation, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -12953,11 +12953,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDeferredOperationKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDeferredOperationKHRWrapper>(pDeferredOperation, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DeferredOperationKHRWrapper>(pDeferredOperation, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanDeferredOperationKHRWrapper, void>(result, device, pDeferredOperation, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::DeferredOperationKHRWrapper, void>(result, device, pDeferredOperation, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDeferredOperationKHR>::Dispatch(manager, result, device, pAllocator, pDeferredOperation);
@@ -12989,10 +12989,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(operation);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDeferredOperationKHRWrapper>(operation);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DeferredOperationKHRWrapper>(operation);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -13000,7 +13000,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR>::Dispatch(manager, device, operation, pAllocator);
 
-    DestroyWrappedHandle<VulkanDeferredOperationKHRWrapper>(operation);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DeferredOperationKHRWrapper>(operation);
 }
 
 VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
@@ -13028,8 +13028,8 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeferredOperationMaxConcurrencyKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(operation);
         encoder->EncodeUInt32Value(result);
         manager->EndApiCallCapture();
     }
@@ -13064,8 +13064,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(operation);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -13100,8 +13100,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(operation);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -13147,7 +13147,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineExecutablePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pPipelineInfo);
         encoder->EncodeUInt32Ptr(pExecutableCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pExecutableCount != nullptr) ? (*pExecutableCount) : 0, omit_output_data);
@@ -13196,7 +13196,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableStatisticsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineExecutableStatisticsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pExecutableInfo);
         encoder->EncodeUInt32Ptr(pStatisticCount, omit_output_data);
         EncodeStructArray(encoder, pStatistics, (pStatisticCount != nullptr) ? (*pStatisticCount) : 0, omit_output_data);
@@ -13245,7 +13245,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableInternalRepresentationsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineExecutableInternalRepresentationsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pExecutableInfo);
         encoder->EncodeUInt32Ptr(pInternalRepresentationCount, omit_output_data);
         EncodeStructArray(encoder, pInternalRepresentations, (pInternalRepresentationCount != nullptr) ? (*pInternalRepresentationCount) : 0, omit_output_data);
@@ -13293,7 +13293,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMapMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pMemoryMapInfo);
         encoder->EncodeVoidPtrPtr(ppData, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -13333,7 +13333,7 @@ VKAPI_ATTR VkResult VKAPI_CALL UnmapMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUnmapMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pMemoryUnmapInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -13376,7 +13376,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoEncodeQualityLevelPropertie
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pQualityLevelInfo);
         EncodeStructPtr(encoder, pQualityLevelProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -13425,7 +13425,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEncodedVideoSessionParametersKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetEncodedVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pVideoSessionParametersInfo);
         EncodeStructPtr(encoder, pFeedbackInfo, omit_output_data);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
@@ -13462,7 +13462,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEncodeVideoKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEncodeVideoKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pEncodeInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEncodeVideoKHRHandles, pEncodeInfo);
     }
@@ -13499,8 +13499,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetEvent2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetEvent2KHRHandles, event, pDependencyInfo);
     }
@@ -13537,8 +13537,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetEvent2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::EventWrapper>(event);
         encoder->EncodeFlags64Value(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEvent2KHRHandles, event);
     }
@@ -13573,9 +13573,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWaitEvents2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(eventCount);
-        encoder->EncodeHandleArray<VulkanEventWrapper>(pEvents, eventCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::EventWrapper>(pEvents, eventCount);
         EncodeStructArray(encoder, pDependencyInfos, eventCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWaitEvents2KHRHandles, eventCount, pEvents, pDependencyInfos);
     }
@@ -13611,7 +13611,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPipelineBarrier2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPipelineBarrier2KHRHandles, pDependencyInfo);
     }
@@ -13649,9 +13649,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteTimestamp2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlags64Value(stage);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestamp2KHRHandles, queryPool);
     }
@@ -13691,10 +13691,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         encoder->EncodeUInt32Value(submitCount);
         EncodeStructArray(encoder, pSubmits, submitCount);
-        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
+        encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -13730,9 +13730,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarker2AMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteBufferMarker2AMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlags64Value(stage);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeUInt32Value(marker);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteBufferMarker2AMDHandles, dstBuffer);
@@ -13769,7 +13769,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointData2NV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueueCheckpointData2NV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         encoder->EncodeUInt32Ptr(pCheckpointDataCount);
         EncodeStructArray(encoder, pCheckpointData, (pCheckpointDataCount != nullptr) ? (*pCheckpointDataCount) : 0);
         manager->EndApiCallCapture();
@@ -13801,7 +13801,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBuffer2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBuffer2KHRHandles, pCopyBufferInfo);
     }
@@ -13837,7 +13837,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImage2KHRHandles, pCopyImageInfo);
     }
@@ -13873,7 +13873,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferToImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferToImage2KHRHandles, pCopyBufferToImageInfo);
     }
@@ -13909,7 +13909,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageToBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageToBuffer2KHRHandles, pCopyImageToBufferInfo);
     }
@@ -13945,7 +13945,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBlitImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBlitImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBlitImage2KHRHandles, pBlitImageInfo);
     }
@@ -13981,7 +13981,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResolveImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pResolveImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResolveImage2KHRHandles, pResolveImageInfo);
     }
@@ -14017,7 +14017,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirect2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysIndirect2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkDeviceAddressValue(indirectDeviceAddress);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -14053,7 +14053,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -14091,7 +14091,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -14130,7 +14130,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -14166,8 +14166,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindIndexBuffer2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeVkDeviceSizeValue(size);
         encoder->EncodeEnumValue(indexType);
@@ -14205,7 +14205,7 @@ VKAPI_ATTR void VKAPI_CALL GetRenderingAreaGranularityKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRenderingAreaGranularityKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pRenderingAreaInfo);
         EncodeStructPtr(encoder, pGranularity);
         manager->EndApiCallCapture();
@@ -14243,7 +14243,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSubresourceLayoutKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSubresourceLayoutKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -14279,8 +14279,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         EncodeStructPtr(encoder, pSubresource);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -14321,7 +14321,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -14357,7 +14357,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineStippleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(lineStippleFactor);
         encoder->EncodeUInt16Value(lineStipplePattern);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -14400,7 +14400,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pTimeDomainCount, omit_output_data);
         encoder->EncodeEnumArray(pTimeDomains, (pTimeDomainCount != nullptr) ? (*pTimeDomainCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -14446,7 +14446,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetCalibratedTimestampsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(timestampCount);
         EncodeStructArray(encoder, pTimestampInfos, timestampCount);
         encoder->EncodeUInt64Array(pTimestamps, timestampCount, omit_output_data);
@@ -14483,7 +14483,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindDescriptorSets2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBindDescriptorSetsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindDescriptorSets2KHRHandles, pBindDescriptorSetsInfo);
     }
@@ -14519,7 +14519,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushConstants2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pPushConstantsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushConstants2KHRHandles, pPushConstantsInfo);
     }
@@ -14555,7 +14555,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSet2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSet2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pPushDescriptorSetInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushDescriptorSet2KHRHandles, pPushDescriptorSetInfo);
     }
@@ -14591,7 +14591,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pPushDescriptorSetWithTemplateInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushDescriptorSetWithTemplate2KHRHandles, pPushDescriptorSetWithTemplateInfo);
     }
@@ -14627,7 +14627,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDescriptorBufferOffsets2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDescriptorBufferOffsets2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSetDescriptorBufferOffsetsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetDescriptorBufferOffsets2EXTHandles, pSetDescriptorBufferOffsetsInfo);
     }
@@ -14663,7 +14663,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorBufferEmbeddedSamplers2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBindDescriptorBufferEmbeddedSamplersInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles, pBindDescriptorBufferEmbeddedSamplersInfo);
     }
@@ -14700,9 +14700,9 @@ VKAPI_ATTR void VKAPI_CALL FrameBoundaryANDROID(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkFrameBoundaryANDROID);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         manager->EndApiCallCapture();
     }
 
@@ -14739,7 +14739,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanDebugReportCallbackEXTWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pCallback, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DebugReportCallbackEXTWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pCallback, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -14749,12 +14749,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDebugReportCallbackEXTWrapper>(pCallback, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DebugReportCallbackEXTWrapper>(pCallback, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanDebugReportCallbackEXTWrapper, VkDebugReportCallbackCreateInfoEXT>(result, instance, pCallback, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::DebugReportCallbackEXTWrapper, VkDebugReportCallbackCreateInfoEXT>(result, instance, pCallback, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pCallback);
@@ -14786,10 +14786,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
-        encoder->EncodeHandleValue<VulkanDebugReportCallbackEXTWrapper>(callback);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::DebugReportCallbackEXTWrapper>(callback);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDebugReportCallbackEXTWrapper>(callback);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DebugReportCallbackEXTWrapper>(callback);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -14797,7 +14797,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(manager, instance, callback, pAllocator);
 
-    DestroyWrappedHandle<VulkanDebugReportCallbackEXTWrapper>(callback);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DebugReportCallbackEXTWrapper>(callback);
 }
 
 VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
@@ -14829,10 +14829,10 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugReportMessageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(GetWrappedId(object, objectType));
+        encoder->EncodeUInt64Value(GetVulkanWrappedId(object, objectType));
         encoder->EncodeSizeTValue(location);
         encoder->EncodeInt32Value(messageCode);
         encoder->EncodeString(pLayerPrefix);
@@ -14873,7 +14873,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectTagEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pTagInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -14912,7 +14912,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectNameEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pNameInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -14946,7 +14946,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -14978,7 +14978,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDebugMarkerEndEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -15010,7 +15010,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -15047,10 +15047,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindTransformFeedbackBuffersEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindTransformFeedbackBuffersEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::BufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pSizes, bindingCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindTransformFeedbackBuffersEXTHandles, bindingCount, pBuffers);
@@ -15087,10 +15087,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginTransformFeedbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstCounterBuffer);
         encoder->EncodeUInt32Value(counterBufferCount);
-        encoder->EncodeHandleArray<VulkanBufferWrapper>(pCounterBuffers, counterBufferCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::BufferWrapper>(pCounterBuffers, counterBufferCount);
         encoder->EncodeVkDeviceSizeArray(pCounterBufferOffsets, counterBufferCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
@@ -15126,10 +15126,10 @@ VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndTransformFeedbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstCounterBuffer);
         encoder->EncodeUInt32Value(counterBufferCount);
-        encoder->EncodeHandleArray<VulkanBufferWrapper>(pCounterBuffers, counterBufferCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::BufferWrapper>(pCounterBuffers, counterBufferCount);
         encoder->EncodeVkDeviceSizeArray(pCounterBufferOffsets, counterBufferCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
@@ -15165,8 +15165,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginQueryIndexedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeUInt32Value(index);
@@ -15203,8 +15203,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndQueryIndexedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeUInt32Value(index);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndQueryIndexedEXTHandles, queryPool);
@@ -15243,10 +15243,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectByteCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(instanceCount);
         encoder->EncodeUInt32Value(firstInstance);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(counterBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(counterBuffer);
         encoder->EncodeVkDeviceSizeValue(counterBufferOffset);
         encoder->EncodeUInt32Value(counterOffset);
         encoder->EncodeUInt32Value(vertexStride);
@@ -15286,7 +15286,7 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageViewHandleNVX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Value(result);
         manager->EndApiCallCapture();
@@ -15329,8 +15329,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageViewAddressNVX(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageViewAddressNVX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(imageView);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -15369,10 +15369,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -15412,10 +15412,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -15462,8 +15462,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderInfoAMD(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderInfoAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         encoder->EncodeEnumValue(shaderStage);
         encoder->EncodeEnumValue(infoType);
         encoder->EncodeSizeTPtr(pInfoSize, omit_output_data);
@@ -15505,7 +15505,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateStreamDescriptorSurfaceGGP(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -15515,12 +15515,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateStreamDescriptorSurfaceGGP(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateStreamDescriptorSurfaceGGP);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkStreamDescriptorSurfaceCreateInfoGGP>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkStreamDescriptorSurfaceCreateInfoGGP>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateStreamDescriptorSurfaceGGP>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -15565,7 +15565,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalImageFormatPropertiesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         encoder->EncodeEnumValue(type);
         encoder->EncodeEnumValue(tiling);
@@ -15615,8 +15615,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryWin32HandleNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         encoder->EncodeFlagsValue(handleType);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -15656,7 +15656,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -15666,12 +15666,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateViSurfaceNN);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkViSurfaceCreateInfoNN>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkViSurfaceCreateInfoNN>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateViSurfaceNN>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -15702,7 +15702,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginConditionalRenderingEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pConditionalRenderingBegin);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginConditionalRenderingEXTHandles, pConditionalRenderingBegin);
     }
@@ -15737,7 +15737,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndConditionalRenderingEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndConditionalRenderingEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -15771,7 +15771,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWScalingNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewportWScalings, viewportCount);
@@ -15808,8 +15808,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -15845,9 +15845,9 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireXlibDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeVoidPtr(dpy);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -15885,7 +15885,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -15895,12 +15895,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeVoidPtr(dpy);
         encoder->EncodeSizeTValue(rrOutput);
-        encoder->EncodeHandlePtr<VulkanDisplayKHRWrapper>(pDisplay, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DisplayKHRWrapper>(pDisplay, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT>::Dispatch(manager, result, physicalDevice, dpy, rrOutput, pDisplay);
@@ -15940,8 +15940,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(surface);
         EncodeStructPtr(encoder, pSurfaceCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -15978,8 +15978,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDisplayPowerControlEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         EncodeStructPtr(encoder, pDisplayPowerInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16018,7 +16018,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanFenceWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::FenceWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16028,12 +16028,12 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkRegisterDeviceEventEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pDeviceEventInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanFenceWrapper>(pFence, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::FenceWrapper>(pFence, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanFenceWrapper, void>(result, device, pFence, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::FenceWrapper, void>(result, device, pFence, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkRegisterDeviceEventEXT>::Dispatch(manager, result, device, pDeviceEventInfo, pAllocator, pFence);
@@ -16070,7 +16070,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanDisplayKHRWrapper, VulkanFenceWrapper>(device, display, pFence, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, vulkan_wrappers::DisplayKHRWrapper, vulkan_wrappers::FenceWrapper>(device, display, pFence, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16080,13 +16080,13 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkRegisterDisplayEventEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         EncodeStructPtr(encoder, pDisplayEventInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanFenceWrapper>(pFence, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::FenceWrapper>(pFence, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanFenceWrapper, void>(result, device, pFence, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::FenceWrapper, void>(result, device, pFence, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkRegisterDisplayEventEXT>::Dispatch(manager, result, device, display, pDisplayEventInfo, pAllocator, pFence);
@@ -16127,8 +16127,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainCounterEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSwapchainCounterEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(counter);
         encoder->EncodeUInt64Ptr(pCounterValue, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16172,8 +16172,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRefreshCycleDurationGOOGLE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pDisplayTimingProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16217,8 +16217,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPastPresentationTimingGOOGLE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt32Ptr(pPresentationTimingCount, omit_output_data);
         EncodeStructArray(encoder, pPresentationTimings, (pPresentationTimingCount != nullptr) ? (*pPresentationTimingCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16255,7 +16255,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstDiscardRectangle);
         encoder->EncodeUInt32Value(discardRectangleCount);
         EncodeStructArray(encoder, pDiscardRectangles, discardRectangleCount);
@@ -16290,7 +16290,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(discardRectangleEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16323,7 +16323,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(discardRectangleMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16358,9 +16358,9 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetHdrMetadataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(swapchainCount);
-        encoder->EncodeHandleArray<VulkanSwapchainKHRWrapper>(pSwapchains, swapchainCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::SwapchainKHRWrapper>(pSwapchains, swapchainCount);
         EncodeStructArray(encoder, pMetadata, swapchainCount);
         manager->EndApiCallCapture();
     }
@@ -16398,7 +16398,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16408,12 +16408,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkIOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkIOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -16449,7 +16449,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16459,12 +16459,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkMacOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkMacOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -16495,14 +16495,14 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDebugUtilsObjectNameInfoEXT* pNameInfo_unwrapped = UnwrapStructPtrHandles(pNameInfo, handle_unwrap_memory);
 
-    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
+    auto device_wrapper = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
     auto physical_device = device_wrapper->physical_device->handle;
     VkResult result = GetVulkanInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT(device, pNameInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pNameInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16536,14 +16536,14 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDebugUtilsObjectTagInfoEXT* pTagInfo_unwrapped = UnwrapStructPtrHandles(pTagInfo, handle_unwrap_memory);
 
-    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
+    auto device_wrapper = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>(device);
     auto physical_device = device_wrapper->physical_device->handle;
     VkResult result = GetVulkanInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT(device, pTagInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTagEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pTagInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16577,7 +16577,7 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndApiCallCapture();
     }
@@ -16609,7 +16609,7 @@ VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueEndDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         manager->EndApiCallCapture();
     }
 
@@ -16641,7 +16641,7 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndApiCallCapture();
     }
@@ -16674,7 +16674,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16706,7 +16706,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -16738,7 +16738,7 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16776,7 +16776,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanDebugUtilsMessengerEXTWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pMessenger, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pMessenger, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16786,12 +16786,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanDebugUtilsMessengerEXTWrapper>(pMessenger, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(pMessenger, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanDebugUtilsMessengerEXTWrapper, VkDebugUtilsMessengerCreateInfoEXT>(result, instance, pMessenger, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::DebugUtilsMessengerEXTWrapper, VkDebugUtilsMessengerCreateInfoEXT>(result, instance, pMessenger, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pMessenger);
@@ -16823,10 +16823,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
-        encoder->EncodeHandleValue<VulkanDebugUtilsMessengerEXTWrapper>(messenger);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(messenger);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanDebugUtilsMessengerEXTWrapper>(messenger);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(messenger);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -16834,7 +16834,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(manager, instance, messenger, pAllocator);
 
-    DestroyWrappedHandle<VulkanDebugUtilsMessengerEXTWrapper>(messenger);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(messenger);
 }
 
 VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
@@ -16862,7 +16862,7 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         encoder->EncodeEnumValue(messageSeverity);
         encoder->EncodeFlagsValue(messageTypes);
         EncodeStructPtr(encoder, pCallbackData);
@@ -16906,7 +16906,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAndroidHardwareBufferPropertiesANDROID);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeVoidPtr(buffer);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16953,7 +16953,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryAndroidHardwareBufferANDROID);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVoidPtrPtr(pBuffer, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16988,7 +16988,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSampleLocationsInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -17024,7 +17024,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMultisamplePropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(samples);
         EncodeStructPtr(encoder, pMultisampleProperties);
         manager->EndApiCallCapture();
@@ -17065,8 +17065,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageDrmFormatModifierPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageDrmFormatModifierPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -17105,7 +17105,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanValidationCacheEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pValidationCache, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::ValidationCacheEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pValidationCache, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -17115,12 +17115,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateValidationCacheEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanValidationCacheEXTWrapper>(pValidationCache, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::ValidationCacheEXTWrapper>(pValidationCache, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanValidationCacheEXTWrapper, VkValidationCacheCreateInfoEXT>(result, device, pValidationCache, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::ValidationCacheEXTWrapper, VkValidationCacheCreateInfoEXT>(result, device, pValidationCache, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateValidationCacheEXT>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pValidationCache);
@@ -17152,10 +17152,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(validationCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ValidationCacheEXTWrapper>(validationCache);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanValidationCacheEXTWrapper>(validationCache);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::ValidationCacheEXTWrapper>(validationCache);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -17163,7 +17163,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(manager, device, validationCache, pAllocator);
 
-    DestroyWrappedHandle<VulkanValidationCacheEXTWrapper>(validationCache);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::ValidationCacheEXTWrapper>(validationCache);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
@@ -17193,10 +17193,10 @@ VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMergeValidationCachesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(dstCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ValidationCacheEXTWrapper>(dstCache);
         encoder->EncodeUInt32Value(srcCacheCount);
-        encoder->EncodeHandleArray<VulkanValidationCacheEXTWrapper>(pSrcCaches, srcCacheCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::ValidationCacheEXTWrapper>(pSrcCaches, srcCacheCount);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -17239,8 +17239,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetValidationCacheDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(validationCache);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ValidationCacheEXTWrapper>(validationCache);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? (*pDataSize) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -17276,8 +17276,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindShadingRateImageNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(imageView);
         encoder->EncodeEnumValue(imageLayout);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindShadingRateImageNVHandles, imageView);
     }
@@ -17312,7 +17312,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportShadingRatePaletteNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pShadingRatePalettes, viewportCount);
@@ -17349,7 +17349,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoarseSampleOrderNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(sampleOrderType);
         encoder->EncodeUInt32Value(customSampleOrderCount);
         EncodeStructArray(encoder, pCustomSampleOrders, customSampleOrderCount);
@@ -17392,7 +17392,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanAccelerationStructureNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pAccelerationStructure, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::AccelerationStructureNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pAccelerationStructure, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -17402,12 +17402,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanAccelerationStructureNVWrapper>(pAccelerationStructure, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::AccelerationStructureNVWrapper>(pAccelerationStructure, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanAccelerationStructureNVWrapper, VkAccelerationStructureCreateInfoNV>(result, device, pAccelerationStructure, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::AccelerationStructureNVWrapper, VkAccelerationStructureCreateInfoNV>(result, device, pAccelerationStructure, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureNV>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pAccelerationStructure);
@@ -17439,10 +17439,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(accelerationStructure);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::AccelerationStructureNVWrapper>(accelerationStructure);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -17450,7 +17450,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
-    DestroyWrappedHandle<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::AccelerationStructureNVWrapper>(accelerationStructure);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
@@ -17482,7 +17482,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureMemoryRequirementsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -17520,7 +17520,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindAccelerationStructureMemoryNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindAccelerationStructureMemoryNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -17562,14 +17562,14 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(instanceData);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(instanceData);
         encoder->EncodeVkDeviceSizeValue(instanceOffset);
         encoder->EncodeVkBool32Value(update);
-        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(dst);
-        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(src);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(scratch);
+        encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(dst);
+        encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(src);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(scratch);
         encoder->EncodeVkDeviceSizeValue(scratchOffset);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBuildAccelerationStructureNVHandles, pInfo, instanceData, dst, src, scratch);
     }
@@ -17607,9 +17607,9 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(dst);
-        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(src);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(dst);
+        encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(src);
         encoder->EncodeEnumValue(mode);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyAccelerationStructureNVHandles, dst, src);
     }
@@ -17655,16 +17655,16 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(raygenShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(raygenShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(raygenShaderBindingOffset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(missShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(missShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(missShaderBindingOffset);
         encoder->EncodeVkDeviceSizeValue(missShaderBindingStride);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(hitShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(hitShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(hitShaderBindingOffset);
         encoder->EncodeVkDeviceSizeValue(hitShaderBindingStride);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(callableShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(callableShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(callableShaderBindingOffset);
         encoder->EncodeVkDeviceSizeValue(callableShaderBindingStride);
         encoder->EncodeUInt32Value(width);
@@ -17713,8 +17713,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(firstGroup);
         encoder->EncodeUInt32Value(groupCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -17763,8 +17763,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(firstGroup);
         encoder->EncodeUInt32Value(groupCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -17811,8 +17811,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAccelerationStructureHandleNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureHandleNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(accelerationStructure);
         encoder->EncodeSizeTValue(dataSize);
         encoder->EncodeVoidArray(pData, dataSize, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -17851,11 +17851,11 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(accelerationStructureCount);
-        encoder->EncodeHandleArray<VulkanAccelerationStructureNVWrapper>(pAccelerationStructures, accelerationStructureCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::AccelerationStructureNVWrapper>(pAccelerationStructures, accelerationStructureCount);
         encoder->EncodeEnumValue(queryType);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteAccelerationStructuresPropertiesNVHandles, accelerationStructureCount, pAccelerationStructures, queryPool);
     }
@@ -17891,8 +17891,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CompileDeferredNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCompileDeferredNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(shader);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -17936,7 +17936,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryHostPointerPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeVoidPtr(pHostPointer);
         EncodeStructPtr(encoder, pMemoryHostPointerProperties, omit_output_data);
@@ -17975,9 +17975,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteBufferMarkerAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineStage);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeUInt32Value(marker);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteBufferMarkerAMDHandles, dstBuffer);
@@ -18020,7 +18020,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pTimeDomainCount, omit_output_data);
         encoder->EncodeEnumArray(pTimeDomains, (pTimeDomainCount != nullptr) ? (*pTimeDomainCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18066,7 +18066,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetCalibratedTimestampsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(timestampCount);
         EncodeStructArray(encoder, pTimestampInfos, timestampCount);
         encoder->EncodeUInt64Array(pTimestamps, timestampCount, omit_output_data);
@@ -18104,7 +18104,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(taskCount);
         encoder->EncodeUInt32Value(firstTask);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18141,8 +18141,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -18182,10 +18182,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -18222,7 +18222,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstExclusiveScissor);
         encoder->EncodeUInt32Value(exclusiveScissorCount);
         encoder->EncodeVkBool32Array(pExclusiveScissorEnables, exclusiveScissorCount);
@@ -18259,7 +18259,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstExclusiveScissor);
         encoder->EncodeUInt32Value(exclusiveScissorCount);
         EncodeStructArray(encoder, pExclusiveScissors, exclusiveScissorCount);
@@ -18294,7 +18294,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCheckpointNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVoidPtr(pCheckpointMarker);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -18330,7 +18330,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueueCheckpointDataNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
         encoder->EncodeUInt32Ptr(pCheckpointDataCount);
         EncodeStructArray(encoder, pCheckpointData, (pCheckpointDataCount != nullptr) ? (*pCheckpointDataCount) : 0);
         manager->EndApiCallCapture();
@@ -18364,7 +18364,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InitializePerformanceApiINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkInitializePerformanceApiINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInitializeInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -18397,7 +18397,7 @@ VKAPI_ATTR void VKAPI_CALL UninitializePerformanceApiINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUninitializePerformanceApiINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         manager->EndApiCallCapture();
     }
 
@@ -18431,7 +18431,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceMarkerINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceMarkerINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18467,7 +18467,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceStreamMarkerINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceStreamMarkerINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18503,7 +18503,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceOverrideINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceOverrideINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pOverrideInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18541,7 +18541,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPerformanceConfigurationINTELWrapper>(device, VulkanNoParentWrapper::kHandleValue, pConfiguration, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::PerformanceConfigurationINTELWrapper>(device, VulkanNoParentWrapper::kHandleValue, pConfiguration, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -18551,11 +18551,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAcquirePerformanceConfigurationINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pAcquireInfo);
-        encoder->EncodeHandlePtr<VulkanPerformanceConfigurationINTELWrapper>(pConfiguration, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(pConfiguration, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanPerformanceConfigurationINTELWrapper, void>(result, device, pConfiguration, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::PerformanceConfigurationINTELWrapper, void>(result, device, pConfiguration, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAcquirePerformanceConfigurationINTEL>::Dispatch(manager, result, device, pAcquireInfo, pConfiguration);
@@ -18589,15 +18589,15 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPerformanceConfigurationINTELWrapper>(configuration);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(configuration);
         encoder->EncodeEnumValue(result);
-        manager->EndDestroyApiCallCapture<VulkanPerformanceConfigurationINTELWrapper>(configuration);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(configuration);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, result, device, configuration);
 
-    DestroyWrappedHandle<VulkanPerformanceConfigurationINTELWrapper>(configuration);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(configuration);
 
     return result;
 }
@@ -18627,8 +18627,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSetPerformanceConfigurationINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSetPerformanceConfigurationINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
-        encoder->EncodeHandleValue<VulkanPerformanceConfigurationINTELWrapper>(configuration);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueueWrapper>(queue);
+        encoder->EncodeHandleValue<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(configuration);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -18670,7 +18670,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPerformanceParameterINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPerformanceParameterINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(parameter);
         EncodeStructPtr(encoder, pValue, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18706,8 +18706,8 @@ VKAPI_ATTR void VKAPI_CALL SetLocalDimmingAMD(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetLocalDimmingAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapChain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapChain);
         encoder->EncodeVkBool32Value(localDimmingEnable);
         manager->EndApiCallCapture();
     }
@@ -18745,7 +18745,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -18755,12 +18755,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkImagePipeSurfaceCreateInfoFUCHSIA>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkImagePipeSurfaceCreateInfoFUCHSIA>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -18796,7 +18796,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -18806,12 +18806,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkMetalSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkMetalSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -18847,7 +18847,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddressEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -18890,7 +18890,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pToolCount, omit_output_data);
         EncodeStructArray(encoder, pToolProperties, (pToolCount != nullptr) ? (*pToolCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18934,7 +18934,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18978,7 +18978,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSupportedFramebufferMixedSamples
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pCombinationCount, omit_output_data);
         EncodeStructArray(encoder, pCombinations, (pCombinationCount != nullptr) ? (*pCombinationCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -19026,7 +19026,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModes2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModes2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pSurfaceInfo);
         encoder->EncodeUInt32Ptr(pPresentModeCount, omit_output_data);
         encoder->EncodeEnumArray(pPresentModes, (pPresentModeCount != nullptr) ? (*pPresentModeCount) : 0, omit_output_data);
@@ -19064,8 +19064,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireFullScreenExclusiveModeEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireFullScreenExclusiveModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -19100,8 +19100,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseFullScreenExclusiveModeEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseFullScreenExclusiveModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -19146,7 +19146,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModes2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pSurfaceInfo);
         encoder->EncodeFlagsPtr(pModes, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -19186,7 +19186,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateHeadlessSurfaceEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -19196,12 +19196,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateHeadlessSurfaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateHeadlessSurfaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkHeadlessSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkHeadlessSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateHeadlessSurfaceEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -19233,7 +19233,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineStippleEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(lineStippleFactor);
         encoder->EncodeUInt16Value(lineStipplePattern);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -19269,8 +19269,8 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPoolEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetQueryPoolEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         manager->EndApiCallCapture();
@@ -19304,7 +19304,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCullModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(cullMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19337,7 +19337,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFrontFaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(frontFace);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19370,7 +19370,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopologyEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopologyEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(primitiveTopology);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19404,7 +19404,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWithCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewports, viewportCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -19439,7 +19439,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetScissorWithCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(scissorCount);
         EncodeStructArray(encoder, pScissors, scissorCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -19478,10 +19478,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::BufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pSizes, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pStrides, bindingCount);
@@ -19516,7 +19516,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthTestEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19549,7 +19549,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthWriteEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19582,7 +19582,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOpEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthCompareOpEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(depthCompareOp);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19615,7 +19615,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBoundsTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19648,7 +19648,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilTestEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(stencilTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19685,7 +19685,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOpEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilOpEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeEnumValue(failOp);
         encoder->EncodeEnumValue(passOp);
@@ -19727,7 +19727,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToImageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToImageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCopyMemoryToImageInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19766,7 +19766,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToMemoryEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyImageToMemoryEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCopyImageToMemoryInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19805,7 +19805,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToImageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyImageToImageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCopyImageToImageInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19845,7 +19845,7 @@ VKAPI_ATTR VkResult VKAPI_CALL TransitionImageLayoutEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkTransitionImageLayoutEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(transitionCount);
         EncodeStructArray(encoder, pTransitions, transitionCount);
         encoder->EncodeEnumValue(result);
@@ -19884,8 +19884,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(image);
         EncodeStructPtr(encoder, pSubresource);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -19922,7 +19922,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseSwapchainImagesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseSwapchainImagesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pReleaseInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19962,7 +19962,7 @@ VKAPI_ATTR void VKAPI_CALL GetGeneratedCommandsMemoryRequirementsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetGeneratedCommandsMemoryRequirementsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -19994,7 +19994,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPreprocessGeneratedCommandsNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPreprocessGeneratedCommandsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pGeneratedCommandsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPreprocessGeneratedCommandsNVHandles, pGeneratedCommandsInfo);
     }
@@ -20031,7 +20031,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteGeneratedCommandsNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdExecuteGeneratedCommandsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(isPreprocessed);
         EncodeStructPtr(encoder, pGeneratedCommandsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdExecuteGeneratedCommandsNVHandles, pGeneratedCommandsInfo);
@@ -20070,9 +20070,9 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipelineShaderGroupNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindPipelineShaderGroupNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(groupIndex);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindPipelineShaderGroupNVHandles, pipeline);
     }
@@ -20113,7 +20113,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanIndirectCommandsLayoutNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pIndirectCommandsLayout, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pIndirectCommandsLayout, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20123,12 +20123,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanIndirectCommandsLayoutNVWrapper>(pIndirectCommandsLayout, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(pIndirectCommandsLayout, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanIndirectCommandsLayoutNVWrapper, VkIndirectCommandsLayoutCreateInfoNV>(result, device, pIndirectCommandsLayout, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::IndirectCommandsLayoutNVWrapper, VkIndirectCommandsLayoutCreateInfoNV>(result, device, pIndirectCommandsLayout, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNV>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
@@ -20160,10 +20160,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanIndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanIndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -20171,7 +20171,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV>::Dispatch(manager, device, indirectCommandsLayout, pAllocator);
 
-    DestroyWrappedHandle<VulkanIndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
@@ -20197,7 +20197,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBias2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDepthBiasInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -20233,9 +20233,9 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireDrmDisplayEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireDrmDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeInt32Value(drmFd);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -20273,7 +20273,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, display, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, display, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20283,12 +20283,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDrmDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeInt32Value(drmFd);
         encoder->EncodeUInt32Value(connectorId);
-        encoder->EncodeHandlePtr<VulkanDisplayKHRWrapper>(display, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DisplayKHRWrapper>(display, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, void>(result, physicalDevice, display, nullptr);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayKHRWrapper, void>(result, physicalDevice, display, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDrmDisplayEXT>::Dispatch(manager, result, physicalDevice, drmFd, connectorId, display);
@@ -20324,7 +20324,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPrivateDataSlotWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::PrivateDataSlotWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20334,12 +20334,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePrivateDataSlotEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanPrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::PrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanPrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::PrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePrivateDataSlotEXT>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPrivateDataSlot);
@@ -20371,10 +20371,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -20382,7 +20382,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
-    DestroyWrappedHandle<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
@@ -20413,10 +20413,10 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetPrivateDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeUInt64Value(GetVulkanWrappedId(objectHandle, objectType));
+        encoder->EncodeHandleValue<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Value(data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -20455,10 +20455,10 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPrivateDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeUInt64Value(GetVulkanWrappedId(objectHandle, objectType));
+        encoder->EncodeHandleValue<vulkan_wrappers::PrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Ptr(pData);
         manager->EndApiCallCapture();
     }
@@ -20490,7 +20490,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateEnumNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateEnumNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(shadingRate);
         encoder->EncodeEnumArray(combinerOps, 2);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -20533,7 +20533,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceFaultInfoEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceFaultInfoEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pFaultCounts, omit_output_data);
         EncodeStructPtr(encoder, pFaultInfo, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -20570,8 +20570,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireWinrtDisplayNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireWinrtDisplayNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -20608,7 +20608,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::PhysicalDeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::DisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20618,11 +20618,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetWinrtDisplayNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(deviceRelativeId);
-        encoder->EncodeHandlePtr<VulkanDisplayKHRWrapper>(pDisplay, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::DisplayKHRWrapper>(pDisplay, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, vulkan_wrappers::DisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetWinrtDisplayNV>::Dispatch(manager, result, physicalDevice, deviceRelativeId, pDisplay);
@@ -20658,7 +20658,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDirectFBSurfaceEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20668,12 +20668,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDirectFBSurfaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDirectFBSurfaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkDirectFBSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkDirectFBSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDirectFBSurfaceEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -20707,7 +20707,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceDirectFBPresentationSupportEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDirectFBPresentationSupportEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(dfb);
         encoder->EncodeVkBool32Value(result);
@@ -20745,7 +20745,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetVertexInputEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetVertexInputEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(vertexBindingDescriptionCount);
         EncodeStructArray(encoder, pVertexBindingDescriptions, vertexBindingDescriptionCount);
         encoder->EncodeUInt32Value(vertexAttributeDescriptionCount);
@@ -20793,7 +20793,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandleFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryZirconHandleFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetZirconHandleInfo);
         encoder->EncodeUInt32Ptr(pZirconHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -20838,7 +20838,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandlePropertiesFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryZirconHandlePropertiesFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeUInt32Value(zirconHandle);
         EncodeStructPtr(encoder, pMemoryZirconHandleProperties, omit_output_data);
@@ -20879,7 +20879,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreZirconHandleFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreZirconHandleFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportSemaphoreZirconHandleInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -20925,7 +20925,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreZirconHandleFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreZirconHandleFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetZirconHandleInfo);
         encoder->EncodeUInt32Ptr(pZirconHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -20961,8 +20961,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindInvocationMaskHUAWEI(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindInvocationMaskHUAWEI);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(imageView);
         encoder->EncodeEnumValue(imageLayout);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindInvocationMaskHUAWEIHandles, imageView);
     }
@@ -21007,7 +21007,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryRemoteAddressNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryRemoteAddressNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pMemoryGetRemoteAddressInfo);
         encoder->EncodeVoidPtrPtr(pAddress, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -21042,7 +21042,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPatchControlPointsEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPatchControlPointsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(patchControlPoints);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21075,7 +21075,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(rasterizerDiscardEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21108,7 +21108,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBiasEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21141,7 +21141,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLogicOpEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(logicOp);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21174,7 +21174,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(primitiveRestartEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21212,7 +21212,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateScreenSurfaceQNX(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::InstanceWrapper, VulkanNoParentWrapper, vulkan_wrappers::SurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -21222,12 +21222,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateScreenSurfaceQNX(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateScreenSurfaceQNX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<vulkan_wrappers::InstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::SurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkScreenSurfaceCreateInfoQNX>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, vulkan_wrappers::SurfaceKHRWrapper, VkScreenSurfaceCreateInfoQNX>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateScreenSurfaceQNX>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -21261,7 +21261,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceScreenPresentationSupportQNX(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceScreenPresentationSupportQNX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(window);
         encoder->EncodeVkBool32Value(result);
@@ -21297,7 +21297,7 @@ VKAPI_ATTR void                                    VKAPI_CALL CmdSetColorWriteEn
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorWriteEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(attachmentCount);
         encoder->EncodeVkBool32Array(pColorWriteEnables, attachmentCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -21335,7 +21335,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMultiEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(drawCount);
         EncodeStructArray(encoder, pVertexInfo, drawCount);
         encoder->EncodeUInt32Value(instanceCount);
@@ -21377,7 +21377,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiIndexedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMultiIndexedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(drawCount);
         EncodeStructArray(encoder, pIndexInfo, drawCount);
         encoder->EncodeUInt32Value(instanceCount);
@@ -21423,7 +21423,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMicromapEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanMicromapEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pMicromap, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::MicromapEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pMicromap, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -21433,12 +21433,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanMicromapEXTWrapper>(pMicromap, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::MicromapEXTWrapper>(pMicromap, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanMicromapEXTWrapper, VkMicromapCreateInfoEXT>(result, device, pMicromap, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::MicromapEXTWrapper, VkMicromapCreateInfoEXT>(result, device, pMicromap, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMicromapEXT>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pMicromap);
@@ -21470,10 +21470,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(micromap);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(micromap);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanMicromapEXTWrapper>(micromap);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::MicromapEXTWrapper>(micromap);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -21481,7 +21481,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyMicromapEXT>::Dispatch(manager, device, micromap, pAllocator);
 
-    DestroyWrappedHandle<VulkanMicromapEXTWrapper>(micromap);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::MicromapEXTWrapper>(micromap);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
@@ -21508,7 +21508,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildMicromapsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBuildMicromapsEXTHandles, infoCount, pInfos);
@@ -21552,8 +21552,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BuildMicromapsEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBuildMicromapsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         encoder->EncodeEnumValue(result);
@@ -21594,8 +21594,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -21635,8 +21635,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapToMemoryEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMicromapToMemoryEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -21676,8 +21676,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToMicromapEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -21724,9 +21724,9 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteMicromapsPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWriteMicromapsPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(micromapCount);
-        encoder->EncodeHandleArray<VulkanMicromapEXTWrapper>(pMicromaps, micromapCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::MicromapEXTWrapper>(pMicromaps, micromapCount);
         encoder->EncodeEnumValue(queryType);
         encoder->EncodeSizeTValue(dataSize);
         encoder->EncodeVoidArray(pData, dataSize, omit_output_data);
@@ -21763,7 +21763,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMicromapEXTHandles, pInfo);
     }
@@ -21799,7 +21799,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapToMemoryEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMicromapToMemoryEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMicromapToMemoryEXTHandles, pInfo);
     }
@@ -21835,7 +21835,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMemoryToMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMemoryToMicromapEXTHandles, pInfo);
     }
@@ -21875,11 +21875,11 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteMicromapsPropertiesEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteMicromapsPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(micromapCount);
-        encoder->EncodeHandleArray<VulkanMicromapEXTWrapper>(pMicromaps, micromapCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::MicromapEXTWrapper>(pMicromaps, micromapCount);
         encoder->EncodeEnumValue(queryType);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteMicromapsPropertiesEXTHandles, micromapCount, pMicromaps, queryPool);
     }
@@ -21915,7 +21915,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMicromapCompatibilityEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMicromapCompatibilityEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pVersionInfo);
         encoder->EncodeEnumPtr(pCompatibility);
         manager->EndApiCallCapture();
@@ -21954,7 +21954,7 @@ VKAPI_ATTR void VKAPI_CALL GetMicromapBuildSizesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMicromapBuildSizesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(buildType);
         EncodeStructPtr(encoder, pBuildInfo);
         EncodeStructPtr(encoder, pSizeInfo);
@@ -21989,7 +21989,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterHUAWEI(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawClusterHUAWEI);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(groupCountX);
         encoder->EncodeUInt32Value(groupCountY);
         encoder->EncodeUInt32Value(groupCountZ);
@@ -22025,8 +22025,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterIndirectHUAWEI(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawClusterIndirectHUAWEI);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawClusterIndirectHUAWEIHandles, buffer);
     }
@@ -22060,8 +22060,8 @@ VKAPI_ATTR void VKAPI_CALL SetDeviceMemoryPriorityEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDeviceMemoryPriorityEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(memory);
         encoder->EncodeFloatValue(priority);
         manager->EndApiCallCapture();
     }
@@ -22100,7 +22100,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutHostMappingInfoVALVE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutHostMappingInfoVALVE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pBindingReference);
         EncodeStructPtr(encoder, pHostMapping);
         manager->EndApiCallCapture();
@@ -22135,8 +22135,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetHostMappingVALVE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetHostMappingVALVE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(descriptorSet);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetWrapper>(descriptorSet);
         encoder->EncodeVoidPtrPtr(ppData);
         manager->EndApiCallCapture();
     }
@@ -22173,7 +22173,7 @@ VKAPI_ATTR void VKAPI_CALL GetPipelineIndirectMemoryRequirementsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineIndirectMemoryRequirementsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -22206,9 +22206,9 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdatePipelineIndirectBufferNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdUpdatePipelineIndirectBufferNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdUpdatePipelineIndirectBufferNVHandles, pipeline);
     }
 
@@ -22245,7 +22245,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetPipelineIndirectDeviceAddressNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineIndirectDeviceAddressNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -22279,7 +22279,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClampEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthClampEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthClampEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22312,7 +22312,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPolygonModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPolygonModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(polygonMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22345,7 +22345,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationSamplesEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizationSamplesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(rasterizationSamples);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22379,7 +22379,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleMaskEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetSampleMaskEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(samples);
         encoder->EncodeVkSampleMaskArray(pSampleMask, (samples + 31) / 32);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -22413,7 +22413,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToCoverageEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetAlphaToCoverageEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(alphaToCoverageEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22446,7 +22446,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToOneEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetAlphaToOneEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(alphaToOneEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22479,7 +22479,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLogicOpEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(logicOpEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22514,7 +22514,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorBlendEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         encoder->EncodeVkBool32Array(pColorBlendEnables, attachmentCount);
@@ -22551,7 +22551,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEquationEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorBlendEquationEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         EncodeStructArray(encoder, pColorBlendEquations, attachmentCount);
@@ -22588,7 +22588,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorWriteMaskEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorWriteMaskEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         encoder->EncodeFlagsArray(pColorWriteMasks, attachmentCount);
@@ -22623,7 +22623,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetTessellationDomainOriginEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetTessellationDomainOriginEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(domainOrigin);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22656,7 +22656,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationStreamEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizationStreamEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(rasterizationStream);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22689,7 +22689,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetConservativeRasterizationModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetConservativeRasterizationModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(conservativeRasterizationMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22722,7 +22722,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExtraPrimitiveOverestimationSizeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetExtraPrimitiveOverestimationSizeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(extraPrimitiveOverestimationSize);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22755,7 +22755,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthClipEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthClipEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22788,7 +22788,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(sampleLocationsEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22823,7 +22823,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendAdvancedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorBlendAdvancedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         EncodeStructArray(encoder, pColorBlendAdvanced, attachmentCount);
@@ -22858,7 +22858,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetProvokingVertexModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetProvokingVertexModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(provokingVertexMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22891,7 +22891,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineRasterizationModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineRasterizationModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(lineRasterizationMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22924,7 +22924,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineStippleEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(stippledLineEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22957,7 +22957,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipNegativeOneToOneEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthClipNegativeOneToOneEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(negativeOneToOne);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22990,7 +22990,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWScalingEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(viewportWScalingEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23025,7 +23025,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportSwizzleNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportSwizzleNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewportSwizzles, viewportCount);
@@ -23060,7 +23060,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageToColorEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(coverageToColorEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23093,7 +23093,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorLocationNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageToColorLocationNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(coverageToColorLocation);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23126,7 +23126,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationModeNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageModulationModeNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(coverageModulationMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23159,7 +23159,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageModulationTableEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(coverageModulationTableEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23193,7 +23193,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageModulationTableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(coverageModulationTableCount);
         encoder->EncodeFloatArray(pCoverageModulationTable, coverageModulationTableCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -23227,7 +23227,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetShadingRateImageEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetShadingRateImageEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(shadingRateImageEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23260,7 +23260,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRepresentativeFragmentTestEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRepresentativeFragmentTestEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(representativeFragmentTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23293,7 +23293,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageReductionModeNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageReductionModeNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(coverageReductionMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23329,8 +23329,8 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleIdentifierEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderModuleIdentifierEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanShaderModuleWrapper>(shaderModule);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ShaderModuleWrapper>(shaderModule);
         EncodeStructPtr(encoder, pIdentifier);
         manager->EndApiCallCapture();
     }
@@ -23367,7 +23367,7 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleCreateInfoIdentifierEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderModuleCreateInfoIdentifierEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pIdentifier);
         manager->EndApiCallCapture();
@@ -23409,7 +23409,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceOpticalFlowImageFormatsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceOpticalFlowImageFormatsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<vulkan_wrappers::PhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pOpticalFlowImageFormatInfo);
         encoder->EncodeUInt32Ptr(pFormatCount, omit_output_data);
         EncodeStructArray(encoder, pImageFormatProperties, (pFormatCount != nullptr) ? (*pFormatCount) : 0, omit_output_data);
@@ -23450,7 +23450,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateOpticalFlowSessionNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanOpticalFlowSessionNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSession, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandle<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::OpticalFlowSessionNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSession, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -23460,12 +23460,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateOpticalFlowSessionNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateOpticalFlowSessionNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanOpticalFlowSessionNVWrapper>(pSession, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::OpticalFlowSessionNVWrapper>(pSession, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanOpticalFlowSessionNVWrapper, VkOpticalFlowSessionCreateInfoNV>(result, device, pSession, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::OpticalFlowSessionNVWrapper, VkOpticalFlowSessionCreateInfoNV>(result, device, pSession, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateOpticalFlowSessionNV>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSession);
@@ -23497,10 +23497,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanOpticalFlowSessionNVWrapper>(session);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::OpticalFlowSessionNVWrapper>(session);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanOpticalFlowSessionNVWrapper>(session);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::OpticalFlowSessionNVWrapper>(session);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -23508,7 +23508,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV>::Dispatch(manager, device, session, pAllocator);
 
-    DestroyWrappedHandle<VulkanOpticalFlowSessionNVWrapper>(session);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::OpticalFlowSessionNVWrapper>(session);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
@@ -23539,10 +23539,10 @@ VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindOpticalFlowSessionImageNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanOpticalFlowSessionNVWrapper>(session);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::OpticalFlowSessionNVWrapper>(session);
         encoder->EncodeEnumValue(bindingPoint);
-        encoder->EncodeHandleValue<VulkanImageViewWrapper>(view);
+        encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(view);
         encoder->EncodeEnumValue(layout);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -23577,8 +23577,8 @@ VKAPI_ATTR void VKAPI_CALL CmdOpticalFlowExecuteNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdOpticalFlowExecuteNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanOpticalFlowSessionNVWrapper>(session);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::OpticalFlowSessionNVWrapper>(session);
         EncodeStructPtr(encoder, pExecuteInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdOpticalFlowExecuteNVHandles, session);
     }
@@ -23620,7 +23620,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanShaderEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pShaders, createInfoCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedVulkanHandles<vulkan_wrappers::DeviceWrapper, VulkanNoParentWrapper, vulkan_wrappers::ShaderEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pShaders, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -23630,13 +23630,13 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateShadersEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<VulkanShaderEXTWrapper>(pShaders, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<vulkan_wrappers::ShaderEXTWrapper>(pShaders, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkDevice, void*, VulkanShaderEXTWrapper, VkShaderCreateInfoEXT>(result, device, nullptr, createInfoCount, pShaders, pCreateInfos);
+        manager->EndGroupCreateApiCallCapture<VkDevice, void*, vulkan_wrappers::ShaderEXTWrapper, VkShaderCreateInfoEXT>(result, device, nullptr, createInfoCount, pShaders, pCreateInfos);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateShadersEXT>::Dispatch(manager, result, device, createInfoCount, pCreateInfos, pAllocator, pShaders);
@@ -23668,10 +23668,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyShaderEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanShaderEXTWrapper>(shader);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ShaderEXTWrapper>(shader);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanShaderEXTWrapper>(shader);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::ShaderEXTWrapper>(shader);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -23679,7 +23679,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderEXT>::Dispatch(manager, device, shader, pAllocator);
 
-    DestroyWrappedHandle<VulkanShaderEXTWrapper>(shader);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::ShaderEXTWrapper>(shader);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
@@ -23715,8 +23715,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderBinaryDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanShaderEXTWrapper>(shader);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::ShaderEXTWrapper>(shader);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? (*pDataSize) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -23753,10 +23753,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadersEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindShadersEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(stageCount);
         encoder->EncodeEnumArray(pStages, stageCount);
-        encoder->EncodeHandleArray<VulkanShaderEXTWrapper>(pShaders, stageCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::ShaderEXTWrapper>(pShaders, stageCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindShadersEXTHandles, stageCount, pShaders);
     }
 
@@ -23798,8 +23798,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFramebufferTilePropertiesQCOM(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFramebufferTilePropertiesQCOM);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanFramebufferWrapper>(framebuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::FramebufferWrapper>(framebuffer);
         encoder->EncodeUInt32Ptr(pPropertiesCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertiesCount != nullptr) ? (*pPropertiesCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -23846,7 +23846,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDynamicRenderingTilePropertiesQCOM(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDynamicRenderingTilePropertiesQCOM);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pRenderingInfo);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -24063,7 +24063,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAttachmentFeedbackLoopEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetAttachmentFeedbackLoopEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(aspectMask);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -24106,12 +24106,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructure, omit_output_data);
+        encoder->EncodeHandlePtr<vulkan_wrappers::AccelerationStructureKHRWrapper>(pAccelerationStructure, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VulkanAccelerationStructureKHRWrapper, VkAccelerationStructureCreateInfoKHR>(result, device, pAccelerationStructure, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, vulkan_wrappers::AccelerationStructureKHRWrapper, VkAccelerationStructureCreateInfoKHR>(result, device, pAccelerationStructure, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pAccelerationStructure);
@@ -24143,10 +24143,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(accelerationStructure);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(accelerationStructure);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VulkanAccelerationStructureKHRWrapper>(accelerationStructure);
+        manager->EndDestroyApiCallCapture<vulkan_wrappers::AccelerationStructureKHRWrapper>(accelerationStructure);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -24154,7 +24154,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
-    DestroyWrappedHandle<VulkanAccelerationStructureKHRWrapper>(accelerationStructure);
+    DestroyWrappedVulkanHandle<vulkan_wrappers::AccelerationStructureKHRWrapper>(accelerationStructure);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
@@ -24182,7 +24182,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         EncodeStructArray2D(encoder, ppBuildRangeInfos, ArraySize2D<VkCommandBuffer, uint32_t, const VkAccelerationStructureBuildGeometryInfoKHR*, const VkAccelerationStructureBuildRangeInfoKHR* const*>(commandBuffer, infoCount, pInfos, ppBuildRangeInfos));
@@ -24221,7 +24221,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresIndirectKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         encoder->EncodeVkDeviceAddressArray(pIndirectDeviceAddresses, infoCount);
@@ -24267,8 +24267,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyAccelerationStructureToMemoryKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -24308,8 +24308,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToAccelerationStructureKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -24356,9 +24356,9 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteAccelerationStructuresPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWriteAccelerationStructuresPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeUInt32Value(accelerationStructureCount);
-        encoder->EncodeHandleArray<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::AccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
         encoder->EncodeEnumValue(queryType);
         encoder->EncodeSizeTValue(dataSize);
         encoder->EncodeVoidArray(pData, dataSize, omit_output_data);
@@ -24395,7 +24395,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyAccelerationStructureKHRHandles, pInfo);
     }
@@ -24431,7 +24431,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureToMemoryKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureToMemoryKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyAccelerationStructureToMemoryKHRHandles, pInfo);
     }
@@ -24467,7 +24467,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMemoryToAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMemoryToAccelerationStructureKHRHandles, pInfo);
     }
@@ -24508,7 +24508,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetAccelerationStructureDeviceAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureDeviceAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -24546,11 +24546,11 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(accelerationStructureCount);
-        encoder->EncodeHandleArray<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
+        encoder->EncodeHandleArray<vulkan_wrappers::AccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
         encoder->EncodeEnumValue(queryType);
-        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteAccelerationStructuresPropertiesKHRHandles, accelerationStructureCount, pAccelerationStructures, queryPool);
     }
@@ -24586,7 +24586,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceAccelerationStructureCompatibilityKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceAccelerationStructureCompatibilityKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         EncodeStructPtr(encoder, pVersionInfo);
         encoder->EncodeEnumPtr(pCompatibility);
         manager->EndApiCallCapture();
@@ -24626,7 +24626,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureBuildSizesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureBuildSizesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
         encoder->EncodeEnumValue(buildType);
         EncodeStructPtr(encoder, pBuildInfo);
         encoder->EncodeUInt32Array(pMaxPrimitiveCounts, (pBuildInfo != nullptr) ? (pBuildInfo->geometryCount) : 0);
@@ -24666,7 +24666,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRaygenShaderBindingTable);
         EncodeStructPtr(encoder, pMissShaderBindingTable);
         EncodeStructPtr(encoder, pHitShaderBindingTable);
@@ -24717,8 +24717,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingCaptureReplayShaderGroupHandlesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(firstGroup);
         encoder->EncodeUInt32Value(groupCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -24759,7 +24759,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirectKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysIndirectKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRaygenShaderBindingTable);
         EncodeStructPtr(encoder, pMissShaderBindingTable);
         EncodeStructPtr(encoder, pHitShaderBindingTable);
@@ -24800,8 +24800,8 @@ VKAPI_ATTR VkDeviceSize VKAPI_CALL GetRayTracingShaderGroupStackSizeKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupStackSizeKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
-        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<vulkan_wrappers::DeviceWrapper>(device);
+        encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(group);
         encoder->EncodeEnumValue(groupShader);
         encoder->EncodeVkDeviceSizeValue(result);
@@ -24836,7 +24836,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRayTracingPipelineStackSizeKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRayTracingPipelineStackSizeKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(pipelineStackSize);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -24871,7 +24871,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(groupCountX);
         encoder->EncodeUInt32Value(groupCountY);
         encoder->EncodeUInt32Value(groupCountZ);
@@ -24909,8 +24909,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -24950,10 +24950,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -75,9 +75,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
     {
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<InstanceWrapper>(pInstance, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanInstanceWrapper>(pInstance, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndCreateApiCallCapture<const void*, InstanceWrapper, VkInstanceCreateInfo>(result, nullptr, pInstance, pCreateInfo);
+        VulkanCaptureManager::Get()->EndCreateApiCallCapture<const void*, VulkanInstanceWrapper, VkInstanceCreateInfo>(result, nullptr, pInstance, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateInstance>::Dispatch(VulkanCaptureManager::Get(), result, pCreateInfo, pAllocator, pInstance);
@@ -108,9 +108,9 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyInstance);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<InstanceWrapper>(instance);
+        manager->EndDestroyApiCallCapture<VulkanInstanceWrapper>(instance);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -118,7 +118,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(manager, instance, pAllocator);
 
-    DestroyWrappedHandle<InstanceWrapper>(instance);
+    DestroyWrappedHandle<VulkanInstanceWrapper>(instance);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
@@ -148,7 +148,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<InstanceWrapper, NoParentWrapper, PhysicalDeviceWrapper>(instance, NoParentWrapper::kHandleValue, pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandles<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanPhysicalDeviceWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -158,11 +158,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceCount, omit_output_data);
-        encoder->EncodeHandleArray<PhysicalDeviceWrapper>(pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<VulkanPhysicalDeviceWrapper>(pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkInstance, void*, PhysicalDeviceWrapper, void>(result, instance, nullptr, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr);
+        manager->EndGroupCreateApiCallCapture<VkInstance, void*, VulkanPhysicalDeviceWrapper, void>(result, instance, nullptr, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices>::Dispatch(manager, result, instance, pPhysicalDeviceCount, pPhysicalDevices);
@@ -195,7 +195,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFeatures);
         manager->EndApiCallCapture();
     }
@@ -229,7 +229,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         EncodeStructPtr(encoder, pFormatProperties);
         manager->EndApiCallCapture();
@@ -274,7 +274,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         encoder->EncodeEnumValue(type);
         encoder->EncodeEnumValue(tiling);
@@ -315,7 +315,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pProperties);
         manager->EndApiCallCapture();
     }
@@ -349,7 +349,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
         EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         manager->EndApiCallCapture();
@@ -383,7 +383,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pMemoryProperties);
         manager->EndApiCallCapture();
     }
@@ -424,12 +424,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDevice);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DeviceWrapper>(pDevice, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDeviceWrapper>(pDevice, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>(result, physicalDevice, pDevice, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDeviceWrapper, VkDeviceCreateInfo>(result, physicalDevice, pDevice, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDevice>::Dispatch(manager, result, physicalDevice, pCreateInfo, pAllocator, pDevice);
@@ -460,9 +460,9 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDevice);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DeviceWrapper>(device);
+        manager->EndDestroyApiCallCapture<VulkanDeviceWrapper>(device);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -470,7 +470,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(manager, device, pAllocator);
 
-    DestroyWrappedHandle<DeviceWrapper>(device);
+    DestroyWrappedHandle<VulkanDeviceWrapper>(device);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
@@ -497,16 +497,16 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
 
     GetVulkanDeviceTable(device)->GetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue);
 
-    CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueueWrapper>(device, NoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
+    CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanQueueWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceQueue);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeUInt32Value(queueIndex);
-        encoder->EncodeHandlePtr<QueueWrapper>(pQueue);
-        manager->EndCreateApiCallCapture<VkDevice, QueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
+        encoder->EncodeHandlePtr<VulkanQueueWrapper>(pQueue);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanQueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDeviceQueue>::Dispatch(manager, device, queueFamilyIndex, queueIndex, pQueue);
@@ -542,10 +542,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         encoder->EncodeUInt32Value(submitCount);
         EncodeStructArray(encoder, pSubmits, submitCount);
-        encoder->EncodeHandleValue<FenceWrapper>(fence);
+        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -579,7 +579,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueWaitIdle(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueWaitIdle);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -613,7 +613,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DeviceWaitIdle(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDeviceWaitIdle);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -656,12 +656,12 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAllocateMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DeviceMemoryWrapper>(pMemory, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDeviceMemoryWrapper>(pMemory, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, DeviceMemoryWrapper, VkMemoryAllocateInfo>(result, device, pMemory, pAllocateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanDeviceMemoryWrapper, VkMemoryAllocateInfo>(result, device, pMemory, pAllocateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateMemory>::Dispatch(manager, result, device, pAllocateInfo, pAllocator, pMemory);
@@ -693,10 +693,10 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DeviceMemoryWrapper>(memory);
+        manager->EndDestroyApiCallCapture<VulkanDeviceMemoryWrapper>(memory);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -704,7 +704,7 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(manager, device, memory, pAllocator);
 
-    DestroyWrappedHandle<DeviceMemoryWrapper>(memory);
+    DestroyWrappedHandle<VulkanDeviceMemoryWrapper>(memory);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
@@ -742,8 +742,8 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMapMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeVkDeviceSizeValue(size);
         encoder->EncodeFlagsValue(flags);
@@ -780,8 +780,8 @@ VKAPI_ATTR void VKAPI_CALL UnmapMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUnmapMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         manager->EndApiCallCapture();
     }
 
@@ -819,7 +819,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FlushMappedMemoryRanges(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkFlushMappedMemoryRanges);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(memoryRangeCount);
         EncodeStructArray(encoder, pMemoryRanges, memoryRangeCount);
         encoder->EncodeEnumValue(result);
@@ -860,7 +860,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkInvalidateMappedMemoryRanges);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(memoryRangeCount);
         EncodeStructArray(encoder, pMemoryRanges, memoryRangeCount);
         encoder->EncodeEnumValue(result);
@@ -898,8 +898,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMemoryCommitment(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryCommitment);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizePtr(pCommittedMemoryInBytes);
         manager->EndApiCallCapture();
     }
@@ -934,9 +934,9 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizeValue(memoryOffset);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -974,9 +974,9 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         encoder->EncodeVkDeviceSizeValue(memoryOffset);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -1013,8 +1013,8 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
     }
@@ -1048,8 +1048,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
     }
@@ -1084,8 +1084,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
         manager->EndApiCallCapture();
@@ -1125,7 +1125,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         encoder->EncodeEnumValue(type);
         encoder->EncodeEnumValue(samples);
@@ -1169,10 +1169,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueBindSparse);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfo, bindInfoCount);
-        encoder->EncodeHandleValue<FenceWrapper>(fence);
+        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1210,7 +1210,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, FenceWrapper>(device, NoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanFenceWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1220,12 +1220,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateFence);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<FenceWrapper>(pFence, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanFenceWrapper>(pFence, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, FenceWrapper, VkFenceCreateInfo>(result, device, pFence, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanFenceWrapper, VkFenceCreateInfo>(result, device, pFence, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFence>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pFence);
@@ -1257,10 +1257,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyFence);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<FenceWrapper>(fence);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<FenceWrapper>(fence);
+        manager->EndDestroyApiCallCapture<VulkanFenceWrapper>(fence);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1268,7 +1268,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(manager, device, fence, pAllocator);
 
-    DestroyWrappedHandle<FenceWrapper>(fence);
+    DestroyWrappedHandle<VulkanFenceWrapper>(fence);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
@@ -1297,9 +1297,9 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetFences);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(fenceCount);
-        encoder->EncodeHandleArray<FenceWrapper>(pFences, fenceCount);
+        encoder->EncodeHandleArray<VulkanFenceWrapper>(pFences, fenceCount);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1334,8 +1334,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceStatus(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFenceStatus);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<FenceWrapper>(fence);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1373,9 +1373,9 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForFences(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitForFences);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(fenceCount);
-        encoder->EncodeHandleArray<FenceWrapper>(pFences, fenceCount);
+        encoder->EncodeHandleArray<VulkanFenceWrapper>(pFences, fenceCount);
         encoder->EncodeVkBool32Value(waitAll);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -1415,7 +1415,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, SemaphoreWrapper>(device, NoParentWrapper::kHandleValue, pSemaphore, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSemaphoreWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSemaphore, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1425,12 +1425,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSemaphore);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SemaphoreWrapper>(pSemaphore, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSemaphoreWrapper>(pSemaphore, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(result, device, pSemaphore, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanSemaphoreWrapper, VkSemaphoreCreateInfo>(result, device, pSemaphore, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSemaphore>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSemaphore);
@@ -1462,10 +1462,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySemaphore);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<SemaphoreWrapper>(semaphore);
+        manager->EndDestroyApiCallCapture<VulkanSemaphoreWrapper>(semaphore);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1473,7 +1473,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(manager, device, semaphore, pAllocator);
 
-    DestroyWrappedHandle<SemaphoreWrapper>(semaphore);
+    DestroyWrappedHandle<VulkanSemaphoreWrapper>(semaphore);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
@@ -1504,7 +1504,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, EventWrapper>(device, NoParentWrapper::kHandleValue, pEvent, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanEventWrapper>(device, VulkanNoParentWrapper::kHandleValue, pEvent, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1514,12 +1514,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<EventWrapper>(pEvent, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanEventWrapper>(pEvent, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, EventWrapper, VkEventCreateInfo>(result, device, pEvent, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanEventWrapper, VkEventCreateInfo>(result, device, pEvent, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateEvent>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pEvent);
@@ -1551,10 +1551,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<EventWrapper>(event);
+        manager->EndDestroyApiCallCapture<VulkanEventWrapper>(event);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1562,7 +1562,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(manager, device, event, pAllocator);
 
-    DestroyWrappedHandle<EventWrapper>(event);
+    DestroyWrappedHandle<VulkanEventWrapper>(event);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
@@ -1590,8 +1590,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetEventStatus);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1626,8 +1626,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetEvent(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1662,8 +1662,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetEvent(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -1701,7 +1701,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueryPoolWrapper>(device, NoParentWrapper::kHandleValue, pQueryPool, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanQueryPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueryPool, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1711,12 +1711,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<QueryPoolWrapper>(pQueryPool, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanQueryPoolWrapper>(pQueryPool, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(result, device, pQueryPool, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanQueryPoolWrapper, VkQueryPoolCreateInfo>(result, device, pQueryPool, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateQueryPool>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pQueryPool);
@@ -1748,10 +1748,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<QueryPoolWrapper>(queryPool);
+        manager->EndDestroyApiCallCapture<VulkanQueryPoolWrapper>(queryPool);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1759,7 +1759,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(manager, device, queryPool, pAllocator);
 
-    DestroyWrappedHandle<QueryPoolWrapper>(queryPool);
+    DestroyWrappedHandle<VulkanQueryPoolWrapper>(queryPool);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
@@ -1799,8 +1799,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueryPoolResults);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -1849,12 +1849,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<BufferWrapper>(pBuffer, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanBufferWrapper>(pBuffer, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, BufferWrapper, VkBufferCreateInfo>(result, device, pBuffer, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanBufferWrapper, VkBufferCreateInfo>(result, device, pBuffer, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBuffer>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pBuffer);
@@ -1886,10 +1886,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<BufferWrapper>(buffer);
+        manager->EndDestroyApiCallCapture<VulkanBufferWrapper>(buffer);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1897,7 +1897,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(manager, device, buffer, pAllocator);
 
-    DestroyWrappedHandle<BufferWrapper>(buffer);
+    DestroyWrappedHandle<VulkanBufferWrapper>(buffer);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
@@ -1931,7 +1931,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, BufferViewWrapper>(device, NoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanBufferViewWrapper>(device, VulkanNoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -1941,12 +1941,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateBufferView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<BufferViewWrapper>(pView, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanBufferViewWrapper>(pView, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, BufferViewWrapper, VkBufferViewCreateInfo>(result, device, pView, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanBufferViewWrapper, VkBufferViewCreateInfo>(result, device, pView, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBufferView>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pView);
@@ -1978,10 +1978,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyBufferView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<BufferViewWrapper>(bufferView);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanBufferViewWrapper>(bufferView);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<BufferViewWrapper>(bufferView);
+        manager->EndDestroyApiCallCapture<VulkanBufferViewWrapper>(bufferView);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -1989,7 +1989,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(manager, device, bufferView, pAllocator);
 
-    DestroyWrappedHandle<BufferViewWrapper>(bufferView);
+    DestroyWrappedHandle<VulkanBufferViewWrapper>(bufferView);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
@@ -2025,12 +2025,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<ImageWrapper>(pImage, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanImageWrapper>(pImage, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, ImageWrapper, VkImageCreateInfo>(result, device, pImage, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanImageWrapper, VkImageCreateInfo>(result, device, pImage, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImage>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pImage);
@@ -2062,10 +2062,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<ImageWrapper>(image);
+        manager->EndDestroyApiCallCapture<VulkanImageWrapper>(image);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2073,7 +2073,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(manager, device, image, pAllocator);
 
-    DestroyWrappedHandle<ImageWrapper>(image);
+    DestroyWrappedHandle<VulkanImageWrapper>(image);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
@@ -2103,8 +2103,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         EncodeStructPtr(encoder, pSubresource);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -2144,7 +2144,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, ImageViewWrapper>(device, NoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanImageViewWrapper>(device, VulkanNoParentWrapper::kHandleValue, pView, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2154,12 +2154,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateImageView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<ImageViewWrapper>(pView, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanImageViewWrapper>(pView, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(result, device, pView, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanImageViewWrapper, VkImageViewCreateInfo>(result, device, pView, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImageView>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pView);
@@ -2191,10 +2191,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyImageView);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<ImageViewWrapper>(imageView);
+        manager->EndDestroyApiCallCapture<VulkanImageViewWrapper>(imageView);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2202,7 +2202,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(manager, device, imageView, pAllocator);
 
-    DestroyWrappedHandle<ImageViewWrapper>(imageView);
+    DestroyWrappedHandle<VulkanImageViewWrapper>(imageView);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
@@ -2236,7 +2236,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, ShaderModuleWrapper>(device, NoParentWrapper::kHandleValue, pShaderModule, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanShaderModuleWrapper>(device, VulkanNoParentWrapper::kHandleValue, pShaderModule, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2246,12 +2246,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateShaderModule);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<ShaderModuleWrapper>(pShaderModule, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanShaderModuleWrapper>(pShaderModule, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, ShaderModuleWrapper, VkShaderModuleCreateInfo>(result, device, pShaderModule, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanShaderModuleWrapper, VkShaderModuleCreateInfo>(result, device, pShaderModule, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateShaderModule>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pShaderModule);
@@ -2283,10 +2283,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyShaderModule);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ShaderModuleWrapper>(shaderModule);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanShaderModuleWrapper>(shaderModule);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<ShaderModuleWrapper>(shaderModule);
+        manager->EndDestroyApiCallCapture<VulkanShaderModuleWrapper>(shaderModule);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2294,7 +2294,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(manager, device, shaderModule, pAllocator);
 
-    DestroyWrappedHandle<ShaderModuleWrapper>(shaderModule);
+    DestroyWrappedHandle<VulkanShaderModuleWrapper>(shaderModule);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
@@ -2325,7 +2325,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, PipelineCacheWrapper>(device, NoParentWrapper::kHandleValue, pPipelineCache, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPipelineCacheWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPipelineCache, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2335,12 +2335,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePipelineCache);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<PipelineCacheWrapper>(pPipelineCache, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanPipelineCacheWrapper>(pPipelineCache, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, PipelineCacheWrapper, VkPipelineCacheCreateInfo>(result, device, pPipelineCache, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanPipelineCacheWrapper, VkPipelineCacheCreateInfo>(result, device, pPipelineCache, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineCache>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPipelineCache);
@@ -2372,10 +2372,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPipelineCache);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<PipelineCacheWrapper>(pipelineCache);
+        manager->EndDestroyApiCallCapture<VulkanPipelineCacheWrapper>(pipelineCache);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2383,7 +2383,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(manager, device, pipelineCache, pAllocator);
 
-    DestroyWrappedHandle<PipelineCacheWrapper>(pipelineCache);
+    DestroyWrappedHandle<VulkanPipelineCacheWrapper>(pipelineCache);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
@@ -2419,8 +2419,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineCacheData);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineCacheWrapper>(pipelineCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(pipelineCache);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? (*pDataSize) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -2459,10 +2459,10 @@ VKAPI_ATTR VkResult VKAPI_CALL MergePipelineCaches(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMergePipelineCaches);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineCacheWrapper>(dstCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineCacheWrapper>(dstCache);
         encoder->EncodeUInt32Value(srcCacheCount);
-        encoder->EncodeHandleArray<PipelineCacheWrapper>(pSrcCaches, srcCacheCount);
+        encoder->EncodeHandleArray<VulkanPipelineCacheWrapper>(pSrcCaches, srcCacheCount);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -2496,10 +2496,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPipeline);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<PipelineWrapper>(pipeline);
+        manager->EndDestroyApiCallCapture<VulkanPipelineWrapper>(pipeline);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2507,7 +2507,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(manager, device, pipeline, pAllocator);
 
-    DestroyWrappedHandle<PipelineWrapper>(pipeline);
+    DestroyWrappedHandle<VulkanPipelineWrapper>(pipeline);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
@@ -2541,7 +2541,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, PipelineLayoutWrapper>(device, NoParentWrapper::kHandleValue, pPipelineLayout, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPipelineLayoutWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPipelineLayout, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2551,12 +2551,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePipelineLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<PipelineLayoutWrapper>(pPipelineLayout, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanPipelineLayoutWrapper>(pPipelineLayout, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(result, device, pPipelineLayout, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanPipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(result, device, pPipelineLayout, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineLayout>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPipelineLayout);
@@ -2588,10 +2588,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPipelineLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineLayoutWrapper>(pipelineLayout);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(pipelineLayout);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<PipelineLayoutWrapper>(pipelineLayout);
+        manager->EndDestroyApiCallCapture<VulkanPipelineLayoutWrapper>(pipelineLayout);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2599,7 +2599,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(manager, device, pipelineLayout, pAllocator);
 
-    DestroyWrappedHandle<PipelineLayoutWrapper>(pipelineLayout);
+    DestroyWrappedHandle<VulkanPipelineLayoutWrapper>(pipelineLayout);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
@@ -2633,7 +2633,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, SamplerWrapper>(device, NoParentWrapper::kHandleValue, pSampler, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSamplerWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSampler, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2643,12 +2643,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSampler);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SamplerWrapper>(pSampler, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSamplerWrapper>(pSampler, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, SamplerWrapper, VkSamplerCreateInfo>(result, device, pSampler, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanSamplerWrapper, VkSamplerCreateInfo>(result, device, pSampler, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSampler>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSampler);
@@ -2680,10 +2680,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySampler);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SamplerWrapper>(sampler);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSamplerWrapper>(sampler);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<SamplerWrapper>(sampler);
+        manager->EndDestroyApiCallCapture<VulkanSamplerWrapper>(sampler);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2691,7 +2691,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(manager, device, sampler, pAllocator);
 
-    DestroyWrappedHandle<SamplerWrapper>(sampler);
+    DestroyWrappedHandle<VulkanSamplerWrapper>(sampler);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
@@ -2725,7 +2725,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, DescriptorSetLayoutWrapper>(device, NoParentWrapper::kHandleValue, pSetLayout, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorSetLayoutWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSetLayout, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2735,12 +2735,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DescriptorSetLayoutWrapper>(pSetLayout, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDescriptorSetLayoutWrapper>(pSetLayout, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, DescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(result, device, pSetLayout, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(result, device, pSetLayout, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSetLayout);
@@ -2772,10 +2772,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorSetLayoutWrapper>(descriptorSetLayout);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorSetLayoutWrapper>(descriptorSetLayout);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DescriptorSetLayoutWrapper>(descriptorSetLayout);
+        manager->EndDestroyApiCallCapture<VulkanDescriptorSetLayoutWrapper>(descriptorSetLayout);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2783,7 +2783,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(manager, device, descriptorSetLayout, pAllocator);
 
-    DestroyWrappedHandle<DescriptorSetLayoutWrapper>(descriptorSetLayout);
+    DestroyWrappedHandle<VulkanDescriptorSetLayoutWrapper>(descriptorSetLayout);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
@@ -2814,7 +2814,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, DescriptorPoolWrapper>(device, NoParentWrapper::kHandleValue, pDescriptorPool, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorPool, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2824,12 +2824,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DescriptorPoolWrapper>(pDescriptorPool, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDescriptorPoolWrapper>(pDescriptorPool, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, DescriptorPoolWrapper, VkDescriptorPoolCreateInfo>(result, device, pDescriptorPool, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorPoolWrapper, VkDescriptorPoolCreateInfo>(result, device, pDescriptorPool, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorPool>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pDescriptorPool);
@@ -2861,10 +2861,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorPoolWrapper>(descriptorPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(descriptorPool);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DescriptorPoolWrapper>(descriptorPool);
+        manager->EndDestroyApiCallCapture<VulkanDescriptorPoolWrapper>(descriptorPool);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -2872,7 +2872,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(manager, device, descriptorPool, pAllocator);
 
-    DestroyWrappedHandle<DescriptorPoolWrapper>(descriptorPool);
+    DestroyWrappedHandle<VulkanDescriptorPoolWrapper>(descriptorPool);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
@@ -2902,8 +2902,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetDescriptorPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorPoolWrapper>(descriptorPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(descriptorPool);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -2944,7 +2944,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, DescriptorPoolWrapper, DescriptorSetWrapper>(device, pAllocateInfo->descriptorPool, pDescriptorSets, pAllocateInfo->descriptorSetCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanDescriptorPoolWrapper, VulkanDescriptorSetWrapper>(device, pAllocateInfo->descriptorPool, pDescriptorSets, pAllocateInfo->descriptorSetCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -2954,11 +2954,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAllocateDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocateInfo);
-        encoder->EncodeHandleArray<DescriptorSetWrapper>(pDescriptorSets, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(pDescriptorSets, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndPoolCreateApiCallCapture<VkDevice, DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, pDescriptorSets, pAllocateInfo);
+        manager->EndPoolCreateApiCallCapture<VkDevice, VulkanDescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->descriptorSetCount) : 0, pDescriptorSets, pAllocateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateDescriptorSets>::Dispatch(manager, result, device, pAllocateInfo, pDescriptorSets);
@@ -2994,17 +2994,17 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorPoolWrapper>(descriptorPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(descriptorPool);
         encoder->EncodeUInt32Value(descriptorSetCount);
-        encoder->EncodeHandleArray<DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
+        encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
         encoder->EncodeEnumValue(result);
-        manager->EndDestroyApiCallCapture<DescriptorSetWrapper>(descriptorSetCount, pDescriptorSets);
+        manager->EndDestroyApiCallCapture<VulkanDescriptorSetWrapper>(descriptorSetCount, pDescriptorSets);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, result, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
-    DestroyWrappedHandles<DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
+    DestroyWrappedHandles<VulkanDescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
 
     return result;
 }
@@ -3035,7 +3035,7 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(descriptorWriteCount);
         EncodeStructArray(encoder, pDescriptorWrites, descriptorWriteCount);
         encoder->EncodeUInt32Value(descriptorCopyCount);
@@ -3083,7 +3083,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, FramebufferWrapper>(device, NoParentWrapper::kHandleValue, pFramebuffer, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanFramebufferWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFramebuffer, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3093,12 +3093,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateFramebuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<FramebufferWrapper>(pFramebuffer, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanFramebufferWrapper>(pFramebuffer, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(result, device, pFramebuffer, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanFramebufferWrapper, VkFramebufferCreateInfo>(result, device, pFramebuffer, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFramebuffer>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pFramebuffer);
@@ -3130,10 +3130,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyFramebuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<FramebufferWrapper>(framebuffer);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanFramebufferWrapper>(framebuffer);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<FramebufferWrapper>(framebuffer);
+        manager->EndDestroyApiCallCapture<VulkanFramebufferWrapper>(framebuffer);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3141,7 +3141,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(manager, device, framebuffer, pAllocator);
 
-    DestroyWrappedHandle<FramebufferWrapper>(framebuffer);
+    DestroyWrappedHandle<VulkanFramebufferWrapper>(framebuffer);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
@@ -3172,7 +3172,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, RenderPassWrapper>(device, NoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanRenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3182,12 +3182,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<RenderPassWrapper>(pRenderPass, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanRenderPassWrapper>(pRenderPass, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo>(result, device, pRenderPass, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo>(result, device, pRenderPass, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -3219,10 +3219,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<RenderPassWrapper>(renderPass);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanRenderPassWrapper>(renderPass);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<RenderPassWrapper>(renderPass);
+        manager->EndDestroyApiCallCapture<VulkanRenderPassWrapper>(renderPass);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3230,7 +3230,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(manager, device, renderPass, pAllocator);
 
-    DestroyWrappedHandle<RenderPassWrapper>(renderPass);
+    DestroyWrappedHandle<VulkanRenderPassWrapper>(renderPass);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
@@ -3259,8 +3259,8 @@ VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRenderAreaGranularity);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<RenderPassWrapper>(renderPass);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanRenderPassWrapper>(renderPass);
         EncodeStructPtr(encoder, pGranularity);
         manager->EndApiCallCapture();
     }
@@ -3296,7 +3296,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, CommandPoolWrapper>(device, NoParentWrapper::kHandleValue, pCommandPool, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanCommandPoolWrapper>(device, VulkanNoParentWrapper::kHandleValue, pCommandPool, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3306,12 +3306,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<CommandPoolWrapper>(pCommandPool, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanCommandPoolWrapper>(pCommandPool, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, CommandPoolWrapper, VkCommandPoolCreateInfo>(result, device, pCommandPool, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanCommandPoolWrapper, VkCommandPoolCreateInfo>(result, device, pCommandPool, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateCommandPool>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pCommandPool);
@@ -3343,10 +3343,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<CommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<CommandPoolWrapper>(commandPool);
+        manager->EndDestroyApiCallCapture<VulkanCommandPoolWrapper>(commandPool);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3354,7 +3354,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(manager, device, commandPool, pAllocator);
 
-    DestroyWrappedHandle<CommandPoolWrapper>(commandPool);
+    DestroyWrappedHandle<VulkanCommandPoolWrapper>(commandPool);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
@@ -3383,8 +3383,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<CommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -3425,7 +3425,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, CommandPoolWrapper, CommandBufferWrapper>(device, pAllocateInfo->commandPool, pCommandBuffers, pAllocateInfo->commandBufferCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanCommandPoolWrapper, VulkanCommandBufferWrapper>(device, pAllocateInfo->commandPool, pCommandBuffers, pAllocateInfo->commandBufferCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -3435,11 +3435,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAllocateCommandBuffers);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocateInfo);
-        encoder->EncodeHandleArray<CommandBufferWrapper>(pCommandBuffers, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(pCommandBuffers, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndPoolCreateApiCallCapture<VkDevice, CommandBufferWrapper, VkCommandBufferAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, pCommandBuffers, pAllocateInfo);
+        manager->EndPoolCreateApiCallCapture<VkDevice, VulkanCommandBufferWrapper, VkCommandBufferAllocateInfo>(result, device, (pAllocateInfo != nullptr) ? (pAllocateInfo->commandBufferCount) : 0, pCommandBuffers, pAllocateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>::Dispatch(manager, result, device, pAllocateInfo, pCommandBuffers);
@@ -3472,11 +3472,11 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeCommandBuffers);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<CommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
         encoder->EncodeUInt32Value(commandBufferCount);
-        encoder->EncodeHandleArray<CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
-        manager->EndDestroyApiCallCapture<CommandBufferWrapper>(commandBufferCount, pCommandBuffers);
+        encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(pCommandBuffers, commandBufferCount);
+        manager->EndDestroyApiCallCapture<VulkanCommandBufferWrapper>(commandBufferCount, pCommandBuffers);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -3484,7 +3484,7 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(manager, device, commandPool, commandBufferCount, pCommandBuffers);
 
-    DestroyWrappedHandles<CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
+    DestroyWrappedHandles<VulkanCommandBufferWrapper>(pCommandBuffers, commandBufferCount);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
@@ -3515,7 +3515,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkBeginCommandBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBeginInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer, TrackBeginCommandBufferHandles, pBeginInfo);
@@ -3550,7 +3550,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EndCommandBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEndCommandBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -3585,7 +3585,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkResetCommandBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3620,9 +3620,9 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindPipeline);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindPipelineHandles, pipeline);
     }
 
@@ -3656,7 +3656,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewport(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewport);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewports, viewportCount);
@@ -3693,7 +3693,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissor(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetScissor);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstScissor);
         encoder->EncodeUInt32Value(scissorCount);
         EncodeStructArray(encoder, pScissors, scissorCount);
@@ -3728,7 +3728,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineWidth(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineWidth);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(lineWidth);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -3763,7 +3763,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBias);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(depthBiasConstantFactor);
         encoder->EncodeFloatValue(depthBiasClamp);
         encoder->EncodeFloatValue(depthBiasSlopeFactor);
@@ -3798,7 +3798,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetBlendConstants(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetBlendConstants);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatArray(blendConstants, 4);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -3832,7 +3832,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBounds(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBounds);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(minDepthBounds);
         encoder->EncodeFloatValue(maxDepthBounds);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3867,7 +3867,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilCompareMask(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilCompareMask);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeUInt32Value(compareMask);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3902,7 +3902,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilWriteMask(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilWriteMask);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeUInt32Value(writeMask);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3937,7 +3937,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilReference(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilReference);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeUInt32Value(reference);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -3977,12 +3977,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindDescriptorSets);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<PipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
         encoder->EncodeUInt32Value(firstSet);
         encoder->EncodeUInt32Value(descriptorSetCount);
-        encoder->EncodeHandleArray<DescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
+        encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(pDescriptorSets, descriptorSetCount);
         encoder->EncodeUInt32Value(dynamicOffsetCount);
         encoder->EncodeUInt32Array(pDynamicOffsets, dynamicOffsetCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindDescriptorSetsHandles, layout, descriptorSetCount, pDescriptorSets);
@@ -4018,8 +4018,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindIndexBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeEnumValue(indexType);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindIndexBufferHandles, buffer);
@@ -4056,10 +4056,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindVertexBuffers);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<BufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindVertexBuffersHandles, bindingCount, pBuffers);
     }
@@ -4095,7 +4095,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDraw(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDraw);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(vertexCount);
         encoder->EncodeUInt32Value(instanceCount);
         encoder->EncodeUInt32Value(firstVertex);
@@ -4135,7 +4135,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexed(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexed);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(indexCount);
         encoder->EncodeUInt32Value(instanceCount);
         encoder->EncodeUInt32Value(firstIndex);
@@ -4175,8 +4175,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirect);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -4214,8 +4214,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -4252,7 +4252,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatch(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatch);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(groupCountX);
         encoder->EncodeUInt32Value(groupCountY);
         encoder->EncodeUInt32Value(groupCountZ);
@@ -4288,8 +4288,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatchIndirect);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDispatchIndirectHandles, buffer);
     }
@@ -4325,9 +4325,9 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(srcBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(srcBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferHandles, srcBuffer, dstBuffer);
@@ -4366,10 +4366,10 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<ImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4410,10 +4410,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBlitImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<ImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4453,9 +4453,9 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBufferToImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(srcBuffer);
-        encoder->EncodeHandleValue<ImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(srcBuffer);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4494,10 +4494,10 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<BufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageToBufferHandles, srcImage, dstBuffer);
@@ -4534,8 +4534,8 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdUpdateBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(dataSize);
         encoder->EncodeVoidArray(pData, static_cast<size_t>(dataSize));
@@ -4573,8 +4573,8 @@ VKAPI_ATTR void VKAPI_CALL CmdFillBuffer(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdFillBuffer);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(size);
         encoder->EncodeUInt32Value(data);
@@ -4613,8 +4613,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdClearColorImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         encoder->EncodeEnumValue(imageLayout);
         EncodeStructPtr(encoder, pColor);
         encoder->EncodeUInt32Value(rangeCount);
@@ -4654,8 +4654,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdClearDepthStencilImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         encoder->EncodeEnumValue(imageLayout);
         EncodeStructPtr(encoder, pDepthStencil);
         encoder->EncodeUInt32Value(rangeCount);
@@ -4694,7 +4694,7 @@ VKAPI_ATTR void VKAPI_CALL CmdClearAttachments(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdClearAttachments);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(attachmentCount);
         EncodeStructArray(encoder, pAttachments, attachmentCount);
         encoder->EncodeUInt32Value(rectCount);
@@ -4735,10 +4735,10 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResolveImage);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageWrapper>(srcImage);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(srcImage);
         encoder->EncodeEnumValue(srcImageLayout);
-        encoder->EncodeHandleValue<ImageWrapper>(dstImage);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
@@ -4774,8 +4774,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         encoder->EncodeFlagsValue(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetEventHandles, event);
     }
@@ -4809,8 +4809,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetEvent);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         encoder->EncodeFlagsValue(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEventHandles, event);
     }
@@ -4852,9 +4852,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWaitEvents);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(eventCount);
-        encoder->EncodeHandleArray<EventWrapper>(pEvents, eventCount);
+        encoder->EncodeHandleArray<VulkanEventWrapper>(pEvents, eventCount);
         encoder->EncodeFlagsValue(srcStageMask);
         encoder->EncodeFlagsValue(dstStageMask);
         encoder->EncodeUInt32Value(memoryBarrierCount);
@@ -4906,7 +4906,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPipelineBarrier);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(srcStageMask);
         encoder->EncodeFlagsValue(dstStageMask);
         encoder->EncodeFlagsValue(dependencyFlags);
@@ -4953,8 +4953,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQuery(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginQuery);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeFlagsValue(flags);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginQueryHandles, queryPool);
@@ -4989,8 +4989,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQuery(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndQuery);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndQueryHandles, queryPool);
     }
@@ -5025,8 +5025,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetQueryPool(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetQueryPoolHandles, queryPool);
@@ -5062,9 +5062,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteTimestamp);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineStage);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestampHandles, queryPool);
     }
@@ -5103,11 +5103,11 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyQueryPoolResults(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyQueryPoolResults);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
-        encoder->EncodeHandleValue<BufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(stride);
         encoder->EncodeFlagsValue(flags);
@@ -5146,8 +5146,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushConstants);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<PipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
         encoder->EncodeFlagsValue(stageFlags);
         encoder->EncodeUInt32Value(offset);
         encoder->EncodeUInt32Value(size);
@@ -5184,7 +5184,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         encoder->EncodeEnumValue(contents);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderPassHandles, pRenderPassBegin);
@@ -5221,7 +5221,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdNextSubpass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(contents);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -5253,7 +5253,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderPass);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -5286,9 +5286,9 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdExecuteCommands);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(commandBufferCount);
-        encoder->EncodeHandleArray<CommandBufferWrapper>(pCommandBuffers, commandBufferCount);
+        encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(pCommandBuffers, commandBufferCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdExecuteCommandsHandles, commandBufferCount, pCommandBuffers);
     }
 
@@ -5326,7 +5326,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -5367,7 +5367,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -5407,7 +5407,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeatures(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeatures);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(heapIndex);
         encoder->EncodeUInt32Value(localDeviceIndex);
         encoder->EncodeUInt32Value(remoteDeviceIndex);
@@ -5441,7 +5441,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMask(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDeviceMask);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(deviceMask);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -5479,7 +5479,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBase(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatchBase);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(baseGroupX);
         encoder->EncodeUInt32Value(baseGroupY);
         encoder->EncodeUInt32Value(baseGroupZ);
@@ -5521,7 +5521,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<InstanceWrapper, NoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, NoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanInstanceWrapper, VulkanNoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -5531,11 +5531,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroups);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceGroupCount, omit_output_data);
         EncodeStructArray(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkInstance, PhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
+        manager->EndStructGroupCreateApiCallCapture<VkInstance, VulkanPhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroups>::Dispatch(manager, result, instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
@@ -5572,7 +5572,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -5610,7 +5610,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -5649,7 +5649,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -5684,7 +5684,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFeatures);
         manager->EndApiCallCapture();
     }
@@ -5717,7 +5717,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pProperties);
         manager->EndApiCallCapture();
     }
@@ -5751,7 +5751,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         EncodeStructPtr(encoder, pFormatProperties);
         manager->EndApiCallCapture();
@@ -5792,7 +5792,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pImageFormatInfo);
         EncodeStructPtr(encoder, pImageFormatProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -5830,7 +5830,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
         EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         manager->EndApiCallCapture();
@@ -5864,7 +5864,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pMemoryProperties);
         manager->EndApiCallCapture();
     }
@@ -5899,7 +5899,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFormatInfo);
         encoder->EncodeUInt32Ptr(pPropertyCount);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
@@ -5933,8 +5933,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkTrimCommandPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<CommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
         encoder->EncodeFlagsValue(flags);
         manager->EndApiCallCapture();
     }
@@ -5967,15 +5967,15 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue2(
 
     GetVulkanDeviceTable(device)->GetDeviceQueue2(device, pQueueInfo, pQueue);
 
-    CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueueWrapper>(device, NoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
+    CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanQueueWrapper>(device, VulkanNoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceQueue2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pQueueInfo);
-        encoder->EncodeHandlePtr<QueueWrapper>(pQueue);
-        manager->EndCreateApiCallCapture<VkDevice, QueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
+        encoder->EncodeHandlePtr<VulkanQueueWrapper>(pQueue);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanQueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDeviceQueue2>::Dispatch(manager, device, pQueueInfo, pQueue);
@@ -6009,7 +6009,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, SamplerYcbcrConversionWrapper>(device, NoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSamplerYcbcrConversionWrapper>(device, VulkanNoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6019,12 +6019,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanSamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -6056,10 +6056,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+        manager->EndDestroyApiCallCapture<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -6067,7 +6067,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
-    DestroyWrappedHandle<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+    DestroyWrappedHandle<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
@@ -6101,7 +6101,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, DescriptorUpdateTemplateWrapper>(device, NoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorUpdateTemplateWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6111,12 +6111,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -6148,10 +6148,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        manager->EndDestroyApiCallCapture<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -6159,7 +6159,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
-    DestroyWrappedHandle<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+    DestroyWrappedHandle<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
@@ -6188,7 +6188,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalBufferInfo);
         EncodeStructPtr(encoder, pExternalBufferProperties);
         manager->EndApiCallCapture();
@@ -6223,7 +6223,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFenceProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFenceProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalFenceInfo);
         EncodeStructPtr(encoder, pExternalFenceProperties);
         manager->EndApiCallCapture();
@@ -6258,7 +6258,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphoreProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphoreProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalSemaphoreInfo);
         EncodeStructPtr(encoder, pExternalSemaphoreProperties);
         manager->EndApiCallCapture();
@@ -6296,7 +6296,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupport(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupport);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pSupport);
         manager->EndApiCallCapture();
@@ -6333,10 +6333,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -6376,10 +6376,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -6419,7 +6419,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, RenderPassWrapper>(device, NoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanRenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6429,12 +6429,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateRenderPass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<RenderPassWrapper>(pRenderPass, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanRenderPassWrapper>(pRenderPass, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass2>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -6466,7 +6466,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderPass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderPass2Handles, pRenderPassBegin);
@@ -6504,7 +6504,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdNextSubpass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -6538,7 +6538,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderPass2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -6573,8 +6573,8 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPool(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetQueryPool);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         manager->EndApiCallCapture();
@@ -6617,8 +6617,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValue(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreCounterValue);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
         encoder->EncodeUInt64Ptr(pValue, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -6658,7 +6658,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphores(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitSemaphores);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pWaitInfo);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -6698,7 +6698,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphore(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSignalSemaphore);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pSignalInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -6737,7 +6737,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddress(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddress);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -6776,7 +6776,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddress(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddress);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -6815,7 +6815,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddress(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddress);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -6858,7 +6858,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolProperties(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolProperties);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pToolCount, omit_output_data);
         EncodeStructArray(encoder, pToolProperties, (pToolCount != nullptr) ? (*pToolCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -6898,7 +6898,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlot(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, PrivateDataSlotWrapper>(device, NoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPrivateDataSlotWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -6908,12 +6908,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlot(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePrivateDataSlot);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<PrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanPrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, PrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanPrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePrivateDataSlot>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPrivateDataSlot);
@@ -6945,10 +6945,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
+        manager->EndDestroyApiCallCapture<VulkanPrivateDataSlotWrapper>(privateDataSlot);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -6956,7 +6956,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
-    DestroyWrappedHandle<PrivateDataSlotWrapper>(privateDataSlot);
+    DestroyWrappedHandle<VulkanPrivateDataSlotWrapper>(privateDataSlot);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
@@ -6987,10 +6987,10 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetPrivateData);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
         encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<PrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Value(data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -7029,10 +7029,10 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateData(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPrivateData);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
         encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<PrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Ptr(pData);
         manager->EndApiCallCapture();
     }
@@ -7064,8 +7064,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetEvent2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetEvent2Handles, event, pDependencyInfo);
     }
@@ -7102,8 +7102,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetEvent2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         encoder->EncodeFlags64Value(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEvent2Handles, event);
     }
@@ -7138,9 +7138,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWaitEvents2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(eventCount);
-        encoder->EncodeHandleArray<EventWrapper>(pEvents, eventCount);
+        encoder->EncodeHandleArray<VulkanEventWrapper>(pEvents, eventCount);
         EncodeStructArray(encoder, pDependencyInfos, eventCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWaitEvents2Handles, eventCount, pEvents, pDependencyInfos);
     }
@@ -7176,7 +7176,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPipelineBarrier2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPipelineBarrier2Handles, pDependencyInfo);
     }
@@ -7214,9 +7214,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteTimestamp2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlags64Value(stage);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestamp2Handles, queryPool);
     }
@@ -7256,10 +7256,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         encoder->EncodeUInt32Value(submitCount);
         EncodeStructArray(encoder, pSubmits, submitCount);
-        encoder->EncodeHandleValue<FenceWrapper>(fence);
+        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -7292,7 +7292,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBuffer2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBuffer2Handles, pCopyBufferInfo);
     }
@@ -7328,7 +7328,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImage2Handles, pCopyImageInfo);
     }
@@ -7364,7 +7364,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferToImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferToImage2Handles, pCopyBufferToImageInfo);
     }
@@ -7400,7 +7400,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageToBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageToBuffer2Handles, pCopyImageToBufferInfo);
     }
@@ -7436,7 +7436,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBlitImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBlitImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBlitImage2Handles, pBlitImageInfo);
     }
@@ -7472,7 +7472,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResolveImage2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pResolveImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResolveImage2Handles, pResolveImageInfo);
     }
@@ -7508,7 +7508,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRendering(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRendering);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderingInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderingHandles, pRenderingInfo);
     }
@@ -7543,7 +7543,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRendering(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRendering);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -7575,7 +7575,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullMode(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCullMode);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(cullMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7608,7 +7608,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFace(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFrontFace);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(frontFace);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7641,7 +7641,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopology(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopology);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(primitiveTopology);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7675,7 +7675,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWithCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewports, viewportCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -7710,7 +7710,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCount(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetScissorWithCount);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(scissorCount);
         EncodeStructArray(encoder, pScissors, scissorCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -7749,10 +7749,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<BufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pSizes, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pStrides, bindingCount);
@@ -7787,7 +7787,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthTestEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7820,7 +7820,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthWriteEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7853,7 +7853,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOp(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthCompareOp);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(depthCompareOp);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7886,7 +7886,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBoundsTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7919,7 +7919,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilTestEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(stencilTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -7956,7 +7956,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOp(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilOp);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeEnumValue(failOp);
         encoder->EncodeEnumValue(passOp);
@@ -7993,7 +7993,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(rasterizerDiscardEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -8026,7 +8026,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBiasEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -8059,7 +8059,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnable(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnable);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(primitiveRestartEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -8095,7 +8095,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -8133,7 +8133,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -8172,7 +8172,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirements(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirements);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -8206,10 +8206,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<SurfaceKHRWrapper>(surface);
+        manager->EndDestroyApiCallCapture<VulkanSurfaceKHRWrapper>(surface);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -8217,7 +8217,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(manager, instance, surface, pAllocator);
 
-    DestroyWrappedHandle<SurfaceKHRWrapper>(surface);
+    DestroyWrappedHandle<VulkanSurfaceKHRWrapper>(surface);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
@@ -8253,9 +8253,9 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         encoder->EncodeVkBool32Ptr(pSupported, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8298,8 +8298,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         EncodeStructPtr(encoder, pSurfaceCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8343,8 +8343,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormatsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormatsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         encoder->EncodeUInt32Ptr(pSurfaceFormatCount, omit_output_data);
         EncodeStructArray(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8389,8 +8389,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         encoder->EncodeUInt32Ptr(pPresentModeCount, omit_output_data);
         encoder->EncodeEnumArray(pPresentModes, (pPresentModeCount != nullptr) ? (*pPresentModeCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8433,7 +8433,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, SwapchainKHRWrapper>(device, NoParentWrapper::kHandleValue, pSwapchain, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSwapchainKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSwapchain, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8443,12 +8443,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSwapchainKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SwapchainKHRWrapper>(pSwapchain, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSwapchainKHRWrapper>(pSwapchain, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, pSwapchain, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanSwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, pSwapchain, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSwapchain);
@@ -8480,10 +8480,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySwapchainKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<SwapchainKHRWrapper>(swapchain);
+        manager->EndDestroyApiCallCapture<VulkanSwapchainKHRWrapper>(swapchain);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -8491,7 +8491,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(manager, device, swapchain, pAllocator);
 
-    DestroyWrappedHandle<SwapchainKHRWrapper>(swapchain);
+    DestroyWrappedHandle<VulkanSwapchainKHRWrapper>(swapchain);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
@@ -8522,7 +8522,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, SwapchainKHRWrapper, ImageWrapper>(device, swapchain, pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanSwapchainKHRWrapper, VulkanImageWrapper>(device, swapchain, pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8532,12 +8532,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt32Ptr(pSwapchainImageCount, omit_output_data);
-        encoder->EncodeHandleArray<ImageWrapper>(pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<VulkanImageWrapper>(pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkDevice, VkSwapchainKHR, ImageWrapper, void>(result, device, swapchain, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr);
+        manager->EndGroupCreateApiCallCapture<VkDevice, VkSwapchainKHR, VulkanImageWrapper, void>(result, device, swapchain, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR>::Dispatch(manager, result, device, swapchain, pSwapchainImageCount, pSwapchainImages);
@@ -8580,11 +8580,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireNextImageKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt64Value(timeout);
-        encoder->EncodeHandleValue<SemaphoreWrapper>(semaphore);
-        encoder->EncodeHandleValue<FenceWrapper>(fence);
+        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
         encoder->EncodeUInt32Ptr(pImageIndex, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8613,7 +8613,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueuePresentKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         EncodeStructPtr(encoder, pPresentInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8655,7 +8655,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupPresentCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPresentCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pDeviceGroupPresentCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8698,8 +8698,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         encoder->EncodeFlagsPtr(pModes, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -8743,8 +8743,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDevicePresentRectanglesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDevicePresentRectanglesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         encoder->EncodeUInt32Ptr(pRectCount, omit_output_data);
         EncodeStructArray(encoder, pRects, (pRectCount != nullptr) ? (*pRectCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8791,7 +8791,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireNextImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pAcquireInfo);
         encoder->EncodeUInt32Ptr(pImageIndex, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -8830,7 +8830,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<PhysicalDeviceWrapper, NoParentWrapper, VkDisplayPropertiesKHR>(physicalDevice, NoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPropertiesKHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8840,11 +8840,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->DisplayKHRWrapper* { return GetWrapper<DisplayKHRWrapper>(handle_struct->display); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -8879,7 +8879,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<PhysicalDeviceWrapper, NoParentWrapper, VkDisplayPlanePropertiesKHR>(physicalDevice, NoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPlanePropertiesKHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8889,11 +8889,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->DisplayKHRWrapper* { return GetWrapper<DisplayKHRWrapper>(handle_struct->currentDisplay); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -8929,7 +8929,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<PhysicalDeviceWrapper, NoParentWrapper, DisplayKHRWrapper>(physicalDevice, NoParentWrapper::kHandleValue, pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8939,12 +8939,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(planeIndex);
         encoder->EncodeUInt32Ptr(pDisplayCount, omit_output_data);
-        encoder->EncodeHandleArray<DisplayKHRWrapper>(pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, omit_output_data);
+        encoder->EncodeHandleArray<VulkanDisplayKHRWrapper>(pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkPhysicalDevice, void*, DisplayKHRWrapper, void>(result, physicalDevice, nullptr, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr);
+        manager->EndGroupCreateApiCallCapture<VkPhysicalDevice, void*, VulkanDisplayKHRWrapper, void>(result, physicalDevice, nullptr, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR>::Dispatch(manager, result, physicalDevice, planeIndex, pDisplayCount, pDisplays);
@@ -8980,7 +8980,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<PhysicalDeviceWrapper, DisplayKHRWrapper, VkDisplayModePropertiesKHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanDisplayKHRWrapper, VkDisplayModePropertiesKHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -8990,12 +8990,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->DisplayModeKHRWrapper* { return GetWrapper<DisplayModeKHRWrapper>(handle_struct->displayMode); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->VulkanDisplayModeKHRWrapper* { return GetWrapper<VulkanDisplayModeKHRWrapper>(handle_struct->displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR>::Dispatch(manager, result, physicalDevice, display, pPropertyCount, pProperties);
@@ -9032,7 +9032,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<PhysicalDeviceWrapper, DisplayKHRWrapper, DisplayModeKHRWrapper>(physicalDevice, display, pMode, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanDisplayKHRWrapper, VulkanDisplayModeKHRWrapper>(physicalDevice, display, pMode, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9042,13 +9042,13 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDisplayModeKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DisplayModeKHRWrapper>(pMode, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDisplayModeKHRWrapper>(pMode, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModeCreateInfoKHR>(result, physicalDevice, pMode, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayModeKHRWrapper, VkDisplayModeCreateInfoKHR>(result, physicalDevice, pMode, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayModeKHR>::Dispatch(manager, result, physicalDevice, display, pCreateInfo, pAllocator, pMode);
@@ -9089,8 +9089,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayPlaneCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<DisplayModeKHRWrapper>(mode);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(mode);
         encoder->EncodeUInt32Value(planeIndex);
         EncodeStructPtr(encoder, pCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -9133,7 +9133,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9143,12 +9143,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkDisplaySurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkDisplaySurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9188,7 +9188,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, NoParentWrapper, SwapchainKHRWrapper>(device, NoParentWrapper::kHandleValue, pSwapchains, swapchainCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSwapchainKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSwapchains, swapchainCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9198,13 +9198,13 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(swapchainCount);
         EncodeStructArray(encoder, pCreateInfos, swapchainCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<SwapchainKHRWrapper>(pSwapchains, swapchainCount, omit_output_data);
+        encoder->EncodeHandleArray<VulkanSwapchainKHRWrapper>(pSwapchains, swapchainCount, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkDevice, void*, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, nullptr, swapchainCount, pSwapchains, pCreateInfos);
+        manager->EndGroupCreateApiCallCapture<VkDevice, void*, VulkanSwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, nullptr, swapchainCount, pSwapchains, pCreateInfos);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR>::Dispatch(manager, result, device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
@@ -9240,7 +9240,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9250,12 +9250,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkXlibSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkXlibSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9290,7 +9290,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXlibPresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceXlibPresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(dpy);
         encoder->EncodeSizeTValue(visualID);
@@ -9331,7 +9331,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9341,12 +9341,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkXcbSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkXcbSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9381,7 +9381,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXcbPresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceXcbPresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(connection);
         encoder->EncodeUInt32Value(visual_id);
@@ -9422,7 +9422,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9432,12 +9432,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkWaylandSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkWaylandSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9471,7 +9471,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWaylandPresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(display);
         encoder->EncodeVkBool32Value(result);
@@ -9511,7 +9511,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9521,12 +9521,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkAndroidSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkAndroidSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9562,7 +9562,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9572,12 +9572,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkWin32SurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkWin32SurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -9610,7 +9610,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWin32PresentationSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceWin32PresentationSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVkBool32Value(result);
         manager->EndApiCallCapture();
@@ -9653,7 +9653,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoCapabilitiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoCapabilitiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pVideoProfile);
         EncodeStructPtr(encoder, pCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -9698,7 +9698,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoFormatPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoFormatPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pVideoFormatInfo);
         encoder->EncodeUInt32Ptr(pVideoFormatPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pVideoFormatProperties, (pVideoFormatPropertyCount != nullptr) ? (*pVideoFormatPropertyCount) : 0, omit_output_data);
@@ -9739,7 +9739,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, VideoSessionKHRWrapper>(device, NoParentWrapper::kHandleValue, pVideoSession, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanVideoSessionKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pVideoSession, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9749,12 +9749,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateVideoSessionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VideoSessionKHRWrapper>(pVideoSession, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanVideoSessionKHRWrapper>(pVideoSession, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VideoSessionKHRWrapper, VkVideoSessionCreateInfoKHR>(result, device, pVideoSession, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanVideoSessionKHRWrapper, VkVideoSessionCreateInfoKHR>(result, device, pVideoSession, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateVideoSessionKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pVideoSession);
@@ -9786,10 +9786,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<VideoSessionKHRWrapper>(videoSession);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(videoSession);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VideoSessionKHRWrapper>(videoSession);
+        manager->EndDestroyApiCallCapture<VulkanVideoSessionKHRWrapper>(videoSession);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -9797,7 +9797,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR>::Dispatch(manager, device, videoSession, pAllocator);
 
-    DestroyWrappedHandle<VideoSessionKHRWrapper>(videoSession);
+    DestroyWrappedHandle<VulkanVideoSessionKHRWrapper>(videoSession);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
@@ -9833,8 +9833,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetVideoSessionMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<VideoSessionKHRWrapper>(videoSession);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(videoSession);
         encoder->EncodeUInt32Ptr(pMemoryRequirementsCount, omit_output_data);
         EncodeStructArray(encoder, pMemoryRequirements, (pMemoryRequirementsCount != nullptr) ? (*pMemoryRequirementsCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -9876,8 +9876,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindVideoSessionMemoryKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindVideoSessionMemoryKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<VideoSessionKHRWrapper>(videoSession);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(videoSession);
         encoder->EncodeUInt32Value(bindSessionMemoryInfoCount);
         EncodeStructArray(encoder, pBindSessionMemoryInfos, bindSessionMemoryInfoCount);
         encoder->EncodeEnumValue(result);
@@ -9920,7 +9920,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, VideoSessionParametersKHRWrapper>(device, NoParentWrapper::kHandleValue, pVideoSessionParameters, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanVideoSessionParametersKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pVideoSessionParameters, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -9930,12 +9930,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<VideoSessionParametersKHRWrapper>(pVideoSessionParameters, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanVideoSessionParametersKHRWrapper>(pVideoSessionParameters, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, VideoSessionParametersKHRWrapper, VkVideoSessionParametersCreateInfoKHR>(result, device, pVideoSessionParameters, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanVideoSessionParametersKHRWrapper, VkVideoSessionParametersCreateInfoKHR>(result, device, pVideoSessionParameters, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateVideoSessionParametersKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pVideoSessionParameters);
@@ -9969,8 +9969,8 @@ VKAPI_ATTR VkResult VKAPI_CALL UpdateVideoSessionParametersKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<VideoSessionParametersKHRWrapper>(videoSessionParameters);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
         EncodeStructPtr(encoder, pUpdateInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -10005,10 +10005,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<VideoSessionParametersKHRWrapper>(videoSessionParameters);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<VideoSessionParametersKHRWrapper>(videoSessionParameters);
+        manager->EndDestroyApiCallCapture<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -10016,7 +10016,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR>::Dispatch(manager, device, videoSessionParameters, pAllocator);
 
-    DestroyWrappedHandle<VideoSessionParametersKHRWrapper>(videoSessionParameters);
+    DestroyWrappedHandle<VulkanVideoSessionParametersKHRWrapper>(videoSessionParameters);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
@@ -10042,7 +10042,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginVideoCodingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBeginInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginVideoCodingKHRHandles, pBeginInfo);
     }
@@ -10078,7 +10078,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndVideoCodingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndVideoCodingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pEndCodingInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -10111,7 +10111,7 @@ VKAPI_ATTR void VKAPI_CALL CmdControlVideoCodingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdControlVideoCodingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCodingControlInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -10144,7 +10144,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDecodeVideoKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDecodeVideoKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDecodeInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDecodeVideoKHRHandles, pDecodeInfo);
     }
@@ -10180,7 +10180,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderingInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderingKHRHandles, pRenderingInfo);
     }
@@ -10215,7 +10215,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderingKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderingKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -10249,7 +10249,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFeatures);
         manager->EndApiCallCapture();
     }
@@ -10282,7 +10282,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pProperties);
         manager->EndApiCallCapture();
     }
@@ -10316,7 +10316,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         EncodeStructPtr(encoder, pFormatProperties);
         manager->EndApiCallCapture();
@@ -10357,7 +10357,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pImageFormatInfo);
         EncodeStructPtr(encoder, pImageFormatProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -10395,7 +10395,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
         EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         manager->EndApiCallCapture();
@@ -10429,7 +10429,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pMemoryProperties);
         manager->EndApiCallCapture();
     }
@@ -10464,7 +10464,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pFormatInfo);
         encoder->EncodeUInt32Ptr(pPropertyCount);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
@@ -10502,7 +10502,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeaturesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeaturesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(heapIndex);
         encoder->EncodeUInt32Value(localDeviceIndex);
         encoder->EncodeUInt32Value(remoteDeviceIndex);
@@ -10536,7 +10536,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDeviceMaskKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(deviceMask);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -10574,7 +10574,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDispatchBaseKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(baseGroupX);
         encoder->EncodeUInt32Value(baseGroupY);
         encoder->EncodeUInt32Value(baseGroupZ);
@@ -10613,8 +10613,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkTrimCommandPoolKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<CommandPoolWrapper>(commandPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(commandPool);
         encoder->EncodeFlagsValue(flags);
         manager->EndApiCallCapture();
     }
@@ -10651,7 +10651,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<InstanceWrapper, NoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, NoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanInstanceWrapper, VulkanNoParentWrapper, VkPhysicalDeviceGroupProperties>(instance, VulkanNoParentWrapper::kHandleValue, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -10661,11 +10661,11 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroupsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceGroupCount, omit_output_data);
         EncodeStructArray(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkInstance, PhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
+        manager->EndStructGroupCreateApiCallCapture<VkInstance, VulkanPhysicalDeviceWrapper, VkPhysicalDeviceGroupProperties>(result, instance, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0, pPhysicalDeviceGroupProperties, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroupsKHR>::Dispatch(manager, result, instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
@@ -10699,7 +10699,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalBufferInfo);
         EncodeStructPtr(encoder, pExternalBufferProperties);
         manager->EndApiCallCapture();
@@ -10743,7 +10743,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -10788,7 +10788,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryWin32HandlePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeVoidPtr(handle);
         EncodeStructPtr(encoder, pMemoryWin32HandleProperties, omit_output_data);
@@ -10836,7 +10836,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -10881,7 +10881,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryFdPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeInt32Value(fd);
         EncodeStructPtr(encoder, pMemoryFdProperties, omit_output_data);
@@ -10920,7 +10920,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphorePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalSemaphoreInfo);
         EncodeStructPtr(encoder, pExternalSemaphoreProperties);
         manager->EndApiCallCapture();
@@ -10957,7 +10957,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportSemaphoreWin32HandleInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11003,7 +11003,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11043,7 +11043,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportSemaphoreFdInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11089,7 +11089,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11128,9 +11128,9 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<PipelineLayoutWrapper>(layout);
+        encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(layout);
         encoder->EncodeUInt32Value(set);
         encoder->EncodeUInt32Value(descriptorWriteCount);
         EncodeStructArray(encoder, pDescriptorWrites, descriptorWriteCount);
@@ -11176,7 +11176,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, DescriptorUpdateTemplateWrapper>(device, NoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDescriptorUpdateTemplateWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDescriptorUpdateTemplate, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11186,12 +11186,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDescriptorUpdateTemplateWrapper>(pDescriptorUpdateTemplate, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanDescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -11223,10 +11223,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+        manager->EndDestroyApiCallCapture<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -11234,7 +11234,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
-    DestroyWrappedHandle<DescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
+    DestroyWrappedHandle<VulkanDescriptorUpdateTemplateWrapper>(descriptorUpdateTemplate);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
@@ -11265,7 +11265,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, RenderPassWrapper>(device, NoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanRenderPassWrapper>(device, VulkanNoParentWrapper::kHandleValue, pRenderPass, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11275,12 +11275,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateRenderPass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<RenderPassWrapper>(pRenderPass, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanRenderPassWrapper>(pRenderPass, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanRenderPassWrapper, VkRenderPassCreateInfo2>(result, device, pRenderPass, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass2KHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -11312,7 +11312,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginRenderPass2KHRHandles, pRenderPassBegin);
@@ -11350,7 +11350,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -11384,7 +11384,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSubpassEndInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -11419,8 +11419,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainStatusKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSwapchainStatusKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -11456,7 +11456,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFencePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFencePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pExternalFenceInfo);
         EncodeStructPtr(encoder, pExternalFenceProperties);
         manager->EndApiCallCapture();
@@ -11493,7 +11493,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportFenceWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportFenceWin32HandleInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11539,7 +11539,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFenceWin32HandleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11579,7 +11579,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportFenceFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportFenceFdInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11625,7 +11625,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceFdKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFenceFdKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11671,7 +11671,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceQueueFamilyPerformanceQuer
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeUInt32Ptr(pCounterCount, omit_output_data);
         EncodeStructArray(encoder, pCounters, (pCounterCount != nullptr) ? (*pCounterCount) : 0, omit_output_data);
@@ -11711,7 +11711,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pPerformanceQueryCreateInfo);
         encoder->EncodeUInt32Ptr(pNumPasses);
         manager->EndApiCallCapture();
@@ -11745,7 +11745,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireProfilingLockKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireProfilingLockKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -11778,7 +11778,7 @@ VKAPI_ATTR void VKAPI_CALL ReleaseProfilingLockKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseProfilingLockKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         manager->EndApiCallCapture();
     }
 
@@ -11822,7 +11822,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pSurfaceInfo);
         EncodeStructPtr(encoder, pSurfaceCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -11870,7 +11870,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormats2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pSurfaceInfo);
         encoder->EncodeUInt32Ptr(pSurfaceFormatCount, omit_output_data);
         EncodeStructArray(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0, omit_output_data);
@@ -11910,7 +11910,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<PhysicalDeviceWrapper, NoParentWrapper, VkDisplayProperties2KHR>(physicalDevice, NoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayProperties2KHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11920,11 +11920,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->DisplayKHRWrapper* { return GetWrapper<DisplayKHRWrapper>(handle_struct->displayProperties.display); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->displayProperties.display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -11959,7 +11959,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<PhysicalDeviceWrapper, NoParentWrapper, VkDisplayPlaneProperties2KHR>(physicalDevice, NoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VkDisplayPlaneProperties2KHR>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -11969,11 +11969,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->DisplayKHRWrapper* { return GetWrapper<DisplayKHRWrapper>(handle_struct->displayPlaneProperties.currentDisplay); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->VulkanDisplayKHRWrapper* { return GetWrapper<VulkanDisplayKHRWrapper>(handle_struct->displayPlaneProperties.currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR>::Dispatch(manager, result, physicalDevice, pPropertyCount, pProperties);
@@ -12009,7 +12009,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
 
     if (result >= 0)
     {
-        CreateWrappedStructArrayHandles<PhysicalDeviceWrapper, DisplayKHRWrapper, VkDisplayModeProperties2KHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedStructArrayHandles<VulkanPhysicalDeviceWrapper, VulkanDisplayKHRWrapper, VkDisplayModeProperties2KHR>(physicalDevice, display, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -12019,12 +12019,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->DisplayModeKHRWrapper* { return GetWrapper<DisplayModeKHRWrapper>(handle_struct->displayModeProperties.displayMode); });
+        manager->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->VulkanDisplayModeKHRWrapper* { return GetWrapper<VulkanDisplayModeKHRWrapper>(handle_struct->displayModeProperties.displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR>::Dispatch(manager, result, physicalDevice, display, pPropertyCount, pProperties);
@@ -12067,7 +12067,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilities2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDisplayPlaneCapabilities2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pDisplayPlaneInfo);
         EncodeStructPtr(encoder, pCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -12108,7 +12108,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -12146,7 +12146,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -12185,7 +12185,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -12223,7 +12223,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, SamplerYcbcrConversionWrapper>(device, NoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanSamplerYcbcrConversionWrapper>(device, VulkanNoParentWrapper::kHandleValue, pYcbcrConversion, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -12233,12 +12233,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSamplerYcbcrConversionWrapper>(pYcbcrConversion, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanSamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -12270,10 +12270,10 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+        manager->EndDestroyApiCallCapture<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -12281,7 +12281,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
-    DestroyWrappedHandle<SamplerYcbcrConversionWrapper>(ycbcrConversion);
+    DestroyWrappedHandle<VulkanSamplerYcbcrConversionWrapper>(ycbcrConversion);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
@@ -12313,7 +12313,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -12354,7 +12354,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -12395,7 +12395,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupportKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pSupport);
         manager->EndApiCallCapture();
@@ -12432,10 +12432,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectCountKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -12475,10 +12475,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -12522,8 +12522,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreCounterValueKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
         encoder->EncodeUInt64Ptr(pValue, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -12563,7 +12563,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitSemaphoresKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pWaitInfo);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -12603,7 +12603,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphoreKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSignalSemaphoreKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pSignalInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -12646,7 +12646,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceFragmentShadingRatesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFragmentShadingRatesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pFragmentShadingRateCount, omit_output_data);
         EncodeStructArray(encoder, pFragmentShadingRates, (pFragmentShadingRateCount != nullptr) ? (*pFragmentShadingRateCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -12682,7 +12682,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pFragmentSize);
         encoder->EncodeEnumArray(combinerOps, 2);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -12716,7 +12716,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingAttachmentLocationsKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRenderingAttachmentLocationsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLocationInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -12749,7 +12749,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingInputAttachmentIndicesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRenderingInputAttachmentIndicesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLocationInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -12786,8 +12786,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForPresentKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitForPresentKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt64Value(presentId);
         encoder->EncodeUInt64Value(timeout);
         encoder->EncodeEnumValue(result);
@@ -12827,7 +12827,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -12866,7 +12866,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -12905,7 +12905,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt64Value(result);
         manager->EndApiCallCapture();
@@ -12943,7 +12943,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, DeferredOperationKHRWrapper>(device, NoParentWrapper::kHandleValue, pDeferredOperation, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanDeferredOperationKHRWrapper>(device, VulkanNoParentWrapper::kHandleValue, pDeferredOperation, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -12953,11 +12953,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDeferredOperationKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DeferredOperationKHRWrapper>(pDeferredOperation, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDeferredOperationKHRWrapper>(pDeferredOperation, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, DeferredOperationKHRWrapper, void>(result, device, pDeferredOperation, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanDeferredOperationKHRWrapper, void>(result, device, pDeferredOperation, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDeferredOperationKHR>::Dispatch(manager, result, device, pAllocator, pDeferredOperation);
@@ -12989,10 +12989,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DeferredOperationKHRWrapper>(operation);
+        manager->EndDestroyApiCallCapture<VulkanDeferredOperationKHRWrapper>(operation);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -13000,7 +13000,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR>::Dispatch(manager, device, operation, pAllocator);
 
-    DestroyWrappedHandle<DeferredOperationKHRWrapper>(operation);
+    DestroyWrappedHandle<VulkanDeferredOperationKHRWrapper>(operation);
 }
 
 VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
@@ -13028,8 +13028,8 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeferredOperationMaxConcurrencyKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
         encoder->EncodeUInt32Value(result);
         manager->EndApiCallCapture();
     }
@@ -13064,8 +13064,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -13100,8 +13100,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(operation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(operation);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -13147,7 +13147,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineExecutablePropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pPipelineInfo);
         encoder->EncodeUInt32Ptr(pExecutableCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pExecutableCount != nullptr) ? (*pExecutableCount) : 0, omit_output_data);
@@ -13196,7 +13196,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableStatisticsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineExecutableStatisticsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pExecutableInfo);
         encoder->EncodeUInt32Ptr(pStatisticCount, omit_output_data);
         EncodeStructArray(encoder, pStatistics, (pStatisticCount != nullptr) ? (*pStatisticCount) : 0, omit_output_data);
@@ -13245,7 +13245,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableInternalRepresentationsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineExecutableInternalRepresentationsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pExecutableInfo);
         encoder->EncodeUInt32Ptr(pInternalRepresentationCount, omit_output_data);
         EncodeStructArray(encoder, pInternalRepresentations, (pInternalRepresentationCount != nullptr) ? (*pInternalRepresentationCount) : 0, omit_output_data);
@@ -13293,7 +13293,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMapMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pMemoryMapInfo);
         encoder->EncodeVoidPtrPtr(ppData, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -13333,7 +13333,7 @@ VKAPI_ATTR VkResult VKAPI_CALL UnmapMemory2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUnmapMemory2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pMemoryUnmapInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -13376,7 +13376,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoEncodeQualityLevelPropertie
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pQualityLevelInfo);
         EncodeStructPtr(encoder, pQualityLevelProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -13425,7 +13425,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEncodedVideoSessionParametersKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetEncodedVideoSessionParametersKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pVideoSessionParametersInfo);
         EncodeStructPtr(encoder, pFeedbackInfo, omit_output_data);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
@@ -13462,7 +13462,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEncodeVideoKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEncodeVideoKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pEncodeInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEncodeVideoKHRHandles, pEncodeInfo);
     }
@@ -13499,8 +13499,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetEvent2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetEvent2KHRHandles, event, pDependencyInfo);
     }
@@ -13537,8 +13537,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResetEvent2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<EventWrapper>(event);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanEventWrapper>(event);
         encoder->EncodeFlags64Value(stageMask);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEvent2KHRHandles, event);
     }
@@ -13573,9 +13573,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWaitEvents2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(eventCount);
-        encoder->EncodeHandleArray<EventWrapper>(pEvents, eventCount);
+        encoder->EncodeHandleArray<VulkanEventWrapper>(pEvents, eventCount);
         EncodeStructArray(encoder, pDependencyInfos, eventCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWaitEvents2KHRHandles, eventCount, pEvents, pDependencyInfos);
     }
@@ -13611,7 +13611,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPipelineBarrier2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDependencyInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPipelineBarrier2KHRHandles, pDependencyInfo);
     }
@@ -13649,9 +13649,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteTimestamp2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlags64Value(stage);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestamp2KHRHandles, queryPool);
     }
@@ -13691,10 +13691,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         encoder->EncodeUInt32Value(submitCount);
         EncodeStructArray(encoder, pSubmits, submitCount);
-        encoder->EncodeHandleValue<FenceWrapper>(fence);
+        encoder->EncodeHandleValue<VulkanFenceWrapper>(fence);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -13730,9 +13730,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarker2AMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteBufferMarker2AMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlags64Value(stage);
-        encoder->EncodeHandleValue<BufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeUInt32Value(marker);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteBufferMarker2AMDHandles, dstBuffer);
@@ -13769,7 +13769,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointData2NV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueueCheckpointData2NV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         encoder->EncodeUInt32Ptr(pCheckpointDataCount);
         EncodeStructArray(encoder, pCheckpointData, (pCheckpointDataCount != nullptr) ? (*pCheckpointDataCount) : 0);
         manager->EndApiCallCapture();
@@ -13801,7 +13801,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBuffer2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBuffer2KHRHandles, pCopyBufferInfo);
     }
@@ -13837,7 +13837,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImage2KHRHandles, pCopyImageInfo);
     }
@@ -13873,7 +13873,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyBufferToImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferToImage2KHRHandles, pCopyBufferToImageInfo);
     }
@@ -13909,7 +13909,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pCopyImageToBufferInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageToBuffer2KHRHandles, pCopyImageToBufferInfo);
     }
@@ -13945,7 +13945,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBlitImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBlitImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBlitImage2KHRHandles, pBlitImageInfo);
     }
@@ -13981,7 +13981,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdResolveImage2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pResolveImageInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResolveImage2KHRHandles, pResolveImageInfo);
     }
@@ -14017,7 +14017,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirect2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysIndirect2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkDeviceAddressValue(indirectDeviceAddress);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -14053,7 +14053,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -14091,7 +14091,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -14130,7 +14130,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirementsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirementsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
         EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
@@ -14166,8 +14166,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindIndexBuffer2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeVkDeviceSizeValue(size);
         encoder->EncodeEnumValue(indexType);
@@ -14205,7 +14205,7 @@ VKAPI_ATTR void VKAPI_CALL GetRenderingAreaGranularityKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRenderingAreaGranularityKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pRenderingAreaInfo);
         EncodeStructPtr(encoder, pGranularity);
         manager->EndApiCallCapture();
@@ -14243,7 +14243,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSubresourceLayoutKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSubresourceLayoutKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -14279,8 +14279,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2KHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         EncodeStructPtr(encoder, pSubresource);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -14321,7 +14321,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -14357,7 +14357,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineStippleKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(lineStippleFactor);
         encoder->EncodeUInt16Value(lineStipplePattern);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -14400,7 +14400,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pTimeDomainCount, omit_output_data);
         encoder->EncodeEnumArray(pTimeDomains, (pTimeDomainCount != nullptr) ? (*pTimeDomainCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -14446,7 +14446,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetCalibratedTimestampsKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(timestampCount);
         EncodeStructArray(encoder, pTimestampInfos, timestampCount);
         encoder->EncodeUInt64Array(pTimestamps, timestampCount, omit_output_data);
@@ -14483,7 +14483,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindDescriptorSets2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBindDescriptorSetsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindDescriptorSets2KHRHandles, pBindDescriptorSetsInfo);
     }
@@ -14519,7 +14519,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushConstants2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pPushConstantsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushConstants2KHRHandles, pPushConstantsInfo);
     }
@@ -14555,7 +14555,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSet2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSet2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pPushDescriptorSetInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushDescriptorSet2KHRHandles, pPushDescriptorSetInfo);
     }
@@ -14591,7 +14591,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pPushDescriptorSetWithTemplateInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushDescriptorSetWithTemplate2KHRHandles, pPushDescriptorSetWithTemplateInfo);
     }
@@ -14627,7 +14627,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDescriptorBufferOffsets2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDescriptorBufferOffsets2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSetDescriptorBufferOffsetsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetDescriptorBufferOffsets2EXTHandles, pSetDescriptorBufferOffsetsInfo);
     }
@@ -14663,7 +14663,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorBufferEmbeddedSamplers2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pBindDescriptorBufferEmbeddedSamplersInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles, pBindDescriptorBufferEmbeddedSamplersInfo);
     }
@@ -14700,9 +14700,9 @@ VKAPI_ATTR void VKAPI_CALL FrameBoundaryANDROID(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkFrameBoundaryANDROID);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SemaphoreWrapper>(semaphore);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(semaphore);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         manager->EndApiCallCapture();
     }
 
@@ -14739,7 +14739,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, DebugReportCallbackEXTWrapper>(instance, NoParentWrapper::kHandleValue, pCallback, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanDebugReportCallbackEXTWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pCallback, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -14749,12 +14749,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DebugReportCallbackEXTWrapper>(pCallback, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDebugReportCallbackEXTWrapper>(pCallback, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, DebugReportCallbackEXTWrapper, VkDebugReportCallbackCreateInfoEXT>(result, instance, pCallback, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanDebugReportCallbackEXTWrapper, VkDebugReportCallbackCreateInfoEXT>(result, instance, pCallback, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pCallback);
@@ -14786,10 +14786,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
-        encoder->EncodeHandleValue<DebugReportCallbackEXTWrapper>(callback);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanDebugReportCallbackEXTWrapper>(callback);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DebugReportCallbackEXTWrapper>(callback);
+        manager->EndDestroyApiCallCapture<VulkanDebugReportCallbackEXTWrapper>(callback);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -14797,7 +14797,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(manager, instance, callback, pAllocator);
 
-    DestroyWrappedHandle<DebugReportCallbackEXTWrapper>(callback);
+    DestroyWrappedHandle<VulkanDebugReportCallbackEXTWrapper>(callback);
 }
 
 VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
@@ -14829,7 +14829,7 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugReportMessageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(objectType);
         encoder->EncodeUInt64Value(GetWrappedId(object, objectType));
@@ -14873,7 +14873,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectTagEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pTagInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -14912,7 +14912,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectNameEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pNameInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -14946,7 +14946,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -14978,7 +14978,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDebugMarkerEndEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -15010,7 +15010,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -15047,10 +15047,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindTransformFeedbackBuffersEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindTransformFeedbackBuffersEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<BufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pSizes, bindingCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindTransformFeedbackBuffersEXTHandles, bindingCount, pBuffers);
@@ -15087,10 +15087,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginTransformFeedbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstCounterBuffer);
         encoder->EncodeUInt32Value(counterBufferCount);
-        encoder->EncodeHandleArray<BufferWrapper>(pCounterBuffers, counterBufferCount);
+        encoder->EncodeHandleArray<VulkanBufferWrapper>(pCounterBuffers, counterBufferCount);
         encoder->EncodeVkDeviceSizeArray(pCounterBufferOffsets, counterBufferCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
@@ -15126,10 +15126,10 @@ VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndTransformFeedbackEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstCounterBuffer);
         encoder->EncodeUInt32Value(counterBufferCount);
-        encoder->EncodeHandleArray<BufferWrapper>(pCounterBuffers, counterBufferCount);
+        encoder->EncodeHandleArray<VulkanBufferWrapper>(pCounterBuffers, counterBufferCount);
         encoder->EncodeVkDeviceSizeArray(pCounterBufferOffsets, counterBufferCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
@@ -15165,8 +15165,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginQueryIndexedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeUInt32Value(index);
@@ -15203,8 +15203,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndQueryIndexedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeUInt32Value(index);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndQueryIndexedEXTHandles, queryPool);
@@ -15243,10 +15243,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectByteCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(instanceCount);
         encoder->EncodeUInt32Value(firstInstance);
-        encoder->EncodeHandleValue<BufferWrapper>(counterBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(counterBuffer);
         encoder->EncodeVkDeviceSizeValue(counterBufferOffset);
         encoder->EncodeUInt32Value(counterOffset);
         encoder->EncodeUInt32Value(vertexStride);
@@ -15286,7 +15286,7 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageViewHandleNVX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Value(result);
         manager->EndApiCallCapture();
@@ -15329,8 +15329,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageViewAddressNVX(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageViewAddressNVX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -15369,10 +15369,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -15412,10 +15412,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -15462,8 +15462,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderInfoAMD(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderInfoAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         encoder->EncodeEnumValue(shaderStage);
         encoder->EncodeEnumValue(infoType);
         encoder->EncodeSizeTPtr(pInfoSize, omit_output_data);
@@ -15505,7 +15505,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateStreamDescriptorSurfaceGGP(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -15515,12 +15515,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateStreamDescriptorSurfaceGGP(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateStreamDescriptorSurfaceGGP);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkStreamDescriptorSurfaceCreateInfoGGP>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkStreamDescriptorSurfaceCreateInfoGGP>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateStreamDescriptorSurfaceGGP>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -15565,7 +15565,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalImageFormatPropertiesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(format);
         encoder->EncodeEnumValue(type);
         encoder->EncodeEnumValue(tiling);
@@ -15615,8 +15615,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryWin32HandleNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         encoder->EncodeFlagsValue(handleType);
         encoder->EncodeVoidPtrPtr(pHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -15656,7 +15656,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -15666,12 +15666,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateViSurfaceNN);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkViSurfaceCreateInfoNN>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkViSurfaceCreateInfoNN>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateViSurfaceNN>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -15702,7 +15702,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginConditionalRenderingEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pConditionalRenderingBegin);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginConditionalRenderingEXTHandles, pConditionalRenderingBegin);
     }
@@ -15737,7 +15737,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndConditionalRenderingEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndConditionalRenderingEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -15771,7 +15771,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWScalingNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewportWScalings, viewportCount);
@@ -15808,8 +15808,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -15845,9 +15845,9 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireXlibDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeVoidPtr(dpy);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -15885,7 +15885,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<PhysicalDeviceWrapper, NoParentWrapper, DisplayKHRWrapper>(physicalDevice, NoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -15895,12 +15895,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeVoidPtr(dpy);
         encoder->EncodeSizeTValue(rrOutput);
-        encoder->EncodeHandlePtr<DisplayKHRWrapper>(pDisplay, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDisplayKHRWrapper>(pDisplay, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT>::Dispatch(manager, result, physicalDevice, dpy, rrOutput, pDisplay);
@@ -15940,8 +15940,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<SurfaceKHRWrapper>(surface);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(surface);
         EncodeStructPtr(encoder, pSurfaceCapabilities, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -15978,8 +15978,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDisplayPowerControlEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         EncodeStructPtr(encoder, pDisplayPowerInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16018,7 +16018,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, FenceWrapper>(device, NoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanFenceWrapper>(device, VulkanNoParentWrapper::kHandleValue, pFence, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16028,12 +16028,12 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkRegisterDeviceEventEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pDeviceEventInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<FenceWrapper>(pFence, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanFenceWrapper>(pFence, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, FenceWrapper, void>(result, device, pFence, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanFenceWrapper, void>(result, device, pFence, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkRegisterDeviceEventEXT>::Dispatch(manager, result, device, pDeviceEventInfo, pAllocator, pFence);
@@ -16070,7 +16070,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, DisplayKHRWrapper, FenceWrapper>(device, display, pFence, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanDisplayKHRWrapper, VulkanFenceWrapper>(device, display, pFence, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16080,13 +16080,13 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkRegisterDisplayEventEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         EncodeStructPtr(encoder, pDisplayEventInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<FenceWrapper>(pFence, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanFenceWrapper>(pFence, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, FenceWrapper, void>(result, device, pFence, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanFenceWrapper, void>(result, device, pFence, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkRegisterDisplayEventEXT>::Dispatch(manager, result, device, display, pDisplayEventInfo, pAllocator, pFence);
@@ -16127,8 +16127,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainCounterEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSwapchainCounterEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(counter);
         encoder->EncodeUInt64Ptr(pCounterValue, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16172,8 +16172,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRefreshCycleDurationGOOGLE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         EncodeStructPtr(encoder, pDisplayTimingProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16217,8 +16217,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPastPresentationTimingGOOGLE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeUInt32Ptr(pPresentationTimingCount, omit_output_data);
         EncodeStructArray(encoder, pPresentationTimings, (pPresentationTimingCount != nullptr) ? (*pPresentationTimingCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16255,7 +16255,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstDiscardRectangle);
         encoder->EncodeUInt32Value(discardRectangleCount);
         EncodeStructArray(encoder, pDiscardRectangles, discardRectangleCount);
@@ -16290,7 +16290,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(discardRectangleEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16323,7 +16323,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(discardRectangleMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16358,9 +16358,9 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetHdrMetadataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(swapchainCount);
-        encoder->EncodeHandleArray<SwapchainKHRWrapper>(pSwapchains, swapchainCount);
+        encoder->EncodeHandleArray<VulkanSwapchainKHRWrapper>(pSwapchains, swapchainCount);
         EncodeStructArray(encoder, pMetadata, swapchainCount);
         manager->EndApiCallCapture();
     }
@@ -16398,7 +16398,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16408,12 +16408,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkIOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkIOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -16449,7 +16449,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16459,12 +16459,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkMacOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkMacOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -16495,14 +16495,14 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDebugUtilsObjectNameInfoEXT* pNameInfo_unwrapped = UnwrapStructPtrHandles(pNameInfo, handle_unwrap_memory);
 
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     auto physical_device = device_wrapper->physical_device->handle;
     VkResult result = GetVulkanInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT(device, pNameInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pNameInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16536,14 +16536,14 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDebugUtilsObjectTagInfoEXT* pTagInfo_unwrapped = UnwrapStructPtrHandles(pTagInfo, handle_unwrap_memory);
 
-    auto device_wrapper = GetWrapper<DeviceWrapper>(device);
+    auto device_wrapper = GetWrapper<VulkanDeviceWrapper>(device);
     auto physical_device = device_wrapper->physical_device->handle;
     VkResult result = GetVulkanInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT(device, pTagInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTagEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pTagInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -16577,7 +16577,7 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndApiCallCapture();
     }
@@ -16609,7 +16609,7 @@ VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueEndDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         manager->EndApiCallCapture();
     }
 
@@ -16641,7 +16641,7 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndApiCallCapture();
     }
@@ -16674,7 +16674,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16706,7 +16706,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdEndDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
@@ -16738,7 +16738,7 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pLabelInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -16776,7 +16776,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, DebugUtilsMessengerEXTWrapper>(instance, NoParentWrapper::kHandleValue, pMessenger, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanDebugUtilsMessengerEXTWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pMessenger, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -16786,12 +16786,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<DebugUtilsMessengerEXTWrapper>(pMessenger, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDebugUtilsMessengerEXTWrapper>(pMessenger, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, DebugUtilsMessengerEXTWrapper, VkDebugUtilsMessengerCreateInfoEXT>(result, instance, pMessenger, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanDebugUtilsMessengerEXTWrapper, VkDebugUtilsMessengerCreateInfoEXT>(result, instance, pMessenger, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pMessenger);
@@ -16823,10 +16823,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
-        encoder->EncodeHandleValue<DebugUtilsMessengerEXTWrapper>(messenger);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanDebugUtilsMessengerEXTWrapper>(messenger);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<DebugUtilsMessengerEXTWrapper>(messenger);
+        manager->EndDestroyApiCallCapture<VulkanDebugUtilsMessengerEXTWrapper>(messenger);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -16834,7 +16834,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(manager, instance, messenger, pAllocator);
 
-    DestroyWrappedHandle<DebugUtilsMessengerEXTWrapper>(messenger);
+    DestroyWrappedHandle<VulkanDebugUtilsMessengerEXTWrapper>(messenger);
 }
 
 VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
@@ -16862,7 +16862,7 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         encoder->EncodeEnumValue(messageSeverity);
         encoder->EncodeFlagsValue(messageTypes);
         EncodeStructPtr(encoder, pCallbackData);
@@ -16906,7 +16906,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAndroidHardwareBufferPropertiesANDROID);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeVoidPtr(buffer);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16953,7 +16953,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryAndroidHardwareBufferANDROID);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVoidPtrPtr(pBuffer, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -16988,7 +16988,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pSampleLocationsInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -17024,7 +17024,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMultisamplePropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeEnumValue(samples);
         EncodeStructPtr(encoder, pMultisampleProperties);
         manager->EndApiCallCapture();
@@ -17065,8 +17065,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageDrmFormatModifierPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageDrmFormatModifierPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -17105,7 +17105,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, ValidationCacheEXTWrapper>(device, NoParentWrapper::kHandleValue, pValidationCache, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanValidationCacheEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pValidationCache, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -17115,12 +17115,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateValidationCacheEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<ValidationCacheEXTWrapper>(pValidationCache, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanValidationCacheEXTWrapper>(pValidationCache, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, ValidationCacheEXTWrapper, VkValidationCacheCreateInfoEXT>(result, device, pValidationCache, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanValidationCacheEXTWrapper, VkValidationCacheCreateInfoEXT>(result, device, pValidationCache, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateValidationCacheEXT>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pValidationCache);
@@ -17152,10 +17152,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ValidationCacheEXTWrapper>(validationCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(validationCache);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<ValidationCacheEXTWrapper>(validationCache);
+        manager->EndDestroyApiCallCapture<VulkanValidationCacheEXTWrapper>(validationCache);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -17163,7 +17163,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(manager, device, validationCache, pAllocator);
 
-    DestroyWrappedHandle<ValidationCacheEXTWrapper>(validationCache);
+    DestroyWrappedHandle<VulkanValidationCacheEXTWrapper>(validationCache);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
@@ -17193,10 +17193,10 @@ VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMergeValidationCachesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ValidationCacheEXTWrapper>(dstCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(dstCache);
         encoder->EncodeUInt32Value(srcCacheCount);
-        encoder->EncodeHandleArray<ValidationCacheEXTWrapper>(pSrcCaches, srcCacheCount);
+        encoder->EncodeHandleArray<VulkanValidationCacheEXTWrapper>(pSrcCaches, srcCacheCount);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -17239,8 +17239,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetValidationCacheDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ValidationCacheEXTWrapper>(validationCache);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(validationCache);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? (*pDataSize) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -17276,8 +17276,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindShadingRateImageNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
         encoder->EncodeEnumValue(imageLayout);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindShadingRateImageNVHandles, imageView);
     }
@@ -17312,7 +17312,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportShadingRatePaletteNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pShadingRatePalettes, viewportCount);
@@ -17349,7 +17349,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoarseSampleOrderNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(sampleOrderType);
         encoder->EncodeUInt32Value(customSampleOrderCount);
         EncodeStructArray(encoder, pCustomSampleOrders, customSampleOrderCount);
@@ -17392,7 +17392,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, AccelerationStructureNVWrapper>(device, NoParentWrapper::kHandleValue, pAccelerationStructure, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanAccelerationStructureNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pAccelerationStructure, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -17402,12 +17402,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<AccelerationStructureNVWrapper>(pAccelerationStructure, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanAccelerationStructureNVWrapper>(pAccelerationStructure, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, AccelerationStructureNVWrapper, VkAccelerationStructureCreateInfoNV>(result, device, pAccelerationStructure, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanAccelerationStructureNVWrapper, VkAccelerationStructureCreateInfoNV>(result, device, pAccelerationStructure, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureNV>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pAccelerationStructure);
@@ -17439,10 +17439,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(accelerationStructure);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<AccelerationStructureNVWrapper>(accelerationStructure);
+        manager->EndDestroyApiCallCapture<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -17450,7 +17450,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
-    DestroyWrappedHandle<AccelerationStructureNVWrapper>(accelerationStructure);
+    DestroyWrappedHandle<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
 }
 
 VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
@@ -17482,7 +17482,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureMemoryRequirementsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -17520,7 +17520,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindAccelerationStructureMemoryNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindAccelerationStructureMemoryNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(bindInfoCount);
         EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
@@ -17562,14 +17562,14 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
-        encoder->EncodeHandleValue<BufferWrapper>(instanceData);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(instanceData);
         encoder->EncodeVkDeviceSizeValue(instanceOffset);
         encoder->EncodeVkBool32Value(update);
-        encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(dst);
-        encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(src);
-        encoder->EncodeHandleValue<BufferWrapper>(scratch);
+        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(dst);
+        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(src);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(scratch);
         encoder->EncodeVkDeviceSizeValue(scratchOffset);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBuildAccelerationStructureNVHandles, pInfo, instanceData, dst, src, scratch);
     }
@@ -17607,9 +17607,9 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(dst);
-        encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(src);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(dst);
+        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(src);
         encoder->EncodeEnumValue(mode);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyAccelerationStructureNVHandles, dst, src);
     }
@@ -17655,16 +17655,16 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(raygenShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(raygenShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(raygenShaderBindingOffset);
-        encoder->EncodeHandleValue<BufferWrapper>(missShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(missShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(missShaderBindingOffset);
         encoder->EncodeVkDeviceSizeValue(missShaderBindingStride);
-        encoder->EncodeHandleValue<BufferWrapper>(hitShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(hitShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(hitShaderBindingOffset);
         encoder->EncodeVkDeviceSizeValue(hitShaderBindingStride);
-        encoder->EncodeHandleValue<BufferWrapper>(callableShaderBindingTableBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(callableShaderBindingTableBuffer);
         encoder->EncodeVkDeviceSizeValue(callableShaderBindingOffset);
         encoder->EncodeVkDeviceSizeValue(callableShaderBindingStride);
         encoder->EncodeUInt32Value(width);
@@ -17713,8 +17713,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(firstGroup);
         encoder->EncodeUInt32Value(groupCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -17763,8 +17763,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(firstGroup);
         encoder->EncodeUInt32Value(groupCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -17811,8 +17811,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAccelerationStructureHandleNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureHandleNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(accelerationStructure);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(accelerationStructure);
         encoder->EncodeSizeTValue(dataSize);
         encoder->EncodeVoidArray(pData, dataSize, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -17851,11 +17851,11 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(accelerationStructureCount);
-        encoder->EncodeHandleArray<AccelerationStructureNVWrapper>(pAccelerationStructures, accelerationStructureCount);
+        encoder->EncodeHandleArray<VulkanAccelerationStructureNVWrapper>(pAccelerationStructures, accelerationStructureCount);
         encoder->EncodeEnumValue(queryType);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteAccelerationStructuresPropertiesNVHandles, accelerationStructureCount, pAccelerationStructures, queryPool);
     }
@@ -17891,8 +17891,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CompileDeferredNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCompileDeferredNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(shader);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -17936,7 +17936,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryHostPointerPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeVoidPtr(pHostPointer);
         EncodeStructPtr(encoder, pMemoryHostPointerProperties, omit_output_data);
@@ -17975,9 +17975,9 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteBufferMarkerAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineStage);
-        encoder->EncodeHandleValue<BufferWrapper>(dstBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeUInt32Value(marker);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteBufferMarkerAMDHandles, dstBuffer);
@@ -18020,7 +18020,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pTimeDomainCount, omit_output_data);
         encoder->EncodeEnumArray(pTimeDomains, (pTimeDomainCount != nullptr) ? (*pTimeDomainCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18066,7 +18066,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetCalibratedTimestampsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(timestampCount);
         EncodeStructArray(encoder, pTimestampInfos, timestampCount);
         encoder->EncodeUInt64Array(pTimestamps, timestampCount, omit_output_data);
@@ -18104,7 +18104,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(taskCount);
         encoder->EncodeUInt32Value(firstTask);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18141,8 +18141,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -18182,10 +18182,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
@@ -18222,7 +18222,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstExclusiveScissor);
         encoder->EncodeUInt32Value(exclusiveScissorCount);
         encoder->EncodeVkBool32Array(pExclusiveScissorEnables, exclusiveScissorCount);
@@ -18259,7 +18259,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstExclusiveScissor);
         encoder->EncodeUInt32Value(exclusiveScissorCount);
         EncodeStructArray(encoder, pExclusiveScissors, exclusiveScissorCount);
@@ -18294,7 +18294,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCheckpointNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVoidPtr(pCheckpointMarker);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -18330,7 +18330,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueueCheckpointDataNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
         encoder->EncodeUInt32Ptr(pCheckpointDataCount);
         EncodeStructArray(encoder, pCheckpointData, (pCheckpointDataCount != nullptr) ? (*pCheckpointDataCount) : 0);
         manager->EndApiCallCapture();
@@ -18364,7 +18364,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InitializePerformanceApiINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkInitializePerformanceApiINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInitializeInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -18397,7 +18397,7 @@ VKAPI_ATTR void VKAPI_CALL UninitializePerformanceApiINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUninitializePerformanceApiINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         manager->EndApiCallCapture();
     }
 
@@ -18431,7 +18431,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceMarkerINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceMarkerINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18467,7 +18467,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceStreamMarkerINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceStreamMarkerINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pMarkerInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18503,7 +18503,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceOverrideINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceOverrideINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pOverrideInfo);
         encoder->EncodeEnumValue(result);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -18541,7 +18541,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, PerformanceConfigurationINTELWrapper>(device, NoParentWrapper::kHandleValue, pConfiguration, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPerformanceConfigurationINTELWrapper>(device, VulkanNoParentWrapper::kHandleValue, pConfiguration, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -18551,11 +18551,11 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkAcquirePerformanceConfigurationINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pAcquireInfo);
-        encoder->EncodeHandlePtr<PerformanceConfigurationINTELWrapper>(pConfiguration, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanPerformanceConfigurationINTELWrapper>(pConfiguration, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, PerformanceConfigurationINTELWrapper, void>(result, device, pConfiguration, nullptr);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanPerformanceConfigurationINTELWrapper, void>(result, device, pConfiguration, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAcquirePerformanceConfigurationINTEL>::Dispatch(manager, result, device, pAcquireInfo, pConfiguration);
@@ -18589,15 +18589,15 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PerformanceConfigurationINTELWrapper>(configuration);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPerformanceConfigurationINTELWrapper>(configuration);
         encoder->EncodeEnumValue(result);
-        manager->EndDestroyApiCallCapture<PerformanceConfigurationINTELWrapper>(configuration);
+        manager->EndDestroyApiCallCapture<VulkanPerformanceConfigurationINTELWrapper>(configuration);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, result, device, configuration);
 
-    DestroyWrappedHandle<PerformanceConfigurationINTELWrapper>(configuration);
+    DestroyWrappedHandle<VulkanPerformanceConfigurationINTELWrapper>(configuration);
 
     return result;
 }
@@ -18627,8 +18627,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSetPerformanceConfigurationINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSetPerformanceConfigurationINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<QueueWrapper>(queue);
-        encoder->EncodeHandleValue<PerformanceConfigurationINTELWrapper>(configuration);
+        encoder->EncodeHandleValue<VulkanQueueWrapper>(queue);
+        encoder->EncodeHandleValue<VulkanPerformanceConfigurationINTELWrapper>(configuration);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -18670,7 +18670,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPerformanceParameterINTEL(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPerformanceParameterINTEL);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(parameter);
         EncodeStructPtr(encoder, pValue, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18706,8 +18706,8 @@ VKAPI_ATTR void VKAPI_CALL SetLocalDimmingAMD(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetLocalDimmingAMD);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapChain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapChain);
         encoder->EncodeVkBool32Value(localDimmingEnable);
         manager->EndApiCallCapture();
     }
@@ -18745,7 +18745,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -18755,12 +18755,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkImagePipeSurfaceCreateInfoFUCHSIA>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkImagePipeSurfaceCreateInfoFUCHSIA>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -18796,7 +18796,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -18806,12 +18806,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkMetalSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkMetalSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -18847,7 +18847,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddressEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -18890,7 +18890,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pToolCount, omit_output_data);
         EncodeStructArray(encoder, pToolProperties, (pToolCount != nullptr) ? (*pToolCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18934,7 +18934,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -18978,7 +18978,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSupportedFramebufferMixedSamples
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Ptr(pCombinationCount, omit_output_data);
         EncodeStructArray(encoder, pCombinations, (pCombinationCount != nullptr) ? (*pCombinationCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -19026,7 +19026,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModes2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModes2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pSurfaceInfo);
         encoder->EncodeUInt32Ptr(pPresentModeCount, omit_output_data);
         encoder->EncodeEnumArray(pPresentModes, (pPresentModeCount != nullptr) ? (*pPresentModeCount) : 0, omit_output_data);
@@ -19064,8 +19064,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireFullScreenExclusiveModeEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireFullScreenExclusiveModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -19100,8 +19100,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseFullScreenExclusiveModeEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseFullScreenExclusiveModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<SwapchainKHRWrapper>(swapchain);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(swapchain);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -19146,7 +19146,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModes2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pSurfaceInfo);
         encoder->EncodeFlagsPtr(pModes, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -19186,7 +19186,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateHeadlessSurfaceEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -19196,12 +19196,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateHeadlessSurfaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateHeadlessSurfaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkHeadlessSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkHeadlessSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateHeadlessSurfaceEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -19233,7 +19233,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineStippleEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(lineStippleFactor);
         encoder->EncodeUInt16Value(lineStipplePattern);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -19269,8 +19269,8 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPoolEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetQueryPoolEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
         manager->EndApiCallCapture();
@@ -19304,7 +19304,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCullModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(cullMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19337,7 +19337,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFrontFaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(frontFace);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19370,7 +19370,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopologyEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopologyEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(primitiveTopology);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19404,7 +19404,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWithCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewports, viewportCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -19439,7 +19439,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetScissorWithCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(scissorCount);
         EncodeStructArray(encoder, pScissors, scissorCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -19478,10 +19478,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstBinding);
         encoder->EncodeUInt32Value(bindingCount);
-        encoder->EncodeHandleArray<BufferWrapper>(pBuffers, bindingCount);
+        encoder->EncodeHandleArray<VulkanBufferWrapper>(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pSizes, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pStrides, bindingCount);
@@ -19516,7 +19516,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthTestEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19549,7 +19549,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthWriteEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19582,7 +19582,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOpEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthCompareOpEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(depthCompareOp);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19615,7 +19615,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBoundsTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19648,7 +19648,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilTestEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(stencilTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -19685,7 +19685,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOpEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetStencilOpEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(faceMask);
         encoder->EncodeEnumValue(failOp);
         encoder->EncodeEnumValue(passOp);
@@ -19727,7 +19727,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToImageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToImageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCopyMemoryToImageInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19766,7 +19766,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToMemoryEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyImageToMemoryEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCopyImageToMemoryInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19805,7 +19805,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToImageEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyImageToImageEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCopyImageToImageInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19845,7 +19845,7 @@ VKAPI_ATTR VkResult VKAPI_CALL TransitionImageLayoutEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkTransitionImageLayoutEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(transitionCount);
         EncodeStructArray(encoder, pTransitions, transitionCount);
         encoder->EncodeEnumValue(result);
@@ -19884,8 +19884,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2EXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ImageWrapper>(image);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanImageWrapper>(image);
         EncodeStructPtr(encoder, pSubresource);
         EncodeStructPtr(encoder, pLayout);
         manager->EndApiCallCapture();
@@ -19922,7 +19922,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseSwapchainImagesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseSwapchainImagesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pReleaseInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -19962,7 +19962,7 @@ VKAPI_ATTR void VKAPI_CALL GetGeneratedCommandsMemoryRequirementsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetGeneratedCommandsMemoryRequirementsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -19994,7 +19994,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPreprocessGeneratedCommandsNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPreprocessGeneratedCommandsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pGeneratedCommandsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPreprocessGeneratedCommandsNVHandles, pGeneratedCommandsInfo);
     }
@@ -20031,7 +20031,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteGeneratedCommandsNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdExecuteGeneratedCommandsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(isPreprocessed);
         EncodeStructPtr(encoder, pGeneratedCommandsInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdExecuteGeneratedCommandsNVHandles, pGeneratedCommandsInfo);
@@ -20070,9 +20070,9 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipelineShaderGroupNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindPipelineShaderGroupNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(groupIndex);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindPipelineShaderGroupNVHandles, pipeline);
     }
@@ -20113,7 +20113,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, IndirectCommandsLayoutNVWrapper>(device, NoParentWrapper::kHandleValue, pIndirectCommandsLayout, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanIndirectCommandsLayoutNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pIndirectCommandsLayout, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20123,12 +20123,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<IndirectCommandsLayoutNVWrapper>(pIndirectCommandsLayout, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanIndirectCommandsLayoutNVWrapper>(pIndirectCommandsLayout, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, IndirectCommandsLayoutNVWrapper, VkIndirectCommandsLayoutCreateInfoNV>(result, device, pIndirectCommandsLayout, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanIndirectCommandsLayoutNVWrapper, VkIndirectCommandsLayoutCreateInfoNV>(result, device, pIndirectCommandsLayout, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNV>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
@@ -20160,10 +20160,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanIndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
+        manager->EndDestroyApiCallCapture<VulkanIndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -20171,7 +20171,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV>::Dispatch(manager, device, indirectCommandsLayout, pAllocator);
 
-    DestroyWrappedHandle<IndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
+    DestroyWrappedHandle<VulkanIndirectCommandsLayoutNVWrapper>(indirectCommandsLayout);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
@@ -20197,7 +20197,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBias2EXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pDepthBiasInfo);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -20233,9 +20233,9 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireDrmDisplayEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireDrmDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeInt32Value(drmFd);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -20273,7 +20273,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<PhysicalDeviceWrapper, NoParentWrapper, DisplayKHRWrapper>(physicalDevice, NoParentWrapper::kHandleValue, display, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, display, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20283,12 +20283,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetDrmDisplayEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeInt32Value(drmFd);
         encoder->EncodeUInt32Value(connectorId);
-        encoder->EncodeHandlePtr<DisplayKHRWrapper>(display, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDisplayKHRWrapper>(display, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, display, nullptr);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, void>(result, physicalDevice, display, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDrmDisplayEXT>::Dispatch(manager, result, physicalDevice, drmFd, connectorId, display);
@@ -20324,7 +20324,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, PrivateDataSlotWrapper>(device, NoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanPrivateDataSlotWrapper>(device, VulkanNoParentWrapper::kHandleValue, pPrivateDataSlot, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20334,12 +20334,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreatePrivateDataSlotEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<PrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanPrivateDataSlotWrapper>(pPrivateDataSlot, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, PrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanPrivateDataSlotWrapper, VkPrivateDataSlotCreateInfo>(result, device, pPrivateDataSlot, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePrivateDataSlotEXT>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pPrivateDataSlot);
@@ -20371,10 +20371,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<PrivateDataSlotWrapper>(privateDataSlot);
+        manager->EndDestroyApiCallCapture<VulkanPrivateDataSlotWrapper>(privateDataSlot);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -20382,7 +20382,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
-    DestroyWrappedHandle<PrivateDataSlotWrapper>(privateDataSlot);
+    DestroyWrappedHandle<VulkanPrivateDataSlotWrapper>(privateDataSlot);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
@@ -20413,10 +20413,10 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetPrivateDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
         encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<PrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Value(data);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -20455,10 +20455,10 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPrivateDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(objectType);
         encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
-        encoder->EncodeHandleValue<PrivateDataSlotWrapper>(privateDataSlot);
+        encoder->EncodeHandleValue<VulkanPrivateDataSlotWrapper>(privateDataSlot);
         encoder->EncodeUInt64Ptr(pData);
         manager->EndApiCallCapture();
     }
@@ -20490,7 +20490,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateEnumNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateEnumNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(shadingRate);
         encoder->EncodeEnumArray(combinerOps, 2);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -20533,7 +20533,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceFaultInfoEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceFaultInfoEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pFaultCounts, omit_output_data);
         EncodeStructPtr(encoder, pFaultInfo, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -20570,8 +20570,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireWinrtDisplayNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireWinrtDisplayNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
-        encoder->EncodeHandleValue<DisplayKHRWrapper>(display);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(display);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
     }
@@ -20608,7 +20608,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<PhysicalDeviceWrapper, NoParentWrapper, DisplayKHRWrapper>(physicalDevice, NoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanPhysicalDeviceWrapper, VulkanNoParentWrapper, VulkanDisplayKHRWrapper>(physicalDevice, VulkanNoParentWrapper::kHandleValue, pDisplay, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20618,11 +20618,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkGetWinrtDisplayNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(deviceRelativeId);
-        encoder->EncodeHandlePtr<DisplayKHRWrapper>(pDisplay, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanDisplayKHRWrapper>(pDisplay, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
+        manager->EndCreateApiCallCapture<VkPhysicalDevice, VulkanDisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetWinrtDisplayNV>::Dispatch(manager, result, physicalDevice, deviceRelativeId, pDisplay);
@@ -20658,7 +20658,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDirectFBSurfaceEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -20668,12 +20668,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDirectFBSurfaceEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateDirectFBSurfaceEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkDirectFBSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkDirectFBSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDirectFBSurfaceEXT>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -20707,7 +20707,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceDirectFBPresentationSupportEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDirectFBPresentationSupportEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(dfb);
         encoder->EncodeVkBool32Value(result);
@@ -20745,7 +20745,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetVertexInputEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetVertexInputEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(vertexBindingDescriptionCount);
         EncodeStructArray(encoder, pVertexBindingDescriptions, vertexBindingDescriptionCount);
         encoder->EncodeUInt32Value(vertexAttributeDescriptionCount);
@@ -20793,7 +20793,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandleFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryZirconHandleFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetZirconHandleInfo);
         encoder->EncodeUInt32Ptr(pZirconHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -20838,7 +20838,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandlePropertiesFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryZirconHandlePropertiesFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeUInt32Value(zirconHandle);
         EncodeStructPtr(encoder, pMemoryZirconHandleProperties, omit_output_data);
@@ -20879,7 +20879,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreZirconHandleFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreZirconHandleFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pImportSemaphoreZirconHandleInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -20925,7 +20925,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreZirconHandleFUCHSIA(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSemaphoreZirconHandleFUCHSIA);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pGetZirconHandleInfo);
         encoder->EncodeUInt32Ptr(pZirconHandle, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -20961,8 +20961,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindInvocationMaskHUAWEI(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindInvocationMaskHUAWEI);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<ImageViewWrapper>(imageView);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanImageViewWrapper>(imageView);
         encoder->EncodeEnumValue(imageLayout);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindInvocationMaskHUAWEIHandles, imageView);
     }
@@ -21007,7 +21007,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryRemoteAddressNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMemoryRemoteAddressNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pMemoryGetRemoteAddressInfo);
         encoder->EncodeVoidPtrPtr(pAddress, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -21042,7 +21042,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPatchControlPointsEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPatchControlPointsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(patchControlPoints);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21075,7 +21075,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(rasterizerDiscardEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21108,7 +21108,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthBiasEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21141,7 +21141,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLogicOpEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(logicOp);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21174,7 +21174,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(primitiveRestartEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -21212,7 +21212,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateScreenSurfaceQNX(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<InstanceWrapper, NoParentWrapper, SurfaceKHRWrapper>(instance, NoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanInstanceWrapper, VulkanNoParentWrapper, VulkanSurfaceKHRWrapper>(instance, VulkanNoParentWrapper::kHandleValue, pSurface, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -21222,12 +21222,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateScreenSurfaceQNX(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateScreenSurfaceQNX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<InstanceWrapper>(instance);
+        encoder->EncodeHandleValue<VulkanInstanceWrapper>(instance);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<SurfaceKHRWrapper>(pSurface, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanSurfaceKHRWrapper>(pSurface, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkInstance, SurfaceKHRWrapper, VkScreenSurfaceCreateInfoQNX>(result, instance, pSurface, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkInstance, VulkanSurfaceKHRWrapper, VkScreenSurfaceCreateInfoQNX>(result, instance, pSurface, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateScreenSurfaceQNX>::Dispatch(manager, result, instance, pCreateInfo, pAllocator, pSurface);
@@ -21261,7 +21261,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceScreenPresentationSupportQNX(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceScreenPresentationSupportQNX);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(window);
         encoder->EncodeVkBool32Value(result);
@@ -21297,7 +21297,7 @@ VKAPI_ATTR void                                    VKAPI_CALL CmdSetColorWriteEn
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorWriteEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(attachmentCount);
         encoder->EncodeVkBool32Array(pColorWriteEnables, attachmentCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -21335,7 +21335,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMultiEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(drawCount);
         EncodeStructArray(encoder, pVertexInfo, drawCount);
         encoder->EncodeUInt32Value(instanceCount);
@@ -21377,7 +21377,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiIndexedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMultiIndexedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(drawCount);
         EncodeStructArray(encoder, pIndexInfo, drawCount);
         encoder->EncodeUInt32Value(instanceCount);
@@ -21423,7 +21423,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMicromapEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, MicromapEXTWrapper>(device, NoParentWrapper::kHandleValue, pMicromap, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanMicromapEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pMicromap, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -21433,12 +21433,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<MicromapEXTWrapper>(pMicromap, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanMicromapEXTWrapper>(pMicromap, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, MicromapEXTWrapper, VkMicromapCreateInfoEXT>(result, device, pMicromap, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanMicromapEXTWrapper, VkMicromapCreateInfoEXT>(result, device, pMicromap, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMicromapEXT>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pMicromap);
@@ -21470,10 +21470,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<MicromapEXTWrapper>(micromap);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(micromap);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<MicromapEXTWrapper>(micromap);
+        manager->EndDestroyApiCallCapture<VulkanMicromapEXTWrapper>(micromap);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -21481,7 +21481,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyMicromapEXT>::Dispatch(manager, device, micromap, pAllocator);
 
-    DestroyWrappedHandle<MicromapEXTWrapper>(micromap);
+    DestroyWrappedHandle<VulkanMicromapEXTWrapper>(micromap);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
@@ -21508,7 +21508,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildMicromapsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBuildMicromapsEXTHandles, infoCount, pInfos);
@@ -21552,8 +21552,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BuildMicromapsEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBuildMicromapsEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         encoder->EncodeEnumValue(result);
@@ -21594,8 +21594,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -21635,8 +21635,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapToMemoryEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMicromapToMemoryEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -21676,8 +21676,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToMicromapEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -21724,9 +21724,9 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteMicromapsPropertiesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWriteMicromapsPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(micromapCount);
-        encoder->EncodeHandleArray<MicromapEXTWrapper>(pMicromaps, micromapCount);
+        encoder->EncodeHandleArray<VulkanMicromapEXTWrapper>(pMicromaps, micromapCount);
         encoder->EncodeEnumValue(queryType);
         encoder->EncodeSizeTValue(dataSize);
         encoder->EncodeVoidArray(pData, dataSize, omit_output_data);
@@ -21763,7 +21763,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMicromapEXTHandles, pInfo);
     }
@@ -21799,7 +21799,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapToMemoryEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMicromapToMemoryEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMicromapToMemoryEXTHandles, pInfo);
     }
@@ -21835,7 +21835,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToMicromapEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMemoryToMicromapEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMemoryToMicromapEXTHandles, pInfo);
     }
@@ -21875,11 +21875,11 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteMicromapsPropertiesEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteMicromapsPropertiesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(micromapCount);
-        encoder->EncodeHandleArray<MicromapEXTWrapper>(pMicromaps, micromapCount);
+        encoder->EncodeHandleArray<VulkanMicromapEXTWrapper>(pMicromaps, micromapCount);
         encoder->EncodeEnumValue(queryType);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteMicromapsPropertiesEXTHandles, micromapCount, pMicromaps, queryPool);
     }
@@ -21915,7 +21915,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMicromapCompatibilityEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMicromapCompatibilityEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pVersionInfo);
         encoder->EncodeEnumPtr(pCompatibility);
         manager->EndApiCallCapture();
@@ -21954,7 +21954,7 @@ VKAPI_ATTR void VKAPI_CALL GetMicromapBuildSizesEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMicromapBuildSizesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(buildType);
         EncodeStructPtr(encoder, pBuildInfo);
         EncodeStructPtr(encoder, pSizeInfo);
@@ -21989,7 +21989,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterHUAWEI(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawClusterHUAWEI);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(groupCountX);
         encoder->EncodeUInt32Value(groupCountY);
         encoder->EncodeUInt32Value(groupCountZ);
@@ -22025,8 +22025,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterIndirectHUAWEI(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawClusterIndirectHUAWEI);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawClusterIndirectHUAWEIHandles, buffer);
     }
@@ -22060,8 +22060,8 @@ VKAPI_ATTR void VKAPI_CALL SetDeviceMemoryPriorityEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDeviceMemoryPriorityEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeviceMemoryWrapper>(memory);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(memory);
         encoder->EncodeFloatValue(priority);
         manager->EndApiCallCapture();
     }
@@ -22100,7 +22100,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutHostMappingInfoVALVE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutHostMappingInfoVALVE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pBindingReference);
         EncodeStructPtr(encoder, pHostMapping);
         manager->EndApiCallCapture();
@@ -22135,8 +22135,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetHostMappingVALVE(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetHostMappingVALVE);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DescriptorSetWrapper>(descriptorSet);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(descriptorSet);
         encoder->EncodeVoidPtrPtr(ppData);
         manager->EndApiCallCapture();
     }
@@ -22173,7 +22173,7 @@ VKAPI_ATTR void VKAPI_CALL GetPipelineIndirectMemoryRequirementsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineIndirectMemoryRequirementsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pMemoryRequirements);
         manager->EndApiCallCapture();
@@ -22206,9 +22206,9 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdatePipelineIndirectBufferNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdUpdatePipelineIndirectBufferNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdUpdatePipelineIndirectBufferNVHandles, pipeline);
     }
 
@@ -22245,7 +22245,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetPipelineIndirectDeviceAddressNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineIndirectDeviceAddressNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -22279,7 +22279,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClampEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthClampEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthClampEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22312,7 +22312,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPolygonModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPolygonModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(polygonMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22345,7 +22345,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationSamplesEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizationSamplesEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(rasterizationSamples);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22379,7 +22379,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleMaskEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetSampleMaskEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(samples);
         encoder->EncodeVkSampleMaskArray(pSampleMask, (samples + 31) / 32);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -22413,7 +22413,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToCoverageEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetAlphaToCoverageEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(alphaToCoverageEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22446,7 +22446,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToOneEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetAlphaToOneEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(alphaToOneEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22479,7 +22479,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLogicOpEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(logicOpEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22514,7 +22514,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorBlendEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         encoder->EncodeVkBool32Array(pColorBlendEnables, attachmentCount);
@@ -22551,7 +22551,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEquationEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorBlendEquationEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         EncodeStructArray(encoder, pColorBlendEquations, attachmentCount);
@@ -22588,7 +22588,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorWriteMaskEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorWriteMaskEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         encoder->EncodeFlagsArray(pColorWriteMasks, attachmentCount);
@@ -22623,7 +22623,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetTessellationDomainOriginEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetTessellationDomainOriginEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(domainOrigin);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22656,7 +22656,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationStreamEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRasterizationStreamEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(rasterizationStream);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22689,7 +22689,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetConservativeRasterizationModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetConservativeRasterizationModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(conservativeRasterizationMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22722,7 +22722,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExtraPrimitiveOverestimationSizeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetExtraPrimitiveOverestimationSizeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFloatValue(extraPrimitiveOverestimationSize);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22755,7 +22755,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthClipEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(depthClipEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22788,7 +22788,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(sampleLocationsEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22823,7 +22823,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendAdvancedEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetColorBlendAdvancedEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstAttachment);
         encoder->EncodeUInt32Value(attachmentCount);
         EncodeStructArray(encoder, pColorBlendAdvanced, attachmentCount);
@@ -22858,7 +22858,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetProvokingVertexModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetProvokingVertexModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(provokingVertexMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22891,7 +22891,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineRasterizationModeEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineRasterizationModeEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(lineRasterizationMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22924,7 +22924,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetLineStippleEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(stippledLineEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22957,7 +22957,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipNegativeOneToOneEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetDepthClipNegativeOneToOneEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(negativeOneToOne);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -22990,7 +22990,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportWScalingEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(viewportWScalingEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23025,7 +23025,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportSwizzleNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetViewportSwizzleNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
         EncodeStructArray(encoder, pViewportSwizzles, viewportCount);
@@ -23060,7 +23060,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageToColorEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(coverageToColorEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23093,7 +23093,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorLocationNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageToColorLocationNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(coverageToColorLocation);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23126,7 +23126,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationModeNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageModulationModeNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(coverageModulationMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23159,7 +23159,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageModulationTableEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(coverageModulationTableEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23193,7 +23193,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageModulationTableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(coverageModulationTableCount);
         encoder->EncodeFloatArray(pCoverageModulationTable, coverageModulationTableCount);
         manager->EndCommandApiCallCapture(commandBuffer);
@@ -23227,7 +23227,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetShadingRateImageEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetShadingRateImageEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(shadingRateImageEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23260,7 +23260,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRepresentativeFragmentTestEnableNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRepresentativeFragmentTestEnableNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeVkBool32Value(representativeFragmentTestEnable);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23293,7 +23293,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageReductionModeNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetCoverageReductionModeNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeEnumValue(coverageReductionMode);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -23329,8 +23329,8 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleIdentifierEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderModuleIdentifierEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ShaderModuleWrapper>(shaderModule);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanShaderModuleWrapper>(shaderModule);
         EncodeStructPtr(encoder, pIdentifier);
         manager->EndApiCallCapture();
     }
@@ -23367,7 +23367,7 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleCreateInfoIdentifierEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderModuleCreateInfoIdentifierEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pIdentifier);
         manager->EndApiCallCapture();
@@ -23409,7 +23409,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceOpticalFlowImageFormatsNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceOpticalFlowImageFormatsNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<PhysicalDeviceWrapper>(physicalDevice);
+        encoder->EncodeHandleValue<VulkanPhysicalDeviceWrapper>(physicalDevice);
         EncodeStructPtr(encoder, pOpticalFlowImageFormatInfo);
         encoder->EncodeUInt32Ptr(pFormatCount, omit_output_data);
         EncodeStructArray(encoder, pImageFormatProperties, (pFormatCount != nullptr) ? (*pFormatCount) : 0, omit_output_data);
@@ -23450,7 +23450,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateOpticalFlowSessionNV(
 
     if (result >= 0)
     {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, OpticalFlowSessionNVWrapper>(device, NoParentWrapper::kHandleValue, pSession, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandle<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanOpticalFlowSessionNVWrapper>(device, VulkanNoParentWrapper::kHandleValue, pSession, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -23460,12 +23460,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateOpticalFlowSessionNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateOpticalFlowSessionNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<OpticalFlowSessionNVWrapper>(pSession, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanOpticalFlowSessionNVWrapper>(pSession, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, OpticalFlowSessionNVWrapper, VkOpticalFlowSessionCreateInfoNV>(result, device, pSession, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanOpticalFlowSessionNVWrapper, VkOpticalFlowSessionCreateInfoNV>(result, device, pSession, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateOpticalFlowSessionNV>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pSession);
@@ -23497,10 +23497,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<OpticalFlowSessionNVWrapper>(session);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanOpticalFlowSessionNVWrapper>(session);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<OpticalFlowSessionNVWrapper>(session);
+        manager->EndDestroyApiCallCapture<VulkanOpticalFlowSessionNVWrapper>(session);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -23508,7 +23508,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV>::Dispatch(manager, device, session, pAllocator);
 
-    DestroyWrappedHandle<OpticalFlowSessionNVWrapper>(session);
+    DestroyWrappedHandle<VulkanOpticalFlowSessionNVWrapper>(session);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
@@ -23539,10 +23539,10 @@ VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindOpticalFlowSessionImageNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<OpticalFlowSessionNVWrapper>(session);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanOpticalFlowSessionNVWrapper>(session);
         encoder->EncodeEnumValue(bindingPoint);
-        encoder->EncodeHandleValue<ImageViewWrapper>(view);
+        encoder->EncodeHandleValue<VulkanImageViewWrapper>(view);
         encoder->EncodeEnumValue(layout);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -23577,8 +23577,8 @@ VKAPI_ATTR void VKAPI_CALL CmdOpticalFlowExecuteNV(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdOpticalFlowExecuteNV);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<OpticalFlowSessionNVWrapper>(session);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanOpticalFlowSessionNVWrapper>(session);
         EncodeStructPtr(encoder, pExecuteInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdOpticalFlowExecuteNVHandles, session);
     }
@@ -23620,7 +23620,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
 
     if (result >= 0)
     {
-        CreateWrappedHandles<DeviceWrapper, NoParentWrapper, ShaderEXTWrapper>(device, NoParentWrapper::kHandleValue, pShaders, createInfoCount, VulkanCaptureManager::GetUniqueId);
+        CreateWrappedHandles<VulkanDeviceWrapper, VulkanNoParentWrapper, VulkanShaderEXTWrapper>(device, VulkanNoParentWrapper::kHandleValue, pShaders, createInfoCount, VulkanCaptureManager::GetUniqueId);
     }
     else
     {
@@ -23630,13 +23630,13 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateShadersEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(createInfoCount);
         EncodeStructArray(encoder, pCreateInfos, createInfoCount);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray<ShaderEXTWrapper>(pShaders, createInfoCount, omit_output_data);
+        encoder->EncodeHandleArray<VulkanShaderEXTWrapper>(pShaders, createInfoCount, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndGroupCreateApiCallCapture<VkDevice, void*, ShaderEXTWrapper, VkShaderCreateInfoEXT>(result, device, nullptr, createInfoCount, pShaders, pCreateInfos);
+        manager->EndGroupCreateApiCallCapture<VkDevice, void*, VulkanShaderEXTWrapper, VkShaderCreateInfoEXT>(result, device, nullptr, createInfoCount, pShaders, pCreateInfos);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateShadersEXT>::Dispatch(manager, result, device, createInfoCount, pCreateInfos, pAllocator, pShaders);
@@ -23668,10 +23668,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyShaderEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ShaderEXTWrapper>(shader);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanShaderEXTWrapper>(shader);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<ShaderEXTWrapper>(shader);
+        manager->EndDestroyApiCallCapture<VulkanShaderEXTWrapper>(shader);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -23679,7 +23679,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderEXT>::Dispatch(manager, device, shader, pAllocator);
 
-    DestroyWrappedHandle<ShaderEXTWrapper>(shader);
+    DestroyWrappedHandle<VulkanShaderEXTWrapper>(shader);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
@@ -23715,8 +23715,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderBinaryDataEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<ShaderEXTWrapper>(shader);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanShaderEXTWrapper>(shader);
         encoder->EncodeSizeTPtr(pDataSize, omit_output_data);
         encoder->EncodeVoidArray(pData, (pDataSize != nullptr) ? (*pDataSize) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -23753,10 +23753,10 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadersEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBindShadersEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(stageCount);
         encoder->EncodeEnumArray(pStages, stageCount);
-        encoder->EncodeHandleArray<ShaderEXTWrapper>(pShaders, stageCount);
+        encoder->EncodeHandleArray<VulkanShaderEXTWrapper>(pShaders, stageCount);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindShadersEXTHandles, stageCount, pShaders);
     }
 
@@ -23798,8 +23798,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFramebufferTilePropertiesQCOM(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFramebufferTilePropertiesQCOM);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<FramebufferWrapper>(framebuffer);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanFramebufferWrapper>(framebuffer);
         encoder->EncodeUInt32Ptr(pPropertiesCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertiesCount != nullptr) ? (*pPropertiesCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -23846,7 +23846,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDynamicRenderingTilePropertiesQCOM(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDynamicRenderingTilePropertiesQCOM);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pRenderingInfo);
         EncodeStructPtr(encoder, pProperties, omit_output_data);
         encoder->EncodeEnumValue(result);
@@ -24063,7 +24063,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAttachmentFeedbackLoopEnableEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetAttachmentFeedbackLoopEnableEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeFlagsValue(aspectMask);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -24106,12 +24106,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCreateAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pCreateInfo);
         EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandlePtr<AccelerationStructureKHRWrapper>(pAccelerationStructure, omit_output_data);
+        encoder->EncodeHandlePtr<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructure, omit_output_data);
         encoder->EncodeEnumValue(result);
-        manager->EndCreateApiCallCapture<VkDevice, AccelerationStructureKHRWrapper, VkAccelerationStructureCreateInfoKHR>(result, device, pAccelerationStructure, pCreateInfo);
+        manager->EndCreateApiCallCapture<VkDevice, VulkanAccelerationStructureKHRWrapper, VkAccelerationStructureCreateInfoKHR>(result, device, pAccelerationStructure, pCreateInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureKHR>::Dispatch(manager, result, device, pCreateInfo, pAllocator, pAccelerationStructure);
@@ -24143,10 +24143,10 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(accelerationStructure);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(accelerationStructure);
         EncodeStructPtr(encoder, pAllocator);
-        manager->EndDestroyApiCallCapture<AccelerationStructureKHRWrapper>(accelerationStructure);
+        manager->EndDestroyApiCallCapture<VulkanAccelerationStructureKHRWrapper>(accelerationStructure);
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
@@ -24154,7 +24154,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
-    DestroyWrappedHandle<AccelerationStructureKHRWrapper>(accelerationStructure);
+    DestroyWrappedHandle<VulkanAccelerationStructureKHRWrapper>(accelerationStructure);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
@@ -24182,7 +24182,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         EncodeStructArray2D(encoder, ppBuildRangeInfos, ArraySize2D<VkCommandBuffer, uint32_t, const VkAccelerationStructureBuildGeometryInfoKHR*, const VkAccelerationStructureBuildRangeInfoKHR* const*>(commandBuffer, infoCount, pInfos, ppBuildRangeInfos));
@@ -24221,7 +24221,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresIndirectKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(infoCount);
         EncodeStructArray(encoder, pInfos, infoCount);
         encoder->EncodeVkDeviceAddressArray(pIndirectDeviceAddresses, infoCount);
@@ -24267,8 +24267,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyAccelerationStructureToMemoryKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -24308,8 +24308,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToAccelerationStructureKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<DeferredOperationKHRWrapper>(deferredOperation);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeferredOperationKHRWrapper>(deferredOperation);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeEnumValue(result);
         manager->EndApiCallCapture();
@@ -24356,9 +24356,9 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteAccelerationStructuresPropertiesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWriteAccelerationStructuresPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeUInt32Value(accelerationStructureCount);
-        encoder->EncodeHandleArray<AccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
+        encoder->EncodeHandleArray<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
         encoder->EncodeEnumValue(queryType);
         encoder->EncodeSizeTValue(dataSize);
         encoder->EncodeVoidArray(pData, dataSize, omit_output_data);
@@ -24395,7 +24395,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyAccelerationStructureKHRHandles, pInfo);
     }
@@ -24431,7 +24431,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureToMemoryKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureToMemoryKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyAccelerationStructureToMemoryKHRHandles, pInfo);
     }
@@ -24467,7 +24467,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToAccelerationStructureKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdCopyMemoryToAccelerationStructureKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pInfo);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyMemoryToAccelerationStructureKHRHandles, pInfo);
     }
@@ -24508,7 +24508,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetAccelerationStructureDeviceAddressKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureDeviceAddressKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         manager->EndApiCallCapture();
@@ -24546,11 +24546,11 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(accelerationStructureCount);
-        encoder->EncodeHandleArray<AccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
+        encoder->EncodeHandleArray<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructures, accelerationStructureCount);
         encoder->EncodeEnumValue(queryType);
-        encoder->EncodeHandleValue<QueryPoolWrapper>(queryPool);
+        encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteAccelerationStructuresPropertiesKHRHandles, accelerationStructureCount, pAccelerationStructures, queryPool);
     }
@@ -24586,7 +24586,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceAccelerationStructureCompatibilityKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceAccelerationStructureCompatibilityKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         EncodeStructPtr(encoder, pVersionInfo);
         encoder->EncodeEnumPtr(pCompatibility);
         manager->EndApiCallCapture();
@@ -24626,7 +24626,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureBuildSizesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureBuildSizesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
         encoder->EncodeEnumValue(buildType);
         EncodeStructPtr(encoder, pBuildInfo);
         encoder->EncodeUInt32Array(pMaxPrimitiveCounts, (pBuildInfo != nullptr) ? (pBuildInfo->geometryCount) : 0);
@@ -24666,7 +24666,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRaygenShaderBindingTable);
         EncodeStructPtr(encoder, pMissShaderBindingTable);
         EncodeStructPtr(encoder, pHitShaderBindingTable);
@@ -24717,8 +24717,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingCaptureReplayShaderGroupHandlesKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(firstGroup);
         encoder->EncodeUInt32Value(groupCount);
         encoder->EncodeSizeTValue(dataSize);
@@ -24759,7 +24759,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirectKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdTraceRaysIndirectKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         EncodeStructPtr(encoder, pRaygenShaderBindingTable);
         EncodeStructPtr(encoder, pMissShaderBindingTable);
         EncodeStructPtr(encoder, pHitShaderBindingTable);
@@ -24800,8 +24800,8 @@ VKAPI_ATTR VkDeviceSize VKAPI_CALL GetRayTracingShaderGroupStackSizeKHR(
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupStackSizeKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<DeviceWrapper>(device);
-        encoder->EncodeHandleValue<PipelineWrapper>(pipeline);
+        encoder->EncodeHandleValue<VulkanDeviceWrapper>(device);
+        encoder->EncodeHandleValue<VulkanPipelineWrapper>(pipeline);
         encoder->EncodeUInt32Value(group);
         encoder->EncodeEnumValue(groupShader);
         encoder->EncodeVkDeviceSizeValue(result);
@@ -24836,7 +24836,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRayTracingPipelineStackSizeKHR(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetRayTracingPipelineStackSizeKHR);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(pipelineStackSize);
         manager->EndCommandApiCallCapture(commandBuffer);
     }
@@ -24871,7 +24871,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
         encoder->EncodeUInt32Value(groupCountX);
         encoder->EncodeUInt32Value(groupCountY);
         encoder->EncodeUInt32Value(groupCountZ);
@@ -24909,8 +24909,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
@@ -24950,10 +24950,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountEXT(
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountEXT);
     if (encoder)
     {
-        encoder->EncodeHandleValue<CommandBufferWrapper>(commandBuffer);
-        encoder->EncodeHandleValue<BufferWrapper>(buffer);
+        encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(commandBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        encoder->EncodeHandleValue<BufferWrapper>(countBuffer);
+        encoder->EncodeHandleValue<VulkanBufferWrapper>(countBuffer);
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -114,7 +114,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetInstanceTable(instance)->DestroyInstance(instance, pAllocator);
+    GetVulkanInstanceTable(instance)->DestroyInstance(instance, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(manager, instance, pAllocator);
 
@@ -144,7 +144,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices>::Dispatch(manager, instance, pPhysicalDeviceCount, pPhysicalDevices);
 
-    VkResult result = GetInstanceTable(instance)->EnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
+    VkResult result = GetVulkanInstanceTable(instance)->EnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
 
     if (result >= 0)
     {
@@ -190,7 +190,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures>::Dispatch(manager, physicalDevice, pFeatures);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceFeatures(physicalDevice, pFeatures);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceFeatures(physicalDevice, pFeatures);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures);
     if (encoder)
@@ -224,7 +224,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties>::Dispatch(manager, physicalDevice, format, pFormatProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceFormatProperties(physicalDevice, format, pFormatProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties);
     if (encoder)
@@ -265,7 +265,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties>::Dispatch(manager, physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -310,7 +310,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties>::Dispatch(manager, physicalDevice, pProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceProperties(physicalDevice, pProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceProperties(physicalDevice, pProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties);
     if (encoder)
@@ -378,7 +378,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties>::Dispatch(manager, physicalDevice, pMemoryProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties);
     if (encoder)
@@ -466,7 +466,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyDevice(device, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyDevice(device, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(manager, device, pAllocator);
 
@@ -495,7 +495,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceQueue>::Dispatch(manager, device, queueFamilyIndex, queueIndex, pQueue);
 
-    GetDeviceTable(device)->GetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue);
+    GetVulkanDeviceTable(device)->GetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue);
 
     CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueueWrapper>(device, NoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
 
@@ -537,7 +537,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSubmitInfo* pSubmits_unwrapped = UnwrapStructArrayHandles(pSubmits, submitCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(queue)->QueueSubmit(queue, submitCount, pSubmits_unwrapped, fence);
+    VkResult result = GetVulkanDeviceTable(queue)->QueueSubmit(queue, submitCount, pSubmits_unwrapped, fence);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit);
     if (encoder)
@@ -574,7 +574,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueWaitIdle(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueWaitIdle>::Dispatch(manager, queue);
 
-    VkResult result = GetDeviceTable(queue)->QueueWaitIdle(queue);
+    VkResult result = GetVulkanDeviceTable(queue)->QueueWaitIdle(queue);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueWaitIdle);
     if (encoder)
@@ -608,7 +608,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DeviceWaitIdle(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDeviceWaitIdle>::Dispatch(manager, device);
 
-    VkResult result = GetDeviceTable(device)->DeviceWaitIdle(device);
+    VkResult result = GetVulkanDeviceTable(device)->DeviceWaitIdle(device);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDeviceWaitIdle);
     if (encoder)
@@ -700,7 +700,7 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->FreeMemory(device, memory, pAllocator);
+    GetVulkanDeviceTable(device)->FreeMemory(device, memory, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(manager, device, memory, pAllocator);
 
@@ -733,7 +733,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkMapMemory>::Dispatch(manager, device, memory, offset, size, flags, ppData);
 
-    VkResult result = GetDeviceTable(device)->MapMemory(device, memory, offset, size, flags, ppData);
+    VkResult result = GetVulkanDeviceTable(device)->MapMemory(device, memory, offset, size, flags, ppData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -785,7 +785,7 @@ VKAPI_ATTR void VKAPI_CALL UnmapMemory(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->UnmapMemory(device, memory);
+    GetVulkanDeviceTable(device)->UnmapMemory(device, memory);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUnmapMemory>::Dispatch(manager, device, memory);
 }
@@ -814,7 +814,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FlushMappedMemoryRanges(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMappedMemoryRange* pMemoryRanges_unwrapped = UnwrapStructArrayHandles(pMemoryRanges, memoryRangeCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->FlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->FlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkFlushMappedMemoryRanges);
     if (encoder)
@@ -855,7 +855,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMappedMemoryRange* pMemoryRanges_unwrapped = UnwrapStructArrayHandles(pMemoryRanges, memoryRangeCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->InvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->InvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkInvalidateMappedMemoryRanges);
     if (encoder)
@@ -893,7 +893,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMemoryCommitment(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceMemoryCommitment>::Dispatch(manager, device, memory, pCommittedMemoryInBytes);
 
-    GetDeviceTable(device)->GetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes);
+    GetVulkanDeviceTable(device)->GetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryCommitment);
     if (encoder)
@@ -929,7 +929,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindBufferMemory>::Dispatch(manager, device, buffer, memory, memoryOffset);
 
-    VkResult result = GetDeviceTable(device)->BindBufferMemory(device, buffer, memory, memoryOffset);
+    VkResult result = GetVulkanDeviceTable(device)->BindBufferMemory(device, buffer, memory, memoryOffset);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory);
     if (encoder)
@@ -969,7 +969,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindImageMemory>::Dispatch(manager, device, image, memory, memoryOffset);
 
-    VkResult result = GetDeviceTable(device)->BindImageMemory(device, image, memory, memoryOffset);
+    VkResult result = GetVulkanDeviceTable(device)->BindImageMemory(device, image, memory, memoryOffset);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory);
     if (encoder)
@@ -1008,7 +1008,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements>::Dispatch(manager, device, buffer, pMemoryRequirements);
 
-    GetDeviceTable(device)->GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements);
     if (encoder)
@@ -1043,7 +1043,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageMemoryRequirements>::Dispatch(manager, device, image, pMemoryRequirements);
 
-    GetDeviceTable(device)->GetImageMemoryRequirements(device, image, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetImageMemoryRequirements(device, image, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements);
     if (encoder)
@@ -1079,7 +1079,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements>::Dispatch(manager, device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 
-    GetDeviceTable(device)->GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements);
     if (encoder)
@@ -1120,7 +1120,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties>::Dispatch(manager, physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, pPropertyCount, pProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties);
     if (encoder)
@@ -1164,7 +1164,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindSparseInfo* pBindInfo_unwrapped = UnwrapStructArrayHandles(pBindInfo, bindInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(queue)->QueueBindSparse(queue, bindInfoCount, pBindInfo_unwrapped, fence);
+    VkResult result = GetVulkanDeviceTable(queue)->QueueBindSparse(queue, bindInfoCount, pBindInfo_unwrapped, fence);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueBindSparse);
     if (encoder)
@@ -1206,7 +1206,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateFence>::Dispatch(manager, device, pCreateInfo, pAllocator, pFence);
 
-    VkResult result = GetDeviceTable(device)->CreateFence(device, pCreateInfo, pAllocator, pFence);
+    VkResult result = GetVulkanDeviceTable(device)->CreateFence(device, pCreateInfo, pAllocator, pFence);
 
     if (result >= 0)
     {
@@ -1264,7 +1264,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyFence(device, fence, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyFence(device, fence, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(manager, device, fence, pAllocator);
 
@@ -1292,7 +1292,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetFences>::Dispatch(manager, device, fenceCount, pFences);
 
-    VkResult result = GetDeviceTable(device)->ResetFences(device, fenceCount, pFences);
+    VkResult result = GetVulkanDeviceTable(device)->ResetFences(device, fenceCount, pFences);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetFences);
     if (encoder)
@@ -1329,7 +1329,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceStatus(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetFenceStatus>::Dispatch(manager, device, fence);
 
-    VkResult result = GetDeviceTable(device)->GetFenceStatus(device, fence);
+    VkResult result = GetVulkanDeviceTable(device)->GetFenceStatus(device, fence);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetFenceStatus);
     if (encoder)
@@ -1368,7 +1368,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForFences(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkWaitForFences>::Dispatch(manager, device, fenceCount, pFences, waitAll, timeout);
 
-    VkResult result = GetDeviceTable(device)->WaitForFences(device, fenceCount, pFences, waitAll, timeout);
+    VkResult result = GetVulkanDeviceTable(device)->WaitForFences(device, fenceCount, pFences, waitAll, timeout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitForFences);
     if (encoder)
@@ -1411,7 +1411,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSemaphore>::Dispatch(manager, device, pCreateInfo, pAllocator, pSemaphore);
 
-    VkResult result = GetDeviceTable(device)->CreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore);
+    VkResult result = GetVulkanDeviceTable(device)->CreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore);
 
     if (result >= 0)
     {
@@ -1469,7 +1469,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroySemaphore(device, semaphore, pAllocator);
+    GetVulkanDeviceTable(device)->DestroySemaphore(device, semaphore, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(manager, device, semaphore, pAllocator);
 
@@ -1500,7 +1500,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateEvent>::Dispatch(manager, device, pCreateInfo, pAllocator, pEvent);
 
-    VkResult result = GetDeviceTable(device)->CreateEvent(device, pCreateInfo, pAllocator, pEvent);
+    VkResult result = GetVulkanDeviceTable(device)->CreateEvent(device, pCreateInfo, pAllocator, pEvent);
 
     if (result >= 0)
     {
@@ -1558,7 +1558,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyEvent(device, event, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyEvent(device, event, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(manager, device, event, pAllocator);
 
@@ -1585,7 +1585,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetEventStatus>::Dispatch(manager, device, event);
 
-    VkResult result = GetDeviceTable(device)->GetEventStatus(device, event);
+    VkResult result = GetVulkanDeviceTable(device)->GetEventStatus(device, event);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetEventStatus);
     if (encoder)
@@ -1621,7 +1621,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetEvent(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetEvent>::Dispatch(manager, device, event);
 
-    VkResult result = GetDeviceTable(device)->SetEvent(device, event);
+    VkResult result = GetVulkanDeviceTable(device)->SetEvent(device, event);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetEvent);
     if (encoder)
@@ -1657,7 +1657,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetEvent(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetEvent>::Dispatch(manager, device, event);
 
-    VkResult result = GetDeviceTable(device)->ResetEvent(device, event);
+    VkResult result = GetVulkanDeviceTable(device)->ResetEvent(device, event);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetEvent);
     if (encoder)
@@ -1697,7 +1697,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateQueryPool>::Dispatch(manager, device, pCreateInfo, pAllocator, pQueryPool);
 
-    VkResult result = GetDeviceTable(device)->CreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool);
+    VkResult result = GetVulkanDeviceTable(device)->CreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool);
 
     if (result >= 0)
     {
@@ -1755,7 +1755,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyQueryPool(device, queryPool, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyQueryPool(device, queryPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(manager, device, queryPool, pAllocator);
 
@@ -1790,7 +1790,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetQueryPoolResults>::Dispatch(manager, device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
 
-    VkResult result = GetDeviceTable(device)->GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
+    VkResult result = GetVulkanDeviceTable(device)->GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
     if (result < 0)
     {
         omit_output_data = true;
@@ -1893,7 +1893,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyBuffer(device, buffer, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyBuffer(device, buffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(manager, device, buffer, pAllocator);
 
@@ -1927,7 +1927,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferViewCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateBufferView(device, pCreateInfo_unwrapped, pAllocator, pView);
+    VkResult result = GetVulkanDeviceTable(device)->CreateBufferView(device, pCreateInfo_unwrapped, pAllocator, pView);
 
     if (result >= 0)
     {
@@ -1985,7 +1985,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyBufferView(device, bufferView, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyBufferView(device, bufferView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(manager, device, bufferView, pAllocator);
 
@@ -2069,7 +2069,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyImage(device, image, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyImage(device, image, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(manager, device, image, pAllocator);
 
@@ -2098,7 +2098,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageSubresourceLayout>::Dispatch(manager, device, image, pSubresource, pLayout);
 
-    GetDeviceTable(device)->GetImageSubresourceLayout(device, image, pSubresource, pLayout);
+    GetVulkanDeviceTable(device)->GetImageSubresourceLayout(device, image, pSubresource, pLayout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout);
     if (encoder)
@@ -2140,7 +2140,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImageViewCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateImageView(device, pCreateInfo_unwrapped, pAllocator, pView);
+    VkResult result = GetVulkanDeviceTable(device)->CreateImageView(device, pCreateInfo_unwrapped, pAllocator, pView);
 
     if (result >= 0)
     {
@@ -2198,7 +2198,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyImageView(device, imageView, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyImageView(device, imageView, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(manager, device, imageView, pAllocator);
 
@@ -2232,7 +2232,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkShaderModuleCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateShaderModule(device, pCreateInfo_unwrapped, pAllocator, pShaderModule);
+    VkResult result = GetVulkanDeviceTable(device)->CreateShaderModule(device, pCreateInfo_unwrapped, pAllocator, pShaderModule);
 
     if (result >= 0)
     {
@@ -2290,7 +2290,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyShaderModule(device, shaderModule, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyShaderModule(device, shaderModule, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(manager, device, shaderModule, pAllocator);
 
@@ -2321,7 +2321,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreatePipelineCache>::Dispatch(manager, device, pCreateInfo, pAllocator, pPipelineCache);
 
-    VkResult result = GetDeviceTable(device)->CreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache);
+    VkResult result = GetVulkanDeviceTable(device)->CreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache);
 
     if (result >= 0)
     {
@@ -2379,7 +2379,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyPipelineCache(device, pipelineCache, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyPipelineCache(device, pipelineCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(manager, device, pipelineCache, pAllocator);
 
@@ -2410,7 +2410,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPipelineCacheData>::Dispatch(manager, device, pipelineCache, pDataSize, pData);
 
-    VkResult result = GetDeviceTable(device)->GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -2454,7 +2454,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MergePipelineCaches(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkMergePipelineCaches>::Dispatch(manager, device, dstCache, srcCacheCount, pSrcCaches);
 
-    VkResult result = GetDeviceTable(device)->MergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches);
+    VkResult result = GetVulkanDeviceTable(device)->MergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMergePipelineCaches);
     if (encoder)
@@ -2503,7 +2503,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyPipeline(device, pipeline, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyPipeline(device, pipeline, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(manager, device, pipeline, pAllocator);
 
@@ -2537,7 +2537,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPipelineLayoutCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreatePipelineLayout(device, pCreateInfo_unwrapped, pAllocator, pPipelineLayout);
+    VkResult result = GetVulkanDeviceTable(device)->CreatePipelineLayout(device, pCreateInfo_unwrapped, pAllocator, pPipelineLayout);
 
     if (result >= 0)
     {
@@ -2595,7 +2595,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(manager, device, pipelineLayout, pAllocator);
 
@@ -2629,7 +2629,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSamplerCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateSampler(device, pCreateInfo_unwrapped, pAllocator, pSampler);
+    VkResult result = GetVulkanDeviceTable(device)->CreateSampler(device, pCreateInfo_unwrapped, pAllocator, pSampler);
 
     if (result >= 0)
     {
@@ -2687,7 +2687,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroySampler(device, sampler, pAllocator);
+    GetVulkanDeviceTable(device)->DestroySampler(device, sampler, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(manager, device, sampler, pAllocator);
 
@@ -2721,7 +2721,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDescriptorSetLayoutCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateDescriptorSetLayout(device, pCreateInfo_unwrapped, pAllocator, pSetLayout);
+    VkResult result = GetVulkanDeviceTable(device)->CreateDescriptorSetLayout(device, pCreateInfo_unwrapped, pAllocator, pSetLayout);
 
     if (result >= 0)
     {
@@ -2779,7 +2779,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(manager, device, descriptorSetLayout, pAllocator);
 
@@ -2810,7 +2810,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDescriptorPool>::Dispatch(manager, device, pCreateInfo, pAllocator, pDescriptorPool);
 
-    VkResult result = GetDeviceTable(device)->CreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool);
+    VkResult result = GetVulkanDeviceTable(device)->CreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool);
 
     if (result >= 0)
     {
@@ -2868,7 +2868,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyDescriptorPool(device, descriptorPool, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyDescriptorPool(device, descriptorPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(manager, device, descriptorPool, pAllocator);
 
@@ -2897,7 +2897,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>::Dispatch(manager, device, descriptorPool, flags);
 
     ScopedDestroyLock exclusive_scoped_lock;
-    VkResult result = GetDeviceTable(device)->ResetDescriptorPool(device, descriptorPool, flags);
+    VkResult result = GetVulkanDeviceTable(device)->ResetDescriptorPool(device, descriptorPool, flags);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetDescriptorPool);
     if (encoder)
@@ -2940,7 +2940,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDescriptorSetAllocateInfo* pAllocateInfo_unwrapped = UnwrapStructPtrHandles(pAllocateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->AllocateDescriptorSets(device, pAllocateInfo_unwrapped, pDescriptorSets);
+    VkResult result = GetVulkanDeviceTable(device)->AllocateDescriptorSets(device, pAllocateInfo_unwrapped, pDescriptorSets);
 
     if (result >= 0)
     {
@@ -2989,7 +2989,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(manager, device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
     ScopedDestroyLock exclusive_scoped_lock;
-    VkResult result = GetDeviceTable(device)->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
+    VkResult result = GetVulkanDeviceTable(device)->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
     if (encoder)
@@ -3047,7 +3047,7 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(
     const VkWriteDescriptorSet* pDescriptorWrites_unwrapped = UnwrapStructArrayHandles(pDescriptorWrites, descriptorWriteCount, handle_unwrap_memory);
     const VkCopyDescriptorSet* pDescriptorCopies_unwrapped = UnwrapStructArrayHandles(pDescriptorCopies, descriptorCopyCount, handle_unwrap_memory);
 
-    GetDeviceTable(device)->UpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites_unwrapped, descriptorCopyCount, pDescriptorCopies_unwrapped);
+    GetVulkanDeviceTable(device)->UpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites_unwrapped, descriptorCopyCount, pDescriptorCopies_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSets>::Dispatch(manager, device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
 }
@@ -3079,7 +3079,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkFramebufferCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateFramebuffer(device, pCreateInfo_unwrapped, pAllocator, pFramebuffer);
+    VkResult result = GetVulkanDeviceTable(device)->CreateFramebuffer(device, pCreateInfo_unwrapped, pAllocator, pFramebuffer);
 
     if (result >= 0)
     {
@@ -3137,7 +3137,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyFramebuffer(device, framebuffer, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyFramebuffer(device, framebuffer, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(manager, device, framebuffer, pAllocator);
 
@@ -3168,7 +3168,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateRenderPass>::Dispatch(manager, device, pCreateInfo, pAllocator, pRenderPass);
 
-    VkResult result = GetDeviceTable(device)->CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
+    VkResult result = GetVulkanDeviceTable(device)->CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
 
     if (result >= 0)
     {
@@ -3226,7 +3226,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyRenderPass(device, renderPass, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyRenderPass(device, renderPass, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(manager, device, renderPass, pAllocator);
 
@@ -3254,7 +3254,7 @@ VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRenderAreaGranularity>::Dispatch(manager, device, renderPass, pGranularity);
 
-    GetDeviceTable(device)->GetRenderAreaGranularity(device, renderPass, pGranularity);
+    GetVulkanDeviceTable(device)->GetRenderAreaGranularity(device, renderPass, pGranularity);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRenderAreaGranularity);
     if (encoder)
@@ -3292,7 +3292,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateCommandPool>::Dispatch(manager, device, pCreateInfo, pAllocator, pCommandPool);
 
-    VkResult result = GetDeviceTable(device)->CreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
+    VkResult result = GetVulkanDeviceTable(device)->CreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
 
     if (result >= 0)
     {
@@ -3350,7 +3350,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyCommandPool(device, commandPool, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyCommandPool(device, commandPool, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(manager, device, commandPool, pAllocator);
 
@@ -3378,7 +3378,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetCommandPool>::Dispatch(manager, device, commandPool, flags);
 
-    VkResult result = GetDeviceTable(device)->ResetCommandPool(device, commandPool, flags);
+    VkResult result = GetVulkanDeviceTable(device)->ResetCommandPool(device, commandPool, flags);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkResetCommandPool);
     if (encoder)
@@ -3421,7 +3421,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCommandBufferAllocateInfo* pAllocateInfo_unwrapped = UnwrapStructPtrHandles(pAllocateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->AllocateCommandBuffers(device, pAllocateInfo_unwrapped, pCommandBuffers);
+    VkResult result = GetVulkanDeviceTable(device)->AllocateCommandBuffers(device, pAllocateInfo_unwrapped, pCommandBuffers);
 
     if (result >= 0)
     {
@@ -3480,7 +3480,7 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
+    GetVulkanDeviceTable(device)->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(manager, device, commandPool, commandBufferCount, pCommandBuffers);
 
@@ -3510,7 +3510,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCommandBufferBeginInfo* pBeginInfo_unwrapped = UnwrapStructPtrHandles(pBeginInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(commandBuffer)->BeginCommandBuffer(commandBuffer, pBeginInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(commandBuffer)->BeginCommandBuffer(commandBuffer, pBeginInfo_unwrapped);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkBeginCommandBuffer);
     if (encoder)
@@ -3545,7 +3545,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EndCommandBuffer(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkEndCommandBuffer>::Dispatch(manager, commandBuffer);
 
-    VkResult result = GetDeviceTable(commandBuffer)->EndCommandBuffer(commandBuffer);
+    VkResult result = GetVulkanDeviceTable(commandBuffer)->EndCommandBuffer(commandBuffer);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkEndCommandBuffer);
     if (encoder)
@@ -3580,7 +3580,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandBuffer(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkResetCommandBuffer>::Dispatch(manager, commandBuffer, flags);
 
-    VkResult result = GetDeviceTable(commandBuffer)->ResetCommandBuffer(commandBuffer, flags);
+    VkResult result = GetVulkanDeviceTable(commandBuffer)->ResetCommandBuffer(commandBuffer, flags);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkResetCommandBuffer);
     if (encoder)
@@ -3626,7 +3626,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindPipelineHandles, pipeline);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindPipeline>::Dispatch(manager, commandBuffer, pipelineBindPoint, pipeline);
 }
@@ -3663,7 +3663,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewport(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewport>::Dispatch(manager, commandBuffer, firstViewport, viewportCount, pViewports);
 }
@@ -3700,7 +3700,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissor(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetScissor>::Dispatch(manager, commandBuffer, firstScissor, scissorCount, pScissors);
 }
@@ -3733,7 +3733,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineWidth(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetLineWidth(commandBuffer, lineWidth);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetLineWidth(commandBuffer, lineWidth);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLineWidth>::Dispatch(manager, commandBuffer, lineWidth);
 }
@@ -3770,7 +3770,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBias>::Dispatch(manager, commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
 }
@@ -3803,7 +3803,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetBlendConstants(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetBlendConstants(commandBuffer, blendConstants);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetBlendConstants(commandBuffer, blendConstants);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetBlendConstants>::Dispatch(manager, commandBuffer, blendConstants);
 }
@@ -3838,7 +3838,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBounds(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBounds>::Dispatch(manager, commandBuffer, minDepthBounds, maxDepthBounds);
 }
@@ -3873,7 +3873,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilCompareMask(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilCompareMask>::Dispatch(manager, commandBuffer, faceMask, compareMask);
 }
@@ -3908,7 +3908,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilWriteMask(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilWriteMask>::Dispatch(manager, commandBuffer, faceMask, writeMask);
 }
@@ -3943,7 +3943,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilReference(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetStencilReference(commandBuffer, faceMask, reference);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetStencilReference(commandBuffer, faceMask, reference);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilReference>::Dispatch(manager, commandBuffer, faceMask, reference);
 }
@@ -3988,7 +3988,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindDescriptorSetsHandles, layout, descriptorSetCount, pDescriptorSets);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindDescriptorSets>::Dispatch(manager, commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
 }
@@ -4025,7 +4025,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindIndexBufferHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindIndexBuffer>::Dispatch(manager, commandBuffer, buffer, offset, indexType);
 }
@@ -4064,7 +4064,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindVertexBuffersHandles, bindingCount, pBuffers);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindVertexBuffers>::Dispatch(manager, commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
 }
@@ -4103,7 +4103,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDraw(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
+    GetVulkanDeviceTable(commandBuffer)->CmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDraw>::Dispatch(manager, commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
 }
@@ -4144,7 +4144,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexed(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexed>::Dispatch(manager, commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 }
@@ -4183,7 +4183,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndirectHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirect>::Dispatch(manager, commandBuffer, buffer, offset, drawCount, stride);
 }
@@ -4222,7 +4222,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndexedIndirectHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect>::Dispatch(manager, commandBuffer, buffer, offset, drawCount, stride);
 }
@@ -4259,7 +4259,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatch(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
+    GetVulkanDeviceTable(commandBuffer)->CmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatch>::Dispatch(manager, commandBuffer, groupCountX, groupCountY, groupCountZ);
 }
@@ -4294,7 +4294,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDispatchIndirectHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDispatchIndirect(commandBuffer, buffer, offset);
+    GetVulkanDeviceTable(commandBuffer)->CmdDispatchIndirect(commandBuffer, buffer, offset);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatchIndirect>::Dispatch(manager, commandBuffer, buffer, offset);
 }
@@ -4333,7 +4333,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferHandles, srcBuffer, dstBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBuffer>::Dispatch(manager, commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 }
@@ -4376,7 +4376,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageHandles, srcImage, dstImage);
     }
 
-    GetDeviceTable(commandBuffer)->CmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImage>::Dispatch(manager, commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 }
@@ -4421,7 +4421,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBlitImageHandles, srcImage, dstImage);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
+    GetVulkanDeviceTable(commandBuffer)->CmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBlitImage>::Dispatch(manager, commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
 }
@@ -4462,7 +4462,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyBufferToImageHandles, srcBuffer, dstImage);
     }
 
-    GetDeviceTable(commandBuffer)->CmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBufferToImage>::Dispatch(manager, commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
 }
@@ -4503,7 +4503,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyImageToBufferHandles, srcImage, dstBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer>::Dispatch(manager, commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
 }
@@ -4542,7 +4542,7 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdUpdateBufferHandles, dstBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
+    GetVulkanDeviceTable(commandBuffer)->CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdUpdateBuffer>::Dispatch(manager, commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 }
@@ -4581,7 +4581,7 @@ VKAPI_ATTR void VKAPI_CALL CmdFillBuffer(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdFillBufferHandles, dstBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
+    GetVulkanDeviceTable(commandBuffer)->CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdFillBuffer>::Dispatch(manager, commandBuffer, dstBuffer, dstOffset, size, data);
 }
@@ -4622,7 +4622,7 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdClearColorImageHandles, image);
     }
 
-    GetDeviceTable(commandBuffer)->CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
+    GetVulkanDeviceTable(commandBuffer)->CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdClearColorImage>::Dispatch(manager, commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 }
@@ -4663,7 +4663,7 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdClearDepthStencilImageHandles, image);
     }
 
-    GetDeviceTable(commandBuffer)->CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
+    GetVulkanDeviceTable(commandBuffer)->CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdClearDepthStencilImage>::Dispatch(manager, commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 }
@@ -4702,7 +4702,7 @@ VKAPI_ATTR void VKAPI_CALL CmdClearAttachments(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
+    GetVulkanDeviceTable(commandBuffer)->CmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdClearAttachments>::Dispatch(manager, commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
 }
@@ -4745,7 +4745,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResolveImageHandles, srcImage, dstImage);
     }
 
-    GetDeviceTable(commandBuffer)->CmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
+    GetVulkanDeviceTable(commandBuffer)->CmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResolveImage>::Dispatch(manager, commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 }
@@ -4780,7 +4780,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdSetEventHandles, event);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetEvent(commandBuffer, event, stageMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetEvent(commandBuffer, event, stageMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetEvent>::Dispatch(manager, commandBuffer, event, stageMask);
 }
@@ -4815,7 +4815,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEventHandles, event);
     }
 
-    GetDeviceTable(commandBuffer)->CmdResetEvent(commandBuffer, event, stageMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdResetEvent(commandBuffer, event, stageMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResetEvent>::Dispatch(manager, commandBuffer, event, stageMask);
 }
@@ -4870,7 +4870,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
     const VkBufferMemoryBarrier* pBufferMemoryBarriers_unwrapped = UnwrapStructArrayHandles(pBufferMemoryBarriers, bufferMemoryBarrierCount, handle_unwrap_memory);
     const VkImageMemoryBarrier* pImageMemoryBarriers_unwrapped = UnwrapStructArrayHandles(pImageMemoryBarriers, imageMemoryBarrierCount, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers_unwrapped, imageMemoryBarrierCount, pImageMemoryBarriers_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers_unwrapped, imageMemoryBarrierCount, pImageMemoryBarriers_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWaitEvents>::Dispatch(manager, commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 }
@@ -4923,7 +4923,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
     const VkBufferMemoryBarrier* pBufferMemoryBarriers_unwrapped = UnwrapStructArrayHandles(pBufferMemoryBarriers, bufferMemoryBarrierCount, handle_unwrap_memory);
     const VkImageMemoryBarrier* pImageMemoryBarriers_unwrapped = UnwrapStructArrayHandles(pImageMemoryBarriers, imageMemoryBarrierCount, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers_unwrapped, imageMemoryBarrierCount, pImageMemoryBarriers_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers_unwrapped, imageMemoryBarrierCount, pImageMemoryBarriers_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier>::Dispatch(manager, commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 }
@@ -4960,7 +4960,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQuery(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginQueryHandles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBeginQuery(commandBuffer, queryPool, query, flags);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginQuery(commandBuffer, queryPool, query, flags);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginQuery>::Dispatch(manager, commandBuffer, queryPool, query, flags);
 }
@@ -4995,7 +4995,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQuery(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndQueryHandles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndQuery(commandBuffer, queryPool, query);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndQuery(commandBuffer, queryPool, query);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndQuery>::Dispatch(manager, commandBuffer, queryPool, query);
 }
@@ -5032,7 +5032,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResetQueryPool(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetQueryPoolHandles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
+    GetVulkanDeviceTable(commandBuffer)->CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResetQueryPool>::Dispatch(manager, commandBuffer, queryPool, firstQuery, queryCount);
 }
@@ -5069,7 +5069,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestampHandles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp>::Dispatch(manager, commandBuffer, pipelineStage, queryPool, query);
 }
@@ -5114,7 +5114,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyQueryPoolResults(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyQueryPoolResultsHandles, queryPool, dstBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyQueryPoolResults>::Dispatch(manager, commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
 }
@@ -5155,7 +5155,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushConstantsHandles, layout);
     }
 
-    GetDeviceTable(commandBuffer)->CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
+    GetVulkanDeviceTable(commandBuffer)->CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushConstants>::Dispatch(manager, commandBuffer, layout, stageFlags, offset, size, pValues);
 }
@@ -5193,7 +5193,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkRenderPassBeginInfo* pRenderPassBegin_unwrapped = UnwrapStructPtrHandles(pRenderPassBegin, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBeginRenderPass(commandBuffer, pRenderPassBegin_unwrapped, contents);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginRenderPass(commandBuffer, pRenderPassBegin_unwrapped, contents);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass>::Dispatch(manager, commandBuffer, pRenderPassBegin, contents);
 }
@@ -5226,7 +5226,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdNextSubpass(commandBuffer, contents);
+    GetVulkanDeviceTable(commandBuffer)->CmdNextSubpass(commandBuffer, contents);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdNextSubpass>::Dispatch(manager, commandBuffer, contents);
 }
@@ -5257,7 +5257,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndRenderPass(commandBuffer);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndRenderPass(commandBuffer);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass>::Dispatch(manager, commandBuffer);
 }
@@ -5292,7 +5292,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdExecuteCommandsHandles, commandBufferCount, pCommandBuffers);
     }
 
-    GetDeviceTable(commandBuffer)->CmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
+    GetVulkanDeviceTable(commandBuffer)->CmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdExecuteCommands>::Dispatch(manager, commandBuffer, commandBufferCount, pCommandBuffers);
 }
@@ -5321,7 +5321,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindBufferMemoryInfo* pBindInfos_unwrapped = UnwrapStructArrayHandles(pBindInfos, bindInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->BindBufferMemory2(device, bindInfoCount, pBindInfos_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->BindBufferMemory2(device, bindInfoCount, pBindInfos_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory2);
     if (encoder)
@@ -5362,7 +5362,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindImageMemoryInfo* pBindInfos_unwrapped = UnwrapStructArrayHandles(pBindInfos, bindInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->BindImageMemory2(device, bindInfoCount, pBindInfos_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->BindImageMemory2(device, bindInfoCount, pBindInfos_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory2);
     if (encoder)
@@ -5402,7 +5402,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeatures(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeatures>::Dispatch(manager, device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
 
-    GetDeviceTable(device)->GetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
+    GetVulkanDeviceTable(device)->GetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeatures);
     if (encoder)
@@ -5446,7 +5446,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMask(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDeviceMask(commandBuffer, deviceMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDeviceMask(commandBuffer, deviceMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDeviceMask>::Dispatch(manager, commandBuffer, deviceMask);
 }
@@ -5489,7 +5489,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBase(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+    GetVulkanDeviceTable(commandBuffer)->CmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatchBase>::Dispatch(manager, commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 }
@@ -5517,7 +5517,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroups>::Dispatch(manager, instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
 
-    VkResult result = GetInstanceTable(instance)->EnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
+    VkResult result = GetVulkanInstanceTable(instance)->EnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
 
     if (result >= 0)
     {
@@ -5567,7 +5567,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImageMemoryRequirementsInfo2* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetImageMemoryRequirements2(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetImageMemoryRequirements2(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2);
     if (encoder)
@@ -5605,7 +5605,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferMemoryRequirementsInfo2* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetBufferMemoryRequirements2(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetBufferMemoryRequirements2(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2);
     if (encoder)
@@ -5644,7 +5644,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImageSparseMemoryRequirementsInfo2* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetImageSparseMemoryRequirements2(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetImageSparseMemoryRequirements2(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2);
     if (encoder)
@@ -5679,7 +5679,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2>::Dispatch(manager, physicalDevice, pFeatures);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2);
     if (encoder)
@@ -5712,7 +5712,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2>::Dispatch(manager, physicalDevice, pProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceProperties2(physicalDevice, pProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceProperties2(physicalDevice, pProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2);
     if (encoder)
@@ -5746,7 +5746,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2>::Dispatch(manager, physicalDevice, format, pFormatProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2);
     if (encoder)
@@ -5783,7 +5783,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2>::Dispatch(manager, physicalDevice, pImageFormatInfo, pImageFormatProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -5859,7 +5859,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2>::Dispatch(manager, physicalDevice, pMemoryProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2);
     if (encoder)
@@ -5894,7 +5894,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2>::Dispatch(manager, physicalDevice, pFormatInfo, pPropertyCount, pProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2);
     if (encoder)
@@ -5939,7 +5939,7 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPool(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->TrimCommandPool(device, commandPool, flags);
+    GetVulkanDeviceTable(device)->TrimCommandPool(device, commandPool, flags);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTrimCommandPool>::Dispatch(manager, device, commandPool, flags);
 }
@@ -5965,7 +5965,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceQueue2>::Dispatch(manager, device, pQueueInfo, pQueue);
 
-    GetDeviceTable(device)->GetDeviceQueue2(device, pQueueInfo, pQueue);
+    GetVulkanDeviceTable(device)->GetDeviceQueue2(device, pQueueInfo, pQueue);
 
     CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueueWrapper>(device, NoParentWrapper::kHandleValue, pQueue, VulkanCaptureManager::GetUniqueId);
 
@@ -6005,7 +6005,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion>::Dispatch(manager, device, pCreateInfo, pAllocator, pYcbcrConversion);
 
-    VkResult result = GetDeviceTable(device)->CreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
+    VkResult result = GetVulkanDeviceTable(device)->CreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
 
     if (result >= 0)
     {
@@ -6063,7 +6063,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
+    GetVulkanDeviceTable(device)->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
@@ -6097,7 +6097,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateDescriptorUpdateTemplate(device, pCreateInfo_unwrapped, pAllocator, pDescriptorUpdateTemplate);
+    VkResult result = GetVulkanDeviceTable(device)->CreateDescriptorUpdateTemplate(device, pCreateInfo_unwrapped, pAllocator, pDescriptorUpdateTemplate);
 
     if (result >= 0)
     {
@@ -6155,7 +6155,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
@@ -6183,7 +6183,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferProperties>::Dispatch(manager, physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferProperties);
     if (encoder)
@@ -6218,7 +6218,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFenceProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFenceProperties>::Dispatch(manager, physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFenceProperties);
     if (encoder)
@@ -6253,7 +6253,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphoreProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphoreProperties>::Dispatch(manager, physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphoreProperties);
     if (encoder)
@@ -6291,7 +6291,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupport(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDescriptorSetLayoutCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDescriptorSetLayoutSupport(device, pCreateInfo_unwrapped, pSupport);
+    GetVulkanDeviceTable(device)->GetDescriptorSetLayoutSupport(device, pCreateInfo_unwrapped, pSupport);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupport);
     if (encoder)
@@ -6343,7 +6343,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCount(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndirectCountHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectCount>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -6386,7 +6386,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCount(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndexedIndirectCountHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCount>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -6415,7 +6415,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateRenderPass2>::Dispatch(manager, device, pCreateInfo, pAllocator, pRenderPass);
 
-    VkResult result = GetDeviceTable(device)->CreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass);
+    VkResult result = GetVulkanDeviceTable(device)->CreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass);
 
     if (result >= 0)
     {
@@ -6475,7 +6475,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkRenderPassBeginInfo* pRenderPassBegin_unwrapped = UnwrapStructPtrHandles(pRenderPassBegin, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBeginRenderPass2(commandBuffer, pRenderPassBegin_unwrapped, pSubpassBeginInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginRenderPass2(commandBuffer, pRenderPassBegin_unwrapped, pSubpassBeginInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass2>::Dispatch(manager, commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 }
@@ -6510,7 +6510,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdNextSubpass2>::Dispatch(manager, commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 }
@@ -6543,7 +6543,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass2>::Dispatch(manager, commandBuffer, pSubpassEndInfo);
 }
@@ -6580,7 +6580,7 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPool(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->ResetQueryPool(device, queryPool, firstQuery, queryCount);
+    GetVulkanDeviceTable(device)->ResetQueryPool(device, queryPool, firstQuery, queryCount);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetQueryPool>::Dispatch(manager, device, queryPool, firstQuery, queryCount);
 }
@@ -6608,7 +6608,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValue(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetSemaphoreCounterValue>::Dispatch(manager, device, semaphore, pValue);
 
-    VkResult result = GetDeviceTable(device)->GetSemaphoreCounterValue(device, semaphore, pValue);
+    VkResult result = GetVulkanDeviceTable(device)->GetSemaphoreCounterValue(device, semaphore, pValue);
     if (result < 0)
     {
         omit_output_data = true;
@@ -6653,7 +6653,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphores(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSemaphoreWaitInfo* pWaitInfo_unwrapped = UnwrapStructPtrHandles(pWaitInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->WaitSemaphores(device, pWaitInfo_unwrapped, timeout);
+    VkResult result = GetVulkanDeviceTable(device)->WaitSemaphores(device, pWaitInfo_unwrapped, timeout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitSemaphores);
     if (encoder)
@@ -6693,7 +6693,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphore(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSemaphoreSignalInfo* pSignalInfo_unwrapped = UnwrapStructPtrHandles(pSignalInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->SignalSemaphore(device, pSignalInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->SignalSemaphore(device, pSignalInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSignalSemaphore);
     if (encoder)
@@ -6732,7 +6732,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddress(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferDeviceAddressInfo* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkDeviceAddress result = GetDeviceTable(device)->GetBufferDeviceAddress(device, pInfo_unwrapped);
+    VkDeviceAddress result = GetVulkanDeviceTable(device)->GetBufferDeviceAddress(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddress);
     if (encoder)
@@ -6771,7 +6771,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddress(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferDeviceAddressInfo* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    uint64_t result = GetDeviceTable(device)->GetBufferOpaqueCaptureAddress(device, pInfo_unwrapped);
+    uint64_t result = GetVulkanDeviceTable(device)->GetBufferOpaqueCaptureAddress(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddress);
     if (encoder)
@@ -6810,7 +6810,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddress(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    uint64_t result = GetDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddress(device, pInfo_unwrapped);
+    uint64_t result = GetVulkanDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddress(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddress);
     if (encoder)
@@ -6849,7 +6849,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolProperties(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolProperties>::Dispatch(manager, physicalDevice, pToolCount, pToolProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceToolProperties(physicalDevice, pToolCount, pToolProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceToolProperties(physicalDevice, pToolCount, pToolProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -6894,7 +6894,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlot(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreatePrivateDataSlot>::Dispatch(manager, device, pCreateInfo, pAllocator, pPrivateDataSlot);
 
-    VkResult result = GetDeviceTable(device)->CreatePrivateDataSlot(device, pCreateInfo, pAllocator, pPrivateDataSlot);
+    VkResult result = GetVulkanDeviceTable(device)->CreatePrivateDataSlot(device, pCreateInfo, pAllocator, pPrivateDataSlot);
 
     if (result >= 0)
     {
@@ -6952,7 +6952,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyPrivateDataSlot(device, privateDataSlot, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyPrivateDataSlot(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
@@ -6982,7 +6982,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetPrivateData>::Dispatch(manager, device, objectType, objectHandle, privateDataSlot, data);
 
-    VkResult result = GetDeviceTable(device)->SetPrivateData(device, objectType, objectHandle, privateDataSlot, data);
+    VkResult result = GetVulkanDeviceTable(device)->SetPrivateData(device, objectType, objectHandle, privateDataSlot, data);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetPrivateData);
     if (encoder)
@@ -7024,7 +7024,7 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateData(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPrivateData>::Dispatch(manager, device, objectType, objectHandle, privateDataSlot, pData);
 
-    GetDeviceTable(device)->GetPrivateData(device, objectType, objectHandle, privateDataSlot, pData);
+    GetVulkanDeviceTable(device)->GetPrivateData(device, objectType, objectHandle, privateDataSlot, pData);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPrivateData);
     if (encoder)
@@ -7073,7 +7073,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDependencyInfo* pDependencyInfo_unwrapped = UnwrapStructPtrHandles(pDependencyInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdSetEvent2(commandBuffer, event, pDependencyInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetEvent2(commandBuffer, event, pDependencyInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetEvent2>::Dispatch(manager, commandBuffer, event, pDependencyInfo);
 }
@@ -7108,7 +7108,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEvent2Handles, event);
     }
 
-    GetDeviceTable(commandBuffer)->CmdResetEvent2(commandBuffer, event, stageMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdResetEvent2(commandBuffer, event, stageMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResetEvent2>::Dispatch(manager, commandBuffer, event, stageMask);
 }
@@ -7148,7 +7148,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDependencyInfo* pDependencyInfos_unwrapped = UnwrapStructArrayHandles(pDependencyInfos, eventCount, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWaitEvents2>::Dispatch(manager, commandBuffer, eventCount, pEvents, pDependencyInfos);
 }
@@ -7184,7 +7184,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDependencyInfo* pDependencyInfo_unwrapped = UnwrapStructPtrHandles(pDependencyInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPipelineBarrier2(commandBuffer, pDependencyInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPipelineBarrier2(commandBuffer, pDependencyInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier2>::Dispatch(manager, commandBuffer, pDependencyInfo);
 }
@@ -7221,7 +7221,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestamp2Handles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp2>::Dispatch(manager, commandBuffer, stage, queryPool, query);
 }
@@ -7251,7 +7251,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSubmitInfo2* pSubmits_unwrapped = UnwrapStructArrayHandles(pSubmits, submitCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(queue)->QueueSubmit2(queue, submitCount, pSubmits_unwrapped, fence);
+    VkResult result = GetVulkanDeviceTable(queue)->QueueSubmit2(queue, submitCount, pSubmits_unwrapped, fence);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit2);
     if (encoder)
@@ -7300,7 +7300,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyBufferInfo2* pCopyBufferInfo_unwrapped = UnwrapStructPtrHandles(pCopyBufferInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyBuffer2(commandBuffer, pCopyBufferInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyBuffer2(commandBuffer, pCopyBufferInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBuffer2>::Dispatch(manager, commandBuffer, pCopyBufferInfo);
 }
@@ -7336,7 +7336,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyImageInfo2* pCopyImageInfo_unwrapped = UnwrapStructPtrHandles(pCopyImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyImage2(commandBuffer, pCopyImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyImage2(commandBuffer, pCopyImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImage2>::Dispatch(manager, commandBuffer, pCopyImageInfo);
 }
@@ -7372,7 +7372,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo_unwrapped = UnwrapStructPtrHandles(pCopyBufferToImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2>::Dispatch(manager, commandBuffer, pCopyBufferToImageInfo);
 }
@@ -7408,7 +7408,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo_unwrapped = UnwrapStructPtrHandles(pCopyImageToBufferInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2>::Dispatch(manager, commandBuffer, pCopyImageToBufferInfo);
 }
@@ -7444,7 +7444,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBlitImageInfo2* pBlitImageInfo_unwrapped = UnwrapStructPtrHandles(pBlitImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBlitImage2(commandBuffer, pBlitImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBlitImage2(commandBuffer, pBlitImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBlitImage2>::Dispatch(manager, commandBuffer, pBlitImageInfo);
 }
@@ -7480,7 +7480,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkResolveImageInfo2* pResolveImageInfo_unwrapped = UnwrapStructPtrHandles(pResolveImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdResolveImage2(commandBuffer, pResolveImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdResolveImage2(commandBuffer, pResolveImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResolveImage2>::Dispatch(manager, commandBuffer, pResolveImageInfo);
 }
@@ -7516,7 +7516,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRendering(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkRenderingInfo* pRenderingInfo_unwrapped = UnwrapStructPtrHandles(pRenderingInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBeginRendering(commandBuffer, pRenderingInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginRendering(commandBuffer, pRenderingInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRendering>::Dispatch(manager, commandBuffer, pRenderingInfo);
 }
@@ -7547,7 +7547,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRendering(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndRendering(commandBuffer);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndRendering(commandBuffer);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRendering>::Dispatch(manager, commandBuffer);
 }
@@ -7580,7 +7580,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullMode(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCullMode(commandBuffer, cullMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCullMode(commandBuffer, cullMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCullMode>::Dispatch(manager, commandBuffer, cullMode);
 }
@@ -7613,7 +7613,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFace(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetFrontFace(commandBuffer, frontFace);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetFrontFace(commandBuffer, frontFace);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetFrontFace>::Dispatch(manager, commandBuffer, frontFace);
 }
@@ -7646,7 +7646,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopology(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetPrimitiveTopology(commandBuffer, primitiveTopology);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetPrimitiveTopology(commandBuffer, primitiveTopology);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopology>::Dispatch(manager, commandBuffer, primitiveTopology);
 }
@@ -7681,7 +7681,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCount(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetViewportWithCount(commandBuffer, viewportCount, pViewports);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetViewportWithCount(commandBuffer, viewportCount, pViewports);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportWithCount>::Dispatch(manager, commandBuffer, viewportCount, pViewports);
 }
@@ -7716,7 +7716,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCount(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetScissorWithCount(commandBuffer, scissorCount, pScissors);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetScissorWithCount(commandBuffer, scissorCount, pScissors);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetScissorWithCount>::Dispatch(manager, commandBuffer, scissorCount, pScissors);
 }
@@ -7759,7 +7759,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindVertexBuffers2Handles, bindingCount, pBuffers);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2>::Dispatch(manager, commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
 }
@@ -7792,7 +7792,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnable(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthTestEnable(commandBuffer, depthTestEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthTestEnable(commandBuffer, depthTestEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthTestEnable>::Dispatch(manager, commandBuffer, depthTestEnable);
 }
@@ -7825,7 +7825,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnable(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthWriteEnable(commandBuffer, depthWriteEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthWriteEnable(commandBuffer, depthWriteEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnable>::Dispatch(manager, commandBuffer, depthWriteEnable);
 }
@@ -7858,7 +7858,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOp(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthCompareOp(commandBuffer, depthCompareOp);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthCompareOp(commandBuffer, depthCompareOp);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthCompareOp>::Dispatch(manager, commandBuffer, depthCompareOp);
 }
@@ -7891,7 +7891,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnable(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthBoundsTestEnable(commandBuffer, depthBoundsTestEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthBoundsTestEnable(commandBuffer, depthBoundsTestEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnable>::Dispatch(manager, commandBuffer, depthBoundsTestEnable);
 }
@@ -7924,7 +7924,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnable(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetStencilTestEnable(commandBuffer, stencilTestEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetStencilTestEnable(commandBuffer, stencilTestEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilTestEnable>::Dispatch(manager, commandBuffer, stencilTestEnable);
 }
@@ -7965,7 +7965,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOp(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetStencilOp(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetStencilOp(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilOp>::Dispatch(manager, commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
 }
@@ -7998,7 +7998,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnable(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRasterizerDiscardEnable(commandBuffer, rasterizerDiscardEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRasterizerDiscardEnable(commandBuffer, rasterizerDiscardEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnable>::Dispatch(manager, commandBuffer, rasterizerDiscardEnable);
 }
@@ -8031,7 +8031,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnable(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthBiasEnable(commandBuffer, depthBiasEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthBiasEnable(commandBuffer, depthBiasEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnable>::Dispatch(manager, commandBuffer, depthBiasEnable);
 }
@@ -8064,7 +8064,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnable(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetPrimitiveRestartEnable(commandBuffer, primitiveRestartEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetPrimitiveRestartEnable(commandBuffer, primitiveRestartEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnable>::Dispatch(manager, commandBuffer, primitiveRestartEnable);
 }
@@ -8090,7 +8090,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirements(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirements>::Dispatch(manager, device, pInfo, pMemoryRequirements);
 
-    GetDeviceTable(device)->GetDeviceBufferMemoryRequirements(device, pInfo, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetDeviceBufferMemoryRequirements(device, pInfo, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirements);
     if (encoder)
@@ -8128,7 +8128,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirements(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDeviceImageMemoryRequirements* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDeviceImageMemoryRequirements(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetDeviceImageMemoryRequirements(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirements);
     if (encoder)
@@ -8167,7 +8167,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirements(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDeviceImageMemoryRequirements* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDeviceImageSparseMemoryRequirements(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetDeviceImageSparseMemoryRequirements(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirements);
     if (encoder)
@@ -8213,7 +8213,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetInstanceTable(instance)->DestroySurfaceKHR(instance, surface, pAllocator);
+    GetVulkanInstanceTable(instance)->DestroySurfaceKHR(instance, surface, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(manager, instance, surface, pAllocator);
 
@@ -8244,7 +8244,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceSupportKHR>::Dispatch(manager, physicalDevice, queueFamilyIndex, surface, pSupported);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8289,7 +8289,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilitiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>::Dispatch(manager, physicalDevice, surface, pSurfaceCapabilities);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8334,7 +8334,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormatsKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormatsKHR>::Dispatch(manager, physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8380,7 +8380,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR>::Dispatch(manager, physicalDevice, surface, pPresentModeCount, pPresentModes);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8429,7 +8429,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSwapchainCreateInfoKHR* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateSwapchainKHR(device, pCreateInfo_unwrapped, pAllocator, pSwapchain);
+    VkResult result = GetVulkanDeviceTable(device)->CreateSwapchainKHR(device, pCreateInfo_unwrapped, pAllocator, pSwapchain);
 
     if (result >= 0)
     {
@@ -8487,7 +8487,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroySwapchainKHR(device, swapchain, pAllocator);
+    GetVulkanDeviceTable(device)->DestroySwapchainKHR(device, swapchain, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(manager, device, swapchain, pAllocator);
 
@@ -8518,7 +8518,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR>::Dispatch(manager, device, swapchain, pSwapchainImageCount, pSwapchainImages);
 
-    VkResult result = GetDeviceTable(device)->GetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages);
+    VkResult result = GetVulkanDeviceTable(device)->GetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages);
 
     if (result >= 0)
     {
@@ -8571,7 +8571,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAcquireNextImageKHR>::Dispatch(manager, device, swapchain, timeout, semaphore, fence, pImageIndex);
 
-    VkResult result = GetDeviceTable(device)->AcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex);
+    VkResult result = GetVulkanDeviceTable(device)->AcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8608,7 +8608,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPresentInfoKHR* pPresentInfo_unwrapped = UnwrapStructPtrHandles(pPresentInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(queue)->QueuePresentKHR(queue, pPresentInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(queue)->QueuePresentKHR(queue, pPresentInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueuePresentKHR);
     if (encoder)
@@ -8646,7 +8646,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupPresentCapabilitiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceGroupPresentCapabilitiesKHR>::Dispatch(manager, device, pDeviceGroupPresentCapabilities);
 
-    VkResult result = GetDeviceTable(device)->GetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities);
+    VkResult result = GetVulkanDeviceTable(device)->GetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8689,7 +8689,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModesKHR>::Dispatch(manager, device, surface, pModes);
 
-    VkResult result = GetDeviceTable(device)->GetDeviceGroupSurfacePresentModesKHR(device, surface, pModes);
+    VkResult result = GetVulkanDeviceTable(device)->GetDeviceGroupSurfacePresentModesKHR(device, surface, pModes);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8734,7 +8734,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDevicePresentRectanglesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDevicePresentRectanglesKHR>::Dispatch(manager, physicalDevice, surface, pRectCount, pRects);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8782,7 +8782,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkAcquireNextImageInfoKHR* pAcquireInfo_unwrapped = UnwrapStructPtrHandles(pAcquireInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->AcquireNextImage2KHR(device, pAcquireInfo_unwrapped, pImageIndex);
+    VkResult result = GetVulkanDeviceTable(device)->AcquireNextImage2KHR(device, pAcquireInfo_unwrapped, pImageIndex);
     if (result < 0)
     {
         omit_output_data = true;
@@ -8826,7 +8826,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR>::Dispatch(manager, physicalDevice, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
 
     if (result >= 0)
     {
@@ -8875,7 +8875,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>::Dispatch(manager, physicalDevice, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties);
 
     if (result >= 0)
     {
@@ -8925,7 +8925,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR>::Dispatch(manager, physicalDevice, planeIndex, pDisplayCount, pDisplays);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays);
 
     if (result >= 0)
     {
@@ -8976,7 +8976,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR>::Dispatch(manager, physicalDevice, display, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties);
 
     if (result >= 0)
     {
@@ -9028,7 +9028,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDisplayModeKHR>::Dispatch(manager, physicalDevice, display, pCreateInfo, pAllocator, pMode);
 
-    VkResult result = GetInstanceTable(physicalDevice)->CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
 
     if (result >= 0)
     {
@@ -9080,7 +9080,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilitiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDisplayPlaneCapabilitiesKHR>::Dispatch(manager, physicalDevice, mode, planeIndex, pCapabilities);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
     if (result < 0)
     {
         omit_output_data = true;
@@ -9129,7 +9129,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDisplaySurfaceCreateInfoKHR* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetInstanceTable(instance)->CreateDisplayPlaneSurfaceKHR(instance, pCreateInfo_unwrapped, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateDisplayPlaneSurfaceKHR(instance, pCreateInfo_unwrapped, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -9184,7 +9184,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSwapchainCreateInfoKHR* pCreateInfos_unwrapped = UnwrapStructArrayHandles(pCreateInfos, swapchainCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos_unwrapped, pAllocator, pSwapchains);
+    VkResult result = GetVulkanDeviceTable(device)->CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos_unwrapped, pAllocator, pSwapchains);
 
     if (result >= 0)
     {
@@ -9236,7 +9236,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -9285,7 +9285,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXlibPresentationSupportKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceXlibPresentationSupportKHR>::Dispatch(manager, physicalDevice, queueFamilyIndex, dpy, visualID);
 
-    VkBool32 result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID);
+    VkBool32 result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceXlibPresentationSupportKHR(physicalDevice, queueFamilyIndex, dpy, visualID);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceXlibPresentationSupportKHR);
     if (encoder)
@@ -9327,7 +9327,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -9376,7 +9376,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXcbPresentationSupportKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceXcbPresentationSupportKHR>::Dispatch(manager, physicalDevice, queueFamilyIndex, connection, visual_id);
 
-    VkBool32 result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id);
+    VkBool32 result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceXcbPresentationSupportKHR(physicalDevice, queueFamilyIndex, connection, visual_id);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceXcbPresentationSupportKHR);
     if (encoder)
@@ -9418,7 +9418,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -9466,7 +9466,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWaylandPresentationSupportKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR>::Dispatch(manager, physicalDevice, queueFamilyIndex, display);
 
-    VkBool32 result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display);
+    VkBool32 result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice, queueFamilyIndex, display);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR);
     if (encoder)
@@ -9507,7 +9507,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -9558,7 +9558,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -9605,7 +9605,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWin32PresentationSupportKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceWin32PresentationSupportKHR>::Dispatch(manager, physicalDevice, queueFamilyIndex);
 
-    VkBool32 result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceWin32PresentationSupportKHR(physicalDevice, queueFamilyIndex);
+    VkBool32 result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceWin32PresentationSupportKHR(physicalDevice, queueFamilyIndex);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceWin32PresentationSupportKHR);
     if (encoder)
@@ -9644,7 +9644,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoCapabilitiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoCapabilitiesKHR>::Dispatch(manager, physicalDevice, pVideoProfile, pCapabilities);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceVideoCapabilitiesKHR(physicalDevice, pVideoProfile, pCapabilities);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceVideoCapabilitiesKHR(physicalDevice, pVideoProfile, pCapabilities);
     if (result < 0)
     {
         omit_output_data = true;
@@ -9689,7 +9689,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoFormatPropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoFormatPropertiesKHR>::Dispatch(manager, physicalDevice, pVideoFormatInfo, pVideoFormatPropertyCount, pVideoFormatProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceVideoFormatPropertiesKHR(physicalDevice, pVideoFormatInfo, pVideoFormatPropertyCount, pVideoFormatProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceVideoFormatPropertiesKHR(physicalDevice, pVideoFormatInfo, pVideoFormatPropertyCount, pVideoFormatProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -9735,7 +9735,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateVideoSessionKHR>::Dispatch(manager, device, pCreateInfo, pAllocator, pVideoSession);
 
-    VkResult result = GetDeviceTable(device)->CreateVideoSessionKHR(device, pCreateInfo, pAllocator, pVideoSession);
+    VkResult result = GetVulkanDeviceTable(device)->CreateVideoSessionKHR(device, pCreateInfo, pAllocator, pVideoSession);
 
     if (result >= 0)
     {
@@ -9793,7 +9793,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyVideoSessionKHR(device, videoSession, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyVideoSessionKHR(device, videoSession, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionKHR>::Dispatch(manager, device, videoSession, pAllocator);
 
@@ -9824,7 +9824,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetVideoSessionMemoryRequirementsKHR>::Dispatch(manager, device, videoSession, pMemoryRequirementsCount, pMemoryRequirements);
 
-    VkResult result = GetDeviceTable(device)->GetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount, pMemoryRequirements);
+    VkResult result = GetVulkanDeviceTable(device)->GetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount, pMemoryRequirements);
     if (result < 0)
     {
         omit_output_data = true;
@@ -9871,7 +9871,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindVideoSessionMemoryKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindVideoSessionMemoryInfoKHR* pBindSessionMemoryInfos_unwrapped = UnwrapStructArrayHandles(pBindSessionMemoryInfos, bindSessionMemoryInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->BindVideoSessionMemoryKHR(device, videoSession, bindSessionMemoryInfoCount, pBindSessionMemoryInfos_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->BindVideoSessionMemoryKHR(device, videoSession, bindSessionMemoryInfoCount, pBindSessionMemoryInfos_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindVideoSessionMemoryKHR);
     if (encoder)
@@ -9916,7 +9916,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkVideoSessionParametersCreateInfoKHR* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateVideoSessionParametersKHR(device, pCreateInfo_unwrapped, pAllocator, pVideoSessionParameters);
+    VkResult result = GetVulkanDeviceTable(device)->CreateVideoSessionParametersKHR(device, pCreateInfo_unwrapped, pAllocator, pVideoSessionParameters);
 
     if (result >= 0)
     {
@@ -9964,7 +9964,7 @@ VKAPI_ATTR VkResult VKAPI_CALL UpdateVideoSessionParametersKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkUpdateVideoSessionParametersKHR>::Dispatch(manager, device, videoSessionParameters, pUpdateInfo);
 
-    VkResult result = GetDeviceTable(device)->UpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo);
+    VkResult result = GetVulkanDeviceTable(device)->UpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUpdateVideoSessionParametersKHR);
     if (encoder)
@@ -10012,7 +10012,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyVideoSessionParametersKHR(device, videoSessionParameters, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyVideoSessionParametersKHR(device, videoSessionParameters, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyVideoSessionParametersKHR>::Dispatch(manager, device, videoSessionParameters, pAllocator);
 
@@ -10050,7 +10050,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkVideoBeginCodingInfoKHR* pBeginInfo_unwrapped = UnwrapStructPtrHandles(pBeginInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBeginVideoCodingKHR(commandBuffer, pBeginInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginVideoCodingKHR(commandBuffer, pBeginInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginVideoCodingKHR>::Dispatch(manager, commandBuffer, pBeginInfo);
 }
@@ -10083,7 +10083,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndVideoCodingKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndVideoCodingKHR(commandBuffer, pEndCodingInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndVideoCodingKHR(commandBuffer, pEndCodingInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndVideoCodingKHR>::Dispatch(manager, commandBuffer, pEndCodingInfo);
 }
@@ -10116,7 +10116,7 @@ VKAPI_ATTR void VKAPI_CALL CmdControlVideoCodingKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdControlVideoCodingKHR(commandBuffer, pCodingControlInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdControlVideoCodingKHR(commandBuffer, pCodingControlInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdControlVideoCodingKHR>::Dispatch(manager, commandBuffer, pCodingControlInfo);
 }
@@ -10152,7 +10152,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDecodeVideoKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkVideoDecodeInfoKHR* pDecodeInfo_unwrapped = UnwrapStructPtrHandles(pDecodeInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdDecodeVideoKHR(commandBuffer, pDecodeInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdDecodeVideoKHR(commandBuffer, pDecodeInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDecodeVideoKHR>::Dispatch(manager, commandBuffer, pDecodeInfo);
 }
@@ -10188,7 +10188,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderingKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkRenderingInfo* pRenderingInfo_unwrapped = UnwrapStructPtrHandles(pRenderingInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBeginRenderingKHR(commandBuffer, pRenderingInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginRenderingKHR(commandBuffer, pRenderingInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderingKHR>::Dispatch(manager, commandBuffer, pRenderingInfo);
 }
@@ -10219,7 +10219,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderingKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndRenderingKHR(commandBuffer);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndRenderingKHR(commandBuffer);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderingKHR>::Dispatch(manager, commandBuffer);
 }
@@ -10244,7 +10244,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2KHR>::Dispatch(manager, physicalDevice, pFeatures);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2KHR);
     if (encoder)
@@ -10277,7 +10277,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2KHR>::Dispatch(manager, physicalDevice, pProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceProperties2KHR(physicalDevice, pProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceProperties2KHR(physicalDevice, pProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2KHR);
     if (encoder)
@@ -10311,7 +10311,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2KHR>::Dispatch(manager, physicalDevice, format, pFormatProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2KHR);
     if (encoder)
@@ -10348,7 +10348,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2KHR>::Dispatch(manager, physicalDevice, pImageFormatInfo, pImageFormatProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -10424,7 +10424,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2KHR>::Dispatch(manager, physicalDevice, pMemoryProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2KHR);
     if (encoder)
@@ -10459,7 +10459,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2KHR>::Dispatch(manager, physicalDevice, pFormatInfo, pPropertyCount, pProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2KHR);
     if (encoder)
@@ -10497,7 +10497,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeaturesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeaturesKHR>::Dispatch(manager, device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
 
-    GetDeviceTable(device)->GetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
+    GetVulkanDeviceTable(device)->GetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeaturesKHR);
     if (encoder)
@@ -10541,7 +10541,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDeviceMaskKHR(commandBuffer, deviceMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDeviceMaskKHR(commandBuffer, deviceMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDeviceMaskKHR>::Dispatch(manager, commandBuffer, deviceMask);
 }
@@ -10584,7 +10584,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+    GetVulkanDeviceTable(commandBuffer)->CmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatchBaseKHR>::Dispatch(manager, commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 }
@@ -10619,7 +10619,7 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->TrimCommandPoolKHR(device, commandPool, flags);
+    GetVulkanDeviceTable(device)->TrimCommandPoolKHR(device, commandPool, flags);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTrimCommandPoolKHR>::Dispatch(manager, device, commandPool, flags);
 }
@@ -10647,7 +10647,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroupsKHR>::Dispatch(manager, instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
 
-    VkResult result = GetInstanceTable(instance)->EnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
+    VkResult result = GetVulkanInstanceTable(instance)->EnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties);
 
     if (result >= 0)
     {
@@ -10694,7 +10694,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferPropertiesKHR>::Dispatch(manager, physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferPropertiesKHR);
     if (encoder)
@@ -10734,7 +10734,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo_unwrapped = UnwrapStructPtrHandles(pGetWin32HandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryWin32HandleKHR(device, pGetWin32HandleInfo_unwrapped, pHandle);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryWin32HandleKHR(device, pGetWin32HandleInfo_unwrapped, pHandle);
     if (result < 0)
     {
         omit_output_data = true;
@@ -10779,7 +10779,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetMemoryWin32HandlePropertiesKHR>::Dispatch(manager, device, handleType, handle, pMemoryWin32HandleProperties);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -10827,7 +10827,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMemoryGetFdInfoKHR* pGetFdInfo_unwrapped = UnwrapStructPtrHandles(pGetFdInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryFdKHR(device, pGetFdInfo_unwrapped, pFd);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryFdKHR(device, pGetFdInfo_unwrapped, pFd);
     if (result < 0)
     {
         omit_output_data = true;
@@ -10872,7 +10872,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetMemoryFdPropertiesKHR>::Dispatch(manager, device, handleType, fd, pMemoryFdProperties);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -10915,7 +10915,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphorePropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>::Dispatch(manager, physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR);
     if (encoder)
@@ -10952,7 +10952,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo_unwrapped = UnwrapStructPtrHandles(pImportSemaphoreWin32HandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->ImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->ImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreWin32HandleKHR);
     if (encoder)
@@ -10994,7 +10994,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo_unwrapped = UnwrapStructPtrHandles(pGetWin32HandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo_unwrapped, pHandle);
+    VkResult result = GetVulkanDeviceTable(device)->GetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo_unwrapped, pHandle);
     if (result < 0)
     {
         omit_output_data = true;
@@ -11038,7 +11038,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo_unwrapped = UnwrapStructPtrHandles(pImportSemaphoreFdInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->ImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->ImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreFdKHR);
     if (encoder)
@@ -11080,7 +11080,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSemaphoreGetFdInfoKHR* pGetFdInfo_unwrapped = UnwrapStructPtrHandles(pGetFdInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetSemaphoreFdKHR(device, pGetFdInfo_unwrapped, pFd);
+    VkResult result = GetVulkanDeviceTable(device)->GetSemaphoreFdKHR(device, pGetFdInfo_unwrapped, pFd);
     if (result < 0)
     {
         omit_output_data = true;
@@ -11140,7 +11140,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkWriteDescriptorSet* pDescriptorWrites_unwrapped = UnwrapStructArrayHandles(pDescriptorWrites, descriptorWriteCount, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR>::Dispatch(manager, commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
 }
@@ -11172,7 +11172,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateDescriptorUpdateTemplateKHR(device, pCreateInfo_unwrapped, pAllocator, pDescriptorUpdateTemplate);
+    VkResult result = GetVulkanDeviceTable(device)->CreateDescriptorUpdateTemplateKHR(device, pCreateInfo_unwrapped, pAllocator, pDescriptorUpdateTemplate);
 
     if (result >= 0)
     {
@@ -11230,7 +11230,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(manager, device, descriptorUpdateTemplate, pAllocator);
 
@@ -11261,7 +11261,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateRenderPass2KHR>::Dispatch(manager, device, pCreateInfo, pAllocator, pRenderPass);
 
-    VkResult result = GetDeviceTable(device)->CreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
+    VkResult result = GetVulkanDeviceTable(device)->CreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
 
     if (result >= 0)
     {
@@ -11321,7 +11321,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkRenderPassBeginInfo* pRenderPassBegin_unwrapped = UnwrapStructPtrHandles(pRenderPassBegin, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin_unwrapped, pSubpassBeginInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin_unwrapped, pSubpassBeginInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR>::Dispatch(manager, commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 }
@@ -11356,7 +11356,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR>::Dispatch(manager, commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 }
@@ -11389,7 +11389,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR>::Dispatch(manager, commandBuffer, pSubpassEndInfo);
 }
@@ -11414,7 +11414,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainStatusKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetSwapchainStatusKHR>::Dispatch(manager, device, swapchain);
 
-    VkResult result = GetDeviceTable(device)->GetSwapchainStatusKHR(device, swapchain);
+    VkResult result = GetVulkanDeviceTable(device)->GetSwapchainStatusKHR(device, swapchain);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetSwapchainStatusKHR);
     if (encoder)
@@ -11451,7 +11451,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFencePropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFencePropertiesKHR>::Dispatch(manager, physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFencePropertiesKHR);
     if (encoder)
@@ -11488,7 +11488,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo_unwrapped = UnwrapStructPtrHandles(pImportFenceWin32HandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->ImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->ImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportFenceWin32HandleKHR);
     if (encoder)
@@ -11530,7 +11530,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo_unwrapped = UnwrapStructPtrHandles(pGetWin32HandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetFenceWin32HandleKHR(device, pGetWin32HandleInfo_unwrapped, pHandle);
+    VkResult result = GetVulkanDeviceTable(device)->GetFenceWin32HandleKHR(device, pGetWin32HandleInfo_unwrapped, pHandle);
     if (result < 0)
     {
         omit_output_data = true;
@@ -11574,7 +11574,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImportFenceFdInfoKHR* pImportFenceFdInfo_unwrapped = UnwrapStructPtrHandles(pImportFenceFdInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->ImportFenceFdKHR(device, pImportFenceFdInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->ImportFenceFdKHR(device, pImportFenceFdInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportFenceFdKHR);
     if (encoder)
@@ -11616,7 +11616,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceFdKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkFenceGetFdInfoKHR* pGetFdInfo_unwrapped = UnwrapStructPtrHandles(pGetFdInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetFenceFdKHR(device, pGetFdInfo_unwrapped, pFd);
+    VkResult result = GetVulkanDeviceTable(device)->GetFenceFdKHR(device, pGetFdInfo_unwrapped, pFd);
     if (result < 0)
     {
         omit_output_data = true;
@@ -11662,7 +11662,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceQueueFamilyPerformanceQuer
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>::Dispatch(manager, physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions);
 
-    VkResult result = GetInstanceTable(physicalDevice)->EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions);
     if (result < 0)
     {
         omit_output_data = true;
@@ -11706,7 +11706,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR>::Dispatch(manager, physicalDevice, pPerformanceQueryCreateInfo, pNumPasses);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, pPerformanceQueryCreateInfo, pNumPasses);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR);
     if (encoder)
@@ -11740,7 +11740,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireProfilingLockKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAcquireProfilingLockKHR>::Dispatch(manager, device, pInfo);
 
-    VkResult result = GetDeviceTable(device)->AcquireProfilingLockKHR(device, pInfo);
+    VkResult result = GetVulkanDeviceTable(device)->AcquireProfilingLockKHR(device, pInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireProfilingLockKHR);
     if (encoder)
@@ -11782,7 +11782,7 @@ VKAPI_ATTR void VKAPI_CALL ReleaseProfilingLockKHR(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->ReleaseProfilingLockKHR(device);
+    GetVulkanDeviceTable(device)->ReleaseProfilingLockKHR(device);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkReleaseProfilingLockKHR>::Dispatch(manager, device);
 }
@@ -11813,7 +11813,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo_unwrapped = UnwrapStructPtrHandles(pSurfaceInfo, handle_unwrap_memory);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo_unwrapped, pSurfaceCapabilities);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo_unwrapped, pSurfaceCapabilities);
     if (result < 0)
     {
         omit_output_data = true;
@@ -11861,7 +11861,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo_unwrapped = UnwrapStructPtrHandles(pSurfaceInfo, handle_unwrap_memory);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo_unwrapped, pSurfaceFormatCount, pSurfaceFormats);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo_unwrapped, pSurfaceFormatCount, pSurfaceFormats);
     if (result < 0)
     {
         omit_output_data = true;
@@ -11906,7 +11906,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR>::Dispatch(manager, physicalDevice, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties);
 
     if (result >= 0)
     {
@@ -11955,7 +11955,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR>::Dispatch(manager, physicalDevice, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties);
 
     if (result >= 0)
     {
@@ -12005,7 +12005,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR>::Dispatch(manager, physicalDevice, display, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties);
 
     if (result >= 0)
     {
@@ -12058,7 +12058,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilities2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo_unwrapped = UnwrapStructPtrHandles(pDisplayPlaneInfo, handle_unwrap_memory);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo_unwrapped, pCapabilities);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo_unwrapped, pCapabilities);
     if (result < 0)
     {
         omit_output_data = true;
@@ -12103,7 +12103,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImageMemoryRequirementsInfo2* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetImageMemoryRequirements2KHR(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetImageMemoryRequirements2KHR(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2KHR);
     if (encoder)
@@ -12141,7 +12141,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferMemoryRequirementsInfo2* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetBufferMemoryRequirements2KHR(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetBufferMemoryRequirements2KHR(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2KHR);
     if (encoder)
@@ -12180,7 +12180,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImageSparseMemoryRequirementsInfo2* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetImageSparseMemoryRequirements2KHR(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetImageSparseMemoryRequirements2KHR(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2KHR);
     if (encoder)
@@ -12219,7 +12219,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR>::Dispatch(manager, device, pCreateInfo, pAllocator, pYcbcrConversion);
 
-    VkResult result = GetDeviceTable(device)->CreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion);
+    VkResult result = GetVulkanDeviceTable(device)->CreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion);
 
     if (result >= 0)
     {
@@ -12277,7 +12277,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
+    GetVulkanDeviceTable(device)->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(manager, device, ycbcrConversion, pAllocator);
 
@@ -12308,7 +12308,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindBufferMemoryInfo* pBindInfos_unwrapped = UnwrapStructArrayHandles(pBindInfos, bindInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->BindBufferMemory2KHR(device, bindInfoCount, pBindInfos_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->BindBufferMemory2KHR(device, bindInfoCount, pBindInfos_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindBufferMemory2KHR);
     if (encoder)
@@ -12349,7 +12349,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindImageMemoryInfo* pBindInfos_unwrapped = UnwrapStructArrayHandles(pBindInfos, bindInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->BindImageMemory2KHR(device, bindInfoCount, pBindInfos_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->BindImageMemory2KHR(device, bindInfoCount, pBindInfos_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindImageMemory2KHR);
     if (encoder)
@@ -12390,7 +12390,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDescriptorSetLayoutCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDescriptorSetLayoutSupportKHR(device, pCreateInfo_unwrapped, pSupport);
+    GetVulkanDeviceTable(device)->GetDescriptorSetLayoutSupportKHR(device, pCreateInfo_unwrapped, pSupport);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupportKHR);
     if (encoder)
@@ -12442,7 +12442,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndirectCountKHRHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectCountKHR>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -12485,7 +12485,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndexedIndirectCountKHRHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountKHR>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -12513,7 +12513,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetSemaphoreCounterValueKHR>::Dispatch(manager, device, semaphore, pValue);
 
-    VkResult result = GetDeviceTable(device)->GetSemaphoreCounterValueKHR(device, semaphore, pValue);
+    VkResult result = GetVulkanDeviceTable(device)->GetSemaphoreCounterValueKHR(device, semaphore, pValue);
     if (result < 0)
     {
         omit_output_data = true;
@@ -12558,7 +12558,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSemaphoreWaitInfo* pWaitInfo_unwrapped = UnwrapStructPtrHandles(pWaitInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->WaitSemaphoresKHR(device, pWaitInfo_unwrapped, timeout);
+    VkResult result = GetVulkanDeviceTable(device)->WaitSemaphoresKHR(device, pWaitInfo_unwrapped, timeout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitSemaphoresKHR);
     if (encoder)
@@ -12598,7 +12598,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphoreKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSemaphoreSignalInfo* pSignalInfo_unwrapped = UnwrapStructPtrHandles(pSignalInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->SignalSemaphoreKHR(device, pSignalInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->SignalSemaphoreKHR(device, pSignalInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSignalSemaphoreKHR);
     if (encoder)
@@ -12637,7 +12637,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceFragmentShadingRatesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceFragmentShadingRatesKHR>::Dispatch(manager, physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates);
     if (result < 0)
     {
         omit_output_data = true;
@@ -12688,7 +12688,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateKHR>::Dispatch(manager, commandBuffer, pFragmentSize, combinerOps);
 }
@@ -12721,7 +12721,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingAttachmentLocationsKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRenderingAttachmentLocationsKHR(commandBuffer, pLocationInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRenderingAttachmentLocationsKHR(commandBuffer, pLocationInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRenderingAttachmentLocationsKHR>::Dispatch(manager, commandBuffer, pLocationInfo);
 }
@@ -12754,7 +12754,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingInputAttachmentIndicesKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRenderingInputAttachmentIndicesKHR(commandBuffer, pLocationInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRenderingInputAttachmentIndicesKHR(commandBuffer, pLocationInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRenderingInputAttachmentIndicesKHR>::Dispatch(manager, commandBuffer, pLocationInfo);
 }
@@ -12781,7 +12781,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForPresentKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkWaitForPresentKHR>::Dispatch(manager, device, swapchain, presentId, timeout);
 
-    VkResult result = GetDeviceTable(device)->WaitForPresentKHR(device, swapchain, presentId, timeout);
+    VkResult result = GetVulkanDeviceTable(device)->WaitForPresentKHR(device, swapchain, presentId, timeout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkWaitForPresentKHR);
     if (encoder)
@@ -12822,7 +12822,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferDeviceAddressInfo* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkDeviceAddress result = GetDeviceTable(device)->GetBufferDeviceAddressKHR(device, pInfo_unwrapped);
+    VkDeviceAddress result = GetVulkanDeviceTable(device)->GetBufferDeviceAddressKHR(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddressKHR);
     if (encoder)
@@ -12861,7 +12861,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddressKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferDeviceAddressInfo* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    uint64_t result = GetDeviceTable(device)->GetBufferOpaqueCaptureAddressKHR(device, pInfo_unwrapped);
+    uint64_t result = GetVulkanDeviceTable(device)->GetBufferOpaqueCaptureAddressKHR(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddressKHR);
     if (encoder)
@@ -12900,7 +12900,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddressKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    uint64_t result = GetDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo_unwrapped);
+    uint64_t result = GetVulkanDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddressKHR);
     if (encoder)
@@ -12939,7 +12939,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDeferredOperationKHR>::Dispatch(manager, device, pAllocator, pDeferredOperation);
 
-    VkResult result = GetDeviceTable(device)->CreateDeferredOperationKHR(device, pAllocator, pDeferredOperation);
+    VkResult result = GetVulkanDeviceTable(device)->CreateDeferredOperationKHR(device, pAllocator, pDeferredOperation);
 
     if (result >= 0)
     {
@@ -12996,7 +12996,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyDeferredOperationKHR(device, operation, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyDeferredOperationKHR(device, operation, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR>::Dispatch(manager, device, operation, pAllocator);
 
@@ -13023,7 +13023,7 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeferredOperationMaxConcurrencyKHR>::Dispatch(manager, device, operation);
 
-    uint32_t result = GetDeviceTable(device)->GetDeferredOperationMaxConcurrencyKHR(device, operation);
+    uint32_t result = GetVulkanDeviceTable(device)->GetDeferredOperationMaxConcurrencyKHR(device, operation);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeferredOperationMaxConcurrencyKHR);
     if (encoder)
@@ -13138,7 +13138,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPipelineInfoKHR* pPipelineInfo_unwrapped = UnwrapStructPtrHandles(pPipelineInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetPipelineExecutablePropertiesKHR(device, pPipelineInfo_unwrapped, pExecutableCount, pProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetPipelineExecutablePropertiesKHR(device, pPipelineInfo_unwrapped, pExecutableCount, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -13187,7 +13187,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableStatisticsKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPipelineExecutableInfoKHR* pExecutableInfo_unwrapped = UnwrapStructPtrHandles(pExecutableInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetPipelineExecutableStatisticsKHR(device, pExecutableInfo_unwrapped, pStatisticCount, pStatistics);
+    VkResult result = GetVulkanDeviceTable(device)->GetPipelineExecutableStatisticsKHR(device, pExecutableInfo_unwrapped, pStatisticCount, pStatistics);
     if (result < 0)
     {
         omit_output_data = true;
@@ -13236,7 +13236,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableInternalRepresentationsKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPipelineExecutableInfoKHR* pExecutableInfo_unwrapped = UnwrapStructPtrHandles(pExecutableInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo_unwrapped, pInternalRepresentationCount, pInternalRepresentations);
+    VkResult result = GetVulkanDeviceTable(device)->GetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo_unwrapped, pInternalRepresentationCount, pInternalRepresentations);
     if (result < 0)
     {
         omit_output_data = true;
@@ -13284,7 +13284,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMemoryMapInfoKHR* pMemoryMapInfo_unwrapped = UnwrapStructPtrHandles(pMemoryMapInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->MapMemory2KHR(device, pMemoryMapInfo_unwrapped, ppData);
+    VkResult result = GetVulkanDeviceTable(device)->MapMemory2KHR(device, pMemoryMapInfo_unwrapped, ppData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -13328,7 +13328,7 @@ VKAPI_ATTR VkResult VKAPI_CALL UnmapMemory2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo_unwrapped = UnwrapStructPtrHandles(pMemoryUnmapInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->UnmapMemory2KHR(device, pMemoryUnmapInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->UnmapMemory2KHR(device, pMemoryUnmapInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkUnmapMemory2KHR);
     if (encoder)
@@ -13367,7 +13367,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoEncodeQualityLevelPropertie
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR>::Dispatch(manager, physicalDevice, pQualityLevelInfo, pQualityLevelProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(physicalDevice, pQualityLevelInfo, pQualityLevelProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(physicalDevice, pQualityLevelInfo, pQualityLevelProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -13416,7 +13416,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEncodedVideoSessionParametersKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkVideoEncodeSessionParametersGetInfoKHR* pVideoSessionParametersInfo_unwrapped = UnwrapStructPtrHandles(pVideoSessionParametersInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetEncodedVideoSessionParametersKHR(device, pVideoSessionParametersInfo_unwrapped, pFeedbackInfo, pDataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetEncodedVideoSessionParametersKHR(device, pVideoSessionParametersInfo_unwrapped, pFeedbackInfo, pDataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -13470,7 +13470,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEncodeVideoKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkVideoEncodeInfoKHR* pEncodeInfo_unwrapped = UnwrapStructPtrHandles(pEncodeInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdEncodeVideoKHR(commandBuffer, pEncodeInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdEncodeVideoKHR(commandBuffer, pEncodeInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEncodeVideoKHR>::Dispatch(manager, commandBuffer, pEncodeInfo);
 }
@@ -13508,7 +13508,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDependencyInfo* pDependencyInfo_unwrapped = UnwrapStructPtrHandles(pDependencyInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdSetEvent2KHR(commandBuffer, event, pDependencyInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetEvent2KHR(commandBuffer, event, pDependencyInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetEvent2KHR>::Dispatch(manager, commandBuffer, event, pDependencyInfo);
 }
@@ -13543,7 +13543,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2KHR(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdResetEvent2KHRHandles, event);
     }
 
-    GetDeviceTable(commandBuffer)->CmdResetEvent2KHR(commandBuffer, event, stageMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdResetEvent2KHR(commandBuffer, event, stageMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResetEvent2KHR>::Dispatch(manager, commandBuffer, event, stageMask);
 }
@@ -13583,7 +13583,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDependencyInfo* pDependencyInfos_unwrapped = UnwrapStructArrayHandles(pDependencyInfos, eventCount, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWaitEvents2KHR>::Dispatch(manager, commandBuffer, eventCount, pEvents, pDependencyInfos);
 }
@@ -13619,7 +13619,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDependencyInfo* pDependencyInfo_unwrapped = UnwrapStructPtrHandles(pDependencyInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier2KHR>::Dispatch(manager, commandBuffer, pDependencyInfo);
 }
@@ -13656,7 +13656,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteTimestamp2KHRHandles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp2KHR>::Dispatch(manager, commandBuffer, stage, queryPool, query);
 }
@@ -13686,7 +13686,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSubmitInfo2* pSubmits_unwrapped = UnwrapStructArrayHandles(pSubmits, submitCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(queue)->QueueSubmit2KHR(queue, submitCount, pSubmits_unwrapped, fence);
+    VkResult result = GetVulkanDeviceTable(queue)->QueueSubmit2KHR(queue, submitCount, pSubmits_unwrapped, fence);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSubmit2KHR);
     if (encoder)
@@ -13738,7 +13738,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarker2AMD(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteBufferMarker2AMDHandles, dstBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteBufferMarker2AMD>::Dispatch(manager, commandBuffer, stage, dstBuffer, dstOffset, marker);
 }
@@ -13764,7 +13764,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointData2NV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetQueueCheckpointData2NV>::Dispatch(manager, queue, pCheckpointDataCount, pCheckpointData);
 
-    GetDeviceTable(queue)->GetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData);
+    GetVulkanDeviceTable(queue)->GetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueueCheckpointData2NV);
     if (encoder)
@@ -13809,7 +13809,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyBufferInfo2* pCopyBufferInfo_unwrapped = UnwrapStructPtrHandles(pCopyBufferInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBuffer2KHR>::Dispatch(manager, commandBuffer, pCopyBufferInfo);
 }
@@ -13845,7 +13845,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyImageInfo2* pCopyImageInfo_unwrapped = UnwrapStructPtrHandles(pCopyImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyImage2KHR(commandBuffer, pCopyImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyImage2KHR(commandBuffer, pCopyImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImage2KHR>::Dispatch(manager, commandBuffer, pCopyImageInfo);
 }
@@ -13881,7 +13881,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo_unwrapped = UnwrapStructPtrHandles(pCopyBufferToImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2KHR>::Dispatch(manager, commandBuffer, pCopyBufferToImageInfo);
 }
@@ -13917,7 +13917,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo_unwrapped = UnwrapStructPtrHandles(pCopyImageToBufferInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2KHR>::Dispatch(manager, commandBuffer, pCopyImageToBufferInfo);
 }
@@ -13953,7 +13953,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBlitImageInfo2* pBlitImageInfo_unwrapped = UnwrapStructPtrHandles(pBlitImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBlitImage2KHR(commandBuffer, pBlitImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBlitImage2KHR(commandBuffer, pBlitImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBlitImage2KHR>::Dispatch(manager, commandBuffer, pBlitImageInfo);
 }
@@ -13989,7 +13989,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkResolveImageInfo2* pResolveImageInfo_unwrapped = UnwrapStructPtrHandles(pResolveImageInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdResolveImage2KHR(commandBuffer, pResolveImageInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdResolveImage2KHR(commandBuffer, pResolveImageInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResolveImage2KHR>::Dispatch(manager, commandBuffer, pResolveImageInfo);
 }
@@ -14022,7 +14022,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirect2KHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdTraceRaysIndirect2KHR(commandBuffer, indirectDeviceAddress);
+    GetVulkanDeviceTable(commandBuffer)->CmdTraceRaysIndirect2KHR(commandBuffer, indirectDeviceAddress);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdTraceRaysIndirect2KHR>::Dispatch(manager, commandBuffer, indirectDeviceAddress);
 }
@@ -14048,7 +14048,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirementsKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirementsKHR>::Dispatch(manager, device, pInfo, pMemoryRequirements);
 
-    GetDeviceTable(device)->GetDeviceBufferMemoryRequirementsKHR(device, pInfo, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetDeviceBufferMemoryRequirementsKHR(device, pInfo, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirementsKHR);
     if (encoder)
@@ -14086,7 +14086,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirementsKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDeviceImageMemoryRequirements* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDeviceImageMemoryRequirementsKHR(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetDeviceImageMemoryRequirementsKHR(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirementsKHR);
     if (encoder)
@@ -14125,7 +14125,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirementsKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDeviceImageMemoryRequirements* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDeviceImageSparseMemoryRequirementsKHR(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetDeviceImageSparseMemoryRequirementsKHR(device, pInfo_unwrapped, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirementsKHR);
     if (encoder)
@@ -14174,7 +14174,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer2KHR(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindIndexBuffer2KHRHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindIndexBuffer2KHR>::Dispatch(manager, commandBuffer, buffer, offset, size, indexType);
 }
@@ -14200,7 +14200,7 @@ VKAPI_ATTR void VKAPI_CALL GetRenderingAreaGranularityKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRenderingAreaGranularityKHR>::Dispatch(manager, device, pRenderingAreaInfo, pGranularity);
 
-    GetDeviceTable(device)->GetRenderingAreaGranularityKHR(device, pRenderingAreaInfo, pGranularity);
+    GetVulkanDeviceTable(device)->GetRenderingAreaGranularityKHR(device, pRenderingAreaInfo, pGranularity);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRenderingAreaGranularityKHR);
     if (encoder)
@@ -14238,7 +14238,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSubresourceLayoutKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDeviceImageSubresourceInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDeviceImageSubresourceLayoutKHR(device, pInfo_unwrapped, pLayout);
+    GetVulkanDeviceTable(device)->GetDeviceImageSubresourceLayoutKHR(device, pInfo_unwrapped, pLayout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceImageSubresourceLayoutKHR);
     if (encoder)
@@ -14274,7 +14274,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2KHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2KHR>::Dispatch(manager, device, image, pSubresource, pLayout);
 
-    GetDeviceTable(device)->GetImageSubresourceLayout2KHR(device, image, pSubresource, pLayout);
+    GetVulkanDeviceTable(device)->GetImageSubresourceLayout2KHR(device, image, pSubresource, pLayout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2KHR);
     if (encoder)
@@ -14312,7 +14312,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR>::Dispatch(manager, physicalDevice, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -14363,7 +14363,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetLineStippleKHR(commandBuffer, lineStippleFactor, lineStipplePattern);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetLineStippleKHR(commandBuffer, lineStippleFactor, lineStipplePattern);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLineStippleKHR>::Dispatch(manager, commandBuffer, lineStippleFactor, lineStipplePattern);
 }
@@ -14391,7 +14391,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR>::Dispatch(manager, physicalDevice, pTimeDomainCount, pTimeDomains);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsKHR(physicalDevice, pTimeDomainCount, pTimeDomains);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsKHR(physicalDevice, pTimeDomainCount, pTimeDomains);
     if (result < 0)
     {
         omit_output_data = true;
@@ -14437,7 +14437,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetCalibratedTimestampsKHR>::Dispatch(manager, device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
 
-    VkResult result = GetDeviceTable(device)->GetCalibratedTimestampsKHR(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
+    VkResult result = GetVulkanDeviceTable(device)->GetCalibratedTimestampsKHR(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
     if (result < 0)
     {
         omit_output_data = true;
@@ -14491,7 +14491,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo_unwrapped = UnwrapStructPtrHandles(pBindDescriptorSetsInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBindDescriptorSets2KHR(commandBuffer, pBindDescriptorSetsInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindDescriptorSets2KHR(commandBuffer, pBindDescriptorSetsInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindDescriptorSets2KHR>::Dispatch(manager, commandBuffer, pBindDescriptorSetsInfo);
 }
@@ -14527,7 +14527,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPushConstantsInfoKHR* pPushConstantsInfo_unwrapped = UnwrapStructPtrHandles(pPushConstantsInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPushConstants2KHR(commandBuffer, pPushConstantsInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPushConstants2KHR(commandBuffer, pPushConstantsInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushConstants2KHR>::Dispatch(manager, commandBuffer, pPushConstantsInfo);
 }
@@ -14563,7 +14563,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSet2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo_unwrapped = UnwrapStructPtrHandles(pPushDescriptorSetInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPushDescriptorSet2KHR(commandBuffer, pPushDescriptorSetInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPushDescriptorSet2KHR(commandBuffer, pPushDescriptorSetInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSet2KHR>::Dispatch(manager, commandBuffer, pPushDescriptorSetInfo);
 }
@@ -14599,7 +14599,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo_unwrapped = UnwrapStructPtrHandles(pPushDescriptorSetWithTemplateInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR>::Dispatch(manager, commandBuffer, pPushDescriptorSetWithTemplateInfo);
 }
@@ -14635,7 +14635,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDescriptorBufferOffsets2EXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo_unwrapped = UnwrapStructPtrHandles(pSetDescriptorBufferOffsetsInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdSetDescriptorBufferOffsets2EXT(commandBuffer, pSetDescriptorBufferOffsetsInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDescriptorBufferOffsets2EXT(commandBuffer, pSetDescriptorBufferOffsetsInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDescriptorBufferOffsets2EXT>::Dispatch(manager, commandBuffer, pSetDescriptorBufferOffsetsInfo);
 }
@@ -14671,7 +14671,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorBufferEmbeddedSamplers2EXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo_unwrapped = UnwrapStructPtrHandles(pBindDescriptorBufferEmbeddedSamplersInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBindDescriptorBufferEmbeddedSamplers2EXT(commandBuffer, pBindDescriptorBufferEmbeddedSamplersInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindDescriptorBufferEmbeddedSamplers2EXT(commandBuffer, pBindDescriptorBufferEmbeddedSamplersInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT>::Dispatch(manager, commandBuffer, pBindDescriptorBufferEmbeddedSamplersInfo);
 }
@@ -14706,7 +14706,7 @@ VKAPI_ATTR void VKAPI_CALL FrameBoundaryANDROID(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->FrameBoundaryANDROID(device, semaphore, image);
+    GetVulkanDeviceTable(device)->FrameBoundaryANDROID(device, semaphore, image);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFrameBoundaryANDROID>::Dispatch(manager, device, semaphore, image);
 }
@@ -14735,7 +14735,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT>::Dispatch(manager, instance, pCreateInfo, pAllocator, pCallback);
 
-    VkResult result = GetInstanceTable(instance)->CreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
 
     if (result >= 0)
     {
@@ -14793,7 +14793,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetInstanceTable(instance)->DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
+    GetVulkanInstanceTable(instance)->DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(manager, instance, callback, pAllocator);
 
@@ -14840,7 +14840,7 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
         manager->EndApiCallCapture();
     }
 
-    GetInstanceTable(instance)->DebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
+    GetVulkanInstanceTable(instance)->DebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDebugReportMessageEXT>::Dispatch(manager, instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
 }
@@ -14868,7 +14868,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDebugMarkerObjectTagInfoEXT* pTagInfo_unwrapped = UnwrapStructPtrHandles(pTagInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->DebugMarkerSetObjectTagEXT(device, pTagInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->DebugMarkerSetObjectTagEXT(device, pTagInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectTagEXT);
     if (encoder)
@@ -14907,7 +14907,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDebugMarkerObjectNameInfoEXT* pNameInfo_unwrapped = UnwrapStructPtrHandles(pNameInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->DebugMarkerSetObjectNameEXT(device, pNameInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->DebugMarkerSetObjectNameEXT(device, pNameInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectNameEXT);
     if (encoder)
@@ -14951,7 +14951,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT>::Dispatch(manager, commandBuffer, pMarkerInfo);
 }
@@ -14982,7 +14982,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDebugMarkerEndEXT(commandBuffer);
+    GetVulkanDeviceTable(commandBuffer)->CmdDebugMarkerEndEXT(commandBuffer);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerEndEXT>::Dispatch(manager, commandBuffer);
 }
@@ -15015,7 +15015,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT>::Dispatch(manager, commandBuffer, pMarkerInfo);
 }
@@ -15056,7 +15056,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindTransformFeedbackBuffersEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindTransformFeedbackBuffersEXTHandles, bindingCount, pBuffers);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindTransformFeedbackBuffersEXT>::Dispatch(manager, commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes);
 }
@@ -15095,7 +15095,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginTransformFeedbackEXT>::Dispatch(manager, commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
 }
@@ -15134,7 +15134,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndTransformFeedbackEXT>::Dispatch(manager, commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
 }
@@ -15173,7 +15173,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBeginQueryIndexedEXTHandles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginQueryIndexedEXT>::Dispatch(manager, commandBuffer, queryPool, query, flags, index);
 }
@@ -15210,7 +15210,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdEndQueryIndexedEXTHandles, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndQueryIndexedEXT>::Dispatch(manager, commandBuffer, queryPool, query, index);
 }
@@ -15253,7 +15253,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndirectByteCountEXTHandles, counterBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectByteCountEXT>::Dispatch(manager, commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
 }
@@ -15281,7 +15281,7 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImageViewHandleInfoNVX* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    uint32_t result = GetDeviceTable(device)->GetImageViewHandleNVX(device, pInfo_unwrapped);
+    uint32_t result = GetVulkanDeviceTable(device)->GetImageViewHandleNVX(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageViewHandleNVX);
     if (encoder)
@@ -15320,7 +15320,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageViewAddressNVX(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageViewAddressNVX>::Dispatch(manager, device, imageView, pProperties);
 
-    VkResult result = GetDeviceTable(device)->GetImageViewAddressNVX(device, imageView, pProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetImageViewAddressNVX(device, imageView, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -15379,7 +15379,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndirectCountAMDHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -15422,7 +15422,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawIndexedIndirectCountAMDHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountAMD>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -15453,7 +15453,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderInfoAMD(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetShaderInfoAMD>::Dispatch(manager, device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
 
-    VkResult result = GetDeviceTable(device)->GetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
+    VkResult result = GetVulkanDeviceTable(device)->GetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
     if (result < 0)
     {
         omit_output_data = true;
@@ -15501,7 +15501,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateStreamDescriptorSurfaceGGP(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateStreamDescriptorSurfaceGGP>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateStreamDescriptorSurfaceGGP(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateStreamDescriptorSurfaceGGP(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -15556,7 +15556,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalImageFormatPropertiesNV>::Dispatch(manager, physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -15606,7 +15606,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetMemoryWin32HandleNV>::Dispatch(manager, device, memory, handleType, pHandle);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryWin32HandleNV(device, memory, handleType, pHandle);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryWin32HandleNV(device, memory, handleType, pHandle);
     if (result < 0)
     {
         omit_output_data = true;
@@ -15652,7 +15652,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateViSurfaceNN>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -15710,7 +15710,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin_unwrapped = UnwrapStructPtrHandles(pConditionalRenderingBegin, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginConditionalRenderingEXT>::Dispatch(manager, commandBuffer, pConditionalRenderingBegin);
 }
@@ -15741,7 +15741,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndConditionalRenderingEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndConditionalRenderingEXT(commandBuffer);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndConditionalRenderingEXT(commandBuffer);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndConditionalRenderingEXT>::Dispatch(manager, commandBuffer);
 }
@@ -15778,7 +15778,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportWScalingNV>::Dispatch(manager, commandBuffer, firstViewport, viewportCount, pViewportWScalings);
 }
@@ -15803,7 +15803,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkReleaseDisplayEXT>::Dispatch(manager, physicalDevice, display);
 
-    VkResult result = GetInstanceTable(physicalDevice)->ReleaseDisplayEXT(physicalDevice, display);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->ReleaseDisplayEXT(physicalDevice, display);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseDisplayEXT);
     if (encoder)
@@ -15840,7 +15840,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAcquireXlibDisplayEXT>::Dispatch(manager, physicalDevice, dpy, display);
 
-    VkResult result = GetInstanceTable(physicalDevice)->AcquireXlibDisplayEXT(physicalDevice, dpy, display);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->AcquireXlibDisplayEXT(physicalDevice, dpy, display);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireXlibDisplayEXT);
     if (encoder)
@@ -15881,7 +15881,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT>::Dispatch(manager, physicalDevice, dpy, rrOutput, pDisplay);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay);
 
     if (result >= 0)
     {
@@ -15931,7 +15931,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2EXT>::Dispatch(manager, physicalDevice, surface, pSurfaceCapabilities);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities);
     if (result < 0)
     {
         omit_output_data = true;
@@ -15973,7 +15973,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDisplayPowerControlEXT>::Dispatch(manager, device, display, pDisplayPowerInfo);
 
-    VkResult result = GetDeviceTable(device)->DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
+    VkResult result = GetVulkanDeviceTable(device)->DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDisplayPowerControlEXT);
     if (encoder)
@@ -16014,7 +16014,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkRegisterDeviceEventEXT>::Dispatch(manager, device, pDeviceEventInfo, pAllocator, pFence);
 
-    VkResult result = GetDeviceTable(device)->RegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence);
+    VkResult result = GetVulkanDeviceTable(device)->RegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence);
 
     if (result >= 0)
     {
@@ -16066,7 +16066,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkRegisterDisplayEventEXT>::Dispatch(manager, device, display, pDisplayEventInfo, pAllocator, pFence);
 
-    VkResult result = GetDeviceTable(device)->RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
+    VkResult result = GetVulkanDeviceTable(device)->RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
 
     if (result >= 0)
     {
@@ -16118,7 +16118,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainCounterEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetSwapchainCounterEXT>::Dispatch(manager, device, swapchain, counter, pCounterValue);
 
-    VkResult result = GetDeviceTable(device)->GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
+    VkResult result = GetVulkanDeviceTable(device)->GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
     if (result < 0)
     {
         omit_output_data = true;
@@ -16163,7 +16163,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRefreshCycleDurationGOOGLE>::Dispatch(manager, device, swapchain, pDisplayTimingProperties);
 
-    VkResult result = GetDeviceTable(device)->GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -16208,7 +16208,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPastPresentationTimingGOOGLE>::Dispatch(manager, device, swapchain, pPresentationTimingCount, pPresentationTimings);
 
-    VkResult result = GetDeviceTable(device)->GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings);
+    VkResult result = GetVulkanDeviceTable(device)->GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings);
     if (result < 0)
     {
         omit_output_data = true;
@@ -16262,7 +16262,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEXT>::Dispatch(manager, commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
 }
@@ -16295,7 +16295,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDiscardRectangleEnableEXT(commandBuffer, discardRectangleEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDiscardRectangleEnableEXT(commandBuffer, discardRectangleEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEnableEXT>::Dispatch(manager, commandBuffer, discardRectangleEnable);
 }
@@ -16328,7 +16328,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleModeEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDiscardRectangleModeEXT(commandBuffer, discardRectangleMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDiscardRectangleModeEXT(commandBuffer, discardRectangleMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleModeEXT>::Dispatch(manager, commandBuffer, discardRectangleMode);
 }
@@ -16365,7 +16365,7 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->SetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
+    GetVulkanDeviceTable(device)->SetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetHdrMetadataEXT>::Dispatch(manager, device, swapchainCount, pSwapchains, pMetadata);
 }
@@ -16394,7 +16394,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -16445,7 +16445,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -16497,7 +16497,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
 
     auto device_wrapper = GetWrapper<DeviceWrapper>(device);
     auto physical_device = device_wrapper->physical_device->handle;
-    VkResult result = GetInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT(device, pNameInfo_unwrapped);
+    VkResult result = GetVulkanInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT(device, pNameInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT);
     if (encoder)
@@ -16538,7 +16538,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
 
     auto device_wrapper = GetWrapper<DeviceWrapper>(device);
     auto physical_device = device_wrapper->physical_device->handle;
-    VkResult result = GetInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT(device, pTagInfo_unwrapped);
+    VkResult result = GetVulkanInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT(device, pTagInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTagEXT);
     if (encoder)
@@ -16582,7 +16582,7 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(queue)->QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
+    GetVulkanDeviceTable(queue)->QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT>::Dispatch(manager, queue, pLabelInfo);
 }
@@ -16613,7 +16613,7 @@ VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(queue)->QueueEndDebugUtilsLabelEXT(queue);
+    GetVulkanDeviceTable(queue)->QueueEndDebugUtilsLabelEXT(queue);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueEndDebugUtilsLabelEXT>::Dispatch(manager, queue);
 }
@@ -16646,7 +16646,7 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(queue)->QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
+    GetVulkanDeviceTable(queue)->QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT>::Dispatch(manager, queue, pLabelInfo);
 }
@@ -16679,7 +16679,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT>::Dispatch(manager, commandBuffer, pLabelInfo);
 }
@@ -16710,7 +16710,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdEndDebugUtilsLabelEXT(commandBuffer);
+    GetVulkanDeviceTable(commandBuffer)->CmdEndDebugUtilsLabelEXT(commandBuffer);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndDebugUtilsLabelEXT>::Dispatch(manager, commandBuffer);
 }
@@ -16743,7 +16743,7 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT>::Dispatch(manager, commandBuffer, pLabelInfo);
 }
@@ -16772,7 +16772,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT>::Dispatch(manager, instance, pCreateInfo, pAllocator, pMessenger);
 
-    VkResult result = GetInstanceTable(instance)->CreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
 
     if (result >= 0)
     {
@@ -16830,7 +16830,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetInstanceTable(instance)->DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
+    GetVulkanInstanceTable(instance)->DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(manager, instance, messenger, pAllocator);
 
@@ -16869,7 +16869,7 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
         manager->EndApiCallCapture();
     }
 
-    GetInstanceTable(instance)->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData);
+    GetVulkanInstanceTable(instance)->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT>::Dispatch(manager, instance, messageSeverity, messageTypes, pCallbackData);
 }
@@ -16897,7 +16897,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetAndroidHardwareBufferPropertiesANDROID>::Dispatch(manager, device, buffer, pProperties);
 
-    VkResult result = GetDeviceTable(device)->GetAndroidHardwareBufferPropertiesANDROID(device, buffer, pProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetAndroidHardwareBufferPropertiesANDROID(device, buffer, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -16944,7 +16944,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryAndroidHardwareBufferANDROID(device, pInfo_unwrapped, pBuffer);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryAndroidHardwareBufferANDROID(device, pInfo_unwrapped, pBuffer);
     if (result < 0)
     {
         omit_output_data = true;
@@ -16993,7 +16993,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT>::Dispatch(manager, commandBuffer, pSampleLocationsInfo);
 }
@@ -17019,7 +17019,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMultisamplePropertiesEXT>::Dispatch(manager, physicalDevice, samples, pMultisampleProperties);
 
-    GetInstanceTable(physicalDevice)->GetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties);
+    GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, pMultisampleProperties);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceMultisamplePropertiesEXT);
     if (encoder)
@@ -17056,7 +17056,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageDrmFormatModifierPropertiesEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageDrmFormatModifierPropertiesEXT>::Dispatch(manager, device, image, pProperties);
 
-    VkResult result = GetDeviceTable(device)->GetImageDrmFormatModifierPropertiesEXT(device, image, pProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetImageDrmFormatModifierPropertiesEXT(device, image, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -17101,7 +17101,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateValidationCacheEXT>::Dispatch(manager, device, pCreateInfo, pAllocator, pValidationCache);
 
-    VkResult result = GetDeviceTable(device)->CreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache);
+    VkResult result = GetVulkanDeviceTable(device)->CreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache);
 
     if (result >= 0)
     {
@@ -17159,7 +17159,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyValidationCacheEXT(device, validationCache, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyValidationCacheEXT(device, validationCache, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(manager, device, validationCache, pAllocator);
 
@@ -17188,7 +17188,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkMergeValidationCachesEXT>::Dispatch(manager, device, dstCache, srcCacheCount, pSrcCaches);
 
-    VkResult result = GetDeviceTable(device)->MergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches);
+    VkResult result = GetVulkanDeviceTable(device)->MergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkMergeValidationCachesEXT);
     if (encoder)
@@ -17230,7 +17230,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetValidationCacheDataEXT>::Dispatch(manager, device, validationCache, pDataSize, pData);
 
-    VkResult result = GetDeviceTable(device)->GetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -17282,7 +17282,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindShadingRateImageNVHandles, imageView);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindShadingRateImageNV>::Dispatch(manager, commandBuffer, imageView, imageLayout);
 }
@@ -17319,7 +17319,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportShadingRatePaletteNV>::Dispatch(manager, commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
 }
@@ -17356,7 +17356,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoarseSampleOrderNV>::Dispatch(manager, commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
 }
@@ -17388,7 +17388,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkAccelerationStructureCreateInfoNV* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateAccelerationStructureNV(device, pCreateInfo_unwrapped, pAllocator, pAccelerationStructure);
+    VkResult result = GetVulkanDeviceTable(device)->CreateAccelerationStructureNV(device, pCreateInfo_unwrapped, pAllocator, pAccelerationStructure);
 
     if (result >= 0)
     {
@@ -17446,7 +17446,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyAccelerationStructureNV(device, accelerationStructure, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyAccelerationStructureNV(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
@@ -17477,7 +17477,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetAccelerationStructureMemoryRequirementsNV(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetAccelerationStructureMemoryRequirementsNV(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureMemoryRequirementsNV);
     if (encoder)
@@ -17515,7 +17515,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindAccelerationStructureMemoryNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBindAccelerationStructureMemoryInfoNV* pBindInfos_unwrapped = UnwrapStructArrayHandles(pBindInfos, bindInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->BindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->BindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindAccelerationStructureMemoryNV);
     if (encoder)
@@ -17577,7 +17577,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkAccelerationStructureInfoNV* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBuildAccelerationStructureNV(commandBuffer, pInfo_unwrapped, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
+    GetVulkanDeviceTable(commandBuffer)->CmdBuildAccelerationStructureNV(commandBuffer, pInfo_unwrapped, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructureNV>::Dispatch(manager, commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
 }
@@ -17614,7 +17614,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdCopyAccelerationStructureNVHandles, dst, src);
     }
 
-    GetDeviceTable(commandBuffer)->CmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureNV>::Dispatch(manager, commandBuffer, dst, src, mode);
 }
@@ -17673,7 +17673,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdTraceRaysNVHandles, raygenShaderBindingTableBuffer, missShaderBindingTableBuffer, hitShaderBindingTableBuffer, callableShaderBindingTableBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
+    GetVulkanDeviceTable(commandBuffer)->CmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdTraceRaysNV>::Dispatch(manager, commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
 }
@@ -17704,7 +17704,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesKHR>::Dispatch(manager, device, pipeline, firstGroup, groupCount, dataSize, pData);
 
-    VkResult result = GetDeviceTable(device)->GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -17754,7 +17754,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesNV>::Dispatch(manager, device, pipeline, firstGroup, groupCount, dataSize, pData);
 
-    VkResult result = GetDeviceTable(device)->GetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -17802,7 +17802,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAccelerationStructureHandleNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetAccelerationStructureHandleNV>::Dispatch(manager, device, accelerationStructure, dataSize, pData);
 
-    VkResult result = GetDeviceTable(device)->GetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -17860,7 +17860,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteAccelerationStructuresPropertiesNVHandles, accelerationStructureCount, pAccelerationStructures, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesNV>::Dispatch(manager, commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
 }
@@ -17886,7 +17886,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CompileDeferredNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCompileDeferredNV>::Dispatch(manager, device, pipeline, shader);
 
-    VkResult result = GetDeviceTable(device)->CompileDeferredNV(device, pipeline, shader);
+    VkResult result = GetVulkanDeviceTable(device)->CompileDeferredNV(device, pipeline, shader);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCompileDeferredNV);
     if (encoder)
@@ -17927,7 +17927,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetMemoryHostPointerPropertiesEXT>::Dispatch(manager, device, handleType, pHostPointer, pMemoryHostPointerProperties);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -17983,7 +17983,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteBufferMarkerAMDHandles, dstBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteBufferMarkerAMD>::Dispatch(manager, commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
 }
@@ -18011,7 +18011,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT>::Dispatch(manager, physicalDevice, pTimeDomainCount, pTimeDomains);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains);
     if (result < 0)
     {
         omit_output_data = true;
@@ -18057,7 +18057,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetCalibratedTimestampsEXT>::Dispatch(manager, device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
 
-    VkResult result = GetDeviceTable(device)->GetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
+    VkResult result = GetVulkanDeviceTable(device)->GetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
     if (result < 0)
     {
         omit_output_data = true;
@@ -18110,7 +18110,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksNV>::Dispatch(manager, commandBuffer, taskCount, firstTask);
 }
@@ -18149,7 +18149,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawMeshTasksIndirectNVHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectNV>::Dispatch(manager, commandBuffer, buffer, offset, drawCount, stride);
 }
@@ -18192,7 +18192,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawMeshTasksIndirectCountNVHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountNV>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -18229,7 +18229,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorEnableNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetExclusiveScissorEnableNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissorEnables);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetExclusiveScissorEnableNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissorEnables);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorEnableNV>::Dispatch(manager, commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissorEnables);
 }
@@ -18266,7 +18266,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorNV>::Dispatch(manager, commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
 }
@@ -18299,7 +18299,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCheckpointNV>::Dispatch(manager, commandBuffer, pCheckpointMarker);
 }
@@ -18325,7 +18325,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetQueueCheckpointDataNV>::Dispatch(manager, queue, pCheckpointDataCount, pCheckpointData);
 
-    GetDeviceTable(queue)->GetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData);
+    GetVulkanDeviceTable(queue)->GetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetQueueCheckpointDataNV);
     if (encoder)
@@ -18359,7 +18359,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InitializePerformanceApiINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkInitializePerformanceApiINTEL>::Dispatch(manager, device, pInitializeInfo);
 
-    VkResult result = GetDeviceTable(device)->InitializePerformanceApiINTEL(device, pInitializeInfo);
+    VkResult result = GetVulkanDeviceTable(device)->InitializePerformanceApiINTEL(device, pInitializeInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkInitializePerformanceApiINTEL);
     if (encoder)
@@ -18401,7 +18401,7 @@ VKAPI_ATTR void VKAPI_CALL UninitializePerformanceApiINTEL(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->UninitializePerformanceApiINTEL(device);
+    GetVulkanDeviceTable(device)->UninitializePerformanceApiINTEL(device);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUninitializePerformanceApiINTEL>::Dispatch(manager, device);
 }
@@ -18426,7 +18426,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceMarkerINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetPerformanceMarkerINTEL>::Dispatch(manager, commandBuffer, pMarkerInfo);
 
-    VkResult result = GetDeviceTable(commandBuffer)->CmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo);
+    VkResult result = GetVulkanDeviceTable(commandBuffer)->CmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceMarkerINTEL);
     if (encoder)
@@ -18462,7 +18462,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceStreamMarkerINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetPerformanceStreamMarkerINTEL>::Dispatch(manager, commandBuffer, pMarkerInfo);
 
-    VkResult result = GetDeviceTable(commandBuffer)->CmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo);
+    VkResult result = GetVulkanDeviceTable(commandBuffer)->CmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceStreamMarkerINTEL);
     if (encoder)
@@ -18498,7 +18498,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceOverrideINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetPerformanceOverrideINTEL>::Dispatch(manager, commandBuffer, pOverrideInfo);
 
-    VkResult result = GetDeviceTable(commandBuffer)->CmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo);
+    VkResult result = GetVulkanDeviceTable(commandBuffer)->CmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdSetPerformanceOverrideINTEL);
     if (encoder)
@@ -18537,7 +18537,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAcquirePerformanceConfigurationINTEL>::Dispatch(manager, device, pAcquireInfo, pConfiguration);
 
-    VkResult result = GetDeviceTable(device)->AcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration);
+    VkResult result = GetVulkanDeviceTable(device)->AcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration);
 
     if (result >= 0)
     {
@@ -18584,7 +18584,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL>::Dispatch(manager, device, configuration);
 
     ScopedDestroyLock exclusive_scoped_lock;
-    VkResult result = GetDeviceTable(device)->ReleasePerformanceConfigurationINTEL(device, configuration);
+    VkResult result = GetVulkanDeviceTable(device)->ReleasePerformanceConfigurationINTEL(device, configuration);
 
     auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL);
     if (encoder)
@@ -18622,7 +18622,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSetPerformanceConfigurationINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSetPerformanceConfigurationINTEL>::Dispatch(manager, queue, configuration);
 
-    VkResult result = GetDeviceTable(queue)->QueueSetPerformanceConfigurationINTEL(queue, configuration);
+    VkResult result = GetVulkanDeviceTable(queue)->QueueSetPerformanceConfigurationINTEL(queue, configuration);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkQueueSetPerformanceConfigurationINTEL);
     if (encoder)
@@ -18661,7 +18661,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPerformanceParameterINTEL(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPerformanceParameterINTEL>::Dispatch(manager, device, parameter, pValue);
 
-    VkResult result = GetDeviceTable(device)->GetPerformanceParameterINTEL(device, parameter, pValue);
+    VkResult result = GetVulkanDeviceTable(device)->GetPerformanceParameterINTEL(device, parameter, pValue);
     if (result < 0)
     {
         omit_output_data = true;
@@ -18712,7 +18712,7 @@ VKAPI_ATTR void VKAPI_CALL SetLocalDimmingAMD(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->SetLocalDimmingAMD(device, swapChain, localDimmingEnable);
+    GetVulkanDeviceTable(device)->SetLocalDimmingAMD(device, swapChain, localDimmingEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetLocalDimmingAMD>::Dispatch(manager, device, swapChain, localDimmingEnable);
 }
@@ -18741,7 +18741,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateImagePipeSurfaceFUCHSIA(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateImagePipeSurfaceFUCHSIA(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -18792,7 +18792,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -18842,7 +18842,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkBufferDeviceAddressInfo* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkDeviceAddress result = GetDeviceTable(device)->GetBufferDeviceAddressEXT(device, pInfo_unwrapped);
+    VkDeviceAddress result = GetVulkanDeviceTable(device)->GetBufferDeviceAddressEXT(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetBufferDeviceAddressEXT);
     if (encoder)
@@ -18925,7 +18925,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV>::Dispatch(manager, physicalDevice, pPropertyCount, pProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -18969,7 +18969,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSupportedFramebufferMixedSamples
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV>::Dispatch(manager, physicalDevice, pCombinationCount, pCombinations);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations);
     if (result < 0)
     {
         omit_output_data = true;
@@ -19017,7 +19017,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModes2EXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo_unwrapped = UnwrapStructPtrHandles(pSurfaceInfo, handle_unwrap_memory);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo_unwrapped, pPresentModeCount, pPresentModes);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo_unwrapped, pPresentModeCount, pPresentModes);
     if (result < 0)
     {
         omit_output_data = true;
@@ -19059,7 +19059,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireFullScreenExclusiveModeEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAcquireFullScreenExclusiveModeEXT>::Dispatch(manager, device, swapchain);
 
-    VkResult result = GetDeviceTable(device)->AcquireFullScreenExclusiveModeEXT(device, swapchain);
+    VkResult result = GetVulkanDeviceTable(device)->AcquireFullScreenExclusiveModeEXT(device, swapchain);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireFullScreenExclusiveModeEXT);
     if (encoder)
@@ -19095,7 +19095,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseFullScreenExclusiveModeEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkReleaseFullScreenExclusiveModeEXT>::Dispatch(manager, device, swapchain);
 
-    VkResult result = GetDeviceTable(device)->ReleaseFullScreenExclusiveModeEXT(device, swapchain);
+    VkResult result = GetVulkanDeviceTable(device)->ReleaseFullScreenExclusiveModeEXT(device, swapchain);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseFullScreenExclusiveModeEXT);
     if (encoder)
@@ -19137,7 +19137,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo_unwrapped = UnwrapStructPtrHandles(pSurfaceInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo_unwrapped, pModes);
+    VkResult result = GetVulkanDeviceTable(device)->GetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo_unwrapped, pModes);
     if (result < 0)
     {
         omit_output_data = true;
@@ -19182,7 +19182,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateHeadlessSurfaceEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateHeadlessSurfaceEXT>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -19239,7 +19239,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLineStippleEXT>::Dispatch(manager, commandBuffer, lineStippleFactor, lineStipplePattern);
 }
@@ -19276,7 +19276,7 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPoolEXT(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->ResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
+    GetVulkanDeviceTable(device)->ResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetQueryPoolEXT>::Dispatch(manager, device, queryPool, firstQuery, queryCount);
 }
@@ -19309,7 +19309,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullModeEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCullModeEXT(commandBuffer, cullMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCullModeEXT(commandBuffer, cullMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCullModeEXT>::Dispatch(manager, commandBuffer, cullMode);
 }
@@ -19342,7 +19342,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFaceEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetFrontFaceEXT(commandBuffer, frontFace);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetFrontFaceEXT(commandBuffer, frontFace);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetFrontFaceEXT>::Dispatch(manager, commandBuffer, frontFace);
 }
@@ -19375,7 +19375,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopologyEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopologyEXT>::Dispatch(manager, commandBuffer, primitiveTopology);
 }
@@ -19410,7 +19410,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCountEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportWithCountEXT>::Dispatch(manager, commandBuffer, viewportCount, pViewports);
 }
@@ -19445,7 +19445,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCountEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetScissorWithCountEXT>::Dispatch(manager, commandBuffer, scissorCount, pScissors);
 }
@@ -19488,7 +19488,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2EXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindVertexBuffers2EXTHandles, bindingCount, pBuffers);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2EXT>::Dispatch(manager, commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
 }
@@ -19521,7 +19521,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthTestEnableEXT>::Dispatch(manager, commandBuffer, depthTestEnable);
 }
@@ -19554,7 +19554,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnableEXT>::Dispatch(manager, commandBuffer, depthWriteEnable);
 }
@@ -19587,7 +19587,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOpEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthCompareOpEXT>::Dispatch(manager, commandBuffer, depthCompareOp);
 }
@@ -19620,7 +19620,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnableEXT>::Dispatch(manager, commandBuffer, depthBoundsTestEnable);
 }
@@ -19653,7 +19653,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilTestEnableEXT>::Dispatch(manager, commandBuffer, stencilTestEnable);
 }
@@ -19694,7 +19694,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOpEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilOpEXT>::Dispatch(manager, commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
 }
@@ -19722,7 +19722,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToImageEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo_unwrapped = UnwrapStructPtrHandles(pCopyMemoryToImageInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyMemoryToImageEXT(device, pCopyMemoryToImageInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyMemoryToImageEXT(device, pCopyMemoryToImageInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToImageEXT);
     if (encoder)
@@ -19761,7 +19761,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToMemoryEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo_unwrapped = UnwrapStructPtrHandles(pCopyImageToMemoryInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyImageToMemoryEXT(device, pCopyImageToMemoryInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyImageToMemoryEXT(device, pCopyImageToMemoryInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyImageToMemoryEXT);
     if (encoder)
@@ -19800,7 +19800,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToImageEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo_unwrapped = UnwrapStructPtrHandles(pCopyImageToImageInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyImageToImageEXT(device, pCopyImageToImageInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyImageToImageEXT(device, pCopyImageToImageInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyImageToImageEXT);
     if (encoder)
@@ -19840,7 +19840,7 @@ VKAPI_ATTR VkResult VKAPI_CALL TransitionImageLayoutEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkHostImageLayoutTransitionInfoEXT* pTransitions_unwrapped = UnwrapStructArrayHandles(pTransitions, transitionCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->TransitionImageLayoutEXT(device, transitionCount, pTransitions_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->TransitionImageLayoutEXT(device, transitionCount, pTransitions_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkTransitionImageLayoutEXT);
     if (encoder)
@@ -19879,7 +19879,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2EXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2EXT>::Dispatch(manager, device, image, pSubresource, pLayout);
 
-    GetDeviceTable(device)->GetImageSubresourceLayout2EXT(device, image, pSubresource, pLayout);
+    GetVulkanDeviceTable(device)->GetImageSubresourceLayout2EXT(device, image, pSubresource, pLayout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetImageSubresourceLayout2EXT);
     if (encoder)
@@ -19917,7 +19917,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseSwapchainImagesEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo_unwrapped = UnwrapStructPtrHandles(pReleaseInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->ReleaseSwapchainImagesEXT(device, pReleaseInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->ReleaseSwapchainImagesEXT(device, pReleaseInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkReleaseSwapchainImagesEXT);
     if (encoder)
@@ -19957,7 +19957,7 @@ VKAPI_ATTR void VKAPI_CALL GetGeneratedCommandsMemoryRequirementsNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkGeneratedCommandsMemoryRequirementsInfoNV* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetGeneratedCommandsMemoryRequirementsNV(device, pInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetGeneratedCommandsMemoryRequirementsNV(device, pInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetGeneratedCommandsMemoryRequirementsNV);
     if (encoder)
@@ -20002,7 +20002,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPreprocessGeneratedCommandsNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo_unwrapped = UnwrapStructPtrHandles(pGeneratedCommandsInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPreprocessGeneratedCommandsNV>::Dispatch(manager, commandBuffer, pGeneratedCommandsInfo);
 }
@@ -20040,7 +20040,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteGeneratedCommandsNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo_unwrapped = UnwrapStructPtrHandles(pGeneratedCommandsInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdExecuteGeneratedCommandsNV>::Dispatch(manager, commandBuffer, isPreprocessed, pGeneratedCommandsInfo);
 }
@@ -20077,7 +20077,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipelineShaderGroupNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindPipelineShaderGroupNVHandles, pipeline);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindPipelineShaderGroupNV>::Dispatch(manager, commandBuffer, pipelineBindPoint, pipeline, groupIndex);
 }
@@ -20109,7 +20109,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkIndirectCommandsLayoutCreateInfoNV* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateIndirectCommandsLayoutNV(device, pCreateInfo_unwrapped, pAllocator, pIndirectCommandsLayout);
+    VkResult result = GetVulkanDeviceTable(device)->CreateIndirectCommandsLayoutNV(device, pCreateInfo_unwrapped, pAllocator, pIndirectCommandsLayout);
 
     if (result >= 0)
     {
@@ -20167,7 +20167,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV>::Dispatch(manager, device, indirectCommandsLayout, pAllocator);
 
@@ -20202,7 +20202,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthBias2EXT(commandBuffer, pDepthBiasInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthBias2EXT(commandBuffer, pDepthBiasInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBias2EXT>::Dispatch(manager, commandBuffer, pDepthBiasInfo);
 }
@@ -20228,7 +20228,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireDrmDisplayEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAcquireDrmDisplayEXT>::Dispatch(manager, physicalDevice, drmFd, display);
 
-    VkResult result = GetInstanceTable(physicalDevice)->AcquireDrmDisplayEXT(physicalDevice, drmFd, display);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->AcquireDrmDisplayEXT(physicalDevice, drmFd, display);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireDrmDisplayEXT);
     if (encoder)
@@ -20269,7 +20269,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDrmDisplayEXT>::Dispatch(manager, physicalDevice, drmFd, connectorId, display);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
 
     if (result >= 0)
     {
@@ -20320,7 +20320,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreatePrivateDataSlotEXT>::Dispatch(manager, device, pCreateInfo, pAllocator, pPrivateDataSlot);
 
-    VkResult result = GetDeviceTable(device)->CreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot);
+    VkResult result = GetVulkanDeviceTable(device)->CreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot);
 
     if (result >= 0)
     {
@@ -20378,7 +20378,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT>::Dispatch(manager, device, privateDataSlot, pAllocator);
 
@@ -20408,7 +20408,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetPrivateDataEXT>::Dispatch(manager, device, objectType, objectHandle, privateDataSlot, data);
 
-    VkResult result = GetDeviceTable(device)->SetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data);
+    VkResult result = GetVulkanDeviceTable(device)->SetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetPrivateDataEXT);
     if (encoder)
@@ -20450,7 +20450,7 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateDataEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPrivateDataEXT>::Dispatch(manager, device, objectType, objectHandle, privateDataSlot, pData);
 
-    GetDeviceTable(device)->GetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData);
+    GetVulkanDeviceTable(device)->GetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPrivateDataEXT);
     if (encoder)
@@ -20496,7 +20496,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateEnumNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateEnumNV>::Dispatch(manager, commandBuffer, shadingRate, combinerOps);
 }
@@ -20524,7 +20524,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceFaultInfoEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceFaultInfoEXT>::Dispatch(manager, device, pFaultCounts, pFaultInfo);
 
-    VkResult result = GetDeviceTable(device)->GetDeviceFaultInfoEXT(device, pFaultCounts, pFaultInfo);
+    VkResult result = GetVulkanDeviceTable(device)->GetDeviceFaultInfoEXT(device, pFaultCounts, pFaultInfo);
     if (result < 0)
     {
         omit_output_data = true;
@@ -20565,7 +20565,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireWinrtDisplayNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAcquireWinrtDisplayNV>::Dispatch(manager, physicalDevice, display);
 
-    VkResult result = GetInstanceTable(physicalDevice)->AcquireWinrtDisplayNV(physicalDevice, display);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->AcquireWinrtDisplayNV(physicalDevice, display);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkAcquireWinrtDisplayNV);
     if (encoder)
@@ -20604,7 +20604,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetWinrtDisplayNV>::Dispatch(manager, physicalDevice, deviceRelativeId, pDisplay);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
 
     if (result >= 0)
     {
@@ -20654,7 +20654,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDirectFBSurfaceEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDirectFBSurfaceEXT>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateDirectFBSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateDirectFBSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -20702,7 +20702,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceDirectFBPresentationSupportEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDirectFBPresentationSupportEXT>::Dispatch(manager, physicalDevice, queueFamilyIndex, dfb);
 
-    VkBool32 result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceDirectFBPresentationSupportEXT(physicalDevice, queueFamilyIndex, dfb);
+    VkBool32 result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceDirectFBPresentationSupportEXT(physicalDevice, queueFamilyIndex, dfb);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceDirectFBPresentationSupportEXT);
     if (encoder)
@@ -20753,7 +20753,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetVertexInputEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetVertexInputEXT>::Dispatch(manager, commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
 }
@@ -20784,7 +20784,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandleFUCHSIA(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMemoryGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo_unwrapped = UnwrapStructPtrHandles(pGetZirconHandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryZirconHandleFUCHSIA(device, pGetZirconHandleInfo_unwrapped, pZirconHandle);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryZirconHandleFUCHSIA(device, pGetZirconHandleInfo_unwrapped, pZirconHandle);
     if (result < 0)
     {
         omit_output_data = true;
@@ -20829,7 +20829,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandlePropertiesFUCHSIA(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetMemoryZirconHandlePropertiesFUCHSIA>::Dispatch(manager, device, handleType, zirconHandle, pMemoryZirconHandleProperties);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryZirconHandlePropertiesFUCHSIA(device, handleType, zirconHandle, pMemoryZirconHandleProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryZirconHandlePropertiesFUCHSIA(device, handleType, zirconHandle, pMemoryZirconHandleProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -20874,7 +20874,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreZirconHandleFUCHSIA(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo_unwrapped = UnwrapStructPtrHandles(pImportSemaphoreZirconHandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->ImportSemaphoreZirconHandleFUCHSIA(device, pImportSemaphoreZirconHandleInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->ImportSemaphoreZirconHandleFUCHSIA(device, pImportSemaphoreZirconHandleInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkImportSemaphoreZirconHandleFUCHSIA);
     if (encoder)
@@ -20916,7 +20916,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreZirconHandleFUCHSIA(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo_unwrapped = UnwrapStructPtrHandles(pGetZirconHandleInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetSemaphoreZirconHandleFUCHSIA(device, pGetZirconHandleInfo_unwrapped, pZirconHandle);
+    VkResult result = GetVulkanDeviceTable(device)->GetSemaphoreZirconHandleFUCHSIA(device, pGetZirconHandleInfo_unwrapped, pZirconHandle);
     if (result < 0)
     {
         omit_output_data = true;
@@ -20967,7 +20967,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindInvocationMaskHUAWEI(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindInvocationMaskHUAWEIHandles, imageView);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindInvocationMaskHUAWEI>::Dispatch(manager, commandBuffer, imageView, imageLayout);
 }
@@ -20998,7 +20998,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryRemoteAddressNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMemoryGetRemoteAddressInfoNV* pMemoryGetRemoteAddressInfo_unwrapped = UnwrapStructPtrHandles(pMemoryGetRemoteAddressInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetMemoryRemoteAddressNV(device, pMemoryGetRemoteAddressInfo_unwrapped, pAddress);
+    VkResult result = GetVulkanDeviceTable(device)->GetMemoryRemoteAddressNV(device, pMemoryGetRemoteAddressInfo_unwrapped, pAddress);
     if (result < 0)
     {
         omit_output_data = true;
@@ -21047,7 +21047,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPatchControlPointsEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetPatchControlPointsEXT>::Dispatch(manager, commandBuffer, patchControlPoints);
 }
@@ -21080,7 +21080,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnableEXT>::Dispatch(manager, commandBuffer, rasterizerDiscardEnable);
 }
@@ -21113,7 +21113,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnableEXT>::Dispatch(manager, commandBuffer, depthBiasEnable);
 }
@@ -21146,7 +21146,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetLogicOpEXT(commandBuffer, logicOp);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetLogicOpEXT(commandBuffer, logicOp);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLogicOpEXT>::Dispatch(manager, commandBuffer, logicOp);
 }
@@ -21179,7 +21179,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnableEXT>::Dispatch(manager, commandBuffer, primitiveRestartEnable);
 }
@@ -21208,7 +21208,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateScreenSurfaceQNX(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateScreenSurfaceQNX>::Dispatch(manager, instance, pCreateInfo, pAllocator, pSurface);
 
-    VkResult result = GetInstanceTable(instance)->CreateScreenSurfaceQNX(instance, pCreateInfo, pAllocator, pSurface);
+    VkResult result = GetVulkanInstanceTable(instance)->CreateScreenSurfaceQNX(instance, pCreateInfo, pAllocator, pSurface);
 
     if (result >= 0)
     {
@@ -21256,7 +21256,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceScreenPresentationSupportQNX(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceScreenPresentationSupportQNX>::Dispatch(manager, physicalDevice, queueFamilyIndex, window);
 
-    VkBool32 result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceScreenPresentationSupportQNX(physicalDevice, queueFamilyIndex, window);
+    VkBool32 result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceScreenPresentationSupportQNX(physicalDevice, queueFamilyIndex, window);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPhysicalDeviceScreenPresentationSupportQNX);
     if (encoder)
@@ -21303,7 +21303,7 @@ VKAPI_ATTR void                                    VKAPI_CALL CmdSetColorWriteEn
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetColorWriteEnableEXT>::Dispatch(manager, commandBuffer, attachmentCount, pColorWriteEnables);
 }
@@ -21344,7 +21344,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMultiEXT>::Dispatch(manager, commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride);
 }
@@ -21387,7 +21387,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiIndexedEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMultiIndexedEXT(commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride, pVertexOffset);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMultiIndexedEXT(commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride, pVertexOffset);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMultiIndexedEXT>::Dispatch(manager, commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride, pVertexOffset);
 }
@@ -21419,7 +21419,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMicromapEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMicromapCreateInfoEXT* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateMicromapEXT(device, pCreateInfo_unwrapped, pAllocator, pMicromap);
+    VkResult result = GetVulkanDeviceTable(device)->CreateMicromapEXT(device, pCreateInfo_unwrapped, pAllocator, pMicromap);
 
     if (result >= 0)
     {
@@ -21477,7 +21477,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyMicromapEXT(device, micromap, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyMicromapEXT(device, micromap, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyMicromapEXT>::Dispatch(manager, device, micromap, pAllocator);
 
@@ -21517,7 +21517,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMicromapBuildInfoEXT* pInfos_unwrapped = UnwrapStructArrayHandles(pInfos, infoCount, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBuildMicromapsEXT(commandBuffer, infoCount, pInfos_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdBuildMicromapsEXT(commandBuffer, infoCount, pInfos_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBuildMicromapsEXT>::Dispatch(manager, commandBuffer, infoCount, pInfos);
 }
@@ -21547,7 +21547,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BuildMicromapsEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMicromapBuildInfoEXT* pInfos_unwrapped = UnwrapStructArrayHandles(pInfos, infoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->BuildMicromapsEXT(device, deferredOperation, infoCount, pInfos_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->BuildMicromapsEXT(device, deferredOperation, infoCount, pInfos_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBuildMicromapsEXT);
     if (encoder)
@@ -21589,7 +21589,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMicromapInfoEXT* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyMicromapEXT(device, deferredOperation, pInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyMicromapEXT(device, deferredOperation, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMicromapEXT);
     if (encoder)
@@ -21630,7 +21630,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapToMemoryEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMicromapToMemoryInfoEXT* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyMicromapToMemoryEXT(device, deferredOperation, pInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyMicromapToMemoryEXT(device, deferredOperation, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMicromapToMemoryEXT);
     if (encoder)
@@ -21671,7 +21671,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToMicromapEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMemoryToMicromapInfoEXT* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyMemoryToMicromapEXT(device, deferredOperation, pInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyMemoryToMicromapEXT(device, deferredOperation, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToMicromapEXT);
     if (encoder)
@@ -21715,7 +21715,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteMicromapsPropertiesEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkWriteMicromapsPropertiesEXT>::Dispatch(manager, device, micromapCount, pMicromaps, queryType, dataSize, pData, stride);
 
-    VkResult result = GetDeviceTable(device)->WriteMicromapsPropertiesEXT(device, micromapCount, pMicromaps, queryType, dataSize, pData, stride);
+    VkResult result = GetVulkanDeviceTable(device)->WriteMicromapsPropertiesEXT(device, micromapCount, pMicromaps, queryType, dataSize, pData, stride);
     if (result < 0)
     {
         omit_output_data = true;
@@ -21771,7 +21771,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMicromapInfoEXT* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyMicromapEXT(commandBuffer, pInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyMicromapEXT(commandBuffer, pInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyMicromapEXT>::Dispatch(manager, commandBuffer, pInfo);
 }
@@ -21807,7 +21807,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapToMemoryEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMicromapToMemoryInfoEXT* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyMicromapToMemoryEXT(commandBuffer, pInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyMicromapToMemoryEXT(commandBuffer, pInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyMicromapToMemoryEXT>::Dispatch(manager, commandBuffer, pInfo);
 }
@@ -21843,7 +21843,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToMicromapEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMemoryToMicromapInfoEXT* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyMemoryToMicromapEXT(commandBuffer, pInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyMemoryToMicromapEXT(commandBuffer, pInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyMemoryToMicromapEXT>::Dispatch(manager, commandBuffer, pInfo);
 }
@@ -21884,7 +21884,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteMicromapsPropertiesEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteMicromapsPropertiesEXTHandles, micromapCount, pMicromaps, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteMicromapsPropertiesEXT(commandBuffer, micromapCount, pMicromaps, queryType, queryPool, firstQuery);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteMicromapsPropertiesEXT(commandBuffer, micromapCount, pMicromaps, queryType, queryPool, firstQuery);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteMicromapsPropertiesEXT>::Dispatch(manager, commandBuffer, micromapCount, pMicromaps, queryType, queryPool, firstQuery);
 }
@@ -21910,7 +21910,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMicromapCompatibilityEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceMicromapCompatibilityEXT>::Dispatch(manager, device, pVersionInfo, pCompatibility);
 
-    GetDeviceTable(device)->GetDeviceMicromapCompatibilityEXT(device, pVersionInfo, pCompatibility);
+    GetVulkanDeviceTable(device)->GetDeviceMicromapCompatibilityEXT(device, pVersionInfo, pCompatibility);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceMicromapCompatibilityEXT);
     if (encoder)
@@ -21949,7 +21949,7 @@ VKAPI_ATTR void VKAPI_CALL GetMicromapBuildSizesEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkMicromapBuildInfoEXT* pBuildInfo_unwrapped = UnwrapStructPtrHandles(pBuildInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetMicromapBuildSizesEXT(device, buildType, pBuildInfo_unwrapped, pSizeInfo);
+    GetVulkanDeviceTable(device)->GetMicromapBuildSizesEXT(device, buildType, pBuildInfo_unwrapped, pSizeInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetMicromapBuildSizesEXT);
     if (encoder)
@@ -21996,7 +21996,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterHUAWEI(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawClusterHUAWEI(commandBuffer, groupCountX, groupCountY, groupCountZ);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawClusterHUAWEI(commandBuffer, groupCountX, groupCountY, groupCountZ);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawClusterHUAWEI>::Dispatch(manager, commandBuffer, groupCountX, groupCountY, groupCountZ);
 }
@@ -22031,7 +22031,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterIndirectHUAWEI(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawClusterIndirectHUAWEIHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawClusterIndirectHUAWEI>::Dispatch(manager, commandBuffer, buffer, offset);
 }
@@ -22066,7 +22066,7 @@ VKAPI_ATTR void VKAPI_CALL SetDeviceMemoryPriorityEXT(
         manager->EndApiCallCapture();
     }
 
-    GetDeviceTable(device)->SetDeviceMemoryPriorityEXT(device, memory, priority);
+    GetVulkanDeviceTable(device)->SetDeviceMemoryPriorityEXT(device, memory, priority);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetDeviceMemoryPriorityEXT>::Dispatch(manager, device, memory, priority);
 }
@@ -22095,7 +22095,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutHostMappingInfoVALVE(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkDescriptorSetBindingReferenceVALVE* pBindingReference_unwrapped = UnwrapStructPtrHandles(pBindingReference, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetDescriptorSetLayoutHostMappingInfoVALVE(device, pBindingReference_unwrapped, pHostMapping);
+    GetVulkanDeviceTable(device)->GetDescriptorSetLayoutHostMappingInfoVALVE(device, pBindingReference_unwrapped, pHostMapping);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutHostMappingInfoVALVE);
     if (encoder)
@@ -22130,7 +22130,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetHostMappingVALVE(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDescriptorSetHostMappingVALVE>::Dispatch(manager, device, descriptorSet, ppData);
 
-    GetDeviceTable(device)->GetDescriptorSetHostMappingVALVE(device, descriptorSet, ppData);
+    GetVulkanDeviceTable(device)->GetDescriptorSetHostMappingVALVE(device, descriptorSet, ppData);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDescriptorSetHostMappingVALVE);
     if (encoder)
@@ -22168,7 +22168,7 @@ VKAPI_ATTR void VKAPI_CALL GetPipelineIndirectMemoryRequirementsNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkComputePipelineCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetPipelineIndirectMemoryRequirementsNV(device, pCreateInfo_unwrapped, pMemoryRequirements);
+    GetVulkanDeviceTable(device)->GetPipelineIndirectMemoryRequirementsNV(device, pCreateInfo_unwrapped, pMemoryRequirements);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineIndirectMemoryRequirementsNV);
     if (encoder)
@@ -22212,7 +22212,7 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdatePipelineIndirectBufferNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdUpdatePipelineIndirectBufferNVHandles, pipeline);
     }
 
-    GetDeviceTable(commandBuffer)->CmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
+    GetVulkanDeviceTable(commandBuffer)->CmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdUpdatePipelineIndirectBufferNV>::Dispatch(manager, commandBuffer, pipelineBindPoint, pipeline);
 }
@@ -22240,7 +22240,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetPipelineIndirectDeviceAddressNV(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkPipelineIndirectDeviceAddressInfoNV* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkDeviceAddress result = GetDeviceTable(device)->GetPipelineIndirectDeviceAddressNV(device, pInfo_unwrapped);
+    VkDeviceAddress result = GetVulkanDeviceTable(device)->GetPipelineIndirectDeviceAddressNV(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPipelineIndirectDeviceAddressNV);
     if (encoder)
@@ -22284,7 +22284,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClampEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthClampEnableEXT(commandBuffer, depthClampEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthClampEnableEXT(commandBuffer, depthClampEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthClampEnableEXT>::Dispatch(manager, commandBuffer, depthClampEnable);
 }
@@ -22317,7 +22317,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPolygonModeEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetPolygonModeEXT(commandBuffer, polygonMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetPolygonModeEXT(commandBuffer, polygonMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetPolygonModeEXT>::Dispatch(manager, commandBuffer, polygonMode);
 }
@@ -22350,7 +22350,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationSamplesEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRasterizationSamplesEXT(commandBuffer, rasterizationSamples);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRasterizationSamplesEXT(commandBuffer, rasterizationSamples);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRasterizationSamplesEXT>::Dispatch(manager, commandBuffer, rasterizationSamples);
 }
@@ -22385,7 +22385,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleMaskEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetSampleMaskEXT(commandBuffer, samples, pSampleMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetSampleMaskEXT(commandBuffer, samples, pSampleMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetSampleMaskEXT>::Dispatch(manager, commandBuffer, samples, pSampleMask);
 }
@@ -22418,7 +22418,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToCoverageEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetAlphaToCoverageEnableEXT(commandBuffer, alphaToCoverageEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetAlphaToCoverageEnableEXT(commandBuffer, alphaToCoverageEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetAlphaToCoverageEnableEXT>::Dispatch(manager, commandBuffer, alphaToCoverageEnable);
 }
@@ -22451,7 +22451,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToOneEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetAlphaToOneEnableEXT(commandBuffer, alphaToOneEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetAlphaToOneEnableEXT(commandBuffer, alphaToOneEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetAlphaToOneEnableEXT>::Dispatch(manager, commandBuffer, alphaToOneEnable);
 }
@@ -22484,7 +22484,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetLogicOpEnableEXT(commandBuffer, logicOpEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetLogicOpEnableEXT(commandBuffer, logicOpEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLogicOpEnableEXT>::Dispatch(manager, commandBuffer, logicOpEnable);
 }
@@ -22521,7 +22521,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetColorBlendEnableEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendEnables);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetColorBlendEnableEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendEnables);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetColorBlendEnableEXT>::Dispatch(manager, commandBuffer, firstAttachment, attachmentCount, pColorBlendEnables);
 }
@@ -22558,7 +22558,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEquationEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetColorBlendEquationEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendEquations);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetColorBlendEquationEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendEquations);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetColorBlendEquationEXT>::Dispatch(manager, commandBuffer, firstAttachment, attachmentCount, pColorBlendEquations);
 }
@@ -22595,7 +22595,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorWriteMaskEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetColorWriteMaskEXT(commandBuffer, firstAttachment, attachmentCount, pColorWriteMasks);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetColorWriteMaskEXT(commandBuffer, firstAttachment, attachmentCount, pColorWriteMasks);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetColorWriteMaskEXT>::Dispatch(manager, commandBuffer, firstAttachment, attachmentCount, pColorWriteMasks);
 }
@@ -22628,7 +22628,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetTessellationDomainOriginEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetTessellationDomainOriginEXT(commandBuffer, domainOrigin);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetTessellationDomainOriginEXT(commandBuffer, domainOrigin);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetTessellationDomainOriginEXT>::Dispatch(manager, commandBuffer, domainOrigin);
 }
@@ -22661,7 +22661,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationStreamEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRasterizationStreamEXT(commandBuffer, rasterizationStream);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRasterizationStreamEXT(commandBuffer, rasterizationStream);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRasterizationStreamEXT>::Dispatch(manager, commandBuffer, rasterizationStream);
 }
@@ -22694,7 +22694,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetConservativeRasterizationModeEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetConservativeRasterizationModeEXT(commandBuffer, conservativeRasterizationMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetConservativeRasterizationModeEXT(commandBuffer, conservativeRasterizationMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetConservativeRasterizationModeEXT>::Dispatch(manager, commandBuffer, conservativeRasterizationMode);
 }
@@ -22727,7 +22727,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExtraPrimitiveOverestimationSizeEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetExtraPrimitiveOverestimationSizeEXT(commandBuffer, extraPrimitiveOverestimationSize);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetExtraPrimitiveOverestimationSizeEXT(commandBuffer, extraPrimitiveOverestimationSize);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetExtraPrimitiveOverestimationSizeEXT>::Dispatch(manager, commandBuffer, extraPrimitiveOverestimationSize);
 }
@@ -22760,7 +22760,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthClipEnableEXT(commandBuffer, depthClipEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthClipEnableEXT(commandBuffer, depthClipEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthClipEnableEXT>::Dispatch(manager, commandBuffer, depthClipEnable);
 }
@@ -22793,7 +22793,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetSampleLocationsEnableEXT(commandBuffer, sampleLocationsEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetSampleLocationsEnableEXT(commandBuffer, sampleLocationsEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEnableEXT>::Dispatch(manager, commandBuffer, sampleLocationsEnable);
 }
@@ -22830,7 +22830,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendAdvancedEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetColorBlendAdvancedEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendAdvanced);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetColorBlendAdvancedEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendAdvanced);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetColorBlendAdvancedEXT>::Dispatch(manager, commandBuffer, firstAttachment, attachmentCount, pColorBlendAdvanced);
 }
@@ -22863,7 +22863,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetProvokingVertexModeEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetProvokingVertexModeEXT(commandBuffer, provokingVertexMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetProvokingVertexModeEXT(commandBuffer, provokingVertexMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetProvokingVertexModeEXT>::Dispatch(manager, commandBuffer, provokingVertexMode);
 }
@@ -22896,7 +22896,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineRasterizationModeEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetLineRasterizationModeEXT(commandBuffer, lineRasterizationMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetLineRasterizationModeEXT(commandBuffer, lineRasterizationMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLineRasterizationModeEXT>::Dispatch(manager, commandBuffer, lineRasterizationMode);
 }
@@ -22929,7 +22929,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetLineStippleEnableEXT(commandBuffer, stippledLineEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetLineStippleEnableEXT(commandBuffer, stippledLineEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLineStippleEnableEXT>::Dispatch(manager, commandBuffer, stippledLineEnable);
 }
@@ -22962,7 +22962,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipNegativeOneToOneEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetDepthClipNegativeOneToOneEXT(commandBuffer, negativeOneToOne);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetDepthClipNegativeOneToOneEXT(commandBuffer, negativeOneToOne);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthClipNegativeOneToOneEXT>::Dispatch(manager, commandBuffer, negativeOneToOne);
 }
@@ -22995,7 +22995,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingEnableNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetViewportWScalingEnableNV(commandBuffer, viewportWScalingEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetViewportWScalingEnableNV(commandBuffer, viewportWScalingEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportWScalingEnableNV>::Dispatch(manager, commandBuffer, viewportWScalingEnable);
 }
@@ -23032,7 +23032,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportSwizzleNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetViewportSwizzleNV(commandBuffer, firstViewport, viewportCount, pViewportSwizzles);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetViewportSwizzleNV(commandBuffer, firstViewport, viewportCount, pViewportSwizzles);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportSwizzleNV>::Dispatch(manager, commandBuffer, firstViewport, viewportCount, pViewportSwizzles);
 }
@@ -23065,7 +23065,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorEnableNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCoverageToColorEnableNV(commandBuffer, coverageToColorEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCoverageToColorEnableNV(commandBuffer, coverageToColorEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoverageToColorEnableNV>::Dispatch(manager, commandBuffer, coverageToColorEnable);
 }
@@ -23098,7 +23098,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorLocationNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCoverageToColorLocationNV(commandBuffer, coverageToColorLocation);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCoverageToColorLocationNV(commandBuffer, coverageToColorLocation);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoverageToColorLocationNV>::Dispatch(manager, commandBuffer, coverageToColorLocation);
 }
@@ -23131,7 +23131,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationModeNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCoverageModulationModeNV(commandBuffer, coverageModulationMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCoverageModulationModeNV(commandBuffer, coverageModulationMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoverageModulationModeNV>::Dispatch(manager, commandBuffer, coverageModulationMode);
 }
@@ -23164,7 +23164,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableEnableNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCoverageModulationTableEnableNV(commandBuffer, coverageModulationTableEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCoverageModulationTableEnableNV(commandBuffer, coverageModulationTableEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoverageModulationTableEnableNV>::Dispatch(manager, commandBuffer, coverageModulationTableEnable);
 }
@@ -23199,7 +23199,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCoverageModulationTableNV(commandBuffer, coverageModulationTableCount, pCoverageModulationTable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCoverageModulationTableNV(commandBuffer, coverageModulationTableCount, pCoverageModulationTable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoverageModulationTableNV>::Dispatch(manager, commandBuffer, coverageModulationTableCount, pCoverageModulationTable);
 }
@@ -23232,7 +23232,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetShadingRateImageEnableNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetShadingRateImageEnableNV(commandBuffer, shadingRateImageEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetShadingRateImageEnableNV(commandBuffer, shadingRateImageEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetShadingRateImageEnableNV>::Dispatch(manager, commandBuffer, shadingRateImageEnable);
 }
@@ -23265,7 +23265,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRepresentativeFragmentTestEnableNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRepresentativeFragmentTestEnableNV(commandBuffer, representativeFragmentTestEnable);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRepresentativeFragmentTestEnableNV(commandBuffer, representativeFragmentTestEnable);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRepresentativeFragmentTestEnableNV>::Dispatch(manager, commandBuffer, representativeFragmentTestEnable);
 }
@@ -23298,7 +23298,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageReductionModeNV(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetCoverageReductionModeNV(commandBuffer, coverageReductionMode);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetCoverageReductionModeNV(commandBuffer, coverageReductionMode);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoverageReductionModeNV>::Dispatch(manager, commandBuffer, coverageReductionMode);
 }
@@ -23324,7 +23324,7 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleIdentifierEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetShaderModuleIdentifierEXT>::Dispatch(manager, device, shaderModule, pIdentifier);
 
-    GetDeviceTable(device)->GetShaderModuleIdentifierEXT(device, shaderModule, pIdentifier);
+    GetVulkanDeviceTable(device)->GetShaderModuleIdentifierEXT(device, shaderModule, pIdentifier);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderModuleIdentifierEXT);
     if (encoder)
@@ -23362,7 +23362,7 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleCreateInfoIdentifierEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkShaderModuleCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetShaderModuleCreateInfoIdentifierEXT(device, pCreateInfo_unwrapped, pIdentifier);
+    GetVulkanDeviceTable(device)->GetShaderModuleCreateInfoIdentifierEXT(device, pCreateInfo_unwrapped, pIdentifier);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetShaderModuleCreateInfoIdentifierEXT);
     if (encoder)
@@ -23400,7 +23400,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceOpticalFlowImageFormatsNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceOpticalFlowImageFormatsNV>::Dispatch(manager, physicalDevice, pOpticalFlowImageFormatInfo, pFormatCount, pImageFormatProperties);
 
-    VkResult result = GetInstanceTable(physicalDevice)->GetPhysicalDeviceOpticalFlowImageFormatsNV(physicalDevice, pOpticalFlowImageFormatInfo, pFormatCount, pImageFormatProperties);
+    VkResult result = GetVulkanInstanceTable(physicalDevice)->GetPhysicalDeviceOpticalFlowImageFormatsNV(physicalDevice, pOpticalFlowImageFormatInfo, pFormatCount, pImageFormatProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -23446,7 +23446,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateOpticalFlowSessionNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateOpticalFlowSessionNV>::Dispatch(manager, device, pCreateInfo, pAllocator, pSession);
 
-    VkResult result = GetDeviceTable(device)->CreateOpticalFlowSessionNV(device, pCreateInfo, pAllocator, pSession);
+    VkResult result = GetVulkanDeviceTable(device)->CreateOpticalFlowSessionNV(device, pCreateInfo, pAllocator, pSession);
 
     if (result >= 0)
     {
@@ -23504,7 +23504,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyOpticalFlowSessionNV(device, session, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyOpticalFlowSessionNV(device, session, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyOpticalFlowSessionNV>::Dispatch(manager, device, session, pAllocator);
 
@@ -23534,7 +23534,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBindOpticalFlowSessionImageNV>::Dispatch(manager, device, session, bindingPoint, view, layout);
 
-    VkResult result = GetDeviceTable(device)->BindOpticalFlowSessionImageNV(device, session, bindingPoint, view, layout);
+    VkResult result = GetVulkanDeviceTable(device)->BindOpticalFlowSessionImageNV(device, session, bindingPoint, view, layout);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkBindOpticalFlowSessionImageNV);
     if (encoder)
@@ -23583,7 +23583,7 @@ VKAPI_ATTR void VKAPI_CALL CmdOpticalFlowExecuteNV(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdOpticalFlowExecuteNVHandles, session);
     }
 
-    GetDeviceTable(commandBuffer)->CmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
+    GetVulkanDeviceTable(commandBuffer)->CmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdOpticalFlowExecuteNV>::Dispatch(manager, commandBuffer, session, pExecuteInfo);
 }
@@ -23616,7 +23616,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkShaderCreateInfoEXT* pCreateInfos_unwrapped = UnwrapStructArrayHandles(pCreateInfos, createInfoCount, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CreateShadersEXT(device, createInfoCount, pCreateInfos_unwrapped, pAllocator, pShaders);
+    VkResult result = GetVulkanDeviceTable(device)->CreateShadersEXT(device, createInfoCount, pCreateInfos_unwrapped, pAllocator, pShaders);
 
     if (result >= 0)
     {
@@ -23675,7 +23675,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyShaderEXT(device, shader, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyShaderEXT(device, shader, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderEXT>::Dispatch(manager, device, shader, pAllocator);
 
@@ -23706,7 +23706,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetShaderBinaryDataEXT>::Dispatch(manager, device, shader, pDataSize, pData);
 
-    VkResult result = GetDeviceTable(device)->GetShaderBinaryDataEXT(device, shader, pDataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetShaderBinaryDataEXT(device, shader, pDataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -23760,7 +23760,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadersEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdBindShadersEXTHandles, stageCount, pShaders);
     }
 
-    GetDeviceTable(commandBuffer)->CmdBindShadersEXT(commandBuffer, stageCount, pStages, pShaders);
+    GetVulkanDeviceTable(commandBuffer)->CmdBindShadersEXT(commandBuffer, stageCount, pStages, pShaders);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindShadersEXT>::Dispatch(manager, commandBuffer, stageCount, pStages, pShaders);
 }
@@ -23789,7 +23789,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFramebufferTilePropertiesQCOM(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetFramebufferTilePropertiesQCOM>::Dispatch(manager, device, framebuffer, pPropertiesCount, pProperties);
 
-    VkResult result = GetDeviceTable(device)->GetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -23837,7 +23837,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDynamicRenderingTilePropertiesQCOM(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkRenderingInfo* pRenderingInfo_unwrapped = UnwrapStructPtrHandles(pRenderingInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->GetDynamicRenderingTilePropertiesQCOM(device, pRenderingInfo_unwrapped, pProperties);
+    VkResult result = GetVulkanDeviceTable(device)->GetDynamicRenderingTilePropertiesQCOM(device, pRenderingInfo_unwrapped, pProperties);
     if (result < 0)
     {
         omit_output_data = true;
@@ -24068,7 +24068,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAttachmentFeedbackLoopEnableEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetAttachmentFeedbackLoopEnableEXT(commandBuffer, aspectMask);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetAttachmentFeedbackLoopEnableEXT(commandBuffer, aspectMask);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetAttachmentFeedbackLoopEnableEXT>::Dispatch(manager, commandBuffer, aspectMask);
 }
@@ -24150,7 +24150,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
     }
 
     ScopedDestroyLock exclusive_scoped_lock;
-    GetDeviceTable(device)->DestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator);
+    GetVulkanDeviceTable(device)->DestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR>::Dispatch(manager, device, accelerationStructure, pAllocator);
 
@@ -24233,7 +24233,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkAccelerationStructureBuildGeometryInfoKHR* pInfos_unwrapped = UnwrapStructArrayHandles(pInfos, infoCount, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos_unwrapped, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
+    GetVulkanDeviceTable(commandBuffer)->CmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos_unwrapped, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresIndirectKHR>::Dispatch(manager, commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
 }
@@ -24262,7 +24262,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyAccelerationStructureToMemoryKHR);
     if (encoder)
@@ -24303,7 +24303,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToAccelerationStructureKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->CopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo_unwrapped);
+    VkResult result = GetVulkanDeviceTable(device)->CopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCopyMemoryToAccelerationStructureKHR);
     if (encoder)
@@ -24347,7 +24347,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteAccelerationStructuresPropertiesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkWriteAccelerationStructuresPropertiesKHR>::Dispatch(manager, device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride);
 
-    VkResult result = GetDeviceTable(device)->WriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride);
+    VkResult result = GetVulkanDeviceTable(device)->WriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride);
     if (result < 0)
     {
         omit_output_data = true;
@@ -24403,7 +24403,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyAccelerationStructureInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyAccelerationStructureKHR(commandBuffer, pInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyAccelerationStructureKHR(commandBuffer, pInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureKHR>::Dispatch(manager, commandBuffer, pInfo);
 }
@@ -24439,7 +24439,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureToMemoryKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureToMemoryKHR>::Dispatch(manager, commandBuffer, pInfo);
 }
@@ -24475,7 +24475,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToAccelerationStructureKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    GetDeviceTable(commandBuffer)->CmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo_unwrapped);
+    GetVulkanDeviceTable(commandBuffer)->CmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo_unwrapped);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyMemoryToAccelerationStructureKHR>::Dispatch(manager, commandBuffer, pInfo);
 }
@@ -24503,7 +24503,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetAccelerationStructureDeviceAddressKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkAccelerationStructureDeviceAddressInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
 
-    VkDeviceAddress result = GetDeviceTable(device)->GetAccelerationStructureDeviceAddressKHR(device, pInfo_unwrapped);
+    VkDeviceAddress result = GetVulkanDeviceTable(device)->GetAccelerationStructureDeviceAddressKHR(device, pInfo_unwrapped);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureDeviceAddressKHR);
     if (encoder)
@@ -24555,7 +24555,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesKHR(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdWriteAccelerationStructuresPropertiesKHRHandles, accelerationStructureCount, pAccelerationStructures, queryPool);
     }
 
-    GetDeviceTable(commandBuffer)->CmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
+    GetVulkanDeviceTable(commandBuffer)->CmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesKHR>::Dispatch(manager, commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
 }
@@ -24581,7 +24581,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceAccelerationStructureCompatibilityKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetDeviceAccelerationStructureCompatibilityKHR>::Dispatch(manager, device, pVersionInfo, pCompatibility);
 
-    GetDeviceTable(device)->GetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility);
+    GetVulkanDeviceTable(device)->GetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetDeviceAccelerationStructureCompatibilityKHR);
     if (encoder)
@@ -24621,7 +24621,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureBuildSizesKHR(
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
     const VkAccelerationStructureBuildGeometryInfoKHR* pBuildInfo_unwrapped = UnwrapStructPtrHandles(pBuildInfo, handle_unwrap_memory);
 
-    GetDeviceTable(device)->GetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo_unwrapped, pMaxPrimitiveCounts, pSizeInfo);
+    GetVulkanDeviceTable(device)->GetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo_unwrapped, pMaxPrimitiveCounts, pSizeInfo);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetAccelerationStructureBuildSizesKHR);
     if (encoder)
@@ -24677,7 +24677,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
+    GetVulkanDeviceTable(commandBuffer)->CmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdTraceRaysKHR>::Dispatch(manager, commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
 }
@@ -24708,7 +24708,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingCaptureReplayShaderGroupHandlesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR>::Dispatch(manager, device, pipeline, firstGroup, groupCount, dataSize, pData);
 
-    VkResult result = GetDeviceTable(device)->GetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
+    VkResult result = GetVulkanDeviceTable(device)->GetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
     if (result < 0)
     {
         omit_output_data = true;
@@ -24768,7 +24768,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirectKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
+    GetVulkanDeviceTable(commandBuffer)->CmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdTraceRaysIndirectKHR>::Dispatch(manager, commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
 }
@@ -24795,7 +24795,7 @@ VKAPI_ATTR VkDeviceSize VKAPI_CALL GetRayTracingShaderGroupStackSizeKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupStackSizeKHR>::Dispatch(manager, device, pipeline, group, groupShader);
 
-    VkDeviceSize result = GetDeviceTable(device)->GetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader);
+    VkDeviceSize result = GetVulkanDeviceTable(device)->GetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader);
 
     auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupStackSizeKHR);
     if (encoder)
@@ -24841,7 +24841,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRayTracingPipelineStackSizeKHR(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize);
+    GetVulkanDeviceTable(commandBuffer)->CmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetRayTracingPipelineStackSizeKHR>::Dispatch(manager, commandBuffer, pipelineStackSize);
 }
@@ -24878,7 +24878,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksEXT(
         manager->EndCommandApiCallCapture(commandBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMeshTasksEXT(commandBuffer, groupCountX, groupCountY, groupCountZ);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMeshTasksEXT(commandBuffer, groupCountX, groupCountY, groupCountZ);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksEXT>::Dispatch(manager, commandBuffer, groupCountX, groupCountY, groupCountZ);
 }
@@ -24917,7 +24917,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawMeshTasksIndirectEXTHandles, buffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectEXT>::Dispatch(manager, commandBuffer, buffer, offset, drawCount, stride);
 }
@@ -24960,7 +24960,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountEXT(
         manager->EndCommandApiCallCapture(commandBuffer, TrackCmdDrawMeshTasksIndirectCountEXTHandles, buffer, countBuffer);
     }
 
-    GetDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectCountEXT(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    GetVulkanDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectCountEXT(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountEXT>::Dispatch(manager, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }

--- a/framework/generated/generated_vulkan_command_buffer_util.cpp
+++ b/framework/generated/generated_vulkan_command_buffer_util.cpp
@@ -35,7 +35,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void TrackBeginCommandBufferHandles(VulkanCommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo)
+void TrackBeginCommandBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo)
 {
     assert(wrapper != nullptr);
 
@@ -43,42 +43,42 @@ void TrackBeginCommandBufferHandles(VulkanCommandBufferWrapper* wrapper, const V
     {
         if (pBeginInfo->pInheritanceInfo != nullptr)
         {
-            if(pBeginInfo->pInheritanceInfo->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pBeginInfo->pInheritanceInfo->renderPass));
-            if(pBeginInfo->pInheritanceInfo->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pBeginInfo->pInheritanceInfo->framebuffer));
+            if(pBeginInfo->pInheritanceInfo->renderPass != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::RenderPassHandle].insert(GetVulkanWrappedId<vulkan_wrappers::RenderPassWrapper>(pBeginInfo->pInheritanceInfo->renderPass));
+            if(pBeginInfo->pInheritanceInfo->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::FramebufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::FramebufferWrapper>(pBeginInfo->pInheritanceInfo->framebuffer));
         }
     }
 }
 
-void TrackCmdBindPipelineHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline)
+void TrackCmdBindPipelineHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipeline pipeline)
 {
     assert(wrapper != nullptr);
 
-    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pipeline));
+    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineWrapper>(pipeline));
 }
 
-void TrackCmdBindDescriptorSetsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets)
+void TrackCmdBindDescriptorSetsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets)
 {
     assert(wrapper != nullptr);
 
-    if(layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(layout));
+    if(layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(layout));
 
     if (pDescriptorSets != nullptr)
     {
         for (uint32_t pDescriptorSets_index = 0; pDescriptorSets_index < descriptorSetCount; ++pDescriptorSets_index)
         {
-            if(pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<VulkanDescriptorSetWrapper>(pDescriptorSets[pDescriptorSets_index]));
+            if(pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetWrapper>(pDescriptorSets[pDescriptorSets_index]));
         }
     }
 }
 
-void TrackCmdBindIndexBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdBindIndexBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdBindVertexBuffersHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindVertexBuffersHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -86,123 +86,123 @@ void TrackCmdBindVertexBuffersHandles(VulkanCommandBufferWrapper* wrapper, uint3
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdDrawIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawIndirectHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdDrawIndexedIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawIndexedIndirectHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdDispatchIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDispatchIndirectHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdCopyBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer)
+void TrackCmdCopyBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(srcBuffer));
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
+    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(srcBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(dstBuffer));
 }
 
-void TrackCmdCopyImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+void TrackCmdCopyImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(srcImage));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(dstImage));
 }
 
-void TrackCmdBlitImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+void TrackCmdBlitImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(srcImage));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(dstImage));
 }
 
-void TrackCmdCopyBufferToImageHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage)
+void TrackCmdCopyBufferToImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(srcBuffer));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
+    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(srcBuffer));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(dstImage));
 }
 
-void TrackCmdCopyImageToBufferHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer)
+void TrackCmdCopyImageToBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(srcImage));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(dstBuffer));
 }
 
-void TrackCmdUpdateBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdUpdateBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(dstBuffer));
 }
 
-void TrackCmdFillBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdFillBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(dstBuffer));
 }
 
-void TrackCmdClearColorImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image)
+void TrackCmdClearColorImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage image)
 {
     assert(wrapper != nullptr);
 
-    if(image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(image));
+    if(image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(image));
 }
 
-void TrackCmdClearDepthStencilImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image)
+void TrackCmdClearDepthStencilImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage image)
 {
     assert(wrapper != nullptr);
 
-    if(image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(image));
+    if(image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(image));
 }
 
-void TrackCmdResolveImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+void TrackCmdResolveImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(srcImage));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(dstImage));
 }
 
-void TrackCmdSetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdSetEventHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(event));
 }
 
-void TrackCmdResetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdResetEventHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(event));
 }
 
-void TrackCmdWaitEventsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
+void TrackCmdWaitEventsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
 {
     assert(wrapper != nullptr);
 
@@ -210,7 +210,7 @@ void TrackCmdWaitEventsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eve
     {
         for (uint32_t pEvents_index = 0; pEvents_index < eventCount; ++pEvents_index)
         {
-            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(pEvents[pEvents_index]));
+            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(pEvents[pEvents_index]));
         }
     }
 
@@ -218,7 +218,7 @@ void TrackCmdWaitEventsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eve
     {
         for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
         {
-            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
         }
     }
 
@@ -226,12 +226,12 @@ void TrackCmdWaitEventsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eve
     {
         for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
         {
-            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
         }
     }
 }
 
-void TrackCmdPipelineBarrierHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
+void TrackCmdPipelineBarrierHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
 {
     assert(wrapper != nullptr);
 
@@ -239,7 +239,7 @@ void TrackCmdPipelineBarrierHandles(VulkanCommandBufferWrapper* wrapper, uint32_
     {
         for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
         {
-            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
         }
     }
 
@@ -247,55 +247,55 @@ void TrackCmdPipelineBarrierHandles(VulkanCommandBufferWrapper* wrapper, uint32_
     {
         for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
         {
-            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
         }
     }
 }
 
-void TrackCmdBeginQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdBeginQueryHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdEndQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdEndQueryHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdResetQueryPoolHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdResetQueryPoolHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdWriteTimestampHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdWriteTimestampHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdCopyQueryPoolResultsHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer)
+void TrackCmdCopyQueryPoolResultsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(dstBuffer));
 }
 
-void TrackCmdPushConstantsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout)
+void TrackCmdPushConstantsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipelineLayout layout)
 {
     assert(wrapper != nullptr);
 
-    if(layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(layout));
+    if(layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(layout));
 }
 
-void TrackCmdBeginRenderPassHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+void TrackCmdBeginRenderPassHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
 {
     assert(wrapper != nullptr);
 
@@ -315,7 +315,7 @@ void TrackCmdBeginRenderPassHandles(VulkanCommandBufferWrapper* wrapper, const V
                     {
                         for (uint32_t pAttachments_index = 0; pAttachments_index < pnext_value->attachmentCount; ++pAttachments_index)
                         {
-                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
+                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
                         }
                     }
                     break;
@@ -323,12 +323,12 @@ void TrackCmdBeginRenderPassHandles(VulkanCommandBufferWrapper* wrapper, const V
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pRenderPassBegin->renderPass));
-        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pRenderPassBegin->framebuffer));
+        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::RenderPassHandle].insert(GetVulkanWrappedId<vulkan_wrappers::RenderPassWrapper>(pRenderPassBegin->renderPass));
+        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::FramebufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::FramebufferWrapper>(pRenderPassBegin->framebuffer));
     }
 }
 
-void TrackCmdExecuteCommandsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers)
+void TrackCmdExecuteCommandsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -336,28 +336,28 @@ void TrackCmdExecuteCommandsHandles(VulkanCommandBufferWrapper* wrapper, uint32_
     {
         for (uint32_t pCommandBuffers_index = 0; pCommandBuffers_index < commandBufferCount; ++pCommandBuffers_index)
         {
-            if(pCommandBuffers[pCommandBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::CommandBufferHandle].insert(GetWrappedId<VulkanCommandBufferWrapper>(pCommandBuffers[pCommandBuffers_index]));
+            if(pCommandBuffers[pCommandBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::CommandBufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::CommandBufferWrapper>(pCommandBuffers[pCommandBuffers_index]));
         }
     }
 }
 
-void TrackCmdDrawIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndirectCountHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
-void TrackCmdDrawIndexedIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndexedIndirectCountHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
-void TrackCmdBeginRenderPass2Handles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+void TrackCmdBeginRenderPass2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
 {
     assert(wrapper != nullptr);
 
@@ -377,7 +377,7 @@ void TrackCmdBeginRenderPass2Handles(VulkanCommandBufferWrapper* wrapper, const 
                     {
                         for (uint32_t pAttachments_index = 0; pAttachments_index < pnext_value->attachmentCount; ++pAttachments_index)
                         {
-                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
+                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
                         }
                     }
                     break;
@@ -385,16 +385,16 @@ void TrackCmdBeginRenderPass2Handles(VulkanCommandBufferWrapper* wrapper, const 
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pRenderPassBegin->renderPass));
-        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pRenderPassBegin->framebuffer));
+        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::RenderPassHandle].insert(GetVulkanWrappedId<vulkan_wrappers::RenderPassWrapper>(pRenderPassBegin->renderPass));
+        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::FramebufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::FramebufferWrapper>(pRenderPassBegin->framebuffer));
     }
 }
 
-void TrackCmdSetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdSetEvent2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(event));
 
     if (pDependencyInfo != nullptr)
     {
@@ -402,7 +402,7 @@ void TrackCmdSetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -410,20 +410,20 @@ void TrackCmdSetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdResetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdResetEvent2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(event));
 }
 
-void TrackCmdWaitEvents2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
+void TrackCmdWaitEvents2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
 {
     assert(wrapper != nullptr);
 
@@ -431,7 +431,7 @@ void TrackCmdWaitEvents2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t ev
     {
         for (uint32_t pEvents_index = 0; pEvents_index < eventCount; ++pEvents_index)
         {
-            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(pEvents[pEvents_index]));
+            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(pEvents[pEvents_index]));
         }
     }
 
@@ -443,7 +443,7 @@ void TrackCmdWaitEvents2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t ev
             {
                 for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
                 }
             }
 
@@ -451,14 +451,14 @@ void TrackCmdWaitEvents2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t ev
             {
                 for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
                 }
             }
         }
     }
 }
 
-void TrackCmdPipelineBarrier2Handles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdPipelineBarrier2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
@@ -468,7 +468,7 @@ void TrackCmdPipelineBarrier2Handles(VulkanCommandBufferWrapper* wrapper, const 
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -476,86 +476,86 @@ void TrackCmdPipelineBarrier2Handles(VulkanCommandBufferWrapper* wrapper, const 
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdWriteTimestamp2Handles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdWriteTimestamp2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdCopyBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
+void TrackCmdCopyBuffer2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferInfo != nullptr)
     {
-        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->srcBuffer));
-        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->dstBuffer));
+        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyBufferInfo->srcBuffer));
+        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdCopyImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
+void TrackCmdCopyImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageInfo != nullptr)
     {
-        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->srcImage));
-        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->dstImage));
+        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyImageInfo->srcImage));
+        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyBufferToImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
+void TrackCmdCopyBufferToImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferToImageInfo != nullptr)
     {
-        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
-        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyBufferToImageInfo->dstImage));
+        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
+        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyBufferToImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyImageToBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
+void TrackCmdCopyImageToBuffer2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageToBufferInfo != nullptr)
     {
-        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageToBufferInfo->srcImage));
-        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
+        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyImageToBufferInfo->srcImage));
+        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdBlitImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
+void TrackCmdBlitImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pBlitImageInfo != nullptr)
     {
-        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->srcImage));
-        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->dstImage));
+        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pBlitImageInfo->srcImage));
+        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pBlitImageInfo->dstImage));
     }
 }
 
-void TrackCmdResolveImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
+void TrackCmdResolveImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pResolveImageInfo != nullptr)
     {
-        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->srcImage));
-        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->dstImage));
+        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pResolveImageInfo->srcImage));
+        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pResolveImageInfo->dstImage));
     }
 }
 
-void TrackCmdBeginRenderingHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
+void TrackCmdBeginRenderingHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
 {
     assert(wrapper != nullptr);
 
@@ -571,13 +571,13 @@ void TrackCmdBeginRenderingHandles(VulkanCommandBufferWrapper* wrapper, const Vk
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
             }
@@ -588,26 +588,26 @@ void TrackCmdBeginRenderingHandles(VulkanCommandBufferWrapper* wrapper, const Vk
         {
             for (uint32_t pColorAttachments_index = 0; pColorAttachments_index < pRenderingInfo->colorAttachmentCount; ++pColorAttachments_index)
             {
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
             }
         }
 
         if (pRenderingInfo->pDepthAttachment != nullptr)
         {
-            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
-            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
+            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
+            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
         }
 
         if (pRenderingInfo->pStencilAttachment != nullptr)
         {
-            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
-            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
+            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
+            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
         }
     }
 }
 
-void TrackCmdBindVertexBuffers2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindVertexBuffers2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -615,19 +615,19 @@ void TrackCmdBindVertexBuffers2Handles(VulkanCommandBufferWrapper* wrapper, uint
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdBeginVideoCodingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo)
+void TrackCmdBeginVideoCodingKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo)
 {
     assert(wrapper != nullptr);
 
     if (pBeginInfo != nullptr)
     {
-        if(pBeginInfo->videoSession != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::VideoSessionKHRHandle].insert(GetWrappedId<VulkanVideoSessionKHRWrapper>(pBeginInfo->videoSession));
-        if(pBeginInfo->videoSessionParameters != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::VideoSessionParametersKHRHandle].insert(GetWrappedId<VulkanVideoSessionParametersKHRWrapper>(pBeginInfo->videoSessionParameters));
+        if(pBeginInfo->videoSession != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::VideoSessionKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::VideoSessionKHRWrapper>(pBeginInfo->videoSession));
+        if(pBeginInfo->videoSessionParameters != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::VideoSessionParametersKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::VideoSessionParametersKHRWrapper>(pBeginInfo->videoSessionParameters));
 
         if (pBeginInfo->pReferenceSlots != nullptr)
         {
@@ -635,14 +635,14 @@ void TrackCmdBeginVideoCodingKHRHandles(VulkanCommandBufferWrapper* wrapper, con
             {
                 if (pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource != nullptr)
                 {
-                    if(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
+                    if(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
                 }
             }
         }
     }
 }
 
-void TrackCmdDecodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo)
+void TrackCmdDecodeVideoKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo)
 {
     assert(wrapper != nullptr);
 
@@ -658,20 +658,20 @@ void TrackCmdDecodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const Vk
                 case VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkVideoInlineQueryInfoKHR*>(pnext_header);
-                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(pnext_value->queryPool));
+                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(pnext_value->queryPool));
                     break;
                 }
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pDecodeInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDecodeInfo->srcBuffer));
-        if(pDecodeInfo->dstPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pDecodeInfo->dstPictureResource.imageViewBinding));
+        if(pDecodeInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pDecodeInfo->srcBuffer));
+        if(pDecodeInfo->dstPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pDecodeInfo->dstPictureResource.imageViewBinding));
 
         if (pDecodeInfo->pSetupReferenceSlot != nullptr)
         {
             if (pDecodeInfo->pSetupReferenceSlot->pPictureResource != nullptr)
             {
-                if(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
+                if(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
             }
         }
 
@@ -681,14 +681,14 @@ void TrackCmdDecodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const Vk
             {
                 if (pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource != nullptr)
                 {
-                    if(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
+                    if(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
                 }
             }
         }
     }
 }
 
-void TrackCmdBeginRenderingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
+void TrackCmdBeginRenderingKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
 {
     assert(wrapper != nullptr);
 
@@ -704,13 +704,13 @@ void TrackCmdBeginRenderingKHRHandles(VulkanCommandBufferWrapper* wrapper, const
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
             }
@@ -721,26 +721,26 @@ void TrackCmdBeginRenderingKHRHandles(VulkanCommandBufferWrapper* wrapper, const
         {
             for (uint32_t pColorAttachments_index = 0; pColorAttachments_index < pRenderingInfo->colorAttachmentCount; ++pColorAttachments_index)
             {
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
             }
         }
 
         if (pRenderingInfo->pDepthAttachment != nullptr)
         {
-            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
-            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
+            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
+            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
         }
 
         if (pRenderingInfo->pStencilAttachment != nullptr)
         {
-            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
-            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
+            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
+            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
         }
     }
 }
 
-void TrackCmdBeginRenderPass2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+void TrackCmdBeginRenderPass2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
 {
     assert(wrapper != nullptr);
 
@@ -760,7 +760,7 @@ void TrackCmdBeginRenderPass2KHRHandles(VulkanCommandBufferWrapper* wrapper, con
                     {
                         for (uint32_t pAttachments_index = 0; pAttachments_index < pnext_value->attachmentCount; ++pAttachments_index)
                         {
-                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
+                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
                         }
                     }
                     break;
@@ -768,28 +768,28 @@ void TrackCmdBeginRenderPass2KHRHandles(VulkanCommandBufferWrapper* wrapper, con
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pRenderPassBegin->renderPass));
-        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pRenderPassBegin->framebuffer));
+        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::RenderPassHandle].insert(GetVulkanWrappedId<vulkan_wrappers::RenderPassWrapper>(pRenderPassBegin->renderPass));
+        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::FramebufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::FramebufferWrapper>(pRenderPassBegin->framebuffer));
     }
 }
 
-void TrackCmdDrawIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndirectCountKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
-void TrackCmdDrawIndexedIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndexedIndirectCountKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
-void TrackCmdEncodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo)
+void TrackCmdEncodeVideoKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo)
 {
     assert(wrapper != nullptr);
 
@@ -805,20 +805,20 @@ void TrackCmdEncodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const Vk
                 case VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkVideoInlineQueryInfoKHR*>(pnext_header);
-                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(pnext_value->queryPool));
+                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(pnext_value->queryPool));
                     break;
                 }
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pEncodeInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pEncodeInfo->dstBuffer));
-        if(pEncodeInfo->srcPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pEncodeInfo->srcPictureResource.imageViewBinding));
+        if(pEncodeInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pEncodeInfo->dstBuffer));
+        if(pEncodeInfo->srcPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pEncodeInfo->srcPictureResource.imageViewBinding));
 
         if (pEncodeInfo->pSetupReferenceSlot != nullptr)
         {
             if (pEncodeInfo->pSetupReferenceSlot->pPictureResource != nullptr)
             {
-                if(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
+                if(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
             }
         }
 
@@ -828,18 +828,18 @@ void TrackCmdEncodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const Vk
             {
                 if (pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource != nullptr)
                 {
-                    if(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
+                    if(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
                 }
             }
         }
     }
 }
 
-void TrackCmdSetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdSetEvent2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(event));
 
     if (pDependencyInfo != nullptr)
     {
@@ -847,7 +847,7 @@ void TrackCmdSetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent ev
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -855,20 +855,20 @@ void TrackCmdSetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent ev
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdResetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdResetEvent2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(event));
 }
 
-void TrackCmdWaitEvents2KHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
+void TrackCmdWaitEvents2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
 {
     assert(wrapper != nullptr);
 
@@ -876,7 +876,7 @@ void TrackCmdWaitEvents2KHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t
     {
         for (uint32_t pEvents_index = 0; pEvents_index < eventCount; ++pEvents_index)
         {
-            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(pEvents[pEvents_index]));
+            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::EventHandle].insert(GetVulkanWrappedId<vulkan_wrappers::EventWrapper>(pEvents[pEvents_index]));
         }
     }
 
@@ -888,7 +888,7 @@ void TrackCmdWaitEvents2KHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t
             {
                 for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
                 }
             }
 
@@ -896,14 +896,14 @@ void TrackCmdWaitEvents2KHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t
             {
                 for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
                 }
             }
         }
     }
 }
 
-void TrackCmdPipelineBarrier2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdPipelineBarrier2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
@@ -913,7 +913,7 @@ void TrackCmdPipelineBarrier2KHRHandles(VulkanCommandBufferWrapper* wrapper, con
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -921,100 +921,100 @@ void TrackCmdPipelineBarrier2KHRHandles(VulkanCommandBufferWrapper* wrapper, con
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdWriteTimestamp2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdWriteTimestamp2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdWriteBufferMarker2AMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdWriteBufferMarker2AMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(dstBuffer));
 }
 
-void TrackCmdCopyBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
+void TrackCmdCopyBuffer2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferInfo != nullptr)
     {
-        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->srcBuffer));
-        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->dstBuffer));
+        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyBufferInfo->srcBuffer));
+        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdCopyImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
+void TrackCmdCopyImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageInfo != nullptr)
     {
-        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->srcImage));
-        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->dstImage));
+        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyImageInfo->srcImage));
+        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyBufferToImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
+void TrackCmdCopyBufferToImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferToImageInfo != nullptr)
     {
-        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
-        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyBufferToImageInfo->dstImage));
+        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
+        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyBufferToImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyImageToBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
+void TrackCmdCopyImageToBuffer2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageToBufferInfo != nullptr)
     {
-        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageToBufferInfo->srcImage));
-        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
+        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pCopyImageToBufferInfo->srcImage));
+        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdBlitImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
+void TrackCmdBlitImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pBlitImageInfo != nullptr)
     {
-        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->srcImage));
-        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->dstImage));
+        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pBlitImageInfo->srcImage));
+        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pBlitImageInfo->dstImage));
     }
 }
 
-void TrackCmdResolveImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
+void TrackCmdResolveImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pResolveImageInfo != nullptr)
     {
-        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->srcImage));
-        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->dstImage));
+        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pResolveImageInfo->srcImage));
+        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageWrapper>(pResolveImageInfo->dstImage));
     }
 }
 
-void TrackCmdBindIndexBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdBindIndexBuffer2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdBindDescriptorSets2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo)
+void TrackCmdBindDescriptorSets2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1034,7 +1034,7 @@ void TrackCmdBindDescriptorSets2KHRHandles(VulkanCommandBufferWrapper* wrapper, 
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1042,19 +1042,19 @@ void TrackCmdBindDescriptorSets2KHRHandles(VulkanCommandBufferWrapper* wrapper, 
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pBindDescriptorSetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pBindDescriptorSetsInfo->layout));
+        if(pBindDescriptorSetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(pBindDescriptorSetsInfo->layout));
 
         if (pBindDescriptorSetsInfo->pDescriptorSets != nullptr)
         {
             for (uint32_t pDescriptorSets_index = 0; pDescriptorSets_index < pBindDescriptorSetsInfo->descriptorSetCount; ++pDescriptorSets_index)
             {
-                if(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<VulkanDescriptorSetWrapper>(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index]));
+                if(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetWrapper>(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index]));
             }
         }
     }
 }
 
-void TrackCmdPushConstants2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo)
+void TrackCmdPushConstants2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1074,7 +1074,7 @@ void TrackCmdPushConstants2KHRHandles(VulkanCommandBufferWrapper* wrapper, const
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1082,11 +1082,11 @@ void TrackCmdPushConstants2KHRHandles(VulkanCommandBufferWrapper* wrapper, const
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pPushConstantsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pPushConstantsInfo->layout));
+        if(pPushConstantsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(pPushConstantsInfo->layout));
     }
 }
 
-void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo)
+void TrackCmdPushDescriptorSet2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1106,7 +1106,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1114,7 +1114,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pPushDescriptorSetInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pPushDescriptorSetInfo->layout));
+        if(pPushDescriptorSetInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(pPushDescriptorSetInfo->layout));
 
         if (pPushDescriptorSetInfo->pDescriptorWrites != nullptr)
         {
@@ -1134,7 +1134,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
                             {
                                 for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pnext_value->accelerationStructureCount; ++pAccelerationStructures_index)
                                 {
-                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
+                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
                             break;
@@ -1146,7 +1146,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
                             {
                                 for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pnext_value->accelerationStructureCount; ++pAccelerationStructures_index)
                                 {
-                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
+                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
                             break;
@@ -1154,14 +1154,14 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
                     }
                     pnext_header = pnext_header->pNext;
                 }
-                if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<VulkanDescriptorSetWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet));
+                if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet));
 
                 if (pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo != nullptr)
                 {
                     for (uint32_t pImageInfo_index = 0; pImageInfo_index < pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].descriptorCount; ++pImageInfo_index)
                     {
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::SamplerHandle].insert(GetWrappedId<VulkanSamplerWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler));
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::SamplerHandle].insert(GetVulkanWrappedId<vulkan_wrappers::SamplerWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView));
                     }
                 }
 
@@ -1169,7 +1169,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
                 {
                     for (uint32_t pBufferInfo_index = 0; pBufferInfo_index < pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].descriptorCount; ++pBufferInfo_index)
                     {
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer));
                     }
                 }
 
@@ -1177,7 +1177,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
                 {
                     for (uint32_t pTexelBufferView_index = 0; pTexelBufferView_index < pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].descriptorCount; ++pTexelBufferView_index)
                     {
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferViewHandle].insert(GetWrappedId<VulkanBufferViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index]));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index]));
                     }
                 }
             }
@@ -1185,7 +1185,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, c
     }
 }
 
-void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo)
+void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1205,7 +1205,7 @@ void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(VulkanCommandBufferWrapper
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1213,12 +1213,12 @@ void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(VulkanCommandBufferWrapper
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorUpdateTemplateHandle].insert(GetWrappedId<VulkanDescriptorUpdateTemplateWrapper>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate));
-        if(pPushDescriptorSetWithTemplateInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pPushDescriptorSetWithTemplateInfo->layout));
+        if(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorUpdateTemplateHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate));
+        if(pPushDescriptorSetWithTemplateInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(pPushDescriptorSetWithTemplateInfo->layout));
     }
 }
 
-void TrackCmdSetDescriptorBufferOffsets2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo)
+void TrackCmdSetDescriptorBufferOffsets2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1238,7 +1238,7 @@ void TrackCmdSetDescriptorBufferOffsets2EXTHandles(VulkanCommandBufferWrapper* w
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1246,11 +1246,11 @@ void TrackCmdSetDescriptorBufferOffsets2EXTHandles(VulkanCommandBufferWrapper* w
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pSetDescriptorBufferOffsetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pSetDescriptorBufferOffsetsInfo->layout));
+        if(pSetDescriptorBufferOffsetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(pSetDescriptorBufferOffsetsInfo->layout));
     }
 }
 
-void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo)
+void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1270,7 +1270,7 @@ void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(VulkanCommandBuffer
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1278,11 +1278,11 @@ void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(VulkanCommandBuffer
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pBindDescriptorBufferEmbeddedSamplersInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pBindDescriptorBufferEmbeddedSamplersInfo->layout));
+        if(pBindDescriptorBufferEmbeddedSamplersInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(pBindDescriptorBufferEmbeddedSamplersInfo->layout));
     }
 }
 
-void TrackCmdBindTransformFeedbackBuffersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindTransformFeedbackBuffersEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1290,12 +1290,12 @@ void TrackCmdBindTransformFeedbackBuffersEXTHandles(VulkanCommandBufferWrapper* 
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdBeginTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
+void TrackCmdBeginTransformFeedbackEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1303,12 +1303,12 @@ void TrackCmdBeginTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrappe
     {
         for (uint32_t pCounterBuffers_index = 0; pCounterBuffers_index < counterBufferCount; ++pCounterBuffers_index)
         {
-            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
+            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
         }
     }
 }
 
-void TrackCmdEndTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
+void TrackCmdEndTransformFeedbackEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1316,66 +1316,66 @@ void TrackCmdEndTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper,
     {
         for (uint32_t pCounterBuffers_index = 0; pCounterBuffers_index < counterBufferCount; ++pCounterBuffers_index)
         {
-            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
+            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
         }
     }
 }
 
-void TrackCmdBeginQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdBeginQueryIndexedEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdEndQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdEndQueryIndexedEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdDrawIndirectByteCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer counterBuffer)
+void TrackCmdDrawIndirectByteCountEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer counterBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(counterBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(counterBuffer));
+    if(counterBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(counterBuffer));
 }
 
-void TrackCmdDrawIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndirectCountAMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
-void TrackCmdDrawIndexedIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndexedIndirectCountAMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
-void TrackCmdBeginConditionalRenderingEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin)
+void TrackCmdBeginConditionalRenderingEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin)
 {
     assert(wrapper != nullptr);
 
     if (pConditionalRenderingBegin != nullptr)
     {
-        if(pConditionalRenderingBegin->buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pConditionalRenderingBegin->buffer));
+        if(pConditionalRenderingBegin->buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pConditionalRenderingBegin->buffer));
     }
 }
 
-void TrackCmdBindShadingRateImageNVHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView)
+void TrackCmdBindShadingRateImageNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImageView imageView)
 {
     assert(wrapper != nullptr);
 
-    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(imageView));
+    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(imageView));
 }
 
-void TrackCmdBuildAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch)
+void TrackCmdBuildAccelerationStructureNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch)
 {
     assert(wrapper != nullptr);
 
@@ -1385,38 +1385,38 @@ void TrackCmdBuildAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wra
         {
             for (uint32_t pGeometries_index = 0; pGeometries_index < pInfo->geometryCount; ++pGeometries_index)
             {
-                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData));
-                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData));
-                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData));
-                if(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData));
             }
         }
     }
-    if(instanceData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(instanceData));
-    if(dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(dst));
-    if(src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(src));
-    if(scratch != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(scratch));
+    if(instanceData != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(instanceData));
+    if(dst != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(dst));
+    if(src != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(src));
+    if(scratch != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(scratch));
 }
 
-void TrackCmdCopyAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src)
+void TrackCmdCopyAccelerationStructureNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src)
 {
     assert(wrapper != nullptr);
 
-    if(dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(dst));
-    if(src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(src));
+    if(dst != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(dst));
+    if(src != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(src));
 }
 
-void TrackCmdTraceRaysNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer)
+void TrackCmdTraceRaysNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(raygenShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(raygenShaderBindingTableBuffer));
-    if(missShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(missShaderBindingTableBuffer));
-    if(hitShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(hitShaderBindingTableBuffer));
-    if(callableShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(callableShaderBindingTableBuffer));
+    if(raygenShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(raygenShaderBindingTableBuffer));
+    if(missShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(missShaderBindingTableBuffer));
+    if(hitShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(hitShaderBindingTableBuffer));
+    if(callableShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(callableShaderBindingTableBuffer));
 }
 
-void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool)
+void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
@@ -1424,35 +1424,35 @@ void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(VulkanCommandBufferW
     {
         for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < accelerationStructureCount; ++pAccelerationStructures_index)
         {
-            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
+            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureNVWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
         }
     }
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdWriteBufferMarkerAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdWriteBufferMarkerAMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(dstBuffer));
 }
 
-void TrackCmdDrawMeshTasksIndirectNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawMeshTasksIndirectNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdDrawMeshTasksIndirectCountNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawMeshTasksIndirectCountNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
-void TrackCmdBindVertexBuffers2EXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindVertexBuffers2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1460,70 +1460,70 @@ void TrackCmdBindVertexBuffers2EXTHandles(VulkanCommandBufferWrapper* wrapper, u
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdPreprocessGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
+void TrackCmdPreprocessGeneratedCommandsNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
 {
     assert(wrapper != nullptr);
 
     if (pGeneratedCommandsInfo != nullptr)
     {
-        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pGeneratedCommandsInfo->pipeline));
-        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetWrappedId<VulkanIndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
+        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineWrapper>(pGeneratedCommandsInfo->pipeline));
+        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
 
         if (pGeneratedCommandsInfo->pStreams != nullptr)
         {
             for (uint32_t pStreams_index = 0; pStreams_index < pGeneratedCommandsInfo->streamCount; ++pStreams_index)
             {
-                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
+                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
             }
         }
-        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
-        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
-        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
+        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
+        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
+        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
     }
 }
 
-void TrackCmdExecuteGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
+void TrackCmdExecuteGeneratedCommandsNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
 {
     assert(wrapper != nullptr);
 
     if (pGeneratedCommandsInfo != nullptr)
     {
-        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pGeneratedCommandsInfo->pipeline));
-        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetWrappedId<VulkanIndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
+        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineWrapper>(pGeneratedCommandsInfo->pipeline));
+        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
 
         if (pGeneratedCommandsInfo->pStreams != nullptr)
         {
             for (uint32_t pStreams_index = 0; pStreams_index < pGeneratedCommandsInfo->streamCount; ++pStreams_index)
             {
-                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
+                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
             }
         }
-        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
-        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
-        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
+        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
+        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
+        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
     }
 }
 
-void TrackCmdBindPipelineShaderGroupNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline)
+void TrackCmdBindPipelineShaderGroupNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipeline pipeline)
 {
     assert(wrapper != nullptr);
 
-    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pipeline));
+    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineWrapper>(pipeline));
 }
 
-void TrackCmdBindInvocationMaskHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView)
+void TrackCmdBindInvocationMaskHUAWEIHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImageView imageView)
 {
     assert(wrapper != nullptr);
 
-    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(imageView));
+    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ImageViewHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ImageViewWrapper>(imageView));
 }
 
-void TrackCmdBuildMicromapsEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos)
+void TrackCmdBuildMicromapsEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos)
 {
     assert(wrapper != nullptr);
 
@@ -1531,43 +1531,43 @@ void TrackCmdBuildMicromapsEXTHandles(VulkanCommandBufferWrapper* wrapper, uint3
     {
         for (uint32_t pInfos_index = 0; pInfos_index < infoCount; ++pInfos_index)
         {
-            if(pInfos[pInfos_index].dstMicromap != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfos[pInfos_index].dstMicromap));
+            if(pInfos[pInfos_index].dstMicromap != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::MicromapEXTHandle].insert(GetVulkanWrappedId<vulkan_wrappers::MicromapEXTWrapper>(pInfos[pInfos_index].dstMicromap));
         }
     }
 }
 
-void TrackCmdCopyMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo)
+void TrackCmdCopyMicromapEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->src));
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->dst));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::MicromapEXTHandle].insert(GetVulkanWrappedId<vulkan_wrappers::MicromapEXTWrapper>(pInfo->src));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::MicromapEXTHandle].insert(GetVulkanWrappedId<vulkan_wrappers::MicromapEXTWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdCopyMicromapToMemoryEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo)
+void TrackCmdCopyMicromapToMemoryEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->src));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::MicromapEXTHandle].insert(GetVulkanWrappedId<vulkan_wrappers::MicromapEXTWrapper>(pInfo->src));
     }
 }
 
-void TrackCmdCopyMemoryToMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo)
+void TrackCmdCopyMemoryToMicromapEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->dst));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::MicromapEXTHandle].insert(GetVulkanWrappedId<vulkan_wrappers::MicromapEXTWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdWriteMicromapsPropertiesEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool)
+void TrackCmdWriteMicromapsPropertiesEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
@@ -1575,34 +1575,34 @@ void TrackCmdWriteMicromapsPropertiesEXTHandles(VulkanCommandBufferWrapper* wrap
     {
         for (uint32_t pMicromaps_index = 0; pMicromaps_index < micromapCount; ++pMicromaps_index)
         {
-            if(pMicromaps[pMicromaps_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pMicromaps[pMicromaps_index]));
+            if(pMicromaps[pMicromaps_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::MicromapEXTHandle].insert(GetVulkanWrappedId<vulkan_wrappers::MicromapEXTWrapper>(pMicromaps[pMicromaps_index]));
         }
     }
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdDrawClusterIndirectHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawClusterIndirectHUAWEIHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdUpdatePipelineIndirectBufferNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline)
+void TrackCmdUpdatePipelineIndirectBufferNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipeline pipeline)
 {
     assert(wrapper != nullptr);
 
-    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pipeline));
+    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineHandle].insert(GetVulkanWrappedId<vulkan_wrappers::PipelineWrapper>(pipeline));
 }
 
-void TrackCmdOpticalFlowExecuteNVHandles(VulkanCommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session)
+void TrackCmdOpticalFlowExecuteNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session)
 {
     assert(wrapper != nullptr);
 
-    if(session != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::OpticalFlowSessionNVHandle].insert(GetWrappedId<VulkanOpticalFlowSessionNVWrapper>(session));
+    if(session != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::OpticalFlowSessionNVHandle].insert(GetVulkanWrappedId<vulkan_wrappers::OpticalFlowSessionNVWrapper>(session));
 }
 
-void TrackCmdBindShadersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders)
+void TrackCmdBindShadersEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders)
 {
     assert(wrapper != nullptr);
 
@@ -1610,12 +1610,12 @@ void TrackCmdBindShadersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t
     {
         for (uint32_t pShaders_index = 0; pShaders_index < stageCount; ++pShaders_index)
         {
-            if(pShaders[pShaders_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ShaderEXTHandle].insert(GetWrappedId<VulkanShaderEXTWrapper>(pShaders[pShaders_index]));
+            if(pShaders[pShaders_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::ShaderEXTHandle].insert(GetVulkanWrappedId<vulkan_wrappers::ShaderEXTWrapper>(pShaders[pShaders_index]));
         }
     }
 }
 
-void TrackCmdBuildAccelerationStructuresKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
+void TrackCmdBuildAccelerationStructuresKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
 {
     assert(wrapper != nullptr);
 
@@ -1623,13 +1623,13 @@ void TrackCmdBuildAccelerationStructuresKHRHandles(VulkanCommandBufferWrapper* w
     {
         for (uint32_t pInfos_index = 0; pInfos_index < infoCount; ++pInfos_index)
         {
-            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
-            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
+            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
+            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
         }
     }
 }
 
-void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
+void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
 {
     assert(wrapper != nullptr);
 
@@ -1637,44 +1637,44 @@ void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(VulkanCommandBufferWr
     {
         for (uint32_t pInfos_index = 0; pInfos_index < infoCount; ++pInfos_index)
         {
-            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
-            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
+            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
+            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
         }
     }
 }
 
-void TrackCmdCopyAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo)
+void TrackCmdCopyAccelerationStructureKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->src));
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->dst));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfo->src));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo)
+void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->src));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfo->src));
     }
 }
 
-void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo)
+void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->dst));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool)
+void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
@@ -1682,25 +1682,25 @@ void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(VulkanCommandBuffer
     {
         for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < accelerationStructureCount; ++pAccelerationStructures_index)
         {
-            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
+            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::AccelerationStructureKHRHandle].insert(GetVulkanWrappedId<vulkan_wrappers::AccelerationStructureKHRWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
         }
     }
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::QueryPoolHandle].insert(GetVulkanWrappedId<vulkan_wrappers::QueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdDrawMeshTasksIndirectEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawMeshTasksIndirectEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
 }
 
-void TrackCmdDrawMeshTasksIndirectCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawMeshTasksIndirectCountEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::BufferHandle].insert(GetVulkanWrappedId<vulkan_wrappers::BufferWrapper>(countBuffer));
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/generated/generated_vulkan_command_buffer_util.cpp
+++ b/framework/generated/generated_vulkan_command_buffer_util.cpp
@@ -35,7 +35,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void TrackBeginCommandBufferHandles(CommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo)
+void TrackBeginCommandBufferHandles(VulkanCommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo)
 {
     assert(wrapper != nullptr);
 
@@ -43,42 +43,42 @@ void TrackBeginCommandBufferHandles(CommandBufferWrapper* wrapper, const VkComma
     {
         if (pBeginInfo->pInheritanceInfo != nullptr)
         {
-            if(pBeginInfo->pInheritanceInfo->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<RenderPassWrapper>(pBeginInfo->pInheritanceInfo->renderPass));
-            if(pBeginInfo->pInheritanceInfo->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<FramebufferWrapper>(pBeginInfo->pInheritanceInfo->framebuffer));
+            if(pBeginInfo->pInheritanceInfo->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pBeginInfo->pInheritanceInfo->renderPass));
+            if(pBeginInfo->pInheritanceInfo->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pBeginInfo->pInheritanceInfo->framebuffer));
         }
     }
 }
 
-void TrackCmdBindPipelineHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline)
+void TrackCmdBindPipelineHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline)
 {
     assert(wrapper != nullptr);
 
-    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<PipelineWrapper>(pipeline));
+    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pipeline));
 }
 
-void TrackCmdBindDescriptorSetsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets)
+void TrackCmdBindDescriptorSetsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets)
 {
     assert(wrapper != nullptr);
 
-    if(layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(layout));
+    if(layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(layout));
 
     if (pDescriptorSets != nullptr)
     {
         for (uint32_t pDescriptorSets_index = 0; pDescriptorSets_index < descriptorSetCount; ++pDescriptorSets_index)
         {
-            if(pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<DescriptorSetWrapper>(pDescriptorSets[pDescriptorSets_index]));
+            if(pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<VulkanDescriptorSetWrapper>(pDescriptorSets[pDescriptorSets_index]));
         }
     }
 }
 
-void TrackCmdBindIndexBufferHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdBindIndexBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdBindVertexBuffersHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindVertexBuffersHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -86,123 +86,123 @@ void TrackCmdBindVertexBuffersHandles(CommandBufferWrapper* wrapper, uint32_t bi
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdDrawIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdDrawIndexedIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawIndexedIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdDispatchIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDispatchIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdCopyBufferHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer)
+void TrackCmdCopyBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(srcBuffer));
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(dstBuffer));
+    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(srcBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
 }
 
-void TrackCmdCopyImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+void TrackCmdCopyImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(srcImage));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(dstImage));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
 }
 
-void TrackCmdBlitImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+void TrackCmdBlitImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(srcImage));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(dstImage));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
 }
 
-void TrackCmdCopyBufferToImageHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage)
+void TrackCmdCopyBufferToImageHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(srcBuffer));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(dstImage));
+    if(srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(srcBuffer));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
 }
 
-void TrackCmdCopyImageToBufferHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer)
+void TrackCmdCopyImageToBufferHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(srcImage));
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(dstBuffer));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
 }
 
-void TrackCmdUpdateBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdUpdateBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
 }
 
-void TrackCmdFillBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdFillBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
 }
 
-void TrackCmdClearColorImageHandles(CommandBufferWrapper* wrapper, VkImage image)
+void TrackCmdClearColorImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image)
 {
     assert(wrapper != nullptr);
 
-    if(image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(image));
+    if(image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(image));
 }
 
-void TrackCmdClearDepthStencilImageHandles(CommandBufferWrapper* wrapper, VkImage image)
+void TrackCmdClearDepthStencilImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image)
 {
     assert(wrapper != nullptr);
 
-    if(image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(image));
+    if(image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(image));
 }
 
-void TrackCmdResolveImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+void TrackCmdResolveImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
 {
     assert(wrapper != nullptr);
 
-    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(srcImage));
-    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(dstImage));
+    if(srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(srcImage));
+    if(dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(dstImage));
 }
 
-void TrackCmdSetEventHandles(CommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdSetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
 }
 
-void TrackCmdResetEventHandles(CommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdResetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
 }
 
-void TrackCmdWaitEventsHandles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
+void TrackCmdWaitEventsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
 {
     assert(wrapper != nullptr);
 
@@ -210,7 +210,7 @@ void TrackCmdWaitEventsHandles(CommandBufferWrapper* wrapper, uint32_t eventCoun
     {
         for (uint32_t pEvents_index = 0; pEvents_index < eventCount; ++pEvents_index)
         {
-            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(pEvents[pEvents_index]));
+            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(pEvents[pEvents_index]));
         }
     }
 
@@ -218,7 +218,7 @@ void TrackCmdWaitEventsHandles(CommandBufferWrapper* wrapper, uint32_t eventCoun
     {
         for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
         {
-            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
         }
     }
 
@@ -226,12 +226,12 @@ void TrackCmdWaitEventsHandles(CommandBufferWrapper* wrapper, uint32_t eventCoun
     {
         for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
         {
-            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
         }
     }
 }
 
-void TrackCmdPipelineBarrierHandles(CommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
+void TrackCmdPipelineBarrierHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
 {
     assert(wrapper != nullptr);
 
@@ -239,7 +239,7 @@ void TrackCmdPipelineBarrierHandles(CommandBufferWrapper* wrapper, uint32_t buff
     {
         for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
         {
-            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+            if(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
         }
     }
 
@@ -247,55 +247,55 @@ void TrackCmdPipelineBarrierHandles(CommandBufferWrapper* wrapper, uint32_t buff
     {
         for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
         {
-            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+            if(pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pImageMemoryBarriers[pImageMemoryBarriers_index].image));
         }
     }
 }
 
-void TrackCmdBeginQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdBeginQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdEndQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdEndQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdResetQueryPoolHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdResetQueryPoolHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdWriteTimestampHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdWriteTimestampHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdCopyQueryPoolResultsHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer)
+void TrackCmdCopyQueryPoolResultsHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(dstBuffer));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
 }
 
-void TrackCmdPushConstantsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout)
+void TrackCmdPushConstantsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout)
 {
     assert(wrapper != nullptr);
 
-    if(layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(layout));
+    if(layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(layout));
 }
 
-void TrackCmdBeginRenderPassHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+void TrackCmdBeginRenderPassHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
 {
     assert(wrapper != nullptr);
 
@@ -315,7 +315,7 @@ void TrackCmdBeginRenderPassHandles(CommandBufferWrapper* wrapper, const VkRende
                     {
                         for (uint32_t pAttachments_index = 0; pAttachments_index < pnext_value->attachmentCount; ++pAttachments_index)
                         {
-                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
+                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
                         }
                     }
                     break;
@@ -323,12 +323,12 @@ void TrackCmdBeginRenderPassHandles(CommandBufferWrapper* wrapper, const VkRende
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<RenderPassWrapper>(pRenderPassBegin->renderPass));
-        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<FramebufferWrapper>(pRenderPassBegin->framebuffer));
+        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pRenderPassBegin->renderPass));
+        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pRenderPassBegin->framebuffer));
     }
 }
 
-void TrackCmdExecuteCommandsHandles(CommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers)
+void TrackCmdExecuteCommandsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -336,28 +336,28 @@ void TrackCmdExecuteCommandsHandles(CommandBufferWrapper* wrapper, uint32_t comm
     {
         for (uint32_t pCommandBuffers_index = 0; pCommandBuffers_index < commandBufferCount; ++pCommandBuffers_index)
         {
-            if(pCommandBuffers[pCommandBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::CommandBufferHandle].insert(GetWrappedId<CommandBufferWrapper>(pCommandBuffers[pCommandBuffers_index]));
+            if(pCommandBuffers[pCommandBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::CommandBufferHandle].insert(GetWrappedId<VulkanCommandBufferWrapper>(pCommandBuffers[pCommandBuffers_index]));
         }
     }
 }
 
-void TrackCmdDrawIndirectCountHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
-void TrackCmdDrawIndexedIndirectCountHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndexedIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
-void TrackCmdBeginRenderPass2Handles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+void TrackCmdBeginRenderPass2Handles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
 {
     assert(wrapper != nullptr);
 
@@ -377,7 +377,7 @@ void TrackCmdBeginRenderPass2Handles(CommandBufferWrapper* wrapper, const VkRend
                     {
                         for (uint32_t pAttachments_index = 0; pAttachments_index < pnext_value->attachmentCount; ++pAttachments_index)
                         {
-                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
+                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
                         }
                     }
                     break;
@@ -385,16 +385,16 @@ void TrackCmdBeginRenderPass2Handles(CommandBufferWrapper* wrapper, const VkRend
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<RenderPassWrapper>(pRenderPassBegin->renderPass));
-        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<FramebufferWrapper>(pRenderPassBegin->framebuffer));
+        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pRenderPassBegin->renderPass));
+        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pRenderPassBegin->framebuffer));
     }
 }
 
-void TrackCmdSetEvent2Handles(CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdSetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
 
     if (pDependencyInfo != nullptr)
     {
@@ -402,7 +402,7 @@ void TrackCmdSetEvent2Handles(CommandBufferWrapper* wrapper, VkEvent event, cons
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -410,20 +410,20 @@ void TrackCmdSetEvent2Handles(CommandBufferWrapper* wrapper, VkEvent event, cons
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdResetEvent2Handles(CommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdResetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
 }
 
-void TrackCmdWaitEvents2Handles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
+void TrackCmdWaitEvents2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
 {
     assert(wrapper != nullptr);
 
@@ -431,7 +431,7 @@ void TrackCmdWaitEvents2Handles(CommandBufferWrapper* wrapper, uint32_t eventCou
     {
         for (uint32_t pEvents_index = 0; pEvents_index < eventCount; ++pEvents_index)
         {
-            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(pEvents[pEvents_index]));
+            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(pEvents[pEvents_index]));
         }
     }
 
@@ -443,7 +443,7 @@ void TrackCmdWaitEvents2Handles(CommandBufferWrapper* wrapper, uint32_t eventCou
             {
                 for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
                 }
             }
 
@@ -451,14 +451,14 @@ void TrackCmdWaitEvents2Handles(CommandBufferWrapper* wrapper, uint32_t eventCou
             {
                 for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
                 }
             }
         }
     }
 }
 
-void TrackCmdPipelineBarrier2Handles(CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdPipelineBarrier2Handles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
@@ -468,7 +468,7 @@ void TrackCmdPipelineBarrier2Handles(CommandBufferWrapper* wrapper, const VkDepe
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -476,86 +476,86 @@ void TrackCmdPipelineBarrier2Handles(CommandBufferWrapper* wrapper, const VkDepe
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdWriteTimestamp2Handles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdWriteTimestamp2Handles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdCopyBuffer2Handles(CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
+void TrackCmdCopyBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferInfo != nullptr)
     {
-        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyBufferInfo->srcBuffer));
-        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyBufferInfo->dstBuffer));
+        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->srcBuffer));
+        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdCopyImage2Handles(CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
+void TrackCmdCopyImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageInfo != nullptr)
     {
-        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyImageInfo->srcImage));
-        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyImageInfo->dstImage));
+        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->srcImage));
+        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyBufferToImage2Handles(CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
+void TrackCmdCopyBufferToImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferToImageInfo != nullptr)
     {
-        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
-        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyBufferToImageInfo->dstImage));
+        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
+        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyBufferToImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyImageToBuffer2Handles(CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
+void TrackCmdCopyImageToBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageToBufferInfo != nullptr)
     {
-        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyImageToBufferInfo->srcImage));
-        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
+        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageToBufferInfo->srcImage));
+        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdBlitImage2Handles(CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
+void TrackCmdBlitImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pBlitImageInfo != nullptr)
     {
-        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pBlitImageInfo->srcImage));
-        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pBlitImageInfo->dstImage));
+        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->srcImage));
+        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->dstImage));
     }
 }
 
-void TrackCmdResolveImage2Handles(CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
+void TrackCmdResolveImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pResolveImageInfo != nullptr)
     {
-        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pResolveImageInfo->srcImage));
-        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pResolveImageInfo->dstImage));
+        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->srcImage));
+        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->dstImage));
     }
 }
 
-void TrackCmdBeginRenderingHandles(CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
+void TrackCmdBeginRenderingHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
 {
     assert(wrapper != nullptr);
 
@@ -571,13 +571,13 @@ void TrackCmdBeginRenderingHandles(CommandBufferWrapper* wrapper, const VkRender
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
             }
@@ -588,26 +588,26 @@ void TrackCmdBeginRenderingHandles(CommandBufferWrapper* wrapper, const VkRender
         {
             for (uint32_t pColorAttachments_index = 0; pColorAttachments_index < pRenderingInfo->colorAttachmentCount; ++pColorAttachments_index)
             {
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
             }
         }
 
         if (pRenderingInfo->pDepthAttachment != nullptr)
         {
-            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
-            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
+            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
+            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
         }
 
         if (pRenderingInfo->pStencilAttachment != nullptr)
         {
-            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
-            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
+            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
+            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
         }
     }
 }
 
-void TrackCmdBindVertexBuffers2Handles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindVertexBuffers2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -615,19 +615,19 @@ void TrackCmdBindVertexBuffers2Handles(CommandBufferWrapper* wrapper, uint32_t b
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdBeginVideoCodingKHRHandles(CommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo)
+void TrackCmdBeginVideoCodingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo)
 {
     assert(wrapper != nullptr);
 
     if (pBeginInfo != nullptr)
     {
-        if(pBeginInfo->videoSession != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::VideoSessionKHRHandle].insert(GetWrappedId<VideoSessionKHRWrapper>(pBeginInfo->videoSession));
-        if(pBeginInfo->videoSessionParameters != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::VideoSessionParametersKHRHandle].insert(GetWrappedId<VideoSessionParametersKHRWrapper>(pBeginInfo->videoSessionParameters));
+        if(pBeginInfo->videoSession != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::VideoSessionKHRHandle].insert(GetWrappedId<VulkanVideoSessionKHRWrapper>(pBeginInfo->videoSession));
+        if(pBeginInfo->videoSessionParameters != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::VideoSessionParametersKHRHandle].insert(GetWrappedId<VulkanVideoSessionParametersKHRWrapper>(pBeginInfo->videoSessionParameters));
 
         if (pBeginInfo->pReferenceSlots != nullptr)
         {
@@ -635,14 +635,14 @@ void TrackCmdBeginVideoCodingKHRHandles(CommandBufferWrapper* wrapper, const VkV
             {
                 if (pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource != nullptr)
                 {
-                    if(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
+                    if(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pBeginInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
                 }
             }
         }
     }
 }
 
-void TrackCmdDecodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo)
+void TrackCmdDecodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo)
 {
     assert(wrapper != nullptr);
 
@@ -658,20 +658,20 @@ void TrackCmdDecodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoD
                 case VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkVideoInlineQueryInfoKHR*>(pnext_header);
-                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(pnext_value->queryPool));
+                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(pnext_value->queryPool));
                     break;
                 }
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pDecodeInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pDecodeInfo->srcBuffer));
-        if(pDecodeInfo->dstPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pDecodeInfo->dstPictureResource.imageViewBinding));
+        if(pDecodeInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDecodeInfo->srcBuffer));
+        if(pDecodeInfo->dstPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pDecodeInfo->dstPictureResource.imageViewBinding));
 
         if (pDecodeInfo->pSetupReferenceSlot != nullptr)
         {
             if (pDecodeInfo->pSetupReferenceSlot->pPictureResource != nullptr)
             {
-                if(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
+                if(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pDecodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
             }
         }
 
@@ -681,14 +681,14 @@ void TrackCmdDecodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoD
             {
                 if (pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource != nullptr)
                 {
-                    if(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
+                    if(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pDecodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
                 }
             }
         }
     }
 }
 
-void TrackCmdBeginRenderingKHRHandles(CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
+void TrackCmdBeginRenderingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo)
 {
     assert(wrapper != nullptr);
 
@@ -704,13 +704,13 @@ void TrackCmdBeginRenderingKHRHandles(CommandBufferWrapper* wrapper, const VkRen
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
                 case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR*>(pnext_header);
-                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pnext_value->imageView));
+                    if(pnext_value->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->imageView));
                     break;
                 }
             }
@@ -721,26 +721,26 @@ void TrackCmdBeginRenderingKHRHandles(CommandBufferWrapper* wrapper, const VkRen
         {
             for (uint32_t pColorAttachments_index = 0; pColorAttachments_index < pRenderingInfo->colorAttachmentCount; ++pColorAttachments_index)
             {
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
-                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].imageView));
+                if(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pColorAttachments[pColorAttachments_index].resolveImageView));
             }
         }
 
         if (pRenderingInfo->pDepthAttachment != nullptr)
         {
-            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
-            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
+            if(pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->imageView));
+            if(pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pDepthAttachment->resolveImageView));
         }
 
         if (pRenderingInfo->pStencilAttachment != nullptr)
         {
-            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
-            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
+            if(pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->imageView));
+            if(pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pRenderingInfo->pStencilAttachment->resolveImageView));
         }
     }
 }
 
-void TrackCmdBeginRenderPass2KHRHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+void TrackCmdBeginRenderPass2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
 {
     assert(wrapper != nullptr);
 
@@ -760,7 +760,7 @@ void TrackCmdBeginRenderPass2KHRHandles(CommandBufferWrapper* wrapper, const VkR
                     {
                         for (uint32_t pAttachments_index = 0; pAttachments_index < pnext_value->attachmentCount; ++pAttachments_index)
                         {
-                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
+                            if(pnext_value->pAttachments[pAttachments_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pnext_value->pAttachments[pAttachments_index]));
                         }
                     }
                     break;
@@ -768,28 +768,28 @@ void TrackCmdBeginRenderPass2KHRHandles(CommandBufferWrapper* wrapper, const VkR
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<RenderPassWrapper>(pRenderPassBegin->renderPass));
-        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<FramebufferWrapper>(pRenderPassBegin->framebuffer));
+        if(pRenderPassBegin->renderPass != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(GetWrappedId<VulkanRenderPassWrapper>(pRenderPassBegin->renderPass));
+        if(pRenderPassBegin->framebuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(GetWrappedId<VulkanFramebufferWrapper>(pRenderPassBegin->framebuffer));
     }
 }
 
-void TrackCmdDrawIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
-void TrackCmdDrawIndexedIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndexedIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
-void TrackCmdEncodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo)
+void TrackCmdEncodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo)
 {
     assert(wrapper != nullptr);
 
@@ -805,20 +805,20 @@ void TrackCmdEncodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoE
                 case VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR:
                 {
                     auto pnext_value = reinterpret_cast<const VkVideoInlineQueryInfoKHR*>(pnext_header);
-                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(pnext_value->queryPool));
+                    if(pnext_value->queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(pnext_value->queryPool));
                     break;
                 }
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pEncodeInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pEncodeInfo->dstBuffer));
-        if(pEncodeInfo->srcPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pEncodeInfo->srcPictureResource.imageViewBinding));
+        if(pEncodeInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pEncodeInfo->dstBuffer));
+        if(pEncodeInfo->srcPictureResource.imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pEncodeInfo->srcPictureResource.imageViewBinding));
 
         if (pEncodeInfo->pSetupReferenceSlot != nullptr)
         {
             if (pEncodeInfo->pSetupReferenceSlot->pPictureResource != nullptr)
             {
-                if(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
+                if(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pEncodeInfo->pSetupReferenceSlot->pPictureResource->imageViewBinding));
             }
         }
 
@@ -828,18 +828,18 @@ void TrackCmdEncodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoE
             {
                 if (pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource != nullptr)
                 {
-                    if(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
+                    if(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pEncodeInfo->pReferenceSlots[pReferenceSlots_index].pPictureResource->imageViewBinding));
                 }
             }
         }
     }
 }
 
-void TrackCmdSetEvent2KHRHandles(CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdSetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
 
     if (pDependencyInfo != nullptr)
     {
@@ -847,7 +847,7 @@ void TrackCmdSetEvent2KHRHandles(CommandBufferWrapper* wrapper, VkEvent event, c
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -855,20 +855,20 @@ void TrackCmdSetEvent2KHRHandles(CommandBufferWrapper* wrapper, VkEvent event, c
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdResetEvent2KHRHandles(CommandBufferWrapper* wrapper, VkEvent event)
+void TrackCmdResetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event)
 {
     assert(wrapper != nullptr);
 
-    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(event));
+    if(event != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(event));
 }
 
-void TrackCmdWaitEvents2KHRHandles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
+void TrackCmdWaitEvents2KHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos)
 {
     assert(wrapper != nullptr);
 
@@ -876,7 +876,7 @@ void TrackCmdWaitEvents2KHRHandles(CommandBufferWrapper* wrapper, uint32_t event
     {
         for (uint32_t pEvents_index = 0; pEvents_index < eventCount; ++pEvents_index)
         {
-            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<EventWrapper>(pEvents[pEvents_index]));
+            if(pEvents[pEvents_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::EventHandle].insert(GetWrappedId<VulkanEventWrapper>(pEvents[pEvents_index]));
         }
     }
 
@@ -888,7 +888,7 @@ void TrackCmdWaitEvents2KHRHandles(CommandBufferWrapper* wrapper, uint32_t event
             {
                 for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                    if(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfos[pDependencyInfos_index].pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
                 }
             }
 
@@ -896,14 +896,14 @@ void TrackCmdWaitEvents2KHRHandles(CommandBufferWrapper* wrapper, uint32_t event
             {
                 for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfos[pDependencyInfos_index].imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
                 {
-                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                    if(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfos[pDependencyInfos_index].pImageMemoryBarriers[pImageMemoryBarriers_index].image));
                 }
             }
         }
     }
 }
 
-void TrackCmdPipelineBarrier2KHRHandles(CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
+void TrackCmdPipelineBarrier2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo)
 {
     assert(wrapper != nullptr);
 
@@ -913,7 +913,7 @@ void TrackCmdPipelineBarrier2KHRHandles(CommandBufferWrapper* wrapper, const VkD
         {
             for (uint32_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pDependencyInfo->bufferMemoryBarrierCount; ++pBufferMemoryBarriers_index)
             {
-                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
+                if(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pDependencyInfo->pBufferMemoryBarriers[pBufferMemoryBarriers_index].buffer));
             }
         }
 
@@ -921,100 +921,100 @@ void TrackCmdPipelineBarrier2KHRHandles(CommandBufferWrapper* wrapper, const VkD
         {
             for (uint32_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pDependencyInfo->imageMemoryBarrierCount; ++pImageMemoryBarriers_index)
             {
-                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
+                if(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pDependencyInfo->pImageMemoryBarriers[pImageMemoryBarriers_index].image));
             }
         }
     }
 }
 
-void TrackCmdWriteTimestamp2KHRHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdWriteTimestamp2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdWriteBufferMarker2AMDHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdWriteBufferMarker2AMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
 }
 
-void TrackCmdCopyBuffer2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
+void TrackCmdCopyBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferInfo != nullptr)
     {
-        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyBufferInfo->srcBuffer));
-        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyBufferInfo->dstBuffer));
+        if(pCopyBufferInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->srcBuffer));
+        if(pCopyBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdCopyImage2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
+void TrackCmdCopyImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageInfo != nullptr)
     {
-        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyImageInfo->srcImage));
-        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyImageInfo->dstImage));
+        if(pCopyImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->srcImage));
+        if(pCopyImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyBufferToImage2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
+void TrackCmdCopyBufferToImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyBufferToImageInfo != nullptr)
     {
-        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
-        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyBufferToImageInfo->dstImage));
+        if(pCopyBufferToImageInfo->srcBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyBufferToImageInfo->srcBuffer));
+        if(pCopyBufferToImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyBufferToImageInfo->dstImage));
     }
 }
 
-void TrackCmdCopyImageToBuffer2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
+void TrackCmdCopyImageToBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
 {
     assert(wrapper != nullptr);
 
     if (pCopyImageToBufferInfo != nullptr)
     {
-        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pCopyImageToBufferInfo->srcImage));
-        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
+        if(pCopyImageToBufferInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pCopyImageToBufferInfo->srcImage));
+        if(pCopyImageToBufferInfo->dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCopyImageToBufferInfo->dstBuffer));
     }
 }
 
-void TrackCmdBlitImage2KHRHandles(CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
+void TrackCmdBlitImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pBlitImageInfo != nullptr)
     {
-        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pBlitImageInfo->srcImage));
-        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pBlitImageInfo->dstImage));
+        if(pBlitImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->srcImage));
+        if(pBlitImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pBlitImageInfo->dstImage));
     }
 }
 
-void TrackCmdResolveImage2KHRHandles(CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
+void TrackCmdResolveImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo)
 {
     assert(wrapper != nullptr);
 
     if (pResolveImageInfo != nullptr)
     {
-        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pResolveImageInfo->srcImage));
-        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<ImageWrapper>(pResolveImageInfo->dstImage));
+        if(pResolveImageInfo->srcImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->srcImage));
+        if(pResolveImageInfo->dstImage != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageHandle].insert(GetWrappedId<VulkanImageWrapper>(pResolveImageInfo->dstImage));
     }
 }
 
-void TrackCmdBindIndexBuffer2KHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdBindIndexBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdBindDescriptorSets2KHRHandles(CommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo)
+void TrackCmdBindDescriptorSets2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1034,7 +1034,7 @@ void TrackCmdBindDescriptorSets2KHRHandles(CommandBufferWrapper* wrapper, const 
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1042,19 +1042,19 @@ void TrackCmdBindDescriptorSets2KHRHandles(CommandBufferWrapper* wrapper, const 
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pBindDescriptorSetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(pBindDescriptorSetsInfo->layout));
+        if(pBindDescriptorSetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pBindDescriptorSetsInfo->layout));
 
         if (pBindDescriptorSetsInfo->pDescriptorSets != nullptr)
         {
             for (uint32_t pDescriptorSets_index = 0; pDescriptorSets_index < pBindDescriptorSetsInfo->descriptorSetCount; ++pDescriptorSets_index)
             {
-                if(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<DescriptorSetWrapper>(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index]));
+                if(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<VulkanDescriptorSetWrapper>(pBindDescriptorSetsInfo->pDescriptorSets[pDescriptorSets_index]));
             }
         }
     }
 }
 
-void TrackCmdPushConstants2KHRHandles(CommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo)
+void TrackCmdPushConstants2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1074,7 +1074,7 @@ void TrackCmdPushConstants2KHRHandles(CommandBufferWrapper* wrapper, const VkPus
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1082,11 +1082,11 @@ void TrackCmdPushConstants2KHRHandles(CommandBufferWrapper* wrapper, const VkPus
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pPushConstantsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(pPushConstantsInfo->layout));
+        if(pPushConstantsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pPushConstantsInfo->layout));
     }
 }
 
-void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo)
+void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1106,7 +1106,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1114,7 +1114,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pPushDescriptorSetInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(pPushDescriptorSetInfo->layout));
+        if(pPushDescriptorSetInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pPushDescriptorSetInfo->layout));
 
         if (pPushDescriptorSetInfo->pDescriptorWrites != nullptr)
         {
@@ -1134,7 +1134,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
                             {
                                 for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pnext_value->accelerationStructureCount; ++pAccelerationStructures_index)
                                 {
-                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
+                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
                             break;
@@ -1146,7 +1146,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
                             {
                                 for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < pnext_value->accelerationStructureCount; ++pAccelerationStructures_index)
                                 {
-                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<AccelerationStructureNVWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
+                                    if(pnext_value->pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(pnext_value->pAccelerationStructures[pAccelerationStructures_index]));
                                 }
                             }
                             break;
@@ -1154,14 +1154,14 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
                     }
                     pnext_header = pnext_header->pNext;
                 }
-                if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<DescriptorSetWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet));
+                if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(GetWrappedId<VulkanDescriptorSetWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].dstSet));
 
                 if (pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo != nullptr)
                 {
                     for (uint32_t pImageInfo_index = 0; pImageInfo_index < pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].descriptorCount; ++pImageInfo_index)
                     {
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::SamplerHandle].insert(GetWrappedId<SamplerWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler));
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::SamplerHandle].insert(GetWrappedId<VulkanSamplerWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].sampler));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pImageInfo[pImageInfo_index].imageView));
                     }
                 }
 
@@ -1169,7 +1169,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
                 {
                     for (uint32_t pBufferInfo_index = 0; pBufferInfo_index < pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].descriptorCount; ++pBufferInfo_index)
                     {
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pBufferInfo[pBufferInfo_index].buffer));
                     }
                 }
 
@@ -1177,7 +1177,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
                 {
                     for (uint32_t pTexelBufferView_index = 0; pTexelBufferView_index < pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].descriptorCount; ++pTexelBufferView_index)
                     {
-                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferViewHandle].insert(GetWrappedId<BufferViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index]));
+                        if(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferViewHandle].insert(GetWrappedId<VulkanBufferViewWrapper>(pPushDescriptorSetInfo->pDescriptorWrites[pDescriptorWrites_index].pTexelBufferView[pTexelBufferView_index]));
                     }
                 }
             }
@@ -1185,7 +1185,7 @@ void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const V
     }
 }
 
-void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(CommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo)
+void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1205,7 +1205,7 @@ void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(CommandBufferWrapper* wrap
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1213,12 +1213,12 @@ void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(CommandBufferWrapper* wrap
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorUpdateTemplateHandle].insert(GetWrappedId<DescriptorUpdateTemplateWrapper>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate));
-        if(pPushDescriptorSetWithTemplateInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(pPushDescriptorSetWithTemplateInfo->layout));
+        if(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorUpdateTemplateHandle].insert(GetWrappedId<VulkanDescriptorUpdateTemplateWrapper>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate));
+        if(pPushDescriptorSetWithTemplateInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pPushDescriptorSetWithTemplateInfo->layout));
     }
 }
 
-void TrackCmdSetDescriptorBufferOffsets2EXTHandles(CommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo)
+void TrackCmdSetDescriptorBufferOffsets2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1238,7 +1238,7 @@ void TrackCmdSetDescriptorBufferOffsets2EXTHandles(CommandBufferWrapper* wrapper
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1246,11 +1246,11 @@ void TrackCmdSetDescriptorBufferOffsets2EXTHandles(CommandBufferWrapper* wrapper
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pSetDescriptorBufferOffsetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(pSetDescriptorBufferOffsetsInfo->layout));
+        if(pSetDescriptorBufferOffsetsInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pSetDescriptorBufferOffsetsInfo->layout));
     }
 }
 
-void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(CommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo)
+void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo)
 {
     assert(wrapper != nullptr);
 
@@ -1270,7 +1270,7 @@ void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(CommandBufferWrappe
                     {
                         for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
                         {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
+                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::DescriptorSetLayoutHandle].insert(GetWrappedId<VulkanDescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
                         }
                     }
                     break;
@@ -1278,11 +1278,11 @@ void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(CommandBufferWrappe
             }
             pnext_header = pnext_header->pNext;
         }
-        if(pBindDescriptorBufferEmbeddedSamplersInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<PipelineLayoutWrapper>(pBindDescriptorBufferEmbeddedSamplersInfo->layout));
+        if(pBindDescriptorBufferEmbeddedSamplersInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(GetWrappedId<VulkanPipelineLayoutWrapper>(pBindDescriptorBufferEmbeddedSamplersInfo->layout));
     }
 }
 
-void TrackCmdBindTransformFeedbackBuffersEXTHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindTransformFeedbackBuffersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1290,12 +1290,12 @@ void TrackCmdBindTransformFeedbackBuffersEXTHandles(CommandBufferWrapper* wrappe
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdBeginTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
+void TrackCmdBeginTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1303,12 +1303,12 @@ void TrackCmdBeginTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uin
     {
         for (uint32_t pCounterBuffers_index = 0; pCounterBuffers_index < counterBufferCount; ++pCounterBuffers_index)
         {
-            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
+            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
         }
     }
 }
 
-void TrackCmdEndTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
+void TrackCmdEndTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1316,66 +1316,66 @@ void TrackCmdEndTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint3
     {
         for (uint32_t pCounterBuffers_index = 0; pCounterBuffers_index < counterBufferCount; ++pCounterBuffers_index)
         {
-            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
+            if(pCounterBuffers[pCounterBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pCounterBuffers[pCounterBuffers_index]));
         }
     }
 }
 
-void TrackCmdBeginQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdBeginQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdEndQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+void TrackCmdEndQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdDrawIndirectByteCountEXTHandles(CommandBufferWrapper* wrapper, VkBuffer counterBuffer)
+void TrackCmdDrawIndirectByteCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer counterBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(counterBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(counterBuffer));
+    if(counterBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(counterBuffer));
 }
 
-void TrackCmdDrawIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
-void TrackCmdDrawIndexedIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawIndexedIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
-void TrackCmdBeginConditionalRenderingEXTHandles(CommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin)
+void TrackCmdBeginConditionalRenderingEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin)
 {
     assert(wrapper != nullptr);
 
     if (pConditionalRenderingBegin != nullptr)
     {
-        if(pConditionalRenderingBegin->buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pConditionalRenderingBegin->buffer));
+        if(pConditionalRenderingBegin->buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pConditionalRenderingBegin->buffer));
     }
 }
 
-void TrackCmdBindShadingRateImageNVHandles(CommandBufferWrapper* wrapper, VkImageView imageView)
+void TrackCmdBindShadingRateImageNVHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView)
 {
     assert(wrapper != nullptr);
 
-    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(imageView));
+    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(imageView));
 }
 
-void TrackCmdBuildAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch)
+void TrackCmdBuildAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch)
 {
     assert(wrapper != nullptr);
 
@@ -1385,38 +1385,38 @@ void TrackCmdBuildAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, 
         {
             for (uint32_t pGeometries_index = 0; pGeometries_index < pInfo->geometryCount; ++pGeometries_index)
             {
-                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData));
-                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData));
-                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData));
-                if(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.vertexData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.indexData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.triangles.transformData));
+                if(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pInfo->pGeometries[pGeometries_index].geometry.aabbs.aabbData));
             }
         }
     }
-    if(instanceData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(instanceData));
-    if(dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<AccelerationStructureNVWrapper>(dst));
-    if(src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<AccelerationStructureNVWrapper>(src));
-    if(scratch != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(scratch));
+    if(instanceData != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(instanceData));
+    if(dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(dst));
+    if(src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(src));
+    if(scratch != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(scratch));
 }
 
-void TrackCmdCopyAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src)
+void TrackCmdCopyAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src)
 {
     assert(wrapper != nullptr);
 
-    if(dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<AccelerationStructureNVWrapper>(dst));
-    if(src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<AccelerationStructureNVWrapper>(src));
+    if(dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(dst));
+    if(src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(src));
 }
 
-void TrackCmdTraceRaysNVHandles(CommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer)
+void TrackCmdTraceRaysNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(raygenShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(raygenShaderBindingTableBuffer));
-    if(missShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(missShaderBindingTableBuffer));
-    if(hitShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(hitShaderBindingTableBuffer));
-    if(callableShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(callableShaderBindingTableBuffer));
+    if(raygenShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(raygenShaderBindingTableBuffer));
+    if(missShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(missShaderBindingTableBuffer));
+    if(hitShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(hitShaderBindingTableBuffer));
+    if(callableShaderBindingTableBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(callableShaderBindingTableBuffer));
 }
 
-void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool)
+void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
@@ -1424,35 +1424,35 @@ void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(CommandBufferWrapper
     {
         for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < accelerationStructureCount; ++pAccelerationStructures_index)
         {
-            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<AccelerationStructureNVWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
+            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(GetWrappedId<VulkanAccelerationStructureNVWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
         }
     }
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdWriteBufferMarkerAMDHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+void TrackCmdWriteBufferMarkerAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(dstBuffer));
+    if(dstBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(dstBuffer));
 }
 
-void TrackCmdDrawMeshTasksIndirectNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawMeshTasksIndirectNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdDrawMeshTasksIndirectCountNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawMeshTasksIndirectCountNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
-void TrackCmdBindVertexBuffers2EXTHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+void TrackCmdBindVertexBuffers2EXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
 {
     assert(wrapper != nullptr);
 
@@ -1460,70 +1460,70 @@ void TrackCmdBindVertexBuffers2EXTHandles(CommandBufferWrapper* wrapper, uint32_
     {
         for (uint32_t pBuffers_index = 0; pBuffers_index < bindingCount; ++pBuffers_index)
         {
-            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pBuffers[pBuffers_index]));
+            if(pBuffers[pBuffers_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pBuffers[pBuffers_index]));
         }
     }
 }
 
-void TrackCmdPreprocessGeneratedCommandsNVHandles(CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
+void TrackCmdPreprocessGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
 {
     assert(wrapper != nullptr);
 
     if (pGeneratedCommandsInfo != nullptr)
     {
-        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<PipelineWrapper>(pGeneratedCommandsInfo->pipeline));
-        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetWrappedId<IndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
+        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pGeneratedCommandsInfo->pipeline));
+        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetWrappedId<VulkanIndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
 
         if (pGeneratedCommandsInfo->pStreams != nullptr)
         {
             for (uint32_t pStreams_index = 0; pStreams_index < pGeneratedCommandsInfo->streamCount; ++pStreams_index)
             {
-                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
+                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
             }
         }
-        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
-        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
-        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
+        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
+        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
+        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
     }
 }
 
-void TrackCmdExecuteGeneratedCommandsNVHandles(CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
+void TrackCmdExecuteGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo)
 {
     assert(wrapper != nullptr);
 
     if (pGeneratedCommandsInfo != nullptr)
     {
-        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<PipelineWrapper>(pGeneratedCommandsInfo->pipeline));
-        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetWrappedId<IndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
+        if(pGeneratedCommandsInfo->pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pGeneratedCommandsInfo->pipeline));
+        if(pGeneratedCommandsInfo->indirectCommandsLayout != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVHandle].insert(GetWrappedId<VulkanIndirectCommandsLayoutNVWrapper>(pGeneratedCommandsInfo->indirectCommandsLayout));
 
         if (pGeneratedCommandsInfo->pStreams != nullptr)
         {
             for (uint32_t pStreams_index = 0; pStreams_index < pGeneratedCommandsInfo->streamCount; ++pStreams_index)
             {
-                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
+                if(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->pStreams[pStreams_index].buffer));
             }
         }
-        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
-        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
-        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
+        if(pGeneratedCommandsInfo->preprocessBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->preprocessBuffer));
+        if(pGeneratedCommandsInfo->sequencesCountBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesCountBuffer));
+        if(pGeneratedCommandsInfo->sequencesIndexBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(pGeneratedCommandsInfo->sequencesIndexBuffer));
     }
 }
 
-void TrackCmdBindPipelineShaderGroupNVHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline)
+void TrackCmdBindPipelineShaderGroupNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline)
 {
     assert(wrapper != nullptr);
 
-    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<PipelineWrapper>(pipeline));
+    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pipeline));
 }
 
-void TrackCmdBindInvocationMaskHUAWEIHandles(CommandBufferWrapper* wrapper, VkImageView imageView)
+void TrackCmdBindInvocationMaskHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView)
 {
     assert(wrapper != nullptr);
 
-    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<ImageViewWrapper>(imageView));
+    if(imageView != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(GetWrappedId<VulkanImageViewWrapper>(imageView));
 }
 
-void TrackCmdBuildMicromapsEXTHandles(CommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos)
+void TrackCmdBuildMicromapsEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos)
 {
     assert(wrapper != nullptr);
 
@@ -1531,43 +1531,43 @@ void TrackCmdBuildMicromapsEXTHandles(CommandBufferWrapper* wrapper, uint32_t in
     {
         for (uint32_t pInfos_index = 0; pInfos_index < infoCount; ++pInfos_index)
         {
-            if(pInfos[pInfos_index].dstMicromap != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<MicromapEXTWrapper>(pInfos[pInfos_index].dstMicromap));
+            if(pInfos[pInfos_index].dstMicromap != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfos[pInfos_index].dstMicromap));
         }
     }
 }
 
-void TrackCmdCopyMicromapEXTHandles(CommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo)
+void TrackCmdCopyMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<MicromapEXTWrapper>(pInfo->src));
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<MicromapEXTWrapper>(pInfo->dst));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->src));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdCopyMicromapToMemoryEXTHandles(CommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo)
+void TrackCmdCopyMicromapToMemoryEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<MicromapEXTWrapper>(pInfo->src));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->src));
     }
 }
 
-void TrackCmdCopyMemoryToMicromapEXTHandles(CommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo)
+void TrackCmdCopyMemoryToMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<MicromapEXTWrapper>(pInfo->dst));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdWriteMicromapsPropertiesEXTHandles(CommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool)
+void TrackCmdWriteMicromapsPropertiesEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
@@ -1575,34 +1575,34 @@ void TrackCmdWriteMicromapsPropertiesEXTHandles(CommandBufferWrapper* wrapper, u
     {
         for (uint32_t pMicromaps_index = 0; pMicromaps_index < micromapCount; ++pMicromaps_index)
         {
-            if(pMicromaps[pMicromaps_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<MicromapEXTWrapper>(pMicromaps[pMicromaps_index]));
+            if(pMicromaps[pMicromaps_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::MicromapEXTHandle].insert(GetWrappedId<VulkanMicromapEXTWrapper>(pMicromaps[pMicromaps_index]));
         }
     }
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdDrawClusterIndirectHUAWEIHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawClusterIndirectHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdUpdatePipelineIndirectBufferNVHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline)
+void TrackCmdUpdatePipelineIndirectBufferNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline)
 {
     assert(wrapper != nullptr);
 
-    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<PipelineWrapper>(pipeline));
+    if(pipeline != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::PipelineHandle].insert(GetWrappedId<VulkanPipelineWrapper>(pipeline));
 }
 
-void TrackCmdOpticalFlowExecuteNVHandles(CommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session)
+void TrackCmdOpticalFlowExecuteNVHandles(VulkanCommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session)
 {
     assert(wrapper != nullptr);
 
-    if(session != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::OpticalFlowSessionNVHandle].insert(GetWrappedId<OpticalFlowSessionNVWrapper>(session));
+    if(session != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::OpticalFlowSessionNVHandle].insert(GetWrappedId<VulkanOpticalFlowSessionNVWrapper>(session));
 }
 
-void TrackCmdBindShadersEXTHandles(CommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders)
+void TrackCmdBindShadersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders)
 {
     assert(wrapper != nullptr);
 
@@ -1610,12 +1610,12 @@ void TrackCmdBindShadersEXTHandles(CommandBufferWrapper* wrapper, uint32_t stage
     {
         for (uint32_t pShaders_index = 0; pShaders_index < stageCount; ++pShaders_index)
         {
-            if(pShaders[pShaders_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ShaderEXTHandle].insert(GetWrappedId<ShaderEXTWrapper>(pShaders[pShaders_index]));
+            if(pShaders[pShaders_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::ShaderEXTHandle].insert(GetWrappedId<VulkanShaderEXTWrapper>(pShaders[pShaders_index]));
         }
     }
 }
 
-void TrackCmdBuildAccelerationStructuresKHRHandles(CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
+void TrackCmdBuildAccelerationStructuresKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
 {
     assert(wrapper != nullptr);
 
@@ -1623,13 +1623,13 @@ void TrackCmdBuildAccelerationStructuresKHRHandles(CommandBufferWrapper* wrapper
     {
         for (uint32_t pInfos_index = 0; pInfos_index < infoCount; ++pInfos_index)
         {
-            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
-            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
+            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
+            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
         }
     }
 }
 
-void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
+void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos)
 {
     assert(wrapper != nullptr);
 
@@ -1637,44 +1637,44 @@ void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(CommandBufferWrapper*
     {
         for (uint32_t pInfos_index = 0; pInfos_index < infoCount; ++pInfos_index)
         {
-            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
-            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
+            if(pInfos[pInfos_index].srcAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].srcAccelerationStructure));
+            if(pInfos[pInfos_index].dstAccelerationStructure != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfos[pInfos_index].dstAccelerationStructure));
         }
     }
 }
 
-void TrackCmdCopyAccelerationStructureKHRHandles(CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo)
+void TrackCmdCopyAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfo->src));
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfo->dst));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->src));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo)
+void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfo->src));
+        if(pInfo->src != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->src));
     }
 }
 
-void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(CommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo)
+void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo)
 {
     assert(wrapper != nullptr);
 
     if (pInfo != nullptr)
     {
-        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pInfo->dst));
+        if(pInfo->dst != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pInfo->dst));
     }
 }
 
-void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool)
+void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool)
 {
     assert(wrapper != nullptr);
 
@@ -1682,25 +1682,25 @@ void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(CommandBufferWrappe
     {
         for (uint32_t pAccelerationStructures_index = 0; pAccelerationStructures_index < accelerationStructureCount; ++pAccelerationStructures_index)
         {
-            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<AccelerationStructureKHRWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
+            if(pAccelerationStructures[pAccelerationStructures_index] != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::AccelerationStructureKHRHandle].insert(GetWrappedId<VulkanAccelerationStructureKHRWrapper>(pAccelerationStructures[pAccelerationStructures_index]));
         }
     }
-    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<QueryPoolWrapper>(queryPool));
+    if(queryPool != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(GetWrappedId<VulkanQueryPoolWrapper>(queryPool));
 }
 
-void TrackCmdDrawMeshTasksIndirectEXTHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+void TrackCmdDrawMeshTasksIndirectEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
 }
 
-void TrackCmdDrawMeshTasksIndirectCountEXTHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+void TrackCmdDrawMeshTasksIndirectCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
 {
     assert(wrapper != nullptr);
 
-    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(buffer));
-    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<BufferWrapper>(countBuffer));
+    if(buffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(buffer));
+    if(countBuffer != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::BufferHandle].insert(GetWrappedId<VulkanBufferWrapper>(countBuffer));
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/generated/generated_vulkan_command_buffer_util.h
+++ b/framework/generated/generated_vulkan_command_buffer_util.h
@@ -45,229 +45,229 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void TrackBeginCommandBufferHandles(VulkanCommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo);
+void TrackBeginCommandBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo);
 
-void TrackCmdBindPipelineHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline);
+void TrackCmdBindPipelineHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipeline pipeline);
 
-void TrackCmdBindDescriptorSetsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets);
+void TrackCmdBindDescriptorSetsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets);
 
-void TrackCmdBindIndexBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdBindIndexBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdBindVertexBuffersHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindVertexBuffersHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdDrawIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawIndirectHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDrawIndexedIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawIndexedIndirectHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDispatchIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDispatchIndirectHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdCopyBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer);
+void TrackCmdCopyBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer);
 
-void TrackCmdCopyImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+void TrackCmdCopyImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
 
-void TrackCmdBlitImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+void TrackCmdBlitImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
 
-void TrackCmdCopyBufferToImageHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage);
+void TrackCmdCopyBufferToImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage);
 
-void TrackCmdCopyImageToBufferHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer);
+void TrackCmdCopyImageToBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer);
 
-void TrackCmdUpdateBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdUpdateBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdFillBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdFillBufferHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdClearColorImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image);
+void TrackCmdClearColorImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage image);
 
-void TrackCmdClearDepthStencilImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image);
+void TrackCmdClearDepthStencilImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage image);
 
-void TrackCmdResolveImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+void TrackCmdResolveImageHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
 
-void TrackCmdSetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdSetEventHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdResetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdResetEventHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdWaitEventsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+void TrackCmdWaitEventsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
 
-void TrackCmdPipelineBarrierHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+void TrackCmdPipelineBarrierHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
 
-void TrackCmdBeginQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdBeginQueryHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdEndQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdEndQueryHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdResetQueryPoolHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdResetQueryPoolHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdWriteTimestampHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdWriteTimestampHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdCopyQueryPoolResultsHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer);
+void TrackCmdCopyQueryPoolResultsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer);
 
-void TrackCmdPushConstantsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout);
+void TrackCmdPushConstantsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipelineLayout layout);
 
-void TrackCmdBeginRenderPassHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+void TrackCmdBeginRenderPassHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
 
-void TrackCmdExecuteCommandsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers);
+void TrackCmdExecuteCommandsHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers);
 
-void TrackCmdDrawIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndirectCountHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdDrawIndexedIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndexedIndirectCountHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdBeginRenderPass2Handles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+void TrackCmdBeginRenderPass2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
 
-void TrackCmdSetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdSetEvent2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdResetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdResetEvent2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdWaitEvents2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
+void TrackCmdWaitEvents2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
 
-void TrackCmdPipelineBarrier2Handles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdPipelineBarrier2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdWriteTimestamp2Handles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdWriteTimestamp2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdCopyBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
+void TrackCmdCopyBuffer2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
 
-void TrackCmdCopyImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
+void TrackCmdCopyImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
 
-void TrackCmdCopyBufferToImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+void TrackCmdCopyBufferToImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
-void TrackCmdCopyImageToBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+void TrackCmdCopyImageToBuffer2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
-void TrackCmdBlitImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
+void TrackCmdBlitImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
 
-void TrackCmdResolveImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
+void TrackCmdResolveImage2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
 
-void TrackCmdBeginRenderingHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
+void TrackCmdBeginRenderingHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
 
-void TrackCmdBindVertexBuffers2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindVertexBuffers2Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdBeginVideoCodingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo);
+void TrackCmdBeginVideoCodingKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo);
 
-void TrackCmdDecodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo);
+void TrackCmdDecodeVideoKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo);
 
-void TrackCmdBeginRenderingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
+void TrackCmdBeginRenderingKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
 
-void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites);
+void TrackCmdPushDescriptorSetKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites);
 
-void TrackCmdBeginRenderPass2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+void TrackCmdBeginRenderPass2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
 
-void TrackCmdDrawIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndirectCountKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdDrawIndexedIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndexedIndirectCountKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdEncodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo);
+void TrackCmdEncodeVideoKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo);
 
-void TrackCmdSetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdSetEvent2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdResetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdResetEvent2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdWaitEvents2KHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
+void TrackCmdWaitEvents2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
 
-void TrackCmdPipelineBarrier2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdPipelineBarrier2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdWriteTimestamp2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdWriteTimestamp2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdWriteBufferMarker2AMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdWriteBufferMarker2AMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdCopyBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
+void TrackCmdCopyBuffer2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
 
-void TrackCmdCopyImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
+void TrackCmdCopyImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
 
-void TrackCmdCopyBufferToImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+void TrackCmdCopyBufferToImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
-void TrackCmdCopyImageToBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+void TrackCmdCopyImageToBuffer2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
-void TrackCmdBlitImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
+void TrackCmdBlitImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
 
-void TrackCmdResolveImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
+void TrackCmdResolveImage2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
 
-void TrackCmdBindIndexBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdBindIndexBuffer2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdBindDescriptorSets2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
+void TrackCmdBindDescriptorSets2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
 
-void TrackCmdPushConstants2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo);
+void TrackCmdPushConstants2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo);
 
-void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo);
+void TrackCmdPushDescriptorSet2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo);
 
-void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
+void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
 
-void TrackCmdSetDescriptorBufferOffsets2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo);
+void TrackCmdSetDescriptorBufferOffsets2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo);
 
-void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo);
+void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo);
 
-void TrackCmdBindTransformFeedbackBuffersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindTransformFeedbackBuffersEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdBeginTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
+void TrackCmdBeginTransformFeedbackEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
 
-void TrackCmdEndTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
+void TrackCmdEndTransformFeedbackEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
 
-void TrackCmdBeginQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdBeginQueryIndexedEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdEndQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdEndQueryIndexedEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdDrawIndirectByteCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer counterBuffer);
+void TrackCmdDrawIndirectByteCountEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer counterBuffer);
 
-void TrackCmdDrawIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndirectCountAMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdDrawIndexedIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndexedIndirectCountAMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdBeginConditionalRenderingEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin);
+void TrackCmdBeginConditionalRenderingEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin);
 
-void TrackCmdBindShadingRateImageNVHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView);
+void TrackCmdBindShadingRateImageNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImageView imageView);
 
-void TrackCmdBuildAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch);
+void TrackCmdBuildAccelerationStructureNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch);
 
-void TrackCmdCopyAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src);
+void TrackCmdCopyAccelerationStructureNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src);
 
-void TrackCmdTraceRaysNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer);
+void TrackCmdTraceRaysNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer);
 
-void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool);
+void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool);
 
-void TrackCmdWriteBufferMarkerAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdWriteBufferMarkerAMDHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdDrawMeshTasksIndirectNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawMeshTasksIndirectNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDrawMeshTasksIndirectCountNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawMeshTasksIndirectCountNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdBindVertexBuffers2EXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindVertexBuffers2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdPreprocessGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
+void TrackCmdPreprocessGeneratedCommandsNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
 
-void TrackCmdExecuteGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
+void TrackCmdExecuteGeneratedCommandsNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
 
-void TrackCmdBindPipelineShaderGroupNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline);
+void TrackCmdBindPipelineShaderGroupNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipeline pipeline);
 
-void TrackCmdBindInvocationMaskHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView);
+void TrackCmdBindInvocationMaskHUAWEIHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkImageView imageView);
 
-void TrackCmdBuildMicromapsEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos);
+void TrackCmdBuildMicromapsEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos);
 
-void TrackCmdCopyMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo);
+void TrackCmdCopyMicromapEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo);
 
-void TrackCmdCopyMicromapToMemoryEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo);
+void TrackCmdCopyMicromapToMemoryEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo);
 
-void TrackCmdCopyMemoryToMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo);
+void TrackCmdCopyMemoryToMicromapEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo);
 
-void TrackCmdWriteMicromapsPropertiesEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool);
+void TrackCmdWriteMicromapsPropertiesEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool);
 
-void TrackCmdDrawClusterIndirectHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawClusterIndirectHUAWEIHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdUpdatePipelineIndirectBufferNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline);
+void TrackCmdUpdatePipelineIndirectBufferNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkPipeline pipeline);
 
-void TrackCmdOpticalFlowExecuteNVHandles(VulkanCommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session);
+void TrackCmdOpticalFlowExecuteNVHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session);
 
-void TrackCmdBindShadersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders);
+void TrackCmdBindShadersEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders);
 
-void TrackCmdBuildAccelerationStructuresKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
+void TrackCmdBuildAccelerationStructuresKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
 
-void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
+void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
 
-void TrackCmdCopyAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo);
+void TrackCmdCopyAccelerationStructureKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo);
 
-void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo);
+void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo);
 
-void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo);
+void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo);
 
-void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool);
+void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool);
 
-void TrackCmdDrawMeshTasksIndirectEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawMeshTasksIndirectEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDrawMeshTasksIndirectCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawMeshTasksIndirectCountEXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_command_buffer_util.h
+++ b/framework/generated/generated_vulkan_command_buffer_util.h
@@ -45,229 +45,229 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void TrackBeginCommandBufferHandles(CommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo);
+void TrackBeginCommandBufferHandles(VulkanCommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo);
 
-void TrackCmdBindPipelineHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline);
+void TrackCmdBindPipelineHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline);
 
-void TrackCmdBindDescriptorSetsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets);
+void TrackCmdBindDescriptorSetsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets);
 
-void TrackCmdBindIndexBufferHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdBindIndexBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdBindVertexBuffersHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindVertexBuffersHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdDrawIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDrawIndexedIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawIndexedIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDispatchIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDispatchIndirectHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdCopyBufferHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer);
+void TrackCmdCopyBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer);
 
-void TrackCmdCopyImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+void TrackCmdCopyImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
 
-void TrackCmdBlitImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+void TrackCmdBlitImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
 
-void TrackCmdCopyBufferToImageHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage);
+void TrackCmdCopyBufferToImageHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage);
 
-void TrackCmdCopyImageToBufferHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer);
+void TrackCmdCopyImageToBufferHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer);
 
-void TrackCmdUpdateBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdUpdateBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdFillBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdFillBufferHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdClearColorImageHandles(CommandBufferWrapper* wrapper, VkImage image);
+void TrackCmdClearColorImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image);
 
-void TrackCmdClearDepthStencilImageHandles(CommandBufferWrapper* wrapper, VkImage image);
+void TrackCmdClearDepthStencilImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage image);
 
-void TrackCmdResolveImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+void TrackCmdResolveImageHandles(VulkanCommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
 
-void TrackCmdSetEventHandles(CommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdSetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdResetEventHandles(CommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdResetEventHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdWaitEventsHandles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+void TrackCmdWaitEventsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
 
-void TrackCmdPipelineBarrierHandles(CommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+void TrackCmdPipelineBarrierHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
 
-void TrackCmdBeginQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdBeginQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdEndQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdEndQueryHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdResetQueryPoolHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdResetQueryPoolHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdWriteTimestampHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdWriteTimestampHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdCopyQueryPoolResultsHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer);
+void TrackCmdCopyQueryPoolResultsHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer);
 
-void TrackCmdPushConstantsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout);
+void TrackCmdPushConstantsHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout);
 
-void TrackCmdBeginRenderPassHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+void TrackCmdBeginRenderPassHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
 
-void TrackCmdExecuteCommandsHandles(CommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers);
+void TrackCmdExecuteCommandsHandles(VulkanCommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers);
 
-void TrackCmdDrawIndirectCountHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdDrawIndexedIndirectCountHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndexedIndirectCountHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdBeginRenderPass2Handles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+void TrackCmdBeginRenderPass2Handles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
 
-void TrackCmdSetEvent2Handles(CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdSetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdResetEvent2Handles(CommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdResetEvent2Handles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdWaitEvents2Handles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
+void TrackCmdWaitEvents2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
 
-void TrackCmdPipelineBarrier2Handles(CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdPipelineBarrier2Handles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdWriteTimestamp2Handles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdWriteTimestamp2Handles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdCopyBuffer2Handles(CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
+void TrackCmdCopyBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
 
-void TrackCmdCopyImage2Handles(CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
+void TrackCmdCopyImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
 
-void TrackCmdCopyBufferToImage2Handles(CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+void TrackCmdCopyBufferToImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
-void TrackCmdCopyImageToBuffer2Handles(CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+void TrackCmdCopyImageToBuffer2Handles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
-void TrackCmdBlitImage2Handles(CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
+void TrackCmdBlitImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
 
-void TrackCmdResolveImage2Handles(CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
+void TrackCmdResolveImage2Handles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
 
-void TrackCmdBeginRenderingHandles(CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
+void TrackCmdBeginRenderingHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
 
-void TrackCmdBindVertexBuffers2Handles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindVertexBuffers2Handles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdBeginVideoCodingKHRHandles(CommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo);
+void TrackCmdBeginVideoCodingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoBeginCodingInfoKHR* pBeginInfo);
 
-void TrackCmdDecodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo);
+void TrackCmdDecodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoDecodeInfoKHR* pDecodeInfo);
 
-void TrackCmdBeginRenderingKHRHandles(CommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
+void TrackCmdBeginRenderingKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderingInfo* pRenderingInfo);
 
-void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites);
+void TrackCmdPushDescriptorSetKHRHandles(VulkanCommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites);
 
-void TrackCmdBeginRenderPass2KHRHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+void TrackCmdBeginRenderPass2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
 
-void TrackCmdDrawIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdDrawIndexedIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndexedIndirectCountKHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdEncodeVideoKHRHandles(CommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo);
+void TrackCmdEncodeVideoKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkVideoEncodeInfoKHR* pEncodeInfo);
 
-void TrackCmdSetEvent2KHRHandles(CommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdSetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdResetEvent2KHRHandles(CommandBufferWrapper* wrapper, VkEvent event);
+void TrackCmdResetEvent2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkEvent event);
 
-void TrackCmdWaitEvents2KHRHandles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
+void TrackCmdWaitEvents2KHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos);
 
-void TrackCmdPipelineBarrier2KHRHandles(CommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
+void TrackCmdPipelineBarrier2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkDependencyInfo* pDependencyInfo);
 
-void TrackCmdWriteTimestamp2KHRHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdWriteTimestamp2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdWriteBufferMarker2AMDHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdWriteBufferMarker2AMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdCopyBuffer2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
+void TrackCmdCopyBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferInfo2* pCopyBufferInfo);
 
-void TrackCmdCopyImage2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
+void TrackCmdCopyImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageInfo2* pCopyImageInfo);
 
-void TrackCmdCopyBufferToImage2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+void TrackCmdCopyBufferToImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
-void TrackCmdCopyImageToBuffer2KHRHandles(CommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+void TrackCmdCopyImageToBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
-void TrackCmdBlitImage2KHRHandles(CommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
+void TrackCmdBlitImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBlitImageInfo2* pBlitImageInfo);
 
-void TrackCmdResolveImage2KHRHandles(CommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
+void TrackCmdResolveImage2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkResolveImageInfo2* pResolveImageInfo);
 
-void TrackCmdBindIndexBuffer2KHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdBindIndexBuffer2KHRHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdBindDescriptorSets2KHRHandles(CommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
+void TrackCmdBindDescriptorSets2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
 
-void TrackCmdPushConstants2KHRHandles(CommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo);
+void TrackCmdPushConstants2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushConstantsInfoKHR* pPushConstantsInfo);
 
-void TrackCmdPushDescriptorSet2KHRHandles(CommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo);
+void TrackCmdPushDescriptorSet2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo);
 
-void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(CommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
+void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(VulkanCommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
 
-void TrackCmdSetDescriptorBufferOffsets2EXTHandles(CommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo);
+void TrackCmdSetDescriptorBufferOffsets2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo);
 
-void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(CommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo);
+void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(VulkanCommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo);
 
-void TrackCmdBindTransformFeedbackBuffersEXTHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindTransformFeedbackBuffersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdBeginTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
+void TrackCmdBeginTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
 
-void TrackCmdEndTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
+void TrackCmdEndTransformFeedbackEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
 
-void TrackCmdBeginQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdBeginQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdEndQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+void TrackCmdEndQueryIndexedEXTHandles(VulkanCommandBufferWrapper* wrapper, VkQueryPool queryPool);
 
-void TrackCmdDrawIndirectByteCountEXTHandles(CommandBufferWrapper* wrapper, VkBuffer counterBuffer);
+void TrackCmdDrawIndirectByteCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer counterBuffer);
 
-void TrackCmdDrawIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdDrawIndexedIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawIndexedIndirectCountAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdBeginConditionalRenderingEXTHandles(CommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin);
+void TrackCmdBeginConditionalRenderingEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin);
 
-void TrackCmdBindShadingRateImageNVHandles(CommandBufferWrapper* wrapper, VkImageView imageView);
+void TrackCmdBindShadingRateImageNVHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView);
 
-void TrackCmdBuildAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch);
+void TrackCmdBuildAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch);
 
-void TrackCmdCopyAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src);
+void TrackCmdCopyAccelerationStructureNVHandles(VulkanCommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src);
 
-void TrackCmdTraceRaysNVHandles(CommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer);
+void TrackCmdTraceRaysNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer);
 
-void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool);
+void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool);
 
-void TrackCmdWriteBufferMarkerAMDHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+void TrackCmdWriteBufferMarkerAMDHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer dstBuffer);
 
-void TrackCmdDrawMeshTasksIndirectNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawMeshTasksIndirectNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDrawMeshTasksIndirectCountNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawMeshTasksIndirectCountNVHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
-void TrackCmdBindVertexBuffers2EXTHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+void TrackCmdBindVertexBuffers2EXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
 
-void TrackCmdPreprocessGeneratedCommandsNVHandles(CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
+void TrackCmdPreprocessGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
 
-void TrackCmdExecuteGeneratedCommandsNVHandles(CommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
+void TrackCmdExecuteGeneratedCommandsNVHandles(VulkanCommandBufferWrapper* wrapper, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
 
-void TrackCmdBindPipelineShaderGroupNVHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline);
+void TrackCmdBindPipelineShaderGroupNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline);
 
-void TrackCmdBindInvocationMaskHUAWEIHandles(CommandBufferWrapper* wrapper, VkImageView imageView);
+void TrackCmdBindInvocationMaskHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkImageView imageView);
 
-void TrackCmdBuildMicromapsEXTHandles(CommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos);
+void TrackCmdBuildMicromapsEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkMicromapBuildInfoEXT* pInfos);
 
-void TrackCmdCopyMicromapEXTHandles(CommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo);
+void TrackCmdCopyMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapInfoEXT* pInfo);
 
-void TrackCmdCopyMicromapToMemoryEXTHandles(CommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo);
+void TrackCmdCopyMicromapToMemoryEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMicromapToMemoryInfoEXT* pInfo);
 
-void TrackCmdCopyMemoryToMicromapEXTHandles(CommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo);
+void TrackCmdCopyMemoryToMicromapEXTHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToMicromapInfoEXT* pInfo);
 
-void TrackCmdWriteMicromapsPropertiesEXTHandles(CommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool);
+void TrackCmdWriteMicromapsPropertiesEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t micromapCount, const VkMicromapEXT* pMicromaps, VkQueryPool queryPool);
 
-void TrackCmdDrawClusterIndirectHUAWEIHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawClusterIndirectHUAWEIHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdUpdatePipelineIndirectBufferNVHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline);
+void TrackCmdUpdatePipelineIndirectBufferNVHandles(VulkanCommandBufferWrapper* wrapper, VkPipeline pipeline);
 
-void TrackCmdOpticalFlowExecuteNVHandles(CommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session);
+void TrackCmdOpticalFlowExecuteNVHandles(VulkanCommandBufferWrapper* wrapper, VkOpticalFlowSessionNV session);
 
-void TrackCmdBindShadersEXTHandles(CommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders);
+void TrackCmdBindShadersEXTHandles(VulkanCommandBufferWrapper* wrapper, uint32_t stageCount, const VkShaderEXT* pShaders);
 
-void TrackCmdBuildAccelerationStructuresKHRHandles(CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
+void TrackCmdBuildAccelerationStructuresKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
 
-void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(CommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
+void TrackCmdBuildAccelerationStructuresIndirectKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos);
 
-void TrackCmdCopyAccelerationStructureKHRHandles(CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo);
+void TrackCmdCopyAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureInfoKHR* pInfo);
 
-void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(CommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo);
+void TrackCmdCopyAccelerationStructureToMemoryKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo);
 
-void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(CommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo);
+void TrackCmdCopyMemoryToAccelerationStructureKHRHandles(VulkanCommandBufferWrapper* wrapper, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo);
 
-void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool);
+void TrackCmdWriteAccelerationStructuresPropertiesKHRHandles(VulkanCommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryPool queryPool);
 
-void TrackCmdDrawMeshTasksIndirectEXTHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+void TrackCmdDrawMeshTasksIndirectEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer);
 
-void TrackCmdDrawMeshTasksIndirectCountEXTHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+void TrackCmdDrawMeshTasksIndirectCountEXTHandles(VulkanCommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_dispatch_table.h
+++ b/framework/generated/generated_vulkan_dispatch_table.h
@@ -703,13 +703,13 @@ static VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountEXT(VkCommandBuff
 // clang-format on
 GFXRECON_END_NAMESPACE(noop)
 
-struct LayerTable
+struct VulkanLayerTable
 {
     PFN_vkCreateInstance CreateInstance{ nullptr };
     PFN_vkCreateDevice CreateDevice{ nullptr };
 };
 
-struct InstanceTable
+struct VulkanInstanceTable
 {
     PFN_vkDestroyInstance DestroyInstance{ noop::DestroyInstance };
     PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices{ noop::EnumeratePhysicalDevices };
@@ -819,7 +819,7 @@ struct InstanceTable
     PFN_vkGetPhysicalDeviceOpticalFlowImageFormatsNV GetPhysicalDeviceOpticalFlowImageFormatsNV{ noop::GetPhysicalDeviceOpticalFlowImageFormatsNV };
 };
 
-struct DeviceTable
+struct VulkanDeviceTable
 {
     PFN_vkGetDeviceProcAddr GetDeviceProcAddr{ noop::GetDeviceProcAddr };
     PFN_vkDestroyDevice DestroyDevice{ noop::DestroyDevice };
@@ -1360,7 +1360,7 @@ static void LoadFunction(GetProcAddr gpa, Handle handle, const char* name, FuncP
     }
 }
 
-static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, InstanceTable* table)
+static void LoadVulkanInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, VulkanInstanceTable* table)
 {
     assert(table != nullptr);
 
@@ -1472,7 +1472,7 @@ static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance
     LoadFunction(gpa, instance, "vkGetPhysicalDeviceOpticalFlowImageFormatsNV", &table->GetPhysicalDeviceOpticalFlowImageFormatsNV);
 }
 
-static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, DeviceTable* table)
+static void LoadVulkanDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, VulkanDeviceTable* table)
 {
     assert(table != nullptr);
 

--- a/framework/generated/generated_vulkan_state_table.h
+++ b/framework/generated/generated_vulkan_state_table.h
@@ -42,282 +42,282 @@ class VulkanStateTable : VulkanStateTableBase
     VulkanStateTable() {}
     ~VulkanStateTable() {}
 
-    bool InsertWrapper(format::HandleId id, AccelerationStructureKHRWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureKHR_map_); }
-    bool InsertWrapper(format::HandleId id, AccelerationStructureNVWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureNV_map_); }
-    bool InsertWrapper(format::HandleId id, BufferWrapper* wrapper) { return InsertEntry(id, wrapper, buffer_map_); }
-    bool InsertWrapper(format::HandleId id, BufferViewWrapper* wrapper) { return InsertEntry(id, wrapper, bufferView_map_); }
-    bool InsertWrapper(format::HandleId id, CommandBufferWrapper* wrapper) { return InsertEntry(id, wrapper, commandBuffer_map_); }
-    bool InsertWrapper(format::HandleId id, CommandPoolWrapper* wrapper) { return InsertEntry(id, wrapper, commandPool_map_); }
-    bool InsertWrapper(format::HandleId id, DebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugReportCallbackEXT_map_); }
-    bool InsertWrapper(format::HandleId id, DebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugUtilsMessengerEXT_map_); }
-    bool InsertWrapper(format::HandleId id, DeferredOperationKHRWrapper* wrapper) { return InsertEntry(id, wrapper, deferredOperationKHR_map_); }
-    bool InsertWrapper(format::HandleId id, DescriptorPoolWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorPool_map_); }
-    bool InsertWrapper(format::HandleId id, DescriptorSetWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSet_map_); }
-    bool InsertWrapper(format::HandleId id, DescriptorSetLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSetLayout_map_); }
-    bool InsertWrapper(format::HandleId id, DescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorUpdateTemplate_map_); }
-    bool InsertWrapper(format::HandleId id, DeviceWrapper* wrapper) { return InsertEntry(id, wrapper, device_map_); }
-    bool InsertWrapper(format::HandleId id, DeviceMemoryWrapper* wrapper) { return InsertEntry(id, wrapper, deviceMemory_map_); }
-    bool InsertWrapper(format::HandleId id, DisplayKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayKHR_map_); }
-    bool InsertWrapper(format::HandleId id, DisplayModeKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayModeKHR_map_); }
-    bool InsertWrapper(format::HandleId id, EventWrapper* wrapper) { return InsertEntry(id, wrapper, event_map_); }
-    bool InsertWrapper(format::HandleId id, FenceWrapper* wrapper) { return InsertEntry(id, wrapper, fence_map_); }
-    bool InsertWrapper(format::HandleId id, FramebufferWrapper* wrapper) { return InsertEntry(id, wrapper, framebuffer_map_); }
-    bool InsertWrapper(format::HandleId id, ImageWrapper* wrapper) { return InsertEntry(id, wrapper, image_map_); }
-    bool InsertWrapper(format::HandleId id, ImageViewWrapper* wrapper) { return InsertEntry(id, wrapper, imageView_map_); }
-    bool InsertWrapper(format::HandleId id, IndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(id, wrapper, indirectCommandsLayoutNV_map_); }
-    bool InsertWrapper(format::HandleId id, InstanceWrapper* wrapper) { return InsertEntry(id, wrapper, instance_map_); }
-    bool InsertWrapper(format::HandleId id, MicromapEXTWrapper* wrapper) { return InsertEntry(id, wrapper, micromapEXT_map_); }
-    bool InsertWrapper(format::HandleId id, OpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(id, wrapper, opticalFlowSessionNV_map_); }
-    bool InsertWrapper(format::HandleId id, PerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(id, wrapper, performanceConfigurationINTEL_map_); }
-    bool InsertWrapper(format::HandleId id, PhysicalDeviceWrapper* wrapper) { return InsertEntry(id, wrapper, physicalDevice_map_); }
-    bool InsertWrapper(format::HandleId id, PipelineWrapper* wrapper) { return InsertEntry(id, wrapper, pipeline_map_); }
-    bool InsertWrapper(format::HandleId id, PipelineCacheWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineCache_map_); }
-    bool InsertWrapper(format::HandleId id, PipelineLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineLayout_map_); }
-    bool InsertWrapper(format::HandleId id, PrivateDataSlotWrapper* wrapper) { return InsertEntry(id, wrapper, privateDataSlot_map_); }
-    bool InsertWrapper(format::HandleId id, QueryPoolWrapper* wrapper) { return InsertEntry(id, wrapper, queryPool_map_); }
-    bool InsertWrapper(format::HandleId id, QueueWrapper* wrapper) { return InsertEntry(id, wrapper, queue_map_); }
-    bool InsertWrapper(format::HandleId id, RenderPassWrapper* wrapper) { return InsertEntry(id, wrapper, renderPass_map_); }
-    bool InsertWrapper(format::HandleId id, SamplerWrapper* wrapper) { return InsertEntry(id, wrapper, sampler_map_); }
-    bool InsertWrapper(format::HandleId id, SamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(id, wrapper, samplerYcbcrConversion_map_); }
-    bool InsertWrapper(format::HandleId id, SemaphoreWrapper* wrapper) { return InsertEntry(id, wrapper, semaphore_map_); }
-    bool InsertWrapper(format::HandleId id, ShaderEXTWrapper* wrapper) { return InsertEntry(id, wrapper, shaderEXT_map_); }
-    bool InsertWrapper(format::HandleId id, ShaderModuleWrapper* wrapper) { return InsertEntry(id, wrapper, shaderModule_map_); }
-    bool InsertWrapper(format::HandleId id, SurfaceKHRWrapper* wrapper) { return InsertEntry(id, wrapper, surfaceKHR_map_); }
-    bool InsertWrapper(format::HandleId id, SwapchainKHRWrapper* wrapper) { return InsertEntry(id, wrapper, swapchainKHR_map_); }
-    bool InsertWrapper(format::HandleId id, ValidationCacheEXTWrapper* wrapper) { return InsertEntry(id, wrapper, validationCacheEXT_map_); }
-    bool InsertWrapper(format::HandleId id, VideoSessionKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionParametersKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanAccelerationStructureKHRWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanAccelerationStructureNVWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureNV_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanBufferWrapper* wrapper) { return InsertEntry(id, wrapper, buffer_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanBufferViewWrapper* wrapper) { return InsertEntry(id, wrapper, bufferView_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanCommandBufferWrapper* wrapper) { return InsertEntry(id, wrapper, commandBuffer_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanCommandPoolWrapper* wrapper) { return InsertEntry(id, wrapper, commandPool_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugReportCallbackEXT_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugUtilsMessengerEXT_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDeferredOperationKHRWrapper* wrapper) { return InsertEntry(id, wrapper, deferredOperationKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDescriptorPoolWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorPool_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDescriptorSetWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSet_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDescriptorSetLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSetLayout_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorUpdateTemplate_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDeviceWrapper* wrapper) { return InsertEntry(id, wrapper, device_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDeviceMemoryWrapper* wrapper) { return InsertEntry(id, wrapper, deviceMemory_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDisplayKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanDisplayModeKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayModeKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanEventWrapper* wrapper) { return InsertEntry(id, wrapper, event_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanFenceWrapper* wrapper) { return InsertEntry(id, wrapper, fence_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanFramebufferWrapper* wrapper) { return InsertEntry(id, wrapper, framebuffer_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanImageWrapper* wrapper) { return InsertEntry(id, wrapper, image_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanImageViewWrapper* wrapper) { return InsertEntry(id, wrapper, imageView_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanIndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(id, wrapper, indirectCommandsLayoutNV_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanInstanceWrapper* wrapper) { return InsertEntry(id, wrapper, instance_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanMicromapEXTWrapper* wrapper) { return InsertEntry(id, wrapper, micromapEXT_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanOpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(id, wrapper, opticalFlowSessionNV_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanPerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(id, wrapper, performanceConfigurationINTEL_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanPhysicalDeviceWrapper* wrapper) { return InsertEntry(id, wrapper, physicalDevice_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanPipelineWrapper* wrapper) { return InsertEntry(id, wrapper, pipeline_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanPipelineCacheWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineCache_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanPipelineLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineLayout_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanPrivateDataSlotWrapper* wrapper) { return InsertEntry(id, wrapper, privateDataSlot_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanQueryPoolWrapper* wrapper) { return InsertEntry(id, wrapper, queryPool_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanQueueWrapper* wrapper) { return InsertEntry(id, wrapper, queue_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanRenderPassWrapper* wrapper) { return InsertEntry(id, wrapper, renderPass_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanSamplerWrapper* wrapper) { return InsertEntry(id, wrapper, sampler_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanSamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(id, wrapper, samplerYcbcrConversion_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanSemaphoreWrapper* wrapper) { return InsertEntry(id, wrapper, semaphore_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanShaderEXTWrapper* wrapper) { return InsertEntry(id, wrapper, shaderEXT_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanShaderModuleWrapper* wrapper) { return InsertEntry(id, wrapper, shaderModule_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanSurfaceKHRWrapper* wrapper) { return InsertEntry(id, wrapper, surfaceKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanSwapchainKHRWrapper* wrapper) { return InsertEntry(id, wrapper, swapchainKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanValidationCacheEXTWrapper* wrapper) { return InsertEntry(id, wrapper, validationCacheEXT_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanVideoSessionKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionKHR_map_); }
+    bool InsertWrapper(format::HandleId id, VulkanVideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionParametersKHR_map_); }
 
-    bool RemoveWrapper(const AccelerationStructureKHRWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureKHR_map_); }
-    bool RemoveWrapper(const AccelerationStructureNVWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureNV_map_); }
-    bool RemoveWrapper(const BufferWrapper* wrapper) { return RemoveEntry(wrapper, buffer_map_); }
-    bool RemoveWrapper(const BufferViewWrapper* wrapper) { return RemoveEntry(wrapper, bufferView_map_); }
-    bool RemoveWrapper(const CommandBufferWrapper* wrapper) { return RemoveEntry(wrapper, commandBuffer_map_); }
-    bool RemoveWrapper(const CommandPoolWrapper* wrapper) { return RemoveEntry(wrapper, commandPool_map_); }
-    bool RemoveWrapper(const DebugReportCallbackEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugReportCallbackEXT_map_); }
-    bool RemoveWrapper(const DebugUtilsMessengerEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugUtilsMessengerEXT_map_); }
-    bool RemoveWrapper(const DeferredOperationKHRWrapper* wrapper) { return RemoveEntry(wrapper, deferredOperationKHR_map_); }
-    bool RemoveWrapper(const DescriptorPoolWrapper* wrapper) { return RemoveEntry(wrapper, descriptorPool_map_); }
-    bool RemoveWrapper(const DescriptorSetWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSet_map_); }
-    bool RemoveWrapper(const DescriptorSetLayoutWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSetLayout_map_); }
-    bool RemoveWrapper(const DescriptorUpdateTemplateWrapper* wrapper) { return RemoveEntry(wrapper, descriptorUpdateTemplate_map_); }
-    bool RemoveWrapper(const DeviceWrapper* wrapper) { return RemoveEntry(wrapper, device_map_); }
-    bool RemoveWrapper(const DeviceMemoryWrapper* wrapper) { return RemoveEntry(wrapper, deviceMemory_map_); }
-    bool RemoveWrapper(const DisplayKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayKHR_map_); }
-    bool RemoveWrapper(const DisplayModeKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayModeKHR_map_); }
-    bool RemoveWrapper(const EventWrapper* wrapper) { return RemoveEntry(wrapper, event_map_); }
-    bool RemoveWrapper(const FenceWrapper* wrapper) { return RemoveEntry(wrapper, fence_map_); }
-    bool RemoveWrapper(const FramebufferWrapper* wrapper) { return RemoveEntry(wrapper, framebuffer_map_); }
-    bool RemoveWrapper(const ImageWrapper* wrapper) { return RemoveEntry(wrapper, image_map_); }
-    bool RemoveWrapper(const ImageViewWrapper* wrapper) { return RemoveEntry(wrapper, imageView_map_); }
-    bool RemoveWrapper(const IndirectCommandsLayoutNVWrapper* wrapper) { return RemoveEntry(wrapper, indirectCommandsLayoutNV_map_); }
-    bool RemoveWrapper(const InstanceWrapper* wrapper) { return RemoveEntry(wrapper, instance_map_); }
-    bool RemoveWrapper(const MicromapEXTWrapper* wrapper) { return RemoveEntry(wrapper, micromapEXT_map_); }
-    bool RemoveWrapper(const OpticalFlowSessionNVWrapper* wrapper) { return RemoveEntry(wrapper, opticalFlowSessionNV_map_); }
-    bool RemoveWrapper(const PerformanceConfigurationINTELWrapper* wrapper) { return RemoveEntry(wrapper, performanceConfigurationINTEL_map_); }
-    bool RemoveWrapper(const PhysicalDeviceWrapper* wrapper) { return RemoveEntry(wrapper, physicalDevice_map_); }
-    bool RemoveWrapper(const PipelineWrapper* wrapper) { return RemoveEntry(wrapper, pipeline_map_); }
-    bool RemoveWrapper(const PipelineCacheWrapper* wrapper) { return RemoveEntry(wrapper, pipelineCache_map_); }
-    bool RemoveWrapper(const PipelineLayoutWrapper* wrapper) { return RemoveEntry(wrapper, pipelineLayout_map_); }
-    bool RemoveWrapper(const PrivateDataSlotWrapper* wrapper) { return RemoveEntry(wrapper, privateDataSlot_map_); }
-    bool RemoveWrapper(const QueryPoolWrapper* wrapper) { return RemoveEntry(wrapper, queryPool_map_); }
-    bool RemoveWrapper(const QueueWrapper* wrapper) { return RemoveEntry(wrapper, queue_map_); }
-    bool RemoveWrapper(const RenderPassWrapper* wrapper) { return RemoveEntry(wrapper, renderPass_map_); }
-    bool RemoveWrapper(const SamplerWrapper* wrapper) { return RemoveEntry(wrapper, sampler_map_); }
-    bool RemoveWrapper(const SamplerYcbcrConversionWrapper* wrapper) { return RemoveEntry(wrapper, samplerYcbcrConversion_map_); }
-    bool RemoveWrapper(const SemaphoreWrapper* wrapper) { return RemoveEntry(wrapper, semaphore_map_); }
-    bool RemoveWrapper(const ShaderEXTWrapper* wrapper) { return RemoveEntry(wrapper, shaderEXT_map_); }
-    bool RemoveWrapper(const ShaderModuleWrapper* wrapper) { return RemoveEntry(wrapper, shaderModule_map_); }
-    bool RemoveWrapper(const SurfaceKHRWrapper* wrapper) { return RemoveEntry(wrapper, surfaceKHR_map_); }
-    bool RemoveWrapper(const SwapchainKHRWrapper* wrapper) { return RemoveEntry(wrapper, swapchainKHR_map_); }
-    bool RemoveWrapper(const ValidationCacheEXTWrapper* wrapper) { return RemoveEntry(wrapper, validationCacheEXT_map_); }
-    bool RemoveWrapper(const VideoSessionKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionKHR_map_); }
-    bool RemoveWrapper(const VideoSessionParametersKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionParametersKHR_map_); }
+    bool RemoveWrapper(const VulkanAccelerationStructureKHRWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureKHR_map_); }
+    bool RemoveWrapper(const VulkanAccelerationStructureNVWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureNV_map_); }
+    bool RemoveWrapper(const VulkanBufferWrapper* wrapper) { return RemoveEntry(wrapper, buffer_map_); }
+    bool RemoveWrapper(const VulkanBufferViewWrapper* wrapper) { return RemoveEntry(wrapper, bufferView_map_); }
+    bool RemoveWrapper(const VulkanCommandBufferWrapper* wrapper) { return RemoveEntry(wrapper, commandBuffer_map_); }
+    bool RemoveWrapper(const VulkanCommandPoolWrapper* wrapper) { return RemoveEntry(wrapper, commandPool_map_); }
+    bool RemoveWrapper(const VulkanDebugReportCallbackEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugReportCallbackEXT_map_); }
+    bool RemoveWrapper(const VulkanDebugUtilsMessengerEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugUtilsMessengerEXT_map_); }
+    bool RemoveWrapper(const VulkanDeferredOperationKHRWrapper* wrapper) { return RemoveEntry(wrapper, deferredOperationKHR_map_); }
+    bool RemoveWrapper(const VulkanDescriptorPoolWrapper* wrapper) { return RemoveEntry(wrapper, descriptorPool_map_); }
+    bool RemoveWrapper(const VulkanDescriptorSetWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSet_map_); }
+    bool RemoveWrapper(const VulkanDescriptorSetLayoutWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSetLayout_map_); }
+    bool RemoveWrapper(const VulkanDescriptorUpdateTemplateWrapper* wrapper) { return RemoveEntry(wrapper, descriptorUpdateTemplate_map_); }
+    bool RemoveWrapper(const VulkanDeviceWrapper* wrapper) { return RemoveEntry(wrapper, device_map_); }
+    bool RemoveWrapper(const VulkanDeviceMemoryWrapper* wrapper) { return RemoveEntry(wrapper, deviceMemory_map_); }
+    bool RemoveWrapper(const VulkanDisplayKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayKHR_map_); }
+    bool RemoveWrapper(const VulkanDisplayModeKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayModeKHR_map_); }
+    bool RemoveWrapper(const VulkanEventWrapper* wrapper) { return RemoveEntry(wrapper, event_map_); }
+    bool RemoveWrapper(const VulkanFenceWrapper* wrapper) { return RemoveEntry(wrapper, fence_map_); }
+    bool RemoveWrapper(const VulkanFramebufferWrapper* wrapper) { return RemoveEntry(wrapper, framebuffer_map_); }
+    bool RemoveWrapper(const VulkanImageWrapper* wrapper) { return RemoveEntry(wrapper, image_map_); }
+    bool RemoveWrapper(const VulkanImageViewWrapper* wrapper) { return RemoveEntry(wrapper, imageView_map_); }
+    bool RemoveWrapper(const VulkanIndirectCommandsLayoutNVWrapper* wrapper) { return RemoveEntry(wrapper, indirectCommandsLayoutNV_map_); }
+    bool RemoveWrapper(const VulkanInstanceWrapper* wrapper) { return RemoveEntry(wrapper, instance_map_); }
+    bool RemoveWrapper(const VulkanMicromapEXTWrapper* wrapper) { return RemoveEntry(wrapper, micromapEXT_map_); }
+    bool RemoveWrapper(const VulkanOpticalFlowSessionNVWrapper* wrapper) { return RemoveEntry(wrapper, opticalFlowSessionNV_map_); }
+    bool RemoveWrapper(const VulkanPerformanceConfigurationINTELWrapper* wrapper) { return RemoveEntry(wrapper, performanceConfigurationINTEL_map_); }
+    bool RemoveWrapper(const VulkanPhysicalDeviceWrapper* wrapper) { return RemoveEntry(wrapper, physicalDevice_map_); }
+    bool RemoveWrapper(const VulkanPipelineWrapper* wrapper) { return RemoveEntry(wrapper, pipeline_map_); }
+    bool RemoveWrapper(const VulkanPipelineCacheWrapper* wrapper) { return RemoveEntry(wrapper, pipelineCache_map_); }
+    bool RemoveWrapper(const VulkanPipelineLayoutWrapper* wrapper) { return RemoveEntry(wrapper, pipelineLayout_map_); }
+    bool RemoveWrapper(const VulkanPrivateDataSlotWrapper* wrapper) { return RemoveEntry(wrapper, privateDataSlot_map_); }
+    bool RemoveWrapper(const VulkanQueryPoolWrapper* wrapper) { return RemoveEntry(wrapper, queryPool_map_); }
+    bool RemoveWrapper(const VulkanQueueWrapper* wrapper) { return RemoveEntry(wrapper, queue_map_); }
+    bool RemoveWrapper(const VulkanRenderPassWrapper* wrapper) { return RemoveEntry(wrapper, renderPass_map_); }
+    bool RemoveWrapper(const VulkanSamplerWrapper* wrapper) { return RemoveEntry(wrapper, sampler_map_); }
+    bool RemoveWrapper(const VulkanSamplerYcbcrConversionWrapper* wrapper) { return RemoveEntry(wrapper, samplerYcbcrConversion_map_); }
+    bool RemoveWrapper(const VulkanSemaphoreWrapper* wrapper) { return RemoveEntry(wrapper, semaphore_map_); }
+    bool RemoveWrapper(const VulkanShaderEXTWrapper* wrapper) { return RemoveEntry(wrapper, shaderEXT_map_); }
+    bool RemoveWrapper(const VulkanShaderModuleWrapper* wrapper) { return RemoveEntry(wrapper, shaderModule_map_); }
+    bool RemoveWrapper(const VulkanSurfaceKHRWrapper* wrapper) { return RemoveEntry(wrapper, surfaceKHR_map_); }
+    bool RemoveWrapper(const VulkanSwapchainKHRWrapper* wrapper) { return RemoveEntry(wrapper, swapchainKHR_map_); }
+    bool RemoveWrapper(const VulkanValidationCacheEXTWrapper* wrapper) { return RemoveEntry(wrapper, validationCacheEXT_map_); }
+    bool RemoveWrapper(const VulkanVideoSessionKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionKHR_map_); }
+    bool RemoveWrapper(const VulkanVideoSessionParametersKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionParametersKHR_map_); }
 
-    const AccelerationStructureKHRWrapper* GetAccelerationStructureKHRWrapper(format::HandleId id) const { return GetWrapper<AccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
-    const AccelerationStructureNVWrapper* GetAccelerationStructureNVWrapper(format::HandleId id) const { return GetWrapper<AccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
-    const BufferWrapper* GetBufferWrapper(format::HandleId id) const { return GetWrapper<BufferWrapper>(id, buffer_map_); }
-    const BufferViewWrapper* GetBufferViewWrapper(format::HandleId id) const { return GetWrapper<BufferViewWrapper>(id, bufferView_map_); }
-    const CommandBufferWrapper* GetCommandBufferWrapper(format::HandleId id) const { return GetWrapper<CommandBufferWrapper>(id, commandBuffer_map_); }
-    const CommandPoolWrapper* GetCommandPoolWrapper(format::HandleId id) const { return GetWrapper<CommandPoolWrapper>(id, commandPool_map_); }
-    const DebugReportCallbackEXTWrapper* GetDebugReportCallbackEXTWrapper(format::HandleId id) const { return GetWrapper<DebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
-    const DebugUtilsMessengerEXTWrapper* GetDebugUtilsMessengerEXTWrapper(format::HandleId id) const { return GetWrapper<DebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
-    const DeferredOperationKHRWrapper* GetDeferredOperationKHRWrapper(format::HandleId id) const { return GetWrapper<DeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
-    const DescriptorPoolWrapper* GetDescriptorPoolWrapper(format::HandleId id) const { return GetWrapper<DescriptorPoolWrapper>(id, descriptorPool_map_); }
-    const DescriptorSetWrapper* GetDescriptorSetWrapper(format::HandleId id) const { return GetWrapper<DescriptorSetWrapper>(id, descriptorSet_map_); }
-    const DescriptorSetLayoutWrapper* GetDescriptorSetLayoutWrapper(format::HandleId id) const { return GetWrapper<DescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
-    const DescriptorUpdateTemplateWrapper* GetDescriptorUpdateTemplateWrapper(format::HandleId id) const { return GetWrapper<DescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
-    const DeviceWrapper* GetDeviceWrapper(format::HandleId id) const { return GetWrapper<DeviceWrapper>(id, device_map_); }
-    const DeviceMemoryWrapper* GetDeviceMemoryWrapper(format::HandleId id) const { return GetWrapper<DeviceMemoryWrapper>(id, deviceMemory_map_); }
-    const DisplayKHRWrapper* GetDisplayKHRWrapper(format::HandleId id) const { return GetWrapper<DisplayKHRWrapper>(id, displayKHR_map_); }
-    const DisplayModeKHRWrapper* GetDisplayModeKHRWrapper(format::HandleId id) const { return GetWrapper<DisplayModeKHRWrapper>(id, displayModeKHR_map_); }
-    const EventWrapper* GetEventWrapper(format::HandleId id) const { return GetWrapper<EventWrapper>(id, event_map_); }
-    const FenceWrapper* GetFenceWrapper(format::HandleId id) const { return GetWrapper<FenceWrapper>(id, fence_map_); }
-    const FramebufferWrapper* GetFramebufferWrapper(format::HandleId id) const { return GetWrapper<FramebufferWrapper>(id, framebuffer_map_); }
-    const ImageWrapper* GetImageWrapper(format::HandleId id) const { return GetWrapper<ImageWrapper>(id, image_map_); }
-    const ImageViewWrapper* GetImageViewWrapper(format::HandleId id) const { return GetWrapper<ImageViewWrapper>(id, imageView_map_); }
-    const IndirectCommandsLayoutNVWrapper* GetIndirectCommandsLayoutNVWrapper(format::HandleId id) const { return GetWrapper<IndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
-    const InstanceWrapper* GetInstanceWrapper(format::HandleId id) const { return GetWrapper<InstanceWrapper>(id, instance_map_); }
-    const MicromapEXTWrapper* GetMicromapEXTWrapper(format::HandleId id) const { return GetWrapper<MicromapEXTWrapper>(id, micromapEXT_map_); }
-    const OpticalFlowSessionNVWrapper* GetOpticalFlowSessionNVWrapper(format::HandleId id) const { return GetWrapper<OpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
-    const PerformanceConfigurationINTELWrapper* GetPerformanceConfigurationINTELWrapper(format::HandleId id) const { return GetWrapper<PerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
-    const PhysicalDeviceWrapper* GetPhysicalDeviceWrapper(format::HandleId id) const { return GetWrapper<PhysicalDeviceWrapper>(id, physicalDevice_map_); }
-    const PipelineWrapper* GetPipelineWrapper(format::HandleId id) const { return GetWrapper<PipelineWrapper>(id, pipeline_map_); }
-    const PipelineCacheWrapper* GetPipelineCacheWrapper(format::HandleId id) const { return GetWrapper<PipelineCacheWrapper>(id, pipelineCache_map_); }
-    const PipelineLayoutWrapper* GetPipelineLayoutWrapper(format::HandleId id) const { return GetWrapper<PipelineLayoutWrapper>(id, pipelineLayout_map_); }
-    const PrivateDataSlotWrapper* GetPrivateDataSlotWrapper(format::HandleId id) const { return GetWrapper<PrivateDataSlotWrapper>(id, privateDataSlot_map_); }
-    const QueryPoolWrapper* GetQueryPoolWrapper(format::HandleId id) const { return GetWrapper<QueryPoolWrapper>(id, queryPool_map_); }
-    const QueueWrapper* GetQueueWrapper(format::HandleId id) const { return GetWrapper<QueueWrapper>(id, queue_map_); }
-    const RenderPassWrapper* GetRenderPassWrapper(format::HandleId id) const { return GetWrapper<RenderPassWrapper>(id, renderPass_map_); }
-    const SamplerWrapper* GetSamplerWrapper(format::HandleId id) const { return GetWrapper<SamplerWrapper>(id, sampler_map_); }
-    const SamplerYcbcrConversionWrapper* GetSamplerYcbcrConversionWrapper(format::HandleId id) const { return GetWrapper<SamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
-    const SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) const { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
-    const ShaderEXTWrapper* GetShaderEXTWrapper(format::HandleId id) const { return GetWrapper<ShaderEXTWrapper>(id, shaderEXT_map_); }
-    const ShaderModuleWrapper* GetShaderModuleWrapper(format::HandleId id) const { return GetWrapper<ShaderModuleWrapper>(id, shaderModule_map_); }
-    const SurfaceKHRWrapper* GetSurfaceKHRWrapper(format::HandleId id) const { return GetWrapper<SurfaceKHRWrapper>(id, surfaceKHR_map_); }
-    const SwapchainKHRWrapper* GetSwapchainKHRWrapper(format::HandleId id) const { return GetWrapper<SwapchainKHRWrapper>(id, swapchainKHR_map_); }
-    const ValidationCacheEXTWrapper* GetValidationCacheEXTWrapper(format::HandleId id) const { return GetWrapper<ValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
-    const VideoSessionKHRWrapper* GetVideoSessionKHRWrapper(format::HandleId id) const { return GetWrapper<VideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
-    const VideoSessionParametersKHRWrapper* GetVideoSessionParametersKHRWrapper(format::HandleId id) const { return GetWrapper<VideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
+    const VulkanAccelerationStructureKHRWrapper* GetVulkanAccelerationStructureKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanAccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
+    const VulkanAccelerationStructureNVWrapper* GetVulkanAccelerationStructureNVWrapper(format::HandleId id) const { return GetWrapper<VulkanAccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
+    const VulkanBufferWrapper* GetVulkanBufferWrapper(format::HandleId id) const { return GetWrapper<VulkanBufferWrapper>(id, buffer_map_); }
+    const VulkanBufferViewWrapper* GetVulkanBufferViewWrapper(format::HandleId id) const { return GetWrapper<VulkanBufferViewWrapper>(id, bufferView_map_); }
+    const VulkanCommandBufferWrapper* GetVulkanCommandBufferWrapper(format::HandleId id) const { return GetWrapper<VulkanCommandBufferWrapper>(id, commandBuffer_map_); }
+    const VulkanCommandPoolWrapper* GetVulkanCommandPoolWrapper(format::HandleId id) const { return GetWrapper<VulkanCommandPoolWrapper>(id, commandPool_map_); }
+    const VulkanDebugReportCallbackEXTWrapper* GetVulkanDebugReportCallbackEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanDebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
+    const VulkanDebugUtilsMessengerEXTWrapper* GetVulkanDebugUtilsMessengerEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
+    const VulkanDeferredOperationKHRWrapper* GetVulkanDeferredOperationKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanDeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
+    const VulkanDescriptorPoolWrapper* GetVulkanDescriptorPoolWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorPoolWrapper>(id, descriptorPool_map_); }
+    const VulkanDescriptorSetWrapper* GetVulkanDescriptorSetWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorSetWrapper>(id, descriptorSet_map_); }
+    const VulkanDescriptorSetLayoutWrapper* GetVulkanDescriptorSetLayoutWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
+    const VulkanDescriptorUpdateTemplateWrapper* GetVulkanDescriptorUpdateTemplateWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
+    const VulkanDeviceWrapper* GetVulkanDeviceWrapper(format::HandleId id) const { return GetWrapper<VulkanDeviceWrapper>(id, device_map_); }
+    const VulkanDeviceMemoryWrapper* GetVulkanDeviceMemoryWrapper(format::HandleId id) const { return GetWrapper<VulkanDeviceMemoryWrapper>(id, deviceMemory_map_); }
+    const VulkanDisplayKHRWrapper* GetVulkanDisplayKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanDisplayKHRWrapper>(id, displayKHR_map_); }
+    const VulkanDisplayModeKHRWrapper* GetVulkanDisplayModeKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanDisplayModeKHRWrapper>(id, displayModeKHR_map_); }
+    const VulkanEventWrapper* GetVulkanEventWrapper(format::HandleId id) const { return GetWrapper<VulkanEventWrapper>(id, event_map_); }
+    const VulkanFenceWrapper* GetVulkanFenceWrapper(format::HandleId id) const { return GetWrapper<VulkanFenceWrapper>(id, fence_map_); }
+    const VulkanFramebufferWrapper* GetVulkanFramebufferWrapper(format::HandleId id) const { return GetWrapper<VulkanFramebufferWrapper>(id, framebuffer_map_); }
+    const VulkanImageWrapper* GetVulkanImageWrapper(format::HandleId id) const { return GetWrapper<VulkanImageWrapper>(id, image_map_); }
+    const VulkanImageViewWrapper* GetVulkanImageViewWrapper(format::HandleId id) const { return GetWrapper<VulkanImageViewWrapper>(id, imageView_map_); }
+    const VulkanIndirectCommandsLayoutNVWrapper* GetVulkanIndirectCommandsLayoutNVWrapper(format::HandleId id) const { return GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
+    const VulkanInstanceWrapper* GetVulkanInstanceWrapper(format::HandleId id) const { return GetWrapper<VulkanInstanceWrapper>(id, instance_map_); }
+    const VulkanMicromapEXTWrapper* GetVulkanMicromapEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanMicromapEXTWrapper>(id, micromapEXT_map_); }
+    const VulkanOpticalFlowSessionNVWrapper* GetVulkanOpticalFlowSessionNVWrapper(format::HandleId id) const { return GetWrapper<VulkanOpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
+    const VulkanPerformanceConfigurationINTELWrapper* GetVulkanPerformanceConfigurationINTELWrapper(format::HandleId id) const { return GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
+    const VulkanPhysicalDeviceWrapper* GetVulkanPhysicalDeviceWrapper(format::HandleId id) const { return GetWrapper<VulkanPhysicalDeviceWrapper>(id, physicalDevice_map_); }
+    const VulkanPipelineWrapper* GetVulkanPipelineWrapper(format::HandleId id) const { return GetWrapper<VulkanPipelineWrapper>(id, pipeline_map_); }
+    const VulkanPipelineCacheWrapper* GetVulkanPipelineCacheWrapper(format::HandleId id) const { return GetWrapper<VulkanPipelineCacheWrapper>(id, pipelineCache_map_); }
+    const VulkanPipelineLayoutWrapper* GetVulkanPipelineLayoutWrapper(format::HandleId id) const { return GetWrapper<VulkanPipelineLayoutWrapper>(id, pipelineLayout_map_); }
+    const VulkanPrivateDataSlotWrapper* GetVulkanPrivateDataSlotWrapper(format::HandleId id) const { return GetWrapper<VulkanPrivateDataSlotWrapper>(id, privateDataSlot_map_); }
+    const VulkanQueryPoolWrapper* GetVulkanQueryPoolWrapper(format::HandleId id) const { return GetWrapper<VulkanQueryPoolWrapper>(id, queryPool_map_); }
+    const VulkanQueueWrapper* GetVulkanQueueWrapper(format::HandleId id) const { return GetWrapper<VulkanQueueWrapper>(id, queue_map_); }
+    const VulkanRenderPassWrapper* GetVulkanRenderPassWrapper(format::HandleId id) const { return GetWrapper<VulkanRenderPassWrapper>(id, renderPass_map_); }
+    const VulkanSamplerWrapper* GetVulkanSamplerWrapper(format::HandleId id) const { return GetWrapper<VulkanSamplerWrapper>(id, sampler_map_); }
+    const VulkanSamplerYcbcrConversionWrapper* GetVulkanSamplerYcbcrConversionWrapper(format::HandleId id) const { return GetWrapper<VulkanSamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
+    const VulkanSemaphoreWrapper* GetVulkanSemaphoreWrapper(format::HandleId id) const { return GetWrapper<VulkanSemaphoreWrapper>(id, semaphore_map_); }
+    const VulkanShaderEXTWrapper* GetVulkanShaderEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanShaderEXTWrapper>(id, shaderEXT_map_); }
+    const VulkanShaderModuleWrapper* GetVulkanShaderModuleWrapper(format::HandleId id) const { return GetWrapper<VulkanShaderModuleWrapper>(id, shaderModule_map_); }
+    const VulkanSurfaceKHRWrapper* GetVulkanSurfaceKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanSurfaceKHRWrapper>(id, surfaceKHR_map_); }
+    const VulkanSwapchainKHRWrapper* GetVulkanSwapchainKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanSwapchainKHRWrapper>(id, swapchainKHR_map_); }
+    const VulkanValidationCacheEXTWrapper* GetVulkanValidationCacheEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
+    const VulkanVideoSessionKHRWrapper* GetVulkanVideoSessionKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanVideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
+    const VulkanVideoSessionParametersKHRWrapper* GetVulkanVideoSessionParametersKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanVideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
 
-    AccelerationStructureKHRWrapper* GetAccelerationStructureKHRWrapper(format::HandleId id) { return GetWrapper<AccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
-    AccelerationStructureNVWrapper* GetAccelerationStructureNVWrapper(format::HandleId id) { return GetWrapper<AccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
-    BufferWrapper* GetBufferWrapper(format::HandleId id) { return GetWrapper<BufferWrapper>(id, buffer_map_); }
-    BufferViewWrapper* GetBufferViewWrapper(format::HandleId id) { return GetWrapper<BufferViewWrapper>(id, bufferView_map_); }
-    CommandBufferWrapper* GetCommandBufferWrapper(format::HandleId id) { return GetWrapper<CommandBufferWrapper>(id, commandBuffer_map_); }
-    CommandPoolWrapper* GetCommandPoolWrapper(format::HandleId id) { return GetWrapper<CommandPoolWrapper>(id, commandPool_map_); }
-    DebugReportCallbackEXTWrapper* GetDebugReportCallbackEXTWrapper(format::HandleId id) { return GetWrapper<DebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
-    DebugUtilsMessengerEXTWrapper* GetDebugUtilsMessengerEXTWrapper(format::HandleId id) { return GetWrapper<DebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
-    DeferredOperationKHRWrapper* GetDeferredOperationKHRWrapper(format::HandleId id) { return GetWrapper<DeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
-    DescriptorPoolWrapper* GetDescriptorPoolWrapper(format::HandleId id) { return GetWrapper<DescriptorPoolWrapper>(id, descriptorPool_map_); }
-    DescriptorSetWrapper* GetDescriptorSetWrapper(format::HandleId id) { return GetWrapper<DescriptorSetWrapper>(id, descriptorSet_map_); }
-    DescriptorSetLayoutWrapper* GetDescriptorSetLayoutWrapper(format::HandleId id) { return GetWrapper<DescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
-    DescriptorUpdateTemplateWrapper* GetDescriptorUpdateTemplateWrapper(format::HandleId id) { return GetWrapper<DescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
-    DeviceWrapper* GetDeviceWrapper(format::HandleId id) { return GetWrapper<DeviceWrapper>(id, device_map_); }
-    DeviceMemoryWrapper* GetDeviceMemoryWrapper(format::HandleId id) { return GetWrapper<DeviceMemoryWrapper>(id, deviceMemory_map_); }
-    DisplayKHRWrapper* GetDisplayKHRWrapper(format::HandleId id) { return GetWrapper<DisplayKHRWrapper>(id, displayKHR_map_); }
-    DisplayModeKHRWrapper* GetDisplayModeKHRWrapper(format::HandleId id) { return GetWrapper<DisplayModeKHRWrapper>(id, displayModeKHR_map_); }
-    EventWrapper* GetEventWrapper(format::HandleId id) { return GetWrapper<EventWrapper>(id, event_map_); }
-    FenceWrapper* GetFenceWrapper(format::HandleId id) { return GetWrapper<FenceWrapper>(id, fence_map_); }
-    FramebufferWrapper* GetFramebufferWrapper(format::HandleId id) { return GetWrapper<FramebufferWrapper>(id, framebuffer_map_); }
-    ImageWrapper* GetImageWrapper(format::HandleId id) { return GetWrapper<ImageWrapper>(id, image_map_); }
-    ImageViewWrapper* GetImageViewWrapper(format::HandleId id) { return GetWrapper<ImageViewWrapper>(id, imageView_map_); }
-    IndirectCommandsLayoutNVWrapper* GetIndirectCommandsLayoutNVWrapper(format::HandleId id) { return GetWrapper<IndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
-    InstanceWrapper* GetInstanceWrapper(format::HandleId id) { return GetWrapper<InstanceWrapper>(id, instance_map_); }
-    MicromapEXTWrapper* GetMicromapEXTWrapper(format::HandleId id) { return GetWrapper<MicromapEXTWrapper>(id, micromapEXT_map_); }
-    OpticalFlowSessionNVWrapper* GetOpticalFlowSessionNVWrapper(format::HandleId id) { return GetWrapper<OpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
-    PerformanceConfigurationINTELWrapper* GetPerformanceConfigurationINTELWrapper(format::HandleId id) { return GetWrapper<PerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
-    PhysicalDeviceWrapper* GetPhysicalDeviceWrapper(format::HandleId id) { return GetWrapper<PhysicalDeviceWrapper>(id, physicalDevice_map_); }
-    PipelineWrapper* GetPipelineWrapper(format::HandleId id) { return GetWrapper<PipelineWrapper>(id, pipeline_map_); }
-    PipelineCacheWrapper* GetPipelineCacheWrapper(format::HandleId id) { return GetWrapper<PipelineCacheWrapper>(id, pipelineCache_map_); }
-    PipelineLayoutWrapper* GetPipelineLayoutWrapper(format::HandleId id) { return GetWrapper<PipelineLayoutWrapper>(id, pipelineLayout_map_); }
-    PrivateDataSlotWrapper* GetPrivateDataSlotWrapper(format::HandleId id) { return GetWrapper<PrivateDataSlotWrapper>(id, privateDataSlot_map_); }
-    QueryPoolWrapper* GetQueryPoolWrapper(format::HandleId id) { return GetWrapper<QueryPoolWrapper>(id, queryPool_map_); }
-    QueueWrapper* GetQueueWrapper(format::HandleId id) { return GetWrapper<QueueWrapper>(id, queue_map_); }
-    RenderPassWrapper* GetRenderPassWrapper(format::HandleId id) { return GetWrapper<RenderPassWrapper>(id, renderPass_map_); }
-    SamplerWrapper* GetSamplerWrapper(format::HandleId id) { return GetWrapper<SamplerWrapper>(id, sampler_map_); }
-    SamplerYcbcrConversionWrapper* GetSamplerYcbcrConversionWrapper(format::HandleId id) { return GetWrapper<SamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
-    SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
-    ShaderEXTWrapper* GetShaderEXTWrapper(format::HandleId id) { return GetWrapper<ShaderEXTWrapper>(id, shaderEXT_map_); }
-    ShaderModuleWrapper* GetShaderModuleWrapper(format::HandleId id) { return GetWrapper<ShaderModuleWrapper>(id, shaderModule_map_); }
-    SurfaceKHRWrapper* GetSurfaceKHRWrapper(format::HandleId id) { return GetWrapper<SurfaceKHRWrapper>(id, surfaceKHR_map_); }
-    SwapchainKHRWrapper* GetSwapchainKHRWrapper(format::HandleId id) { return GetWrapper<SwapchainKHRWrapper>(id, swapchainKHR_map_); }
-    ValidationCacheEXTWrapper* GetValidationCacheEXTWrapper(format::HandleId id) { return GetWrapper<ValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
-    VideoSessionKHRWrapper* GetVideoSessionKHRWrapper(format::HandleId id) { return GetWrapper<VideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
-    VideoSessionParametersKHRWrapper* GetVideoSessionParametersKHRWrapper(format::HandleId id) { return GetWrapper<VideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
+    VulkanAccelerationStructureKHRWrapper* GetVulkanAccelerationStructureKHRWrapper(format::HandleId id) { return GetWrapper<VulkanAccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
+    VulkanAccelerationStructureNVWrapper* GetVulkanAccelerationStructureNVWrapper(format::HandleId id) { return GetWrapper<VulkanAccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
+    VulkanBufferWrapper* GetVulkanBufferWrapper(format::HandleId id) { return GetWrapper<VulkanBufferWrapper>(id, buffer_map_); }
+    VulkanBufferViewWrapper* GetVulkanBufferViewWrapper(format::HandleId id) { return GetWrapper<VulkanBufferViewWrapper>(id, bufferView_map_); }
+    VulkanCommandBufferWrapper* GetVulkanCommandBufferWrapper(format::HandleId id) { return GetWrapper<VulkanCommandBufferWrapper>(id, commandBuffer_map_); }
+    VulkanCommandPoolWrapper* GetVulkanCommandPoolWrapper(format::HandleId id) { return GetWrapper<VulkanCommandPoolWrapper>(id, commandPool_map_); }
+    VulkanDebugReportCallbackEXTWrapper* GetVulkanDebugReportCallbackEXTWrapper(format::HandleId id) { return GetWrapper<VulkanDebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
+    VulkanDebugUtilsMessengerEXTWrapper* GetVulkanDebugUtilsMessengerEXTWrapper(format::HandleId id) { return GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
+    VulkanDeferredOperationKHRWrapper* GetVulkanDeferredOperationKHRWrapper(format::HandleId id) { return GetWrapper<VulkanDeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
+    VulkanDescriptorPoolWrapper* GetVulkanDescriptorPoolWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorPoolWrapper>(id, descriptorPool_map_); }
+    VulkanDescriptorSetWrapper* GetVulkanDescriptorSetWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorSetWrapper>(id, descriptorSet_map_); }
+    VulkanDescriptorSetLayoutWrapper* GetVulkanDescriptorSetLayoutWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
+    VulkanDescriptorUpdateTemplateWrapper* GetVulkanDescriptorUpdateTemplateWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
+    VulkanDeviceWrapper* GetVulkanDeviceWrapper(format::HandleId id) { return GetWrapper<VulkanDeviceWrapper>(id, device_map_); }
+    VulkanDeviceMemoryWrapper* GetVulkanDeviceMemoryWrapper(format::HandleId id) { return GetWrapper<VulkanDeviceMemoryWrapper>(id, deviceMemory_map_); }
+    VulkanDisplayKHRWrapper* GetVulkanDisplayKHRWrapper(format::HandleId id) { return GetWrapper<VulkanDisplayKHRWrapper>(id, displayKHR_map_); }
+    VulkanDisplayModeKHRWrapper* GetVulkanDisplayModeKHRWrapper(format::HandleId id) { return GetWrapper<VulkanDisplayModeKHRWrapper>(id, displayModeKHR_map_); }
+    VulkanEventWrapper* GetVulkanEventWrapper(format::HandleId id) { return GetWrapper<VulkanEventWrapper>(id, event_map_); }
+    VulkanFenceWrapper* GetVulkanFenceWrapper(format::HandleId id) { return GetWrapper<VulkanFenceWrapper>(id, fence_map_); }
+    VulkanFramebufferWrapper* GetVulkanFramebufferWrapper(format::HandleId id) { return GetWrapper<VulkanFramebufferWrapper>(id, framebuffer_map_); }
+    VulkanImageWrapper* GetVulkanImageWrapper(format::HandleId id) { return GetWrapper<VulkanImageWrapper>(id, image_map_); }
+    VulkanImageViewWrapper* GetVulkanImageViewWrapper(format::HandleId id) { return GetWrapper<VulkanImageViewWrapper>(id, imageView_map_); }
+    VulkanIndirectCommandsLayoutNVWrapper* GetVulkanIndirectCommandsLayoutNVWrapper(format::HandleId id) { return GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
+    VulkanInstanceWrapper* GetVulkanInstanceWrapper(format::HandleId id) { return GetWrapper<VulkanInstanceWrapper>(id, instance_map_); }
+    VulkanMicromapEXTWrapper* GetVulkanMicromapEXTWrapper(format::HandleId id) { return GetWrapper<VulkanMicromapEXTWrapper>(id, micromapEXT_map_); }
+    VulkanOpticalFlowSessionNVWrapper* GetVulkanOpticalFlowSessionNVWrapper(format::HandleId id) { return GetWrapper<VulkanOpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
+    VulkanPerformanceConfigurationINTELWrapper* GetVulkanPerformanceConfigurationINTELWrapper(format::HandleId id) { return GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
+    VulkanPhysicalDeviceWrapper* GetVulkanPhysicalDeviceWrapper(format::HandleId id) { return GetWrapper<VulkanPhysicalDeviceWrapper>(id, physicalDevice_map_); }
+    VulkanPipelineWrapper* GetVulkanPipelineWrapper(format::HandleId id) { return GetWrapper<VulkanPipelineWrapper>(id, pipeline_map_); }
+    VulkanPipelineCacheWrapper* GetVulkanPipelineCacheWrapper(format::HandleId id) { return GetWrapper<VulkanPipelineCacheWrapper>(id, pipelineCache_map_); }
+    VulkanPipelineLayoutWrapper* GetVulkanPipelineLayoutWrapper(format::HandleId id) { return GetWrapper<VulkanPipelineLayoutWrapper>(id, pipelineLayout_map_); }
+    VulkanPrivateDataSlotWrapper* GetVulkanPrivateDataSlotWrapper(format::HandleId id) { return GetWrapper<VulkanPrivateDataSlotWrapper>(id, privateDataSlot_map_); }
+    VulkanQueryPoolWrapper* GetVulkanQueryPoolWrapper(format::HandleId id) { return GetWrapper<VulkanQueryPoolWrapper>(id, queryPool_map_); }
+    VulkanQueueWrapper* GetVulkanQueueWrapper(format::HandleId id) { return GetWrapper<VulkanQueueWrapper>(id, queue_map_); }
+    VulkanRenderPassWrapper* GetVulkanRenderPassWrapper(format::HandleId id) { return GetWrapper<VulkanRenderPassWrapper>(id, renderPass_map_); }
+    VulkanSamplerWrapper* GetVulkanSamplerWrapper(format::HandleId id) { return GetWrapper<VulkanSamplerWrapper>(id, sampler_map_); }
+    VulkanSamplerYcbcrConversionWrapper* GetVulkanSamplerYcbcrConversionWrapper(format::HandleId id) { return GetWrapper<VulkanSamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
+    VulkanSemaphoreWrapper* GetVulkanSemaphoreWrapper(format::HandleId id) { return GetWrapper<VulkanSemaphoreWrapper>(id, semaphore_map_); }
+    VulkanShaderEXTWrapper* GetVulkanShaderEXTWrapper(format::HandleId id) { return GetWrapper<VulkanShaderEXTWrapper>(id, shaderEXT_map_); }
+    VulkanShaderModuleWrapper* GetVulkanShaderModuleWrapper(format::HandleId id) { return GetWrapper<VulkanShaderModuleWrapper>(id, shaderModule_map_); }
+    VulkanSurfaceKHRWrapper* GetVulkanSurfaceKHRWrapper(format::HandleId id) { return GetWrapper<VulkanSurfaceKHRWrapper>(id, surfaceKHR_map_); }
+    VulkanSwapchainKHRWrapper* GetVulkanSwapchainKHRWrapper(format::HandleId id) { return GetWrapper<VulkanSwapchainKHRWrapper>(id, swapchainKHR_map_); }
+    VulkanValidationCacheEXTWrapper* GetVulkanValidationCacheEXTWrapper(format::HandleId id) { return GetWrapper<VulkanValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
+    VulkanVideoSessionKHRWrapper* GetVulkanVideoSessionKHRWrapper(format::HandleId id) { return GetWrapper<VulkanVideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
+    VulkanVideoSessionParametersKHRWrapper* GetVulkanVideoSessionParametersKHRWrapper(format::HandleId id) { return GetWrapper<VulkanVideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
 
-    void VisitWrappers(std::function<void(AccelerationStructureKHRWrapper*)> visitor) const { for (auto entry : accelerationStructureKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(AccelerationStructureNVWrapper*)> visitor) const { for (auto entry : accelerationStructureNV_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(BufferWrapper*)> visitor) const { for (auto entry : buffer_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(BufferViewWrapper*)> visitor) const { for (auto entry : bufferView_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(CommandBufferWrapper*)> visitor) const { for (auto entry : commandBuffer_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(CommandPoolWrapper*)> visitor) const { for (auto entry : commandPool_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DebugReportCallbackEXTWrapper*)> visitor) const { for (auto entry : debugReportCallbackEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DebugUtilsMessengerEXTWrapper*)> visitor) const { for (auto entry : debugUtilsMessengerEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DeferredOperationKHRWrapper*)> visitor) const { for (auto entry : deferredOperationKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DescriptorPoolWrapper*)> visitor) const { for (auto entry : descriptorPool_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DescriptorSetWrapper*)> visitor) const { for (auto entry : descriptorSet_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DescriptorSetLayoutWrapper*)> visitor) const { for (auto entry : descriptorSetLayout_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DescriptorUpdateTemplateWrapper*)> visitor) const { for (auto entry : descriptorUpdateTemplate_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DeviceWrapper*)> visitor) const { for (auto entry : device_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DeviceMemoryWrapper*)> visitor) const { for (auto entry : deviceMemory_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DisplayKHRWrapper*)> visitor) const { for (auto entry : displayKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(DisplayModeKHRWrapper*)> visitor) const { for (auto entry : displayModeKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(EventWrapper*)> visitor) const { for (auto entry : event_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(FenceWrapper*)> visitor) const { for (auto entry : fence_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(FramebufferWrapper*)> visitor) const { for (auto entry : framebuffer_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(ImageWrapper*)> visitor) const { for (auto entry : image_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(ImageViewWrapper*)> visitor) const { for (auto entry : imageView_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(IndirectCommandsLayoutNVWrapper*)> visitor) const { for (auto entry : indirectCommandsLayoutNV_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(InstanceWrapper*)> visitor) const { for (auto entry : instance_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(MicromapEXTWrapper*)> visitor) const { for (auto entry : micromapEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(OpticalFlowSessionNVWrapper*)> visitor) const { for (auto entry : opticalFlowSessionNV_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(PerformanceConfigurationINTELWrapper*)> visitor) const { for (auto entry : performanceConfigurationINTEL_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(PhysicalDeviceWrapper*)> visitor) const { for (auto entry : physicalDevice_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(PipelineWrapper*)> visitor) const { for (auto entry : pipeline_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(PipelineCacheWrapper*)> visitor) const { for (auto entry : pipelineCache_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(PipelineLayoutWrapper*)> visitor) const { for (auto entry : pipelineLayout_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(PrivateDataSlotWrapper*)> visitor) const { for (auto entry : privateDataSlot_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(QueryPoolWrapper*)> visitor) const { for (auto entry : queryPool_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(QueueWrapper*)> visitor) const { for (auto entry : queue_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(RenderPassWrapper*)> visitor) const { for (auto entry : renderPass_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(SamplerWrapper*)> visitor) const { for (auto entry : sampler_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(SamplerYcbcrConversionWrapper*)> visitor) const { for (auto entry : samplerYcbcrConversion_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(SemaphoreWrapper*)> visitor) const { for (auto entry : semaphore_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(ShaderEXTWrapper*)> visitor) const { for (auto entry : shaderEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(ShaderModuleWrapper*)> visitor) const { for (auto entry : shaderModule_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(SurfaceKHRWrapper*)> visitor) const { for (auto entry : surfaceKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(SwapchainKHRWrapper*)> visitor) const { for (auto entry : swapchainKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(ValidationCacheEXTWrapper*)> visitor) const { for (auto entry : validationCacheEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VideoSessionKHRWrapper*)> visitor) const { for (auto entry : videoSessionKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VideoSessionParametersKHRWrapper*)> visitor) const { for (auto entry : videoSessionParametersKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanAccelerationStructureKHRWrapper*)> visitor) const { for (auto entry : accelerationStructureKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanAccelerationStructureNVWrapper*)> visitor) const { for (auto entry : accelerationStructureNV_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanBufferWrapper*)> visitor) const { for (auto entry : buffer_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanBufferViewWrapper*)> visitor) const { for (auto entry : bufferView_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanCommandBufferWrapper*)> visitor) const { for (auto entry : commandBuffer_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanCommandPoolWrapper*)> visitor) const { for (auto entry : commandPool_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDebugReportCallbackEXTWrapper*)> visitor) const { for (auto entry : debugReportCallbackEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDebugUtilsMessengerEXTWrapper*)> visitor) const { for (auto entry : debugUtilsMessengerEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDeferredOperationKHRWrapper*)> visitor) const { for (auto entry : deferredOperationKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDescriptorPoolWrapper*)> visitor) const { for (auto entry : descriptorPool_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDescriptorSetWrapper*)> visitor) const { for (auto entry : descriptorSet_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDescriptorSetLayoutWrapper*)> visitor) const { for (auto entry : descriptorSetLayout_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDescriptorUpdateTemplateWrapper*)> visitor) const { for (auto entry : descriptorUpdateTemplate_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDeviceWrapper*)> visitor) const { for (auto entry : device_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDeviceMemoryWrapper*)> visitor) const { for (auto entry : deviceMemory_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDisplayKHRWrapper*)> visitor) const { for (auto entry : displayKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanDisplayModeKHRWrapper*)> visitor) const { for (auto entry : displayModeKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanEventWrapper*)> visitor) const { for (auto entry : event_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanFenceWrapper*)> visitor) const { for (auto entry : fence_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanFramebufferWrapper*)> visitor) const { for (auto entry : framebuffer_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanImageWrapper*)> visitor) const { for (auto entry : image_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanImageViewWrapper*)> visitor) const { for (auto entry : imageView_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanIndirectCommandsLayoutNVWrapper*)> visitor) const { for (auto entry : indirectCommandsLayoutNV_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanInstanceWrapper*)> visitor) const { for (auto entry : instance_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanMicromapEXTWrapper*)> visitor) const { for (auto entry : micromapEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanOpticalFlowSessionNVWrapper*)> visitor) const { for (auto entry : opticalFlowSessionNV_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanPerformanceConfigurationINTELWrapper*)> visitor) const { for (auto entry : performanceConfigurationINTEL_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanPhysicalDeviceWrapper*)> visitor) const { for (auto entry : physicalDevice_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanPipelineWrapper*)> visitor) const { for (auto entry : pipeline_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanPipelineCacheWrapper*)> visitor) const { for (auto entry : pipelineCache_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanPipelineLayoutWrapper*)> visitor) const { for (auto entry : pipelineLayout_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanPrivateDataSlotWrapper*)> visitor) const { for (auto entry : privateDataSlot_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanQueryPoolWrapper*)> visitor) const { for (auto entry : queryPool_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanQueueWrapper*)> visitor) const { for (auto entry : queue_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanRenderPassWrapper*)> visitor) const { for (auto entry : renderPass_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanSamplerWrapper*)> visitor) const { for (auto entry : sampler_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanSamplerYcbcrConversionWrapper*)> visitor) const { for (auto entry : samplerYcbcrConversion_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanSemaphoreWrapper*)> visitor) const { for (auto entry : semaphore_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanShaderEXTWrapper*)> visitor) const { for (auto entry : shaderEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanShaderModuleWrapper*)> visitor) const { for (auto entry : shaderModule_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanSurfaceKHRWrapper*)> visitor) const { for (auto entry : surfaceKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanSwapchainKHRWrapper*)> visitor) const { for (auto entry : swapchainKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanValidationCacheEXTWrapper*)> visitor) const { for (auto entry : validationCacheEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanVideoSessionKHRWrapper*)> visitor) const { for (auto entry : videoSessionKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(VulkanVideoSessionParametersKHRWrapper*)> visitor) const { for (auto entry : videoSessionParametersKHR_map_) { visitor(entry.second); } }
 
   private:
-    std::map<format::HandleId, AccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
-    std::map<format::HandleId, AccelerationStructureNVWrapper*> accelerationStructureNV_map_;
-    std::map<format::HandleId, BufferWrapper*> buffer_map_;
-    std::map<format::HandleId, BufferViewWrapper*> bufferView_map_;
-    std::map<format::HandleId, CommandBufferWrapper*> commandBuffer_map_;
-    std::map<format::HandleId, CommandPoolWrapper*> commandPool_map_;
-    std::map<format::HandleId, DebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
-    std::map<format::HandleId, DebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
-    std::map<format::HandleId, DeferredOperationKHRWrapper*> deferredOperationKHR_map_;
-    std::map<format::HandleId, DescriptorPoolWrapper*> descriptorPool_map_;
-    std::map<format::HandleId, DescriptorSetWrapper*> descriptorSet_map_;
-    std::map<format::HandleId, DescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
-    std::map<format::HandleId, DescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
-    std::map<format::HandleId, DeviceWrapper*> device_map_;
-    std::map<format::HandleId, DeviceMemoryWrapper*> deviceMemory_map_;
-    std::map<format::HandleId, DisplayKHRWrapper*> displayKHR_map_;
-    std::map<format::HandleId, DisplayModeKHRWrapper*> displayModeKHR_map_;
-    std::map<format::HandleId, EventWrapper*> event_map_;
-    std::map<format::HandleId, FenceWrapper*> fence_map_;
-    std::map<format::HandleId, FramebufferWrapper*> framebuffer_map_;
-    std::map<format::HandleId, ImageWrapper*> image_map_;
-    std::map<format::HandleId, ImageViewWrapper*> imageView_map_;
-    std::map<format::HandleId, IndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
-    std::map<format::HandleId, InstanceWrapper*> instance_map_;
-    std::map<format::HandleId, MicromapEXTWrapper*> micromapEXT_map_;
-    std::map<format::HandleId, OpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
-    std::map<format::HandleId, PerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
-    std::map<format::HandleId, PhysicalDeviceWrapper*> physicalDevice_map_;
-    std::map<format::HandleId, PipelineWrapper*> pipeline_map_;
-    std::map<format::HandleId, PipelineCacheWrapper*> pipelineCache_map_;
-    std::map<format::HandleId, PipelineLayoutWrapper*> pipelineLayout_map_;
-    std::map<format::HandleId, PrivateDataSlotWrapper*> privateDataSlot_map_;
-    std::map<format::HandleId, QueryPoolWrapper*> queryPool_map_;
-    std::map<format::HandleId, QueueWrapper*> queue_map_;
-    std::map<format::HandleId, RenderPassWrapper*> renderPass_map_;
-    std::map<format::HandleId, SamplerWrapper*> sampler_map_;
-    std::map<format::HandleId, SamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
-    std::map<format::HandleId, SemaphoreWrapper*> semaphore_map_;
-    std::map<format::HandleId, ShaderEXTWrapper*> shaderEXT_map_;
-    std::map<format::HandleId, ShaderModuleWrapper*> shaderModule_map_;
-    std::map<format::HandleId, SurfaceKHRWrapper*> surfaceKHR_map_;
-    std::map<format::HandleId, SwapchainKHRWrapper*> swapchainKHR_map_;
-    std::map<format::HandleId, ValidationCacheEXTWrapper*> validationCacheEXT_map_;
-    std::map<format::HandleId, VideoSessionKHRWrapper*> videoSessionKHR_map_;
-    std::map<format::HandleId, VideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
+    std::map<format::HandleId, VulkanAccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
+    std::map<format::HandleId, VulkanAccelerationStructureNVWrapper*> accelerationStructureNV_map_;
+    std::map<format::HandleId, VulkanBufferWrapper*> buffer_map_;
+    std::map<format::HandleId, VulkanBufferViewWrapper*> bufferView_map_;
+    std::map<format::HandleId, VulkanCommandBufferWrapper*> commandBuffer_map_;
+    std::map<format::HandleId, VulkanCommandPoolWrapper*> commandPool_map_;
+    std::map<format::HandleId, VulkanDebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
+    std::map<format::HandleId, VulkanDebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
+    std::map<format::HandleId, VulkanDeferredOperationKHRWrapper*> deferredOperationKHR_map_;
+    std::map<format::HandleId, VulkanDescriptorPoolWrapper*> descriptorPool_map_;
+    std::map<format::HandleId, VulkanDescriptorSetWrapper*> descriptorSet_map_;
+    std::map<format::HandleId, VulkanDescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
+    std::map<format::HandleId, VulkanDescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
+    std::map<format::HandleId, VulkanDeviceWrapper*> device_map_;
+    std::map<format::HandleId, VulkanDeviceMemoryWrapper*> deviceMemory_map_;
+    std::map<format::HandleId, VulkanDisplayKHRWrapper*> displayKHR_map_;
+    std::map<format::HandleId, VulkanDisplayModeKHRWrapper*> displayModeKHR_map_;
+    std::map<format::HandleId, VulkanEventWrapper*> event_map_;
+    std::map<format::HandleId, VulkanFenceWrapper*> fence_map_;
+    std::map<format::HandleId, VulkanFramebufferWrapper*> framebuffer_map_;
+    std::map<format::HandleId, VulkanImageWrapper*> image_map_;
+    std::map<format::HandleId, VulkanImageViewWrapper*> imageView_map_;
+    std::map<format::HandleId, VulkanIndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
+    std::map<format::HandleId, VulkanInstanceWrapper*> instance_map_;
+    std::map<format::HandleId, VulkanMicromapEXTWrapper*> micromapEXT_map_;
+    std::map<format::HandleId, VulkanOpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
+    std::map<format::HandleId, VulkanPerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
+    std::map<format::HandleId, VulkanPhysicalDeviceWrapper*> physicalDevice_map_;
+    std::map<format::HandleId, VulkanPipelineWrapper*> pipeline_map_;
+    std::map<format::HandleId, VulkanPipelineCacheWrapper*> pipelineCache_map_;
+    std::map<format::HandleId, VulkanPipelineLayoutWrapper*> pipelineLayout_map_;
+    std::map<format::HandleId, VulkanPrivateDataSlotWrapper*> privateDataSlot_map_;
+    std::map<format::HandleId, VulkanQueryPoolWrapper*> queryPool_map_;
+    std::map<format::HandleId, VulkanQueueWrapper*> queue_map_;
+    std::map<format::HandleId, VulkanRenderPassWrapper*> renderPass_map_;
+    std::map<format::HandleId, VulkanSamplerWrapper*> sampler_map_;
+    std::map<format::HandleId, VulkanSamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
+    std::map<format::HandleId, VulkanSemaphoreWrapper*> semaphore_map_;
+    std::map<format::HandleId, VulkanShaderEXTWrapper*> shaderEXT_map_;
+    std::map<format::HandleId, VulkanShaderModuleWrapper*> shaderModule_map_;
+    std::map<format::HandleId, VulkanSurfaceKHRWrapper*> surfaceKHR_map_;
+    std::map<format::HandleId, VulkanSwapchainKHRWrapper*> swapchainKHR_map_;
+    std::map<format::HandleId, VulkanValidationCacheEXTWrapper*> validationCacheEXT_map_;
+    std::map<format::HandleId, VulkanVideoSessionKHRWrapper*> videoSessionKHR_map_;
+    std::map<format::HandleId, VulkanVideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
 };
 
 class VulkanStateHandleTable : VulkanStateTableBase
@@ -326,229 +326,229 @@ class VulkanStateHandleTable : VulkanStateTableBase
     VulkanStateHandleTable() {}
     ~VulkanStateHandleTable() {}
 
-    bool InsertWrapper(AccelerationStructureKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureKHR_map_); }
-    bool InsertWrapper(AccelerationStructureNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureNV_map_); }
-    bool InsertWrapper(BufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, buffer_map_); }
-    bool InsertWrapper(BufferViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, bufferView_map_); }
-    bool InsertWrapper(CommandBufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandBuffer_map_); }
-    bool InsertWrapper(CommandPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandPool_map_); }
-    bool InsertWrapper(DebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugReportCallbackEXT_map_); }
-    bool InsertWrapper(DebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugUtilsMessengerEXT_map_); }
-    bool InsertWrapper(DeferredOperationKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deferredOperationKHR_map_); }
-    bool InsertWrapper(DescriptorPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorPool_map_); }
-    bool InsertWrapper(DescriptorSetWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSet_map_); }
-    bool InsertWrapper(DescriptorSetLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSetLayout_map_); }
-    bool InsertWrapper(DescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorUpdateTemplate_map_); }
-    bool InsertWrapper(DeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, device_map_); }
-    bool InsertWrapper(DeviceMemoryWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deviceMemory_map_); }
-    bool InsertWrapper(DisplayKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayKHR_map_); }
-    bool InsertWrapper(DisplayModeKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayModeKHR_map_); }
-    bool InsertWrapper(EventWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, event_map_); }
-    bool InsertWrapper(FenceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, fence_map_); }
-    bool InsertWrapper(FramebufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, framebuffer_map_); }
-    bool InsertWrapper(ImageWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, image_map_); }
-    bool InsertWrapper(ImageViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, imageView_map_); }
-    bool InsertWrapper(IndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, indirectCommandsLayoutNV_map_); }
-    bool InsertWrapper(InstanceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, instance_map_); }
-    bool InsertWrapper(MicromapEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, micromapEXT_map_); }
-    bool InsertWrapper(OpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, opticalFlowSessionNV_map_); }
-    bool InsertWrapper(PerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, performanceConfigurationINTEL_map_); }
-    bool InsertWrapper(PhysicalDeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, physicalDevice_map_); }
-    bool InsertWrapper(PipelineWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipeline_map_); }
-    bool InsertWrapper(PipelineCacheWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineCache_map_); }
-    bool InsertWrapper(PipelineLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineLayout_map_); }
-    bool InsertWrapper(PrivateDataSlotWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, privateDataSlot_map_); }
-    bool InsertWrapper(QueryPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queryPool_map_); }
-    bool InsertWrapper(QueueWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queue_map_); }
-    bool InsertWrapper(RenderPassWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, renderPass_map_); }
-    bool InsertWrapper(SamplerWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, sampler_map_); }
-    bool InsertWrapper(SamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, samplerYcbcrConversion_map_); }
-    bool InsertWrapper(SemaphoreWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, semaphore_map_); }
-    bool InsertWrapper(ShaderEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderEXT_map_); }
-    bool InsertWrapper(ShaderModuleWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderModule_map_); }
-    bool InsertWrapper(SurfaceKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, surfaceKHR_map_); }
-    bool InsertWrapper(SwapchainKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, swapchainKHR_map_); }
-    bool InsertWrapper(ValidationCacheEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, validationCacheEXT_map_); }
-    bool InsertWrapper(VideoSessionKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionKHR_map_); }
-    bool InsertWrapper(VideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionParametersKHR_map_); }
+    bool InsertWrapper(VulkanAccelerationStructureKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureKHR_map_); }
+    bool InsertWrapper(VulkanAccelerationStructureNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureNV_map_); }
+    bool InsertWrapper(VulkanBufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, buffer_map_); }
+    bool InsertWrapper(VulkanBufferViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, bufferView_map_); }
+    bool InsertWrapper(VulkanCommandBufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandBuffer_map_); }
+    bool InsertWrapper(VulkanCommandPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandPool_map_); }
+    bool InsertWrapper(VulkanDebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugReportCallbackEXT_map_); }
+    bool InsertWrapper(VulkanDebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugUtilsMessengerEXT_map_); }
+    bool InsertWrapper(VulkanDeferredOperationKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deferredOperationKHR_map_); }
+    bool InsertWrapper(VulkanDescriptorPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorPool_map_); }
+    bool InsertWrapper(VulkanDescriptorSetWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSet_map_); }
+    bool InsertWrapper(VulkanDescriptorSetLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSetLayout_map_); }
+    bool InsertWrapper(VulkanDescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorUpdateTemplate_map_); }
+    bool InsertWrapper(VulkanDeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, device_map_); }
+    bool InsertWrapper(VulkanDeviceMemoryWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deviceMemory_map_); }
+    bool InsertWrapper(VulkanDisplayKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayKHR_map_); }
+    bool InsertWrapper(VulkanDisplayModeKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayModeKHR_map_); }
+    bool InsertWrapper(VulkanEventWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, event_map_); }
+    bool InsertWrapper(VulkanFenceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, fence_map_); }
+    bool InsertWrapper(VulkanFramebufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, framebuffer_map_); }
+    bool InsertWrapper(VulkanImageWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, image_map_); }
+    bool InsertWrapper(VulkanImageViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, imageView_map_); }
+    bool InsertWrapper(VulkanIndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, indirectCommandsLayoutNV_map_); }
+    bool InsertWrapper(VulkanInstanceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, instance_map_); }
+    bool InsertWrapper(VulkanMicromapEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, micromapEXT_map_); }
+    bool InsertWrapper(VulkanOpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, opticalFlowSessionNV_map_); }
+    bool InsertWrapper(VulkanPerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, performanceConfigurationINTEL_map_); }
+    bool InsertWrapper(VulkanPhysicalDeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, physicalDevice_map_); }
+    bool InsertWrapper(VulkanPipelineWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipeline_map_); }
+    bool InsertWrapper(VulkanPipelineCacheWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineCache_map_); }
+    bool InsertWrapper(VulkanPipelineLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineLayout_map_); }
+    bool InsertWrapper(VulkanPrivateDataSlotWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, privateDataSlot_map_); }
+    bool InsertWrapper(VulkanQueryPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queryPool_map_); }
+    bool InsertWrapper(VulkanQueueWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queue_map_); }
+    bool InsertWrapper(VulkanRenderPassWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, renderPass_map_); }
+    bool InsertWrapper(VulkanSamplerWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, sampler_map_); }
+    bool InsertWrapper(VulkanSamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, samplerYcbcrConversion_map_); }
+    bool InsertWrapper(VulkanSemaphoreWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, semaphore_map_); }
+    bool InsertWrapper(VulkanShaderEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderEXT_map_); }
+    bool InsertWrapper(VulkanShaderModuleWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderModule_map_); }
+    bool InsertWrapper(VulkanSurfaceKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, surfaceKHR_map_); }
+    bool InsertWrapper(VulkanSwapchainKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, swapchainKHR_map_); }
+    bool InsertWrapper(VulkanValidationCacheEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, validationCacheEXT_map_); }
+    bool InsertWrapper(VulkanVideoSessionKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionKHR_map_); }
+    bool InsertWrapper(VulkanVideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionParametersKHR_map_); }
 
-    bool RemoveWrapper(const AccelerationStructureKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanAccelerationStructureKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, accelerationStructureKHR_map_);
     }
-    bool RemoveWrapper(const AccelerationStructureNVWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanAccelerationStructureNVWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, accelerationStructureNV_map_);
     }
-    bool RemoveWrapper(const BufferWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanBufferWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, buffer_map_);
     }
-    bool RemoveWrapper(const BufferViewWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanBufferViewWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, bufferView_map_);
     }
-    bool RemoveWrapper(const CommandBufferWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanCommandBufferWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, commandBuffer_map_);
     }
-    bool RemoveWrapper(const CommandPoolWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanCommandPoolWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, commandPool_map_);
     }
-    bool RemoveWrapper(const DebugReportCallbackEXTWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDebugReportCallbackEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, debugReportCallbackEXT_map_);
     }
-    bool RemoveWrapper(const DebugUtilsMessengerEXTWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDebugUtilsMessengerEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, debugUtilsMessengerEXT_map_);
     }
-    bool RemoveWrapper(const DeferredOperationKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDeferredOperationKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, deferredOperationKHR_map_);
     }
-    bool RemoveWrapper(const DescriptorPoolWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDescriptorPoolWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorPool_map_);
     }
-    bool RemoveWrapper(const DescriptorSetWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDescriptorSetWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorSet_map_);
     }
-    bool RemoveWrapper(const DescriptorSetLayoutWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDescriptorSetLayoutWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorSetLayout_map_);
     }
-    bool RemoveWrapper(const DescriptorUpdateTemplateWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDescriptorUpdateTemplateWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorUpdateTemplate_map_);
     }
-    bool RemoveWrapper(const DeviceWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDeviceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, device_map_);
     }
-    bool RemoveWrapper(const DeviceMemoryWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDeviceMemoryWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, deviceMemory_map_);
     }
-    bool RemoveWrapper(const DisplayKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDisplayKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, displayKHR_map_);
     }
-    bool RemoveWrapper(const DisplayModeKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanDisplayModeKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, displayModeKHR_map_);
     }
-    bool RemoveWrapper(const EventWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanEventWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, event_map_);
     }
-    bool RemoveWrapper(const FenceWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanFenceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, fence_map_);
     }
-    bool RemoveWrapper(const FramebufferWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanFramebufferWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, framebuffer_map_);
     }
-    bool RemoveWrapper(const ImageWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanImageWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, image_map_);
     }
-    bool RemoveWrapper(const ImageViewWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanImageViewWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, imageView_map_);
     }
-    bool RemoveWrapper(const IndirectCommandsLayoutNVWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanIndirectCommandsLayoutNVWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, indirectCommandsLayoutNV_map_);
     }
-    bool RemoveWrapper(const InstanceWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanInstanceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, instance_map_);
     }
-    bool RemoveWrapper(const MicromapEXTWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanMicromapEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, micromapEXT_map_);
     }
-    bool RemoveWrapper(const OpticalFlowSessionNVWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanOpticalFlowSessionNVWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, opticalFlowSessionNV_map_);
     }
-    bool RemoveWrapper(const PerformanceConfigurationINTELWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanPerformanceConfigurationINTELWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, performanceConfigurationINTEL_map_);
     }
-    bool RemoveWrapper(const PhysicalDeviceWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanPhysicalDeviceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, physicalDevice_map_);
     }
-    bool RemoveWrapper(const PipelineWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanPipelineWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, pipeline_map_);
     }
-    bool RemoveWrapper(const PipelineCacheWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanPipelineCacheWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, pipelineCache_map_);
     }
-    bool RemoveWrapper(const PipelineLayoutWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanPipelineLayoutWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, pipelineLayout_map_);
     }
-    bool RemoveWrapper(const PrivateDataSlotWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanPrivateDataSlotWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, privateDataSlot_map_);
     }
-    bool RemoveWrapper(const QueryPoolWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanQueryPoolWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, queryPool_map_);
     }
-    bool RemoveWrapper(const QueueWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanQueueWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, queue_map_);
     }
-    bool RemoveWrapper(const RenderPassWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanRenderPassWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, renderPass_map_);
     }
-    bool RemoveWrapper(const SamplerWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanSamplerWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, sampler_map_);
     }
-    bool RemoveWrapper(const SamplerYcbcrConversionWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanSamplerYcbcrConversionWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, samplerYcbcrConversion_map_);
     }
-    bool RemoveWrapper(const SemaphoreWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanSemaphoreWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, semaphore_map_);
     }
-    bool RemoveWrapper(const ShaderEXTWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanShaderEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, shaderEXT_map_);
     }
-    bool RemoveWrapper(const ShaderModuleWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanShaderModuleWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, shaderModule_map_);
     }
-    bool RemoveWrapper(const SurfaceKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanSurfaceKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, surfaceKHR_map_);
     }
-    bool RemoveWrapper(const SwapchainKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanSwapchainKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, swapchainKHR_map_);
     }
-    bool RemoveWrapper(const ValidationCacheEXTWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanValidationCacheEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, validationCacheEXT_map_);
     }
-    bool RemoveWrapper(const VideoSessionKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanVideoSessionKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, videoSessionKHR_map_);
     }
-    bool RemoveWrapper(const VideoSessionParametersKHRWrapper* wrapper) {
+    bool RemoveWrapper(const VulkanVideoSessionParametersKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, videoSessionParametersKHR_map_);
     }
@@ -558,144 +558,144 @@ class VulkanStateHandleTable : VulkanStateTableBase
     template<typename Wrapper> Wrapper* GetWrapper(typename Wrapper::HandleType handle) { return nullptr; }
 
   private:
-    std::unordered_map<VkAccelerationStructureKHR, AccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
-    std::unordered_map<VkAccelerationStructureNV, AccelerationStructureNVWrapper*> accelerationStructureNV_map_;
-    std::unordered_map<VkBuffer, BufferWrapper*> buffer_map_;
-    std::unordered_map<VkBufferView, BufferViewWrapper*> bufferView_map_;
-    std::unordered_map<VkCommandBuffer, CommandBufferWrapper*> commandBuffer_map_;
-    std::unordered_map<VkCommandPool, CommandPoolWrapper*> commandPool_map_;
-    std::unordered_map<VkDebugReportCallbackEXT, DebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
-    std::unordered_map<VkDebugUtilsMessengerEXT, DebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
-    std::unordered_map<VkDeferredOperationKHR, DeferredOperationKHRWrapper*> deferredOperationKHR_map_;
-    std::unordered_map<VkDescriptorPool, DescriptorPoolWrapper*> descriptorPool_map_;
-    std::unordered_map<VkDescriptorSet, DescriptorSetWrapper*> descriptorSet_map_;
-    std::unordered_map<VkDescriptorSetLayout, DescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
-    std::unordered_map<VkDescriptorUpdateTemplate, DescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
-    std::unordered_map<VkDevice, DeviceWrapper*> device_map_;
-    std::unordered_map<VkDeviceMemory, DeviceMemoryWrapper*> deviceMemory_map_;
-    std::unordered_map<VkDisplayKHR, DisplayKHRWrapper*> displayKHR_map_;
-    std::unordered_map<VkDisplayModeKHR, DisplayModeKHRWrapper*> displayModeKHR_map_;
-    std::unordered_map<VkEvent, EventWrapper*> event_map_;
-    std::unordered_map<VkFence, FenceWrapper*> fence_map_;
-    std::unordered_map<VkFramebuffer, FramebufferWrapper*> framebuffer_map_;
-    std::unordered_map<VkImage, ImageWrapper*> image_map_;
-    std::unordered_map<VkImageView, ImageViewWrapper*> imageView_map_;
-    std::unordered_map<VkIndirectCommandsLayoutNV, IndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
-    std::unordered_map<VkInstance, InstanceWrapper*> instance_map_;
-    std::unordered_map<VkMicromapEXT, MicromapEXTWrapper*> micromapEXT_map_;
-    std::unordered_map<VkOpticalFlowSessionNV, OpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
-    std::unordered_map<VkPerformanceConfigurationINTEL, PerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
-    std::unordered_map<VkPhysicalDevice, PhysicalDeviceWrapper*> physicalDevice_map_;
-    std::unordered_map<VkPipeline, PipelineWrapper*> pipeline_map_;
-    std::unordered_map<VkPipelineCache, PipelineCacheWrapper*> pipelineCache_map_;
-    std::unordered_map<VkPipelineLayout, PipelineLayoutWrapper*> pipelineLayout_map_;
-    std::unordered_map<VkPrivateDataSlot, PrivateDataSlotWrapper*> privateDataSlot_map_;
-    std::unordered_map<VkQueryPool, QueryPoolWrapper*> queryPool_map_;
-    std::unordered_map<VkQueue, QueueWrapper*> queue_map_;
-    std::unordered_map<VkRenderPass, RenderPassWrapper*> renderPass_map_;
-    std::unordered_map<VkSampler, SamplerWrapper*> sampler_map_;
-    std::unordered_map<VkSamplerYcbcrConversion, SamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
-    std::unordered_map<VkSemaphore, SemaphoreWrapper*> semaphore_map_;
-    std::unordered_map<VkShaderEXT, ShaderEXTWrapper*> shaderEXT_map_;
-    std::unordered_map<VkShaderModule, ShaderModuleWrapper*> shaderModule_map_;
-    std::unordered_map<VkSurfaceKHR, SurfaceKHRWrapper*> surfaceKHR_map_;
-    std::unordered_map<VkSwapchainKHR, SwapchainKHRWrapper*> swapchainKHR_map_;
-    std::unordered_map<VkValidationCacheEXT, ValidationCacheEXTWrapper*> validationCacheEXT_map_;
-    std::unordered_map<VkVideoSessionKHR, VideoSessionKHRWrapper*> videoSessionKHR_map_;
-    std::unordered_map<VkVideoSessionParametersKHR, VideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
+    std::unordered_map<VkAccelerationStructureKHR, VulkanAccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
+    std::unordered_map<VkAccelerationStructureNV, VulkanAccelerationStructureNVWrapper*> accelerationStructureNV_map_;
+    std::unordered_map<VkBuffer, VulkanBufferWrapper*> buffer_map_;
+    std::unordered_map<VkBufferView, VulkanBufferViewWrapper*> bufferView_map_;
+    std::unordered_map<VkCommandBuffer, VulkanCommandBufferWrapper*> commandBuffer_map_;
+    std::unordered_map<VkCommandPool, VulkanCommandPoolWrapper*> commandPool_map_;
+    std::unordered_map<VkDebugReportCallbackEXT, VulkanDebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
+    std::unordered_map<VkDebugUtilsMessengerEXT, VulkanDebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
+    std::unordered_map<VkDeferredOperationKHR, VulkanDeferredOperationKHRWrapper*> deferredOperationKHR_map_;
+    std::unordered_map<VkDescriptorPool, VulkanDescriptorPoolWrapper*> descriptorPool_map_;
+    std::unordered_map<VkDescriptorSet, VulkanDescriptorSetWrapper*> descriptorSet_map_;
+    std::unordered_map<VkDescriptorSetLayout, VulkanDescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
+    std::unordered_map<VkDescriptorUpdateTemplate, VulkanDescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
+    std::unordered_map<VkDevice, VulkanDeviceWrapper*> device_map_;
+    std::unordered_map<VkDeviceMemory, VulkanDeviceMemoryWrapper*> deviceMemory_map_;
+    std::unordered_map<VkDisplayKHR, VulkanDisplayKHRWrapper*> displayKHR_map_;
+    std::unordered_map<VkDisplayModeKHR, VulkanDisplayModeKHRWrapper*> displayModeKHR_map_;
+    std::unordered_map<VkEvent, VulkanEventWrapper*> event_map_;
+    std::unordered_map<VkFence, VulkanFenceWrapper*> fence_map_;
+    std::unordered_map<VkFramebuffer, VulkanFramebufferWrapper*> framebuffer_map_;
+    std::unordered_map<VkImage, VulkanImageWrapper*> image_map_;
+    std::unordered_map<VkImageView, VulkanImageViewWrapper*> imageView_map_;
+    std::unordered_map<VkIndirectCommandsLayoutNV, VulkanIndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
+    std::unordered_map<VkInstance, VulkanInstanceWrapper*> instance_map_;
+    std::unordered_map<VkMicromapEXT, VulkanMicromapEXTWrapper*> micromapEXT_map_;
+    std::unordered_map<VkOpticalFlowSessionNV, VulkanOpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
+    std::unordered_map<VkPerformanceConfigurationINTEL, VulkanPerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
+    std::unordered_map<VkPhysicalDevice, VulkanPhysicalDeviceWrapper*> physicalDevice_map_;
+    std::unordered_map<VkPipeline, VulkanPipelineWrapper*> pipeline_map_;
+    std::unordered_map<VkPipelineCache, VulkanPipelineCacheWrapper*> pipelineCache_map_;
+    std::unordered_map<VkPipelineLayout, VulkanPipelineLayoutWrapper*> pipelineLayout_map_;
+    std::unordered_map<VkPrivateDataSlot, VulkanPrivateDataSlotWrapper*> privateDataSlot_map_;
+    std::unordered_map<VkQueryPool, VulkanQueryPoolWrapper*> queryPool_map_;
+    std::unordered_map<VkQueue, VulkanQueueWrapper*> queue_map_;
+    std::unordered_map<VkRenderPass, VulkanRenderPassWrapper*> renderPass_map_;
+    std::unordered_map<VkSampler, VulkanSamplerWrapper*> sampler_map_;
+    std::unordered_map<VkSamplerYcbcrConversion, VulkanSamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
+    std::unordered_map<VkSemaphore, VulkanSemaphoreWrapper*> semaphore_map_;
+    std::unordered_map<VkShaderEXT, VulkanShaderEXTWrapper*> shaderEXT_map_;
+    std::unordered_map<VkShaderModule, VulkanShaderModuleWrapper*> shaderModule_map_;
+    std::unordered_map<VkSurfaceKHR, VulkanSurfaceKHRWrapper*> surfaceKHR_map_;
+    std::unordered_map<VkSwapchainKHR, VulkanSwapchainKHRWrapper*> swapchainKHR_map_;
+    std::unordered_map<VkValidationCacheEXT, VulkanValidationCacheEXTWrapper*> validationCacheEXT_map_;
+    std::unordered_map<VkVideoSessionKHR, VulkanVideoSessionKHRWrapper*> videoSessionKHR_map_;
+    std::unordered_map<VkVideoSessionParametersKHR, VulkanVideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
 };
 
-template<> inline const AccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<AccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
-template<> inline const AccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<AccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
-template<> inline const BufferWrapper* VulkanStateHandleTable::GetWrapper<BufferWrapper>(VkBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
-template<> inline const BufferViewWrapper* VulkanStateHandleTable::GetWrapper<BufferViewWrapper>(VkBufferView handle) const { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
-template<> inline const CommandBufferWrapper* VulkanStateHandleTable::GetWrapper<CommandBufferWrapper>(VkCommandBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
-template<> inline const CommandPoolWrapper* VulkanStateHandleTable::GetWrapper<CommandPoolWrapper>(VkCommandPool handle) const { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
-template<> inline const DebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<DebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
-template<> inline const DebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<DebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
-template<> inline const DeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<DeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
-template<> inline const DescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<DescriptorPoolWrapper>(VkDescriptorPool handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
-template<> inline const DescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<DescriptorSetWrapper>(VkDescriptorSet handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
-template<> inline const DescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<DescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
-template<> inline const DescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<DescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
-template<> inline const DeviceWrapper* VulkanStateHandleTable::GetWrapper<DeviceWrapper>(VkDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
-template<> inline const DeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<DeviceMemoryWrapper>(VkDeviceMemory handle) const { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
-template<> inline const DisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<DisplayKHRWrapper>(VkDisplayKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
-template<> inline const DisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<DisplayModeKHRWrapper>(VkDisplayModeKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
-template<> inline const EventWrapper* VulkanStateHandleTable::GetWrapper<EventWrapper>(VkEvent handle) const { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
-template<> inline const FenceWrapper* VulkanStateHandleTable::GetWrapper<FenceWrapper>(VkFence handle) const { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
-template<> inline const FramebufferWrapper* VulkanStateHandleTable::GetWrapper<FramebufferWrapper>(VkFramebuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
-template<> inline const ImageWrapper* VulkanStateHandleTable::GetWrapper<ImageWrapper>(VkImage handle) const { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
-template<> inline const ImageViewWrapper* VulkanStateHandleTable::GetWrapper<ImageViewWrapper>(VkImageView handle) const { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
-template<> inline const IndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<IndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) const { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
-template<> inline const InstanceWrapper* VulkanStateHandleTable::GetWrapper<InstanceWrapper>(VkInstance handle) const { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
-template<> inline const MicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<MicromapEXTWrapper>(VkMicromapEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
-template<> inline const OpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<OpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) const { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
-template<> inline const PerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<PerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) const { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
-template<> inline const PhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<PhysicalDeviceWrapper>(VkPhysicalDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
-template<> inline const PipelineWrapper* VulkanStateHandleTable::GetWrapper<PipelineWrapper>(VkPipeline handle) const { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
-template<> inline const PipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<PipelineCacheWrapper>(VkPipelineCache handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
-template<> inline const PipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<PipelineLayoutWrapper>(VkPipelineLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
-template<> inline const PrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<PrivateDataSlotWrapper>(VkPrivateDataSlot handle) const { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
-template<> inline const QueryPoolWrapper* VulkanStateHandleTable::GetWrapper<QueryPoolWrapper>(VkQueryPool handle) const { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
-template<> inline const QueueWrapper* VulkanStateHandleTable::GetWrapper<QueueWrapper>(VkQueue handle) const { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
-template<> inline const RenderPassWrapper* VulkanStateHandleTable::GetWrapper<RenderPassWrapper>(VkRenderPass handle) const { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
-template<> inline const SamplerWrapper* VulkanStateHandleTable::GetWrapper<SamplerWrapper>(VkSampler handle) const { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
-template<> inline const SamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<SamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) const { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
-template<> inline const SemaphoreWrapper* VulkanStateHandleTable::GetWrapper<SemaphoreWrapper>(VkSemaphore handle) const { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
-template<> inline const ShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<ShaderEXTWrapper>(VkShaderEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
-template<> inline const ShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<ShaderModuleWrapper>(VkShaderModule handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
-template<> inline const SurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<SurfaceKHRWrapper>(VkSurfaceKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
-template<> inline const SwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<SwapchainKHRWrapper>(VkSwapchainKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
-template<> inline const ValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<ValidationCacheEXTWrapper>(VkValidationCacheEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
-template<> inline const VideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<VideoSessionKHRWrapper>(VkVideoSessionKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
-template<> inline const VideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<VideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
+template<> inline const VulkanAccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
+template<> inline const VulkanAccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
+template<> inline const VulkanBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferWrapper>(VkBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
+template<> inline const VulkanBufferViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferViewWrapper>(VkBufferView handle) const { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
+template<> inline const VulkanCommandBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandBufferWrapper>(VkCommandBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
+template<> inline const VulkanCommandPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandPoolWrapper>(VkCommandPool handle) const { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
+template<> inline const VulkanDebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
+template<> inline const VulkanDebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
+template<> inline const VulkanDeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
+template<> inline const VulkanDescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorPoolWrapper>(VkDescriptorPool handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
+template<> inline const VulkanDescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetWrapper>(VkDescriptorSet handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
+template<> inline const VulkanDescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
+template<> inline const VulkanDescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
+template<> inline const VulkanDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceWrapper>(VkDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
+template<> inline const VulkanDeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceMemoryWrapper>(VkDeviceMemory handle) const { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
+template<> inline const VulkanDisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayKHRWrapper>(VkDisplayKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
+template<> inline const VulkanDisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayModeKHRWrapper>(VkDisplayModeKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
+template<> inline const VulkanEventWrapper* VulkanStateHandleTable::GetWrapper<VulkanEventWrapper>(VkEvent handle) const { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
+template<> inline const VulkanFenceWrapper* VulkanStateHandleTable::GetWrapper<VulkanFenceWrapper>(VkFence handle) const { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
+template<> inline const VulkanFramebufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanFramebufferWrapper>(VkFramebuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
+template<> inline const VulkanImageWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageWrapper>(VkImage handle) const { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
+template<> inline const VulkanImageViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageViewWrapper>(VkImageView handle) const { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
+template<> inline const VulkanIndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) const { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
+template<> inline const VulkanInstanceWrapper* VulkanStateHandleTable::GetWrapper<VulkanInstanceWrapper>(VkInstance handle) const { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
+template<> inline const VulkanMicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanMicromapEXTWrapper>(VkMicromapEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
+template<> inline const VulkanOpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanOpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) const { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
+template<> inline const VulkanPerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) const { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
+template<> inline const VulkanPhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanPhysicalDeviceWrapper>(VkPhysicalDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
+template<> inline const VulkanPipelineWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineWrapper>(VkPipeline handle) const { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
+template<> inline const VulkanPipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineCacheWrapper>(VkPipelineCache handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
+template<> inline const VulkanPipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineLayoutWrapper>(VkPipelineLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
+template<> inline const VulkanPrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<VulkanPrivateDataSlotWrapper>(VkPrivateDataSlot handle) const { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
+template<> inline const VulkanQueryPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueryPoolWrapper>(VkQueryPool handle) const { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
+template<> inline const VulkanQueueWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueueWrapper>(VkQueue handle) const { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
+template<> inline const VulkanRenderPassWrapper* VulkanStateHandleTable::GetWrapper<VulkanRenderPassWrapper>(VkRenderPass handle) const { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
+template<> inline const VulkanSamplerWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerWrapper>(VkSampler handle) const { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
+template<> inline const VulkanSamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) const { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
+template<> inline const VulkanSemaphoreWrapper* VulkanStateHandleTable::GetWrapper<VulkanSemaphoreWrapper>(VkSemaphore handle) const { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
+template<> inline const VulkanShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderEXTWrapper>(VkShaderEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
+template<> inline const VulkanShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderModuleWrapper>(VkShaderModule handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
+template<> inline const VulkanSurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSurfaceKHRWrapper>(VkSurfaceKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
+template<> inline const VulkanSwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSwapchainKHRWrapper>(VkSwapchainKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
+template<> inline const VulkanValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanValidationCacheEXTWrapper>(VkValidationCacheEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
+template<> inline const VulkanVideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionKHRWrapper>(VkVideoSessionKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
+template<> inline const VulkanVideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
 
-template<> inline AccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<AccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
-template<> inline AccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<AccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
-template<> inline BufferWrapper* VulkanStateHandleTable::GetWrapper<BufferWrapper>(VkBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
-template<> inline BufferViewWrapper* VulkanStateHandleTable::GetWrapper<BufferViewWrapper>(VkBufferView handle) { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
-template<> inline CommandBufferWrapper* VulkanStateHandleTable::GetWrapper<CommandBufferWrapper>(VkCommandBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
-template<> inline CommandPoolWrapper* VulkanStateHandleTable::GetWrapper<CommandPoolWrapper>(VkCommandPool handle) { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
-template<> inline DebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<DebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
-template<> inline DebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<DebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
-template<> inline DeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<DeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
-template<> inline DescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<DescriptorPoolWrapper>(VkDescriptorPool handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
-template<> inline DescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<DescriptorSetWrapper>(VkDescriptorSet handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
-template<> inline DescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<DescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
-template<> inline DescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<DescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
-template<> inline DeviceWrapper* VulkanStateHandleTable::GetWrapper<DeviceWrapper>(VkDevice handle) { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
-template<> inline DeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<DeviceMemoryWrapper>(VkDeviceMemory handle) { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
-template<> inline DisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<DisplayKHRWrapper>(VkDisplayKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
-template<> inline DisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<DisplayModeKHRWrapper>(VkDisplayModeKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
-template<> inline EventWrapper* VulkanStateHandleTable::GetWrapper<EventWrapper>(VkEvent handle) { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
-template<> inline FenceWrapper* VulkanStateHandleTable::GetWrapper<FenceWrapper>(VkFence handle) { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
-template<> inline FramebufferWrapper* VulkanStateHandleTable::GetWrapper<FramebufferWrapper>(VkFramebuffer handle) { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
-template<> inline ImageWrapper* VulkanStateHandleTable::GetWrapper<ImageWrapper>(VkImage handle) { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
-template<> inline ImageViewWrapper* VulkanStateHandleTable::GetWrapper<ImageViewWrapper>(VkImageView handle) { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
-template<> inline IndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<IndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
-template<> inline InstanceWrapper* VulkanStateHandleTable::GetWrapper<InstanceWrapper>(VkInstance handle) { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
-template<> inline MicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<MicromapEXTWrapper>(VkMicromapEXT handle) { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
-template<> inline OpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<OpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
-template<> inline PerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<PerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
-template<> inline PhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<PhysicalDeviceWrapper>(VkPhysicalDevice handle) { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
-template<> inline PipelineWrapper* VulkanStateHandleTable::GetWrapper<PipelineWrapper>(VkPipeline handle) { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
-template<> inline PipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<PipelineCacheWrapper>(VkPipelineCache handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
-template<> inline PipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<PipelineLayoutWrapper>(VkPipelineLayout handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
-template<> inline PrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<PrivateDataSlotWrapper>(VkPrivateDataSlot handle) { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
-template<> inline QueryPoolWrapper* VulkanStateHandleTable::GetWrapper<QueryPoolWrapper>(VkQueryPool handle) { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
-template<> inline QueueWrapper* VulkanStateHandleTable::GetWrapper<QueueWrapper>(VkQueue handle) { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
-template<> inline RenderPassWrapper* VulkanStateHandleTable::GetWrapper<RenderPassWrapper>(VkRenderPass handle) { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
-template<> inline SamplerWrapper* VulkanStateHandleTable::GetWrapper<SamplerWrapper>(VkSampler handle) { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
-template<> inline SamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<SamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
-template<> inline SemaphoreWrapper* VulkanStateHandleTable::GetWrapper<SemaphoreWrapper>(VkSemaphore handle) { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
-template<> inline ShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<ShaderEXTWrapper>(VkShaderEXT handle) { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
-template<> inline ShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<ShaderModuleWrapper>(VkShaderModule handle) { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
-template<> inline SurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<SurfaceKHRWrapper>(VkSurfaceKHR handle) { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
-template<> inline SwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<SwapchainKHRWrapper>(VkSwapchainKHR handle) { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
-template<> inline ValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<ValidationCacheEXTWrapper>(VkValidationCacheEXT handle) { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
-template<> inline VideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<VideoSessionKHRWrapper>(VkVideoSessionKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
-template<> inline VideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<VideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
+template<> inline VulkanAccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
+template<> inline VulkanAccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
+template<> inline VulkanBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferWrapper>(VkBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
+template<> inline VulkanBufferViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferViewWrapper>(VkBufferView handle) { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
+template<> inline VulkanCommandBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandBufferWrapper>(VkCommandBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
+template<> inline VulkanCommandPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandPoolWrapper>(VkCommandPool handle) { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
+template<> inline VulkanDebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
+template<> inline VulkanDebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
+template<> inline VulkanDeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
+template<> inline VulkanDescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorPoolWrapper>(VkDescriptorPool handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
+template<> inline VulkanDescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetWrapper>(VkDescriptorSet handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
+template<> inline VulkanDescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
+template<> inline VulkanDescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
+template<> inline VulkanDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceWrapper>(VkDevice handle) { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
+template<> inline VulkanDeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceMemoryWrapper>(VkDeviceMemory handle) { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
+template<> inline VulkanDisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayKHRWrapper>(VkDisplayKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
+template<> inline VulkanDisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayModeKHRWrapper>(VkDisplayModeKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
+template<> inline VulkanEventWrapper* VulkanStateHandleTable::GetWrapper<VulkanEventWrapper>(VkEvent handle) { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
+template<> inline VulkanFenceWrapper* VulkanStateHandleTable::GetWrapper<VulkanFenceWrapper>(VkFence handle) { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
+template<> inline VulkanFramebufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanFramebufferWrapper>(VkFramebuffer handle) { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
+template<> inline VulkanImageWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageWrapper>(VkImage handle) { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
+template<> inline VulkanImageViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageViewWrapper>(VkImageView handle) { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
+template<> inline VulkanIndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
+template<> inline VulkanInstanceWrapper* VulkanStateHandleTable::GetWrapper<VulkanInstanceWrapper>(VkInstance handle) { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
+template<> inline VulkanMicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanMicromapEXTWrapper>(VkMicromapEXT handle) { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
+template<> inline VulkanOpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanOpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
+template<> inline VulkanPerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
+template<> inline VulkanPhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanPhysicalDeviceWrapper>(VkPhysicalDevice handle) { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
+template<> inline VulkanPipelineWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineWrapper>(VkPipeline handle) { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
+template<> inline VulkanPipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineCacheWrapper>(VkPipelineCache handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
+template<> inline VulkanPipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineLayoutWrapper>(VkPipelineLayout handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
+template<> inline VulkanPrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<VulkanPrivateDataSlotWrapper>(VkPrivateDataSlot handle) { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
+template<> inline VulkanQueryPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueryPoolWrapper>(VkQueryPool handle) { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
+template<> inline VulkanQueueWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueueWrapper>(VkQueue handle) { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
+template<> inline VulkanRenderPassWrapper* VulkanStateHandleTable::GetWrapper<VulkanRenderPassWrapper>(VkRenderPass handle) { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
+template<> inline VulkanSamplerWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerWrapper>(VkSampler handle) { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
+template<> inline VulkanSamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
+template<> inline VulkanSemaphoreWrapper* VulkanStateHandleTable::GetWrapper<VulkanSemaphoreWrapper>(VkSemaphore handle) { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
+template<> inline VulkanShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderEXTWrapper>(VkShaderEXT handle) { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
+template<> inline VulkanShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderModuleWrapper>(VkShaderModule handle) { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
+template<> inline VulkanSurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSurfaceKHRWrapper>(VkSurfaceKHR handle) { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
+template<> inline VulkanSwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSwapchainKHRWrapper>(VkSwapchainKHR handle) { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
+template<> inline VulkanValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanValidationCacheEXTWrapper>(VkValidationCacheEXT handle) { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
+template<> inline VulkanVideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionKHRWrapper>(VkVideoSessionKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
+template<> inline VulkanVideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_state_table.h
+++ b/framework/generated/generated_vulkan_state_table.h
@@ -42,282 +42,282 @@ class VulkanStateTable : VulkanStateTableBase
     VulkanStateTable() {}
     ~VulkanStateTable() {}
 
-    bool InsertWrapper(format::HandleId id, VulkanAccelerationStructureKHRWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanAccelerationStructureNVWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureNV_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanBufferWrapper* wrapper) { return InsertEntry(id, wrapper, buffer_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanBufferViewWrapper* wrapper) { return InsertEntry(id, wrapper, bufferView_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanCommandBufferWrapper* wrapper) { return InsertEntry(id, wrapper, commandBuffer_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanCommandPoolWrapper* wrapper) { return InsertEntry(id, wrapper, commandPool_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugReportCallbackEXT_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugUtilsMessengerEXT_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDeferredOperationKHRWrapper* wrapper) { return InsertEntry(id, wrapper, deferredOperationKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDescriptorPoolWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorPool_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDescriptorSetWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSet_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDescriptorSetLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSetLayout_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorUpdateTemplate_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDeviceWrapper* wrapper) { return InsertEntry(id, wrapper, device_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDeviceMemoryWrapper* wrapper) { return InsertEntry(id, wrapper, deviceMemory_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDisplayKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanDisplayModeKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayModeKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanEventWrapper* wrapper) { return InsertEntry(id, wrapper, event_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanFenceWrapper* wrapper) { return InsertEntry(id, wrapper, fence_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanFramebufferWrapper* wrapper) { return InsertEntry(id, wrapper, framebuffer_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanImageWrapper* wrapper) { return InsertEntry(id, wrapper, image_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanImageViewWrapper* wrapper) { return InsertEntry(id, wrapper, imageView_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanIndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(id, wrapper, indirectCommandsLayoutNV_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanInstanceWrapper* wrapper) { return InsertEntry(id, wrapper, instance_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanMicromapEXTWrapper* wrapper) { return InsertEntry(id, wrapper, micromapEXT_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanOpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(id, wrapper, opticalFlowSessionNV_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanPerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(id, wrapper, performanceConfigurationINTEL_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanPhysicalDeviceWrapper* wrapper) { return InsertEntry(id, wrapper, physicalDevice_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanPipelineWrapper* wrapper) { return InsertEntry(id, wrapper, pipeline_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanPipelineCacheWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineCache_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanPipelineLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineLayout_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanPrivateDataSlotWrapper* wrapper) { return InsertEntry(id, wrapper, privateDataSlot_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanQueryPoolWrapper* wrapper) { return InsertEntry(id, wrapper, queryPool_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanQueueWrapper* wrapper) { return InsertEntry(id, wrapper, queue_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanRenderPassWrapper* wrapper) { return InsertEntry(id, wrapper, renderPass_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanSamplerWrapper* wrapper) { return InsertEntry(id, wrapper, sampler_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanSamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(id, wrapper, samplerYcbcrConversion_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanSemaphoreWrapper* wrapper) { return InsertEntry(id, wrapper, semaphore_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanShaderEXTWrapper* wrapper) { return InsertEntry(id, wrapper, shaderEXT_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanShaderModuleWrapper* wrapper) { return InsertEntry(id, wrapper, shaderModule_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanSurfaceKHRWrapper* wrapper) { return InsertEntry(id, wrapper, surfaceKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanSwapchainKHRWrapper* wrapper) { return InsertEntry(id, wrapper, swapchainKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanValidationCacheEXTWrapper* wrapper) { return InsertEntry(id, wrapper, validationCacheEXT_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanVideoSessionKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionKHR_map_); }
-    bool InsertWrapper(format::HandleId id, VulkanVideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionParametersKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::AccelerationStructureNVWrapper* wrapper) { return InsertEntry(id, wrapper, accelerationStructureNV_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::BufferWrapper* wrapper) { return InsertEntry(id, wrapper, buffer_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::BufferViewWrapper* wrapper) { return InsertEntry(id, wrapper, bufferView_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::CommandBufferWrapper* wrapper) { return InsertEntry(id, wrapper, commandBuffer_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::CommandPoolWrapper* wrapper) { return InsertEntry(id, wrapper, commandPool_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugReportCallbackEXT_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(id, wrapper, debugUtilsMessengerEXT_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DeferredOperationKHRWrapper* wrapper) { return InsertEntry(id, wrapper, deferredOperationKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DescriptorPoolWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorPool_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DescriptorSetWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSet_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DescriptorSetLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorSetLayout_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(id, wrapper, descriptorUpdateTemplate_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DeviceWrapper* wrapper) { return InsertEntry(id, wrapper, device_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DeviceMemoryWrapper* wrapper) { return InsertEntry(id, wrapper, deviceMemory_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DisplayKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::DisplayModeKHRWrapper* wrapper) { return InsertEntry(id, wrapper, displayModeKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::EventWrapper* wrapper) { return InsertEntry(id, wrapper, event_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::FenceWrapper* wrapper) { return InsertEntry(id, wrapper, fence_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::FramebufferWrapper* wrapper) { return InsertEntry(id, wrapper, framebuffer_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::ImageWrapper* wrapper) { return InsertEntry(id, wrapper, image_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::ImageViewWrapper* wrapper) { return InsertEntry(id, wrapper, imageView_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::IndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(id, wrapper, indirectCommandsLayoutNV_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::InstanceWrapper* wrapper) { return InsertEntry(id, wrapper, instance_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::MicromapEXTWrapper* wrapper) { return InsertEntry(id, wrapper, micromapEXT_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::OpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(id, wrapper, opticalFlowSessionNV_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::PerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(id, wrapper, performanceConfigurationINTEL_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::PhysicalDeviceWrapper* wrapper) { return InsertEntry(id, wrapper, physicalDevice_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::PipelineWrapper* wrapper) { return InsertEntry(id, wrapper, pipeline_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::PipelineCacheWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineCache_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::PipelineLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineLayout_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::PrivateDataSlotWrapper* wrapper) { return InsertEntry(id, wrapper, privateDataSlot_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::QueryPoolWrapper* wrapper) { return InsertEntry(id, wrapper, queryPool_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::QueueWrapper* wrapper) { return InsertEntry(id, wrapper, queue_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::RenderPassWrapper* wrapper) { return InsertEntry(id, wrapper, renderPass_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::SamplerWrapper* wrapper) { return InsertEntry(id, wrapper, sampler_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::SamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(id, wrapper, samplerYcbcrConversion_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::SemaphoreWrapper* wrapper) { return InsertEntry(id, wrapper, semaphore_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::ShaderEXTWrapper* wrapper) { return InsertEntry(id, wrapper, shaderEXT_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::ShaderModuleWrapper* wrapper) { return InsertEntry(id, wrapper, shaderModule_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::SurfaceKHRWrapper* wrapper) { return InsertEntry(id, wrapper, surfaceKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::SwapchainKHRWrapper* wrapper) { return InsertEntry(id, wrapper, swapchainKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::ValidationCacheEXTWrapper* wrapper) { return InsertEntry(id, wrapper, validationCacheEXT_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::VideoSessionKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionKHR_map_); }
+    bool InsertWrapper(format::HandleId id, vulkan_wrappers::VideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(id, wrapper, videoSessionParametersKHR_map_); }
 
-    bool RemoveWrapper(const VulkanAccelerationStructureKHRWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureKHR_map_); }
-    bool RemoveWrapper(const VulkanAccelerationStructureNVWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureNV_map_); }
-    bool RemoveWrapper(const VulkanBufferWrapper* wrapper) { return RemoveEntry(wrapper, buffer_map_); }
-    bool RemoveWrapper(const VulkanBufferViewWrapper* wrapper) { return RemoveEntry(wrapper, bufferView_map_); }
-    bool RemoveWrapper(const VulkanCommandBufferWrapper* wrapper) { return RemoveEntry(wrapper, commandBuffer_map_); }
-    bool RemoveWrapper(const VulkanCommandPoolWrapper* wrapper) { return RemoveEntry(wrapper, commandPool_map_); }
-    bool RemoveWrapper(const VulkanDebugReportCallbackEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugReportCallbackEXT_map_); }
-    bool RemoveWrapper(const VulkanDebugUtilsMessengerEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugUtilsMessengerEXT_map_); }
-    bool RemoveWrapper(const VulkanDeferredOperationKHRWrapper* wrapper) { return RemoveEntry(wrapper, deferredOperationKHR_map_); }
-    bool RemoveWrapper(const VulkanDescriptorPoolWrapper* wrapper) { return RemoveEntry(wrapper, descriptorPool_map_); }
-    bool RemoveWrapper(const VulkanDescriptorSetWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSet_map_); }
-    bool RemoveWrapper(const VulkanDescriptorSetLayoutWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSetLayout_map_); }
-    bool RemoveWrapper(const VulkanDescriptorUpdateTemplateWrapper* wrapper) { return RemoveEntry(wrapper, descriptorUpdateTemplate_map_); }
-    bool RemoveWrapper(const VulkanDeviceWrapper* wrapper) { return RemoveEntry(wrapper, device_map_); }
-    bool RemoveWrapper(const VulkanDeviceMemoryWrapper* wrapper) { return RemoveEntry(wrapper, deviceMemory_map_); }
-    bool RemoveWrapper(const VulkanDisplayKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayKHR_map_); }
-    bool RemoveWrapper(const VulkanDisplayModeKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayModeKHR_map_); }
-    bool RemoveWrapper(const VulkanEventWrapper* wrapper) { return RemoveEntry(wrapper, event_map_); }
-    bool RemoveWrapper(const VulkanFenceWrapper* wrapper) { return RemoveEntry(wrapper, fence_map_); }
-    bool RemoveWrapper(const VulkanFramebufferWrapper* wrapper) { return RemoveEntry(wrapper, framebuffer_map_); }
-    bool RemoveWrapper(const VulkanImageWrapper* wrapper) { return RemoveEntry(wrapper, image_map_); }
-    bool RemoveWrapper(const VulkanImageViewWrapper* wrapper) { return RemoveEntry(wrapper, imageView_map_); }
-    bool RemoveWrapper(const VulkanIndirectCommandsLayoutNVWrapper* wrapper) { return RemoveEntry(wrapper, indirectCommandsLayoutNV_map_); }
-    bool RemoveWrapper(const VulkanInstanceWrapper* wrapper) { return RemoveEntry(wrapper, instance_map_); }
-    bool RemoveWrapper(const VulkanMicromapEXTWrapper* wrapper) { return RemoveEntry(wrapper, micromapEXT_map_); }
-    bool RemoveWrapper(const VulkanOpticalFlowSessionNVWrapper* wrapper) { return RemoveEntry(wrapper, opticalFlowSessionNV_map_); }
-    bool RemoveWrapper(const VulkanPerformanceConfigurationINTELWrapper* wrapper) { return RemoveEntry(wrapper, performanceConfigurationINTEL_map_); }
-    bool RemoveWrapper(const VulkanPhysicalDeviceWrapper* wrapper) { return RemoveEntry(wrapper, physicalDevice_map_); }
-    bool RemoveWrapper(const VulkanPipelineWrapper* wrapper) { return RemoveEntry(wrapper, pipeline_map_); }
-    bool RemoveWrapper(const VulkanPipelineCacheWrapper* wrapper) { return RemoveEntry(wrapper, pipelineCache_map_); }
-    bool RemoveWrapper(const VulkanPipelineLayoutWrapper* wrapper) { return RemoveEntry(wrapper, pipelineLayout_map_); }
-    bool RemoveWrapper(const VulkanPrivateDataSlotWrapper* wrapper) { return RemoveEntry(wrapper, privateDataSlot_map_); }
-    bool RemoveWrapper(const VulkanQueryPoolWrapper* wrapper) { return RemoveEntry(wrapper, queryPool_map_); }
-    bool RemoveWrapper(const VulkanQueueWrapper* wrapper) { return RemoveEntry(wrapper, queue_map_); }
-    bool RemoveWrapper(const VulkanRenderPassWrapper* wrapper) { return RemoveEntry(wrapper, renderPass_map_); }
-    bool RemoveWrapper(const VulkanSamplerWrapper* wrapper) { return RemoveEntry(wrapper, sampler_map_); }
-    bool RemoveWrapper(const VulkanSamplerYcbcrConversionWrapper* wrapper) { return RemoveEntry(wrapper, samplerYcbcrConversion_map_); }
-    bool RemoveWrapper(const VulkanSemaphoreWrapper* wrapper) { return RemoveEntry(wrapper, semaphore_map_); }
-    bool RemoveWrapper(const VulkanShaderEXTWrapper* wrapper) { return RemoveEntry(wrapper, shaderEXT_map_); }
-    bool RemoveWrapper(const VulkanShaderModuleWrapper* wrapper) { return RemoveEntry(wrapper, shaderModule_map_); }
-    bool RemoveWrapper(const VulkanSurfaceKHRWrapper* wrapper) { return RemoveEntry(wrapper, surfaceKHR_map_); }
-    bool RemoveWrapper(const VulkanSwapchainKHRWrapper* wrapper) { return RemoveEntry(wrapper, swapchainKHR_map_); }
-    bool RemoveWrapper(const VulkanValidationCacheEXTWrapper* wrapper) { return RemoveEntry(wrapper, validationCacheEXT_map_); }
-    bool RemoveWrapper(const VulkanVideoSessionKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionKHR_map_); }
-    bool RemoveWrapper(const VulkanVideoSessionParametersKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionParametersKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::AccelerationStructureNVWrapper* wrapper) { return RemoveEntry(wrapper, accelerationStructureNV_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::BufferWrapper* wrapper) { return RemoveEntry(wrapper, buffer_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::BufferViewWrapper* wrapper) { return RemoveEntry(wrapper, bufferView_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::CommandBufferWrapper* wrapper) { return RemoveEntry(wrapper, commandBuffer_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::CommandPoolWrapper* wrapper) { return RemoveEntry(wrapper, commandPool_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DebugReportCallbackEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugReportCallbackEXT_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DebugUtilsMessengerEXTWrapper* wrapper) { return RemoveEntry(wrapper, debugUtilsMessengerEXT_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DeferredOperationKHRWrapper* wrapper) { return RemoveEntry(wrapper, deferredOperationKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorPoolWrapper* wrapper) { return RemoveEntry(wrapper, descriptorPool_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorSetWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSet_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorSetLayoutWrapper* wrapper) { return RemoveEntry(wrapper, descriptorSetLayout_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorUpdateTemplateWrapper* wrapper) { return RemoveEntry(wrapper, descriptorUpdateTemplate_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DeviceWrapper* wrapper) { return RemoveEntry(wrapper, device_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DeviceMemoryWrapper* wrapper) { return RemoveEntry(wrapper, deviceMemory_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DisplayKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::DisplayModeKHRWrapper* wrapper) { return RemoveEntry(wrapper, displayModeKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::EventWrapper* wrapper) { return RemoveEntry(wrapper, event_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::FenceWrapper* wrapper) { return RemoveEntry(wrapper, fence_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::FramebufferWrapper* wrapper) { return RemoveEntry(wrapper, framebuffer_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::ImageWrapper* wrapper) { return RemoveEntry(wrapper, image_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::ImageViewWrapper* wrapper) { return RemoveEntry(wrapper, imageView_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::IndirectCommandsLayoutNVWrapper* wrapper) { return RemoveEntry(wrapper, indirectCommandsLayoutNV_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::InstanceWrapper* wrapper) { return RemoveEntry(wrapper, instance_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::MicromapEXTWrapper* wrapper) { return RemoveEntry(wrapper, micromapEXT_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::OpticalFlowSessionNVWrapper* wrapper) { return RemoveEntry(wrapper, opticalFlowSessionNV_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::PerformanceConfigurationINTELWrapper* wrapper) { return RemoveEntry(wrapper, performanceConfigurationINTEL_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::PhysicalDeviceWrapper* wrapper) { return RemoveEntry(wrapper, physicalDevice_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::PipelineWrapper* wrapper) { return RemoveEntry(wrapper, pipeline_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::PipelineCacheWrapper* wrapper) { return RemoveEntry(wrapper, pipelineCache_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::PipelineLayoutWrapper* wrapper) { return RemoveEntry(wrapper, pipelineLayout_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::PrivateDataSlotWrapper* wrapper) { return RemoveEntry(wrapper, privateDataSlot_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::QueryPoolWrapper* wrapper) { return RemoveEntry(wrapper, queryPool_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::QueueWrapper* wrapper) { return RemoveEntry(wrapper, queue_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::RenderPassWrapper* wrapper) { return RemoveEntry(wrapper, renderPass_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::SamplerWrapper* wrapper) { return RemoveEntry(wrapper, sampler_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::SamplerYcbcrConversionWrapper* wrapper) { return RemoveEntry(wrapper, samplerYcbcrConversion_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::SemaphoreWrapper* wrapper) { return RemoveEntry(wrapper, semaphore_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::ShaderEXTWrapper* wrapper) { return RemoveEntry(wrapper, shaderEXT_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::ShaderModuleWrapper* wrapper) { return RemoveEntry(wrapper, shaderModule_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::SurfaceKHRWrapper* wrapper) { return RemoveEntry(wrapper, surfaceKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::SwapchainKHRWrapper* wrapper) { return RemoveEntry(wrapper, swapchainKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::ValidationCacheEXTWrapper* wrapper) { return RemoveEntry(wrapper, validationCacheEXT_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::VideoSessionKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionKHR_map_); }
+    bool RemoveWrapper(const vulkan_wrappers::VideoSessionParametersKHRWrapper* wrapper) { return RemoveEntry(wrapper, videoSessionParametersKHR_map_); }
 
-    const VulkanAccelerationStructureKHRWrapper* GetVulkanAccelerationStructureKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanAccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
-    const VulkanAccelerationStructureNVWrapper* GetVulkanAccelerationStructureNVWrapper(format::HandleId id) const { return GetWrapper<VulkanAccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
-    const VulkanBufferWrapper* GetVulkanBufferWrapper(format::HandleId id) const { return GetWrapper<VulkanBufferWrapper>(id, buffer_map_); }
-    const VulkanBufferViewWrapper* GetVulkanBufferViewWrapper(format::HandleId id) const { return GetWrapper<VulkanBufferViewWrapper>(id, bufferView_map_); }
-    const VulkanCommandBufferWrapper* GetVulkanCommandBufferWrapper(format::HandleId id) const { return GetWrapper<VulkanCommandBufferWrapper>(id, commandBuffer_map_); }
-    const VulkanCommandPoolWrapper* GetVulkanCommandPoolWrapper(format::HandleId id) const { return GetWrapper<VulkanCommandPoolWrapper>(id, commandPool_map_); }
-    const VulkanDebugReportCallbackEXTWrapper* GetVulkanDebugReportCallbackEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanDebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
-    const VulkanDebugUtilsMessengerEXTWrapper* GetVulkanDebugUtilsMessengerEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
-    const VulkanDeferredOperationKHRWrapper* GetVulkanDeferredOperationKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanDeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
-    const VulkanDescriptorPoolWrapper* GetVulkanDescriptorPoolWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorPoolWrapper>(id, descriptorPool_map_); }
-    const VulkanDescriptorSetWrapper* GetVulkanDescriptorSetWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorSetWrapper>(id, descriptorSet_map_); }
-    const VulkanDescriptorSetLayoutWrapper* GetVulkanDescriptorSetLayoutWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
-    const VulkanDescriptorUpdateTemplateWrapper* GetVulkanDescriptorUpdateTemplateWrapper(format::HandleId id) const { return GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
-    const VulkanDeviceWrapper* GetVulkanDeviceWrapper(format::HandleId id) const { return GetWrapper<VulkanDeviceWrapper>(id, device_map_); }
-    const VulkanDeviceMemoryWrapper* GetVulkanDeviceMemoryWrapper(format::HandleId id) const { return GetWrapper<VulkanDeviceMemoryWrapper>(id, deviceMemory_map_); }
-    const VulkanDisplayKHRWrapper* GetVulkanDisplayKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanDisplayKHRWrapper>(id, displayKHR_map_); }
-    const VulkanDisplayModeKHRWrapper* GetVulkanDisplayModeKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanDisplayModeKHRWrapper>(id, displayModeKHR_map_); }
-    const VulkanEventWrapper* GetVulkanEventWrapper(format::HandleId id) const { return GetWrapper<VulkanEventWrapper>(id, event_map_); }
-    const VulkanFenceWrapper* GetVulkanFenceWrapper(format::HandleId id) const { return GetWrapper<VulkanFenceWrapper>(id, fence_map_); }
-    const VulkanFramebufferWrapper* GetVulkanFramebufferWrapper(format::HandleId id) const { return GetWrapper<VulkanFramebufferWrapper>(id, framebuffer_map_); }
-    const VulkanImageWrapper* GetVulkanImageWrapper(format::HandleId id) const { return GetWrapper<VulkanImageWrapper>(id, image_map_); }
-    const VulkanImageViewWrapper* GetVulkanImageViewWrapper(format::HandleId id) const { return GetWrapper<VulkanImageViewWrapper>(id, imageView_map_); }
-    const VulkanIndirectCommandsLayoutNVWrapper* GetVulkanIndirectCommandsLayoutNVWrapper(format::HandleId id) const { return GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
-    const VulkanInstanceWrapper* GetVulkanInstanceWrapper(format::HandleId id) const { return GetWrapper<VulkanInstanceWrapper>(id, instance_map_); }
-    const VulkanMicromapEXTWrapper* GetVulkanMicromapEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanMicromapEXTWrapper>(id, micromapEXT_map_); }
-    const VulkanOpticalFlowSessionNVWrapper* GetVulkanOpticalFlowSessionNVWrapper(format::HandleId id) const { return GetWrapper<VulkanOpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
-    const VulkanPerformanceConfigurationINTELWrapper* GetVulkanPerformanceConfigurationINTELWrapper(format::HandleId id) const { return GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
-    const VulkanPhysicalDeviceWrapper* GetVulkanPhysicalDeviceWrapper(format::HandleId id) const { return GetWrapper<VulkanPhysicalDeviceWrapper>(id, physicalDevice_map_); }
-    const VulkanPipelineWrapper* GetVulkanPipelineWrapper(format::HandleId id) const { return GetWrapper<VulkanPipelineWrapper>(id, pipeline_map_); }
-    const VulkanPipelineCacheWrapper* GetVulkanPipelineCacheWrapper(format::HandleId id) const { return GetWrapper<VulkanPipelineCacheWrapper>(id, pipelineCache_map_); }
-    const VulkanPipelineLayoutWrapper* GetVulkanPipelineLayoutWrapper(format::HandleId id) const { return GetWrapper<VulkanPipelineLayoutWrapper>(id, pipelineLayout_map_); }
-    const VulkanPrivateDataSlotWrapper* GetVulkanPrivateDataSlotWrapper(format::HandleId id) const { return GetWrapper<VulkanPrivateDataSlotWrapper>(id, privateDataSlot_map_); }
-    const VulkanQueryPoolWrapper* GetVulkanQueryPoolWrapper(format::HandleId id) const { return GetWrapper<VulkanQueryPoolWrapper>(id, queryPool_map_); }
-    const VulkanQueueWrapper* GetVulkanQueueWrapper(format::HandleId id) const { return GetWrapper<VulkanQueueWrapper>(id, queue_map_); }
-    const VulkanRenderPassWrapper* GetVulkanRenderPassWrapper(format::HandleId id) const { return GetWrapper<VulkanRenderPassWrapper>(id, renderPass_map_); }
-    const VulkanSamplerWrapper* GetVulkanSamplerWrapper(format::HandleId id) const { return GetWrapper<VulkanSamplerWrapper>(id, sampler_map_); }
-    const VulkanSamplerYcbcrConversionWrapper* GetVulkanSamplerYcbcrConversionWrapper(format::HandleId id) const { return GetWrapper<VulkanSamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
-    const VulkanSemaphoreWrapper* GetVulkanSemaphoreWrapper(format::HandleId id) const { return GetWrapper<VulkanSemaphoreWrapper>(id, semaphore_map_); }
-    const VulkanShaderEXTWrapper* GetVulkanShaderEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanShaderEXTWrapper>(id, shaderEXT_map_); }
-    const VulkanShaderModuleWrapper* GetVulkanShaderModuleWrapper(format::HandleId id) const { return GetWrapper<VulkanShaderModuleWrapper>(id, shaderModule_map_); }
-    const VulkanSurfaceKHRWrapper* GetVulkanSurfaceKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanSurfaceKHRWrapper>(id, surfaceKHR_map_); }
-    const VulkanSwapchainKHRWrapper* GetVulkanSwapchainKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanSwapchainKHRWrapper>(id, swapchainKHR_map_); }
-    const VulkanValidationCacheEXTWrapper* GetVulkanValidationCacheEXTWrapper(format::HandleId id) const { return GetWrapper<VulkanValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
-    const VulkanVideoSessionKHRWrapper* GetVulkanVideoSessionKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanVideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
-    const VulkanVideoSessionParametersKHRWrapper* GetVulkanVideoSessionParametersKHRWrapper(format::HandleId id) const { return GetWrapper<VulkanVideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
+    const vulkan_wrappers::AccelerationStructureKHRWrapper* GetAccelerationStructureKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
+    const vulkan_wrappers::AccelerationStructureNVWrapper* GetAccelerationStructureNVWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::AccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
+    const vulkan_wrappers::BufferWrapper* GetBufferWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::BufferWrapper>(id, buffer_map_); }
+    const vulkan_wrappers::BufferViewWrapper* GetBufferViewWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::BufferViewWrapper>(id, bufferView_map_); }
+    const vulkan_wrappers::CommandBufferWrapper* GetCommandBufferWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::CommandBufferWrapper>(id, commandBuffer_map_); }
+    const vulkan_wrappers::CommandPoolWrapper* GetCommandPoolWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::CommandPoolWrapper>(id, commandPool_map_); }
+    const vulkan_wrappers::DebugReportCallbackEXTWrapper* GetDebugReportCallbackEXTWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
+    const vulkan_wrappers::DebugUtilsMessengerEXTWrapper* GetDebugUtilsMessengerEXTWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
+    const vulkan_wrappers::DeferredOperationKHRWrapper* GetDeferredOperationKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
+    const vulkan_wrappers::DescriptorPoolWrapper* GetDescriptorPoolWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DescriptorPoolWrapper>(id, descriptorPool_map_); }
+    const vulkan_wrappers::DescriptorSetWrapper* GetDescriptorSetWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DescriptorSetWrapper>(id, descriptorSet_map_); }
+    const vulkan_wrappers::DescriptorSetLayoutWrapper* GetDescriptorSetLayoutWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
+    const vulkan_wrappers::DescriptorUpdateTemplateWrapper* GetDescriptorUpdateTemplateWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
+    const vulkan_wrappers::DeviceWrapper* GetDeviceWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DeviceWrapper>(id, device_map_); }
+    const vulkan_wrappers::DeviceMemoryWrapper* GetDeviceMemoryWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DeviceMemoryWrapper>(id, deviceMemory_map_); }
+    const vulkan_wrappers::DisplayKHRWrapper* GetDisplayKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DisplayKHRWrapper>(id, displayKHR_map_); }
+    const vulkan_wrappers::DisplayModeKHRWrapper* GetDisplayModeKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::DisplayModeKHRWrapper>(id, displayModeKHR_map_); }
+    const vulkan_wrappers::EventWrapper* GetEventWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::EventWrapper>(id, event_map_); }
+    const vulkan_wrappers::FenceWrapper* GetFenceWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::FenceWrapper>(id, fence_map_); }
+    const vulkan_wrappers::FramebufferWrapper* GetFramebufferWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::FramebufferWrapper>(id, framebuffer_map_); }
+    const vulkan_wrappers::ImageWrapper* GetImageWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::ImageWrapper>(id, image_map_); }
+    const vulkan_wrappers::ImageViewWrapper* GetImageViewWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::ImageViewWrapper>(id, imageView_map_); }
+    const vulkan_wrappers::IndirectCommandsLayoutNVWrapper* GetIndirectCommandsLayoutNVWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
+    const vulkan_wrappers::InstanceWrapper* GetInstanceWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::InstanceWrapper>(id, instance_map_); }
+    const vulkan_wrappers::MicromapEXTWrapper* GetMicromapEXTWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::MicromapEXTWrapper>(id, micromapEXT_map_); }
+    const vulkan_wrappers::OpticalFlowSessionNVWrapper* GetOpticalFlowSessionNVWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::OpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
+    const vulkan_wrappers::PerformanceConfigurationINTELWrapper* GetPerformanceConfigurationINTELWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
+    const vulkan_wrappers::PhysicalDeviceWrapper* GetPhysicalDeviceWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(id, physicalDevice_map_); }
+    const vulkan_wrappers::PipelineWrapper* GetPipelineWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::PipelineWrapper>(id, pipeline_map_); }
+    const vulkan_wrappers::PipelineCacheWrapper* GetPipelineCacheWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::PipelineCacheWrapper>(id, pipelineCache_map_); }
+    const vulkan_wrappers::PipelineLayoutWrapper* GetPipelineLayoutWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::PipelineLayoutWrapper>(id, pipelineLayout_map_); }
+    const vulkan_wrappers::PrivateDataSlotWrapper* GetPrivateDataSlotWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::PrivateDataSlotWrapper>(id, privateDataSlot_map_); }
+    const vulkan_wrappers::QueryPoolWrapper* GetQueryPoolWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::QueryPoolWrapper>(id, queryPool_map_); }
+    const vulkan_wrappers::QueueWrapper* GetQueueWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::QueueWrapper>(id, queue_map_); }
+    const vulkan_wrappers::RenderPassWrapper* GetRenderPassWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::RenderPassWrapper>(id, renderPass_map_); }
+    const vulkan_wrappers::SamplerWrapper* GetSamplerWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::SamplerWrapper>(id, sampler_map_); }
+    const vulkan_wrappers::SamplerYcbcrConversionWrapper* GetSamplerYcbcrConversionWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::SamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
+    const vulkan_wrappers::SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::SemaphoreWrapper>(id, semaphore_map_); }
+    const vulkan_wrappers::ShaderEXTWrapper* GetShaderEXTWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::ShaderEXTWrapper>(id, shaderEXT_map_); }
+    const vulkan_wrappers::ShaderModuleWrapper* GetShaderModuleWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(id, shaderModule_map_); }
+    const vulkan_wrappers::SurfaceKHRWrapper* GetSurfaceKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::SurfaceKHRWrapper>(id, surfaceKHR_map_); }
+    const vulkan_wrappers::SwapchainKHRWrapper* GetSwapchainKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::SwapchainKHRWrapper>(id, swapchainKHR_map_); }
+    const vulkan_wrappers::ValidationCacheEXTWrapper* GetValidationCacheEXTWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::ValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
+    const vulkan_wrappers::VideoSessionKHRWrapper* GetVideoSessionKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::VideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
+    const vulkan_wrappers::VideoSessionParametersKHRWrapper* GetVideoSessionParametersKHRWrapper(format::HandleId id) const { return GetWrapper<vulkan_wrappers::VideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
 
-    VulkanAccelerationStructureKHRWrapper* GetVulkanAccelerationStructureKHRWrapper(format::HandleId id) { return GetWrapper<VulkanAccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
-    VulkanAccelerationStructureNVWrapper* GetVulkanAccelerationStructureNVWrapper(format::HandleId id) { return GetWrapper<VulkanAccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
-    VulkanBufferWrapper* GetVulkanBufferWrapper(format::HandleId id) { return GetWrapper<VulkanBufferWrapper>(id, buffer_map_); }
-    VulkanBufferViewWrapper* GetVulkanBufferViewWrapper(format::HandleId id) { return GetWrapper<VulkanBufferViewWrapper>(id, bufferView_map_); }
-    VulkanCommandBufferWrapper* GetVulkanCommandBufferWrapper(format::HandleId id) { return GetWrapper<VulkanCommandBufferWrapper>(id, commandBuffer_map_); }
-    VulkanCommandPoolWrapper* GetVulkanCommandPoolWrapper(format::HandleId id) { return GetWrapper<VulkanCommandPoolWrapper>(id, commandPool_map_); }
-    VulkanDebugReportCallbackEXTWrapper* GetVulkanDebugReportCallbackEXTWrapper(format::HandleId id) { return GetWrapper<VulkanDebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
-    VulkanDebugUtilsMessengerEXTWrapper* GetVulkanDebugUtilsMessengerEXTWrapper(format::HandleId id) { return GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
-    VulkanDeferredOperationKHRWrapper* GetVulkanDeferredOperationKHRWrapper(format::HandleId id) { return GetWrapper<VulkanDeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
-    VulkanDescriptorPoolWrapper* GetVulkanDescriptorPoolWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorPoolWrapper>(id, descriptorPool_map_); }
-    VulkanDescriptorSetWrapper* GetVulkanDescriptorSetWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorSetWrapper>(id, descriptorSet_map_); }
-    VulkanDescriptorSetLayoutWrapper* GetVulkanDescriptorSetLayoutWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
-    VulkanDescriptorUpdateTemplateWrapper* GetVulkanDescriptorUpdateTemplateWrapper(format::HandleId id) { return GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
-    VulkanDeviceWrapper* GetVulkanDeviceWrapper(format::HandleId id) { return GetWrapper<VulkanDeviceWrapper>(id, device_map_); }
-    VulkanDeviceMemoryWrapper* GetVulkanDeviceMemoryWrapper(format::HandleId id) { return GetWrapper<VulkanDeviceMemoryWrapper>(id, deviceMemory_map_); }
-    VulkanDisplayKHRWrapper* GetVulkanDisplayKHRWrapper(format::HandleId id) { return GetWrapper<VulkanDisplayKHRWrapper>(id, displayKHR_map_); }
-    VulkanDisplayModeKHRWrapper* GetVulkanDisplayModeKHRWrapper(format::HandleId id) { return GetWrapper<VulkanDisplayModeKHRWrapper>(id, displayModeKHR_map_); }
-    VulkanEventWrapper* GetVulkanEventWrapper(format::HandleId id) { return GetWrapper<VulkanEventWrapper>(id, event_map_); }
-    VulkanFenceWrapper* GetVulkanFenceWrapper(format::HandleId id) { return GetWrapper<VulkanFenceWrapper>(id, fence_map_); }
-    VulkanFramebufferWrapper* GetVulkanFramebufferWrapper(format::HandleId id) { return GetWrapper<VulkanFramebufferWrapper>(id, framebuffer_map_); }
-    VulkanImageWrapper* GetVulkanImageWrapper(format::HandleId id) { return GetWrapper<VulkanImageWrapper>(id, image_map_); }
-    VulkanImageViewWrapper* GetVulkanImageViewWrapper(format::HandleId id) { return GetWrapper<VulkanImageViewWrapper>(id, imageView_map_); }
-    VulkanIndirectCommandsLayoutNVWrapper* GetVulkanIndirectCommandsLayoutNVWrapper(format::HandleId id) { return GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
-    VulkanInstanceWrapper* GetVulkanInstanceWrapper(format::HandleId id) { return GetWrapper<VulkanInstanceWrapper>(id, instance_map_); }
-    VulkanMicromapEXTWrapper* GetVulkanMicromapEXTWrapper(format::HandleId id) { return GetWrapper<VulkanMicromapEXTWrapper>(id, micromapEXT_map_); }
-    VulkanOpticalFlowSessionNVWrapper* GetVulkanOpticalFlowSessionNVWrapper(format::HandleId id) { return GetWrapper<VulkanOpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
-    VulkanPerformanceConfigurationINTELWrapper* GetVulkanPerformanceConfigurationINTELWrapper(format::HandleId id) { return GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
-    VulkanPhysicalDeviceWrapper* GetVulkanPhysicalDeviceWrapper(format::HandleId id) { return GetWrapper<VulkanPhysicalDeviceWrapper>(id, physicalDevice_map_); }
-    VulkanPipelineWrapper* GetVulkanPipelineWrapper(format::HandleId id) { return GetWrapper<VulkanPipelineWrapper>(id, pipeline_map_); }
-    VulkanPipelineCacheWrapper* GetVulkanPipelineCacheWrapper(format::HandleId id) { return GetWrapper<VulkanPipelineCacheWrapper>(id, pipelineCache_map_); }
-    VulkanPipelineLayoutWrapper* GetVulkanPipelineLayoutWrapper(format::HandleId id) { return GetWrapper<VulkanPipelineLayoutWrapper>(id, pipelineLayout_map_); }
-    VulkanPrivateDataSlotWrapper* GetVulkanPrivateDataSlotWrapper(format::HandleId id) { return GetWrapper<VulkanPrivateDataSlotWrapper>(id, privateDataSlot_map_); }
-    VulkanQueryPoolWrapper* GetVulkanQueryPoolWrapper(format::HandleId id) { return GetWrapper<VulkanQueryPoolWrapper>(id, queryPool_map_); }
-    VulkanQueueWrapper* GetVulkanQueueWrapper(format::HandleId id) { return GetWrapper<VulkanQueueWrapper>(id, queue_map_); }
-    VulkanRenderPassWrapper* GetVulkanRenderPassWrapper(format::HandleId id) { return GetWrapper<VulkanRenderPassWrapper>(id, renderPass_map_); }
-    VulkanSamplerWrapper* GetVulkanSamplerWrapper(format::HandleId id) { return GetWrapper<VulkanSamplerWrapper>(id, sampler_map_); }
-    VulkanSamplerYcbcrConversionWrapper* GetVulkanSamplerYcbcrConversionWrapper(format::HandleId id) { return GetWrapper<VulkanSamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
-    VulkanSemaphoreWrapper* GetVulkanSemaphoreWrapper(format::HandleId id) { return GetWrapper<VulkanSemaphoreWrapper>(id, semaphore_map_); }
-    VulkanShaderEXTWrapper* GetVulkanShaderEXTWrapper(format::HandleId id) { return GetWrapper<VulkanShaderEXTWrapper>(id, shaderEXT_map_); }
-    VulkanShaderModuleWrapper* GetVulkanShaderModuleWrapper(format::HandleId id) { return GetWrapper<VulkanShaderModuleWrapper>(id, shaderModule_map_); }
-    VulkanSurfaceKHRWrapper* GetVulkanSurfaceKHRWrapper(format::HandleId id) { return GetWrapper<VulkanSurfaceKHRWrapper>(id, surfaceKHR_map_); }
-    VulkanSwapchainKHRWrapper* GetVulkanSwapchainKHRWrapper(format::HandleId id) { return GetWrapper<VulkanSwapchainKHRWrapper>(id, swapchainKHR_map_); }
-    VulkanValidationCacheEXTWrapper* GetVulkanValidationCacheEXTWrapper(format::HandleId id) { return GetWrapper<VulkanValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
-    VulkanVideoSessionKHRWrapper* GetVulkanVideoSessionKHRWrapper(format::HandleId id) { return GetWrapper<VulkanVideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
-    VulkanVideoSessionParametersKHRWrapper* GetVulkanVideoSessionParametersKHRWrapper(format::HandleId id) { return GetWrapper<VulkanVideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
+    vulkan_wrappers::AccelerationStructureKHRWrapper* GetAccelerationStructureKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(id, accelerationStructureKHR_map_); }
+    vulkan_wrappers::AccelerationStructureNVWrapper* GetAccelerationStructureNVWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::AccelerationStructureNVWrapper>(id, accelerationStructureNV_map_); }
+    vulkan_wrappers::BufferWrapper* GetBufferWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::BufferWrapper>(id, buffer_map_); }
+    vulkan_wrappers::BufferViewWrapper* GetBufferViewWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::BufferViewWrapper>(id, bufferView_map_); }
+    vulkan_wrappers::CommandBufferWrapper* GetCommandBufferWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::CommandBufferWrapper>(id, commandBuffer_map_); }
+    vulkan_wrappers::CommandPoolWrapper* GetCommandPoolWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::CommandPoolWrapper>(id, commandPool_map_); }
+    vulkan_wrappers::DebugReportCallbackEXTWrapper* GetDebugReportCallbackEXTWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DebugReportCallbackEXTWrapper>(id, debugReportCallbackEXT_map_); }
+    vulkan_wrappers::DebugUtilsMessengerEXTWrapper* GetDebugUtilsMessengerEXTWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(id, debugUtilsMessengerEXT_map_); }
+    vulkan_wrappers::DeferredOperationKHRWrapper* GetDeferredOperationKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DeferredOperationKHRWrapper>(id, deferredOperationKHR_map_); }
+    vulkan_wrappers::DescriptorPoolWrapper* GetDescriptorPoolWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DescriptorPoolWrapper>(id, descriptorPool_map_); }
+    vulkan_wrappers::DescriptorSetWrapper* GetDescriptorSetWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DescriptorSetWrapper>(id, descriptorSet_map_); }
+    vulkan_wrappers::DescriptorSetLayoutWrapper* GetDescriptorSetLayoutWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DescriptorSetLayoutWrapper>(id, descriptorSetLayout_map_); }
+    vulkan_wrappers::DescriptorUpdateTemplateWrapper* GetDescriptorUpdateTemplateWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(id, descriptorUpdateTemplate_map_); }
+    vulkan_wrappers::DeviceWrapper* GetDeviceWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DeviceWrapper>(id, device_map_); }
+    vulkan_wrappers::DeviceMemoryWrapper* GetDeviceMemoryWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DeviceMemoryWrapper>(id, deviceMemory_map_); }
+    vulkan_wrappers::DisplayKHRWrapper* GetDisplayKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DisplayKHRWrapper>(id, displayKHR_map_); }
+    vulkan_wrappers::DisplayModeKHRWrapper* GetDisplayModeKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::DisplayModeKHRWrapper>(id, displayModeKHR_map_); }
+    vulkan_wrappers::EventWrapper* GetEventWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::EventWrapper>(id, event_map_); }
+    vulkan_wrappers::FenceWrapper* GetFenceWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::FenceWrapper>(id, fence_map_); }
+    vulkan_wrappers::FramebufferWrapper* GetFramebufferWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::FramebufferWrapper>(id, framebuffer_map_); }
+    vulkan_wrappers::ImageWrapper* GetImageWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::ImageWrapper>(id, image_map_); }
+    vulkan_wrappers::ImageViewWrapper* GetImageViewWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::ImageViewWrapper>(id, imageView_map_); }
+    vulkan_wrappers::IndirectCommandsLayoutNVWrapper* GetIndirectCommandsLayoutNVWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(id, indirectCommandsLayoutNV_map_); }
+    vulkan_wrappers::InstanceWrapper* GetInstanceWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::InstanceWrapper>(id, instance_map_); }
+    vulkan_wrappers::MicromapEXTWrapper* GetMicromapEXTWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::MicromapEXTWrapper>(id, micromapEXT_map_); }
+    vulkan_wrappers::OpticalFlowSessionNVWrapper* GetOpticalFlowSessionNVWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::OpticalFlowSessionNVWrapper>(id, opticalFlowSessionNV_map_); }
+    vulkan_wrappers::PerformanceConfigurationINTELWrapper* GetPerformanceConfigurationINTELWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(id, performanceConfigurationINTEL_map_); }
+    vulkan_wrappers::PhysicalDeviceWrapper* GetPhysicalDeviceWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(id, physicalDevice_map_); }
+    vulkan_wrappers::PipelineWrapper* GetPipelineWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::PipelineWrapper>(id, pipeline_map_); }
+    vulkan_wrappers::PipelineCacheWrapper* GetPipelineCacheWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::PipelineCacheWrapper>(id, pipelineCache_map_); }
+    vulkan_wrappers::PipelineLayoutWrapper* GetPipelineLayoutWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::PipelineLayoutWrapper>(id, pipelineLayout_map_); }
+    vulkan_wrappers::PrivateDataSlotWrapper* GetPrivateDataSlotWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::PrivateDataSlotWrapper>(id, privateDataSlot_map_); }
+    vulkan_wrappers::QueryPoolWrapper* GetQueryPoolWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::QueryPoolWrapper>(id, queryPool_map_); }
+    vulkan_wrappers::QueueWrapper* GetQueueWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::QueueWrapper>(id, queue_map_); }
+    vulkan_wrappers::RenderPassWrapper* GetRenderPassWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::RenderPassWrapper>(id, renderPass_map_); }
+    vulkan_wrappers::SamplerWrapper* GetSamplerWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::SamplerWrapper>(id, sampler_map_); }
+    vulkan_wrappers::SamplerYcbcrConversionWrapper* GetSamplerYcbcrConversionWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::SamplerYcbcrConversionWrapper>(id, samplerYcbcrConversion_map_); }
+    vulkan_wrappers::SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::SemaphoreWrapper>(id, semaphore_map_); }
+    vulkan_wrappers::ShaderEXTWrapper* GetShaderEXTWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::ShaderEXTWrapper>(id, shaderEXT_map_); }
+    vulkan_wrappers::ShaderModuleWrapper* GetShaderModuleWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(id, shaderModule_map_); }
+    vulkan_wrappers::SurfaceKHRWrapper* GetSurfaceKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::SurfaceKHRWrapper>(id, surfaceKHR_map_); }
+    vulkan_wrappers::SwapchainKHRWrapper* GetSwapchainKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::SwapchainKHRWrapper>(id, swapchainKHR_map_); }
+    vulkan_wrappers::ValidationCacheEXTWrapper* GetValidationCacheEXTWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::ValidationCacheEXTWrapper>(id, validationCacheEXT_map_); }
+    vulkan_wrappers::VideoSessionKHRWrapper* GetVideoSessionKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::VideoSessionKHRWrapper>(id, videoSessionKHR_map_); }
+    vulkan_wrappers::VideoSessionParametersKHRWrapper* GetVideoSessionParametersKHRWrapper(format::HandleId id) { return GetWrapper<vulkan_wrappers::VideoSessionParametersKHRWrapper>(id, videoSessionParametersKHR_map_); }
 
-    void VisitWrappers(std::function<void(VulkanAccelerationStructureKHRWrapper*)> visitor) const { for (auto entry : accelerationStructureKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanAccelerationStructureNVWrapper*)> visitor) const { for (auto entry : accelerationStructureNV_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanBufferWrapper*)> visitor) const { for (auto entry : buffer_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanBufferViewWrapper*)> visitor) const { for (auto entry : bufferView_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanCommandBufferWrapper*)> visitor) const { for (auto entry : commandBuffer_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanCommandPoolWrapper*)> visitor) const { for (auto entry : commandPool_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDebugReportCallbackEXTWrapper*)> visitor) const { for (auto entry : debugReportCallbackEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDebugUtilsMessengerEXTWrapper*)> visitor) const { for (auto entry : debugUtilsMessengerEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDeferredOperationKHRWrapper*)> visitor) const { for (auto entry : deferredOperationKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDescriptorPoolWrapper*)> visitor) const { for (auto entry : descriptorPool_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDescriptorSetWrapper*)> visitor) const { for (auto entry : descriptorSet_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDescriptorSetLayoutWrapper*)> visitor) const { for (auto entry : descriptorSetLayout_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDescriptorUpdateTemplateWrapper*)> visitor) const { for (auto entry : descriptorUpdateTemplate_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDeviceWrapper*)> visitor) const { for (auto entry : device_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDeviceMemoryWrapper*)> visitor) const { for (auto entry : deviceMemory_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDisplayKHRWrapper*)> visitor) const { for (auto entry : displayKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanDisplayModeKHRWrapper*)> visitor) const { for (auto entry : displayModeKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanEventWrapper*)> visitor) const { for (auto entry : event_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanFenceWrapper*)> visitor) const { for (auto entry : fence_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanFramebufferWrapper*)> visitor) const { for (auto entry : framebuffer_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanImageWrapper*)> visitor) const { for (auto entry : image_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanImageViewWrapper*)> visitor) const { for (auto entry : imageView_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanIndirectCommandsLayoutNVWrapper*)> visitor) const { for (auto entry : indirectCommandsLayoutNV_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanInstanceWrapper*)> visitor) const { for (auto entry : instance_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanMicromapEXTWrapper*)> visitor) const { for (auto entry : micromapEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanOpticalFlowSessionNVWrapper*)> visitor) const { for (auto entry : opticalFlowSessionNV_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanPerformanceConfigurationINTELWrapper*)> visitor) const { for (auto entry : performanceConfigurationINTEL_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanPhysicalDeviceWrapper*)> visitor) const { for (auto entry : physicalDevice_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanPipelineWrapper*)> visitor) const { for (auto entry : pipeline_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanPipelineCacheWrapper*)> visitor) const { for (auto entry : pipelineCache_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanPipelineLayoutWrapper*)> visitor) const { for (auto entry : pipelineLayout_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanPrivateDataSlotWrapper*)> visitor) const { for (auto entry : privateDataSlot_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanQueryPoolWrapper*)> visitor) const { for (auto entry : queryPool_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanQueueWrapper*)> visitor) const { for (auto entry : queue_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanRenderPassWrapper*)> visitor) const { for (auto entry : renderPass_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanSamplerWrapper*)> visitor) const { for (auto entry : sampler_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanSamplerYcbcrConversionWrapper*)> visitor) const { for (auto entry : samplerYcbcrConversion_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanSemaphoreWrapper*)> visitor) const { for (auto entry : semaphore_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanShaderEXTWrapper*)> visitor) const { for (auto entry : shaderEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanShaderModuleWrapper*)> visitor) const { for (auto entry : shaderModule_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanSurfaceKHRWrapper*)> visitor) const { for (auto entry : surfaceKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanSwapchainKHRWrapper*)> visitor) const { for (auto entry : swapchainKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanValidationCacheEXTWrapper*)> visitor) const { for (auto entry : validationCacheEXT_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanVideoSessionKHRWrapper*)> visitor) const { for (auto entry : videoSessionKHR_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(VulkanVideoSessionParametersKHRWrapper*)> visitor) const { for (auto entry : videoSessionParametersKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::AccelerationStructureKHRWrapper*)> visitor) const { for (auto entry : accelerationStructureKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::AccelerationStructureNVWrapper*)> visitor) const { for (auto entry : accelerationStructureNV_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::BufferWrapper*)> visitor) const { for (auto entry : buffer_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::BufferViewWrapper*)> visitor) const { for (auto entry : bufferView_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::CommandBufferWrapper*)> visitor) const { for (auto entry : commandBuffer_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::CommandPoolWrapper*)> visitor) const { for (auto entry : commandPool_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DebugReportCallbackEXTWrapper*)> visitor) const { for (auto entry : debugReportCallbackEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DebugUtilsMessengerEXTWrapper*)> visitor) const { for (auto entry : debugUtilsMessengerEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DeferredOperationKHRWrapper*)> visitor) const { for (auto entry : deferredOperationKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DescriptorPoolWrapper*)> visitor) const { for (auto entry : descriptorPool_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DescriptorSetWrapper*)> visitor) const { for (auto entry : descriptorSet_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DescriptorSetLayoutWrapper*)> visitor) const { for (auto entry : descriptorSetLayout_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DescriptorUpdateTemplateWrapper*)> visitor) const { for (auto entry : descriptorUpdateTemplate_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DeviceWrapper*)> visitor) const { for (auto entry : device_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DeviceMemoryWrapper*)> visitor) const { for (auto entry : deviceMemory_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DisplayKHRWrapper*)> visitor) const { for (auto entry : displayKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::DisplayModeKHRWrapper*)> visitor) const { for (auto entry : displayModeKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::EventWrapper*)> visitor) const { for (auto entry : event_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::FenceWrapper*)> visitor) const { for (auto entry : fence_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::FramebufferWrapper*)> visitor) const { for (auto entry : framebuffer_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::ImageWrapper*)> visitor) const { for (auto entry : image_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::ImageViewWrapper*)> visitor) const { for (auto entry : imageView_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::IndirectCommandsLayoutNVWrapper*)> visitor) const { for (auto entry : indirectCommandsLayoutNV_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::InstanceWrapper*)> visitor) const { for (auto entry : instance_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::MicromapEXTWrapper*)> visitor) const { for (auto entry : micromapEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::OpticalFlowSessionNVWrapper*)> visitor) const { for (auto entry : opticalFlowSessionNV_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::PerformanceConfigurationINTELWrapper*)> visitor) const { for (auto entry : performanceConfigurationINTEL_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::PhysicalDeviceWrapper*)> visitor) const { for (auto entry : physicalDevice_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::PipelineWrapper*)> visitor) const { for (auto entry : pipeline_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::PipelineCacheWrapper*)> visitor) const { for (auto entry : pipelineCache_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::PipelineLayoutWrapper*)> visitor) const { for (auto entry : pipelineLayout_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::PrivateDataSlotWrapper*)> visitor) const { for (auto entry : privateDataSlot_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::QueryPoolWrapper*)> visitor) const { for (auto entry : queryPool_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::QueueWrapper*)> visitor) const { for (auto entry : queue_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::RenderPassWrapper*)> visitor) const { for (auto entry : renderPass_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::SamplerWrapper*)> visitor) const { for (auto entry : sampler_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::SamplerYcbcrConversionWrapper*)> visitor) const { for (auto entry : samplerYcbcrConversion_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::SemaphoreWrapper*)> visitor) const { for (auto entry : semaphore_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::ShaderEXTWrapper*)> visitor) const { for (auto entry : shaderEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::ShaderModuleWrapper*)> visitor) const { for (auto entry : shaderModule_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::SurfaceKHRWrapper*)> visitor) const { for (auto entry : surfaceKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::SwapchainKHRWrapper*)> visitor) const { for (auto entry : swapchainKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::ValidationCacheEXTWrapper*)> visitor) const { for (auto entry : validationCacheEXT_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::VideoSessionKHRWrapper*)> visitor) const { for (auto entry : videoSessionKHR_map_) { visitor(entry.second); } }
+    void VisitWrappers(std::function<void(vulkan_wrappers::VideoSessionParametersKHRWrapper*)> visitor) const { for (auto entry : videoSessionParametersKHR_map_) { visitor(entry.second); } }
 
   private:
-    std::map<format::HandleId, VulkanAccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
-    std::map<format::HandleId, VulkanAccelerationStructureNVWrapper*> accelerationStructureNV_map_;
-    std::map<format::HandleId, VulkanBufferWrapper*> buffer_map_;
-    std::map<format::HandleId, VulkanBufferViewWrapper*> bufferView_map_;
-    std::map<format::HandleId, VulkanCommandBufferWrapper*> commandBuffer_map_;
-    std::map<format::HandleId, VulkanCommandPoolWrapper*> commandPool_map_;
-    std::map<format::HandleId, VulkanDebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
-    std::map<format::HandleId, VulkanDebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
-    std::map<format::HandleId, VulkanDeferredOperationKHRWrapper*> deferredOperationKHR_map_;
-    std::map<format::HandleId, VulkanDescriptorPoolWrapper*> descriptorPool_map_;
-    std::map<format::HandleId, VulkanDescriptorSetWrapper*> descriptorSet_map_;
-    std::map<format::HandleId, VulkanDescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
-    std::map<format::HandleId, VulkanDescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
-    std::map<format::HandleId, VulkanDeviceWrapper*> device_map_;
-    std::map<format::HandleId, VulkanDeviceMemoryWrapper*> deviceMemory_map_;
-    std::map<format::HandleId, VulkanDisplayKHRWrapper*> displayKHR_map_;
-    std::map<format::HandleId, VulkanDisplayModeKHRWrapper*> displayModeKHR_map_;
-    std::map<format::HandleId, VulkanEventWrapper*> event_map_;
-    std::map<format::HandleId, VulkanFenceWrapper*> fence_map_;
-    std::map<format::HandleId, VulkanFramebufferWrapper*> framebuffer_map_;
-    std::map<format::HandleId, VulkanImageWrapper*> image_map_;
-    std::map<format::HandleId, VulkanImageViewWrapper*> imageView_map_;
-    std::map<format::HandleId, VulkanIndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
-    std::map<format::HandleId, VulkanInstanceWrapper*> instance_map_;
-    std::map<format::HandleId, VulkanMicromapEXTWrapper*> micromapEXT_map_;
-    std::map<format::HandleId, VulkanOpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
-    std::map<format::HandleId, VulkanPerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
-    std::map<format::HandleId, VulkanPhysicalDeviceWrapper*> physicalDevice_map_;
-    std::map<format::HandleId, VulkanPipelineWrapper*> pipeline_map_;
-    std::map<format::HandleId, VulkanPipelineCacheWrapper*> pipelineCache_map_;
-    std::map<format::HandleId, VulkanPipelineLayoutWrapper*> pipelineLayout_map_;
-    std::map<format::HandleId, VulkanPrivateDataSlotWrapper*> privateDataSlot_map_;
-    std::map<format::HandleId, VulkanQueryPoolWrapper*> queryPool_map_;
-    std::map<format::HandleId, VulkanQueueWrapper*> queue_map_;
-    std::map<format::HandleId, VulkanRenderPassWrapper*> renderPass_map_;
-    std::map<format::HandleId, VulkanSamplerWrapper*> sampler_map_;
-    std::map<format::HandleId, VulkanSamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
-    std::map<format::HandleId, VulkanSemaphoreWrapper*> semaphore_map_;
-    std::map<format::HandleId, VulkanShaderEXTWrapper*> shaderEXT_map_;
-    std::map<format::HandleId, VulkanShaderModuleWrapper*> shaderModule_map_;
-    std::map<format::HandleId, VulkanSurfaceKHRWrapper*> surfaceKHR_map_;
-    std::map<format::HandleId, VulkanSwapchainKHRWrapper*> swapchainKHR_map_;
-    std::map<format::HandleId, VulkanValidationCacheEXTWrapper*> validationCacheEXT_map_;
-    std::map<format::HandleId, VulkanVideoSessionKHRWrapper*> videoSessionKHR_map_;
-    std::map<format::HandleId, VulkanVideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::AccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::AccelerationStructureNVWrapper*> accelerationStructureNV_map_;
+    std::map<format::HandleId, vulkan_wrappers::BufferWrapper*> buffer_map_;
+    std::map<format::HandleId, vulkan_wrappers::BufferViewWrapper*> bufferView_map_;
+    std::map<format::HandleId, vulkan_wrappers::CommandBufferWrapper*> commandBuffer_map_;
+    std::map<format::HandleId, vulkan_wrappers::CommandPoolWrapper*> commandPool_map_;
+    std::map<format::HandleId, vulkan_wrappers::DebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
+    std::map<format::HandleId, vulkan_wrappers::DebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
+    std::map<format::HandleId, vulkan_wrappers::DeferredOperationKHRWrapper*> deferredOperationKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::DescriptorPoolWrapper*> descriptorPool_map_;
+    std::map<format::HandleId, vulkan_wrappers::DescriptorSetWrapper*> descriptorSet_map_;
+    std::map<format::HandleId, vulkan_wrappers::DescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
+    std::map<format::HandleId, vulkan_wrappers::DescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
+    std::map<format::HandleId, vulkan_wrappers::DeviceWrapper*> device_map_;
+    std::map<format::HandleId, vulkan_wrappers::DeviceMemoryWrapper*> deviceMemory_map_;
+    std::map<format::HandleId, vulkan_wrappers::DisplayKHRWrapper*> displayKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::DisplayModeKHRWrapper*> displayModeKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::EventWrapper*> event_map_;
+    std::map<format::HandleId, vulkan_wrappers::FenceWrapper*> fence_map_;
+    std::map<format::HandleId, vulkan_wrappers::FramebufferWrapper*> framebuffer_map_;
+    std::map<format::HandleId, vulkan_wrappers::ImageWrapper*> image_map_;
+    std::map<format::HandleId, vulkan_wrappers::ImageViewWrapper*> imageView_map_;
+    std::map<format::HandleId, vulkan_wrappers::IndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
+    std::map<format::HandleId, vulkan_wrappers::InstanceWrapper*> instance_map_;
+    std::map<format::HandleId, vulkan_wrappers::MicromapEXTWrapper*> micromapEXT_map_;
+    std::map<format::HandleId, vulkan_wrappers::OpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
+    std::map<format::HandleId, vulkan_wrappers::PerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
+    std::map<format::HandleId, vulkan_wrappers::PhysicalDeviceWrapper*> physicalDevice_map_;
+    std::map<format::HandleId, vulkan_wrappers::PipelineWrapper*> pipeline_map_;
+    std::map<format::HandleId, vulkan_wrappers::PipelineCacheWrapper*> pipelineCache_map_;
+    std::map<format::HandleId, vulkan_wrappers::PipelineLayoutWrapper*> pipelineLayout_map_;
+    std::map<format::HandleId, vulkan_wrappers::PrivateDataSlotWrapper*> privateDataSlot_map_;
+    std::map<format::HandleId, vulkan_wrappers::QueryPoolWrapper*> queryPool_map_;
+    std::map<format::HandleId, vulkan_wrappers::QueueWrapper*> queue_map_;
+    std::map<format::HandleId, vulkan_wrappers::RenderPassWrapper*> renderPass_map_;
+    std::map<format::HandleId, vulkan_wrappers::SamplerWrapper*> sampler_map_;
+    std::map<format::HandleId, vulkan_wrappers::SamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
+    std::map<format::HandleId, vulkan_wrappers::SemaphoreWrapper*> semaphore_map_;
+    std::map<format::HandleId, vulkan_wrappers::ShaderEXTWrapper*> shaderEXT_map_;
+    std::map<format::HandleId, vulkan_wrappers::ShaderModuleWrapper*> shaderModule_map_;
+    std::map<format::HandleId, vulkan_wrappers::SurfaceKHRWrapper*> surfaceKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::SwapchainKHRWrapper*> swapchainKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::ValidationCacheEXTWrapper*> validationCacheEXT_map_;
+    std::map<format::HandleId, vulkan_wrappers::VideoSessionKHRWrapper*> videoSessionKHR_map_;
+    std::map<format::HandleId, vulkan_wrappers::VideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
 };
 
 class VulkanStateHandleTable : VulkanStateTableBase
@@ -326,229 +326,229 @@ class VulkanStateHandleTable : VulkanStateTableBase
     VulkanStateHandleTable() {}
     ~VulkanStateHandleTable() {}
 
-    bool InsertWrapper(VulkanAccelerationStructureKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureKHR_map_); }
-    bool InsertWrapper(VulkanAccelerationStructureNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureNV_map_); }
-    bool InsertWrapper(VulkanBufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, buffer_map_); }
-    bool InsertWrapper(VulkanBufferViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, bufferView_map_); }
-    bool InsertWrapper(VulkanCommandBufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandBuffer_map_); }
-    bool InsertWrapper(VulkanCommandPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandPool_map_); }
-    bool InsertWrapper(VulkanDebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugReportCallbackEXT_map_); }
-    bool InsertWrapper(VulkanDebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugUtilsMessengerEXT_map_); }
-    bool InsertWrapper(VulkanDeferredOperationKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deferredOperationKHR_map_); }
-    bool InsertWrapper(VulkanDescriptorPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorPool_map_); }
-    bool InsertWrapper(VulkanDescriptorSetWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSet_map_); }
-    bool InsertWrapper(VulkanDescriptorSetLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSetLayout_map_); }
-    bool InsertWrapper(VulkanDescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorUpdateTemplate_map_); }
-    bool InsertWrapper(VulkanDeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, device_map_); }
-    bool InsertWrapper(VulkanDeviceMemoryWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deviceMemory_map_); }
-    bool InsertWrapper(VulkanDisplayKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayKHR_map_); }
-    bool InsertWrapper(VulkanDisplayModeKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayModeKHR_map_); }
-    bool InsertWrapper(VulkanEventWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, event_map_); }
-    bool InsertWrapper(VulkanFenceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, fence_map_); }
-    bool InsertWrapper(VulkanFramebufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, framebuffer_map_); }
-    bool InsertWrapper(VulkanImageWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, image_map_); }
-    bool InsertWrapper(VulkanImageViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, imageView_map_); }
-    bool InsertWrapper(VulkanIndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, indirectCommandsLayoutNV_map_); }
-    bool InsertWrapper(VulkanInstanceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, instance_map_); }
-    bool InsertWrapper(VulkanMicromapEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, micromapEXT_map_); }
-    bool InsertWrapper(VulkanOpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, opticalFlowSessionNV_map_); }
-    bool InsertWrapper(VulkanPerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, performanceConfigurationINTEL_map_); }
-    bool InsertWrapper(VulkanPhysicalDeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, physicalDevice_map_); }
-    bool InsertWrapper(VulkanPipelineWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipeline_map_); }
-    bool InsertWrapper(VulkanPipelineCacheWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineCache_map_); }
-    bool InsertWrapper(VulkanPipelineLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineLayout_map_); }
-    bool InsertWrapper(VulkanPrivateDataSlotWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, privateDataSlot_map_); }
-    bool InsertWrapper(VulkanQueryPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queryPool_map_); }
-    bool InsertWrapper(VulkanQueueWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queue_map_); }
-    bool InsertWrapper(VulkanRenderPassWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, renderPass_map_); }
-    bool InsertWrapper(VulkanSamplerWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, sampler_map_); }
-    bool InsertWrapper(VulkanSamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, samplerYcbcrConversion_map_); }
-    bool InsertWrapper(VulkanSemaphoreWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, semaphore_map_); }
-    bool InsertWrapper(VulkanShaderEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderEXT_map_); }
-    bool InsertWrapper(VulkanShaderModuleWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderModule_map_); }
-    bool InsertWrapper(VulkanSurfaceKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, surfaceKHR_map_); }
-    bool InsertWrapper(VulkanSwapchainKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, swapchainKHR_map_); }
-    bool InsertWrapper(VulkanValidationCacheEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, validationCacheEXT_map_); }
-    bool InsertWrapper(VulkanVideoSessionKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionKHR_map_); }
-    bool InsertWrapper(VulkanVideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionParametersKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::AccelerationStructureNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, accelerationStructureNV_map_); }
+    bool InsertWrapper(vulkan_wrappers::BufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, buffer_map_); }
+    bool InsertWrapper(vulkan_wrappers::BufferViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, bufferView_map_); }
+    bool InsertWrapper(vulkan_wrappers::CommandBufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandBuffer_map_); }
+    bool InsertWrapper(vulkan_wrappers::CommandPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, commandPool_map_); }
+    bool InsertWrapper(vulkan_wrappers::DebugReportCallbackEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugReportCallbackEXT_map_); }
+    bool InsertWrapper(vulkan_wrappers::DebugUtilsMessengerEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, debugUtilsMessengerEXT_map_); }
+    bool InsertWrapper(vulkan_wrappers::DeferredOperationKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deferredOperationKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::DescriptorPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorPool_map_); }
+    bool InsertWrapper(vulkan_wrappers::DescriptorSetWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSet_map_); }
+    bool InsertWrapper(vulkan_wrappers::DescriptorSetLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorSetLayout_map_); }
+    bool InsertWrapper(vulkan_wrappers::DescriptorUpdateTemplateWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, descriptorUpdateTemplate_map_); }
+    bool InsertWrapper(vulkan_wrappers::DeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, device_map_); }
+    bool InsertWrapper(vulkan_wrappers::DeviceMemoryWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, deviceMemory_map_); }
+    bool InsertWrapper(vulkan_wrappers::DisplayKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::DisplayModeKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, displayModeKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::EventWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, event_map_); }
+    bool InsertWrapper(vulkan_wrappers::FenceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, fence_map_); }
+    bool InsertWrapper(vulkan_wrappers::FramebufferWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, framebuffer_map_); }
+    bool InsertWrapper(vulkan_wrappers::ImageWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, image_map_); }
+    bool InsertWrapper(vulkan_wrappers::ImageViewWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, imageView_map_); }
+    bool InsertWrapper(vulkan_wrappers::IndirectCommandsLayoutNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, indirectCommandsLayoutNV_map_); }
+    bool InsertWrapper(vulkan_wrappers::InstanceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, instance_map_); }
+    bool InsertWrapper(vulkan_wrappers::MicromapEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, micromapEXT_map_); }
+    bool InsertWrapper(vulkan_wrappers::OpticalFlowSessionNVWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, opticalFlowSessionNV_map_); }
+    bool InsertWrapper(vulkan_wrappers::PerformanceConfigurationINTELWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, performanceConfigurationINTEL_map_); }
+    bool InsertWrapper(vulkan_wrappers::PhysicalDeviceWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, physicalDevice_map_); }
+    bool InsertWrapper(vulkan_wrappers::PipelineWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipeline_map_); }
+    bool InsertWrapper(vulkan_wrappers::PipelineCacheWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineCache_map_); }
+    bool InsertWrapper(vulkan_wrappers::PipelineLayoutWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, pipelineLayout_map_); }
+    bool InsertWrapper(vulkan_wrappers::PrivateDataSlotWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, privateDataSlot_map_); }
+    bool InsertWrapper(vulkan_wrappers::QueryPoolWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queryPool_map_); }
+    bool InsertWrapper(vulkan_wrappers::QueueWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, queue_map_); }
+    bool InsertWrapper(vulkan_wrappers::RenderPassWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, renderPass_map_); }
+    bool InsertWrapper(vulkan_wrappers::SamplerWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, sampler_map_); }
+    bool InsertWrapper(vulkan_wrappers::SamplerYcbcrConversionWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, samplerYcbcrConversion_map_); }
+    bool InsertWrapper(vulkan_wrappers::SemaphoreWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, semaphore_map_); }
+    bool InsertWrapper(vulkan_wrappers::ShaderEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderEXT_map_); }
+    bool InsertWrapper(vulkan_wrappers::ShaderModuleWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, shaderModule_map_); }
+    bool InsertWrapper(vulkan_wrappers::SurfaceKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, surfaceKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::SwapchainKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, swapchainKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::ValidationCacheEXTWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, validationCacheEXT_map_); }
+    bool InsertWrapper(vulkan_wrappers::VideoSessionKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionKHR_map_); }
+    bool InsertWrapper(vulkan_wrappers::VideoSessionParametersKHRWrapper* wrapper) { return InsertEntry(wrapper->handle, wrapper, videoSessionParametersKHR_map_); }
 
-    bool RemoveWrapper(const VulkanAccelerationStructureKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::AccelerationStructureKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, accelerationStructureKHR_map_);
     }
-    bool RemoveWrapper(const VulkanAccelerationStructureNVWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::AccelerationStructureNVWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, accelerationStructureNV_map_);
     }
-    bool RemoveWrapper(const VulkanBufferWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::BufferWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, buffer_map_);
     }
-    bool RemoveWrapper(const VulkanBufferViewWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::BufferViewWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, bufferView_map_);
     }
-    bool RemoveWrapper(const VulkanCommandBufferWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::CommandBufferWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, commandBuffer_map_);
     }
-    bool RemoveWrapper(const VulkanCommandPoolWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::CommandPoolWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, commandPool_map_);
     }
-    bool RemoveWrapper(const VulkanDebugReportCallbackEXTWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DebugReportCallbackEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, debugReportCallbackEXT_map_);
     }
-    bool RemoveWrapper(const VulkanDebugUtilsMessengerEXTWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DebugUtilsMessengerEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, debugUtilsMessengerEXT_map_);
     }
-    bool RemoveWrapper(const VulkanDeferredOperationKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DeferredOperationKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, deferredOperationKHR_map_);
     }
-    bool RemoveWrapper(const VulkanDescriptorPoolWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorPoolWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorPool_map_);
     }
-    bool RemoveWrapper(const VulkanDescriptorSetWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorSetWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorSet_map_);
     }
-    bool RemoveWrapper(const VulkanDescriptorSetLayoutWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorSetLayoutWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorSetLayout_map_);
     }
-    bool RemoveWrapper(const VulkanDescriptorUpdateTemplateWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DescriptorUpdateTemplateWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, descriptorUpdateTemplate_map_);
     }
-    bool RemoveWrapper(const VulkanDeviceWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DeviceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, device_map_);
     }
-    bool RemoveWrapper(const VulkanDeviceMemoryWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DeviceMemoryWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, deviceMemory_map_);
     }
-    bool RemoveWrapper(const VulkanDisplayKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DisplayKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, displayKHR_map_);
     }
-    bool RemoveWrapper(const VulkanDisplayModeKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::DisplayModeKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, displayModeKHR_map_);
     }
-    bool RemoveWrapper(const VulkanEventWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::EventWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, event_map_);
     }
-    bool RemoveWrapper(const VulkanFenceWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::FenceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, fence_map_);
     }
-    bool RemoveWrapper(const VulkanFramebufferWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::FramebufferWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, framebuffer_map_);
     }
-    bool RemoveWrapper(const VulkanImageWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::ImageWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, image_map_);
     }
-    bool RemoveWrapper(const VulkanImageViewWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::ImageViewWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, imageView_map_);
     }
-    bool RemoveWrapper(const VulkanIndirectCommandsLayoutNVWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::IndirectCommandsLayoutNVWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, indirectCommandsLayoutNV_map_);
     }
-    bool RemoveWrapper(const VulkanInstanceWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::InstanceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, instance_map_);
     }
-    bool RemoveWrapper(const VulkanMicromapEXTWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::MicromapEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, micromapEXT_map_);
     }
-    bool RemoveWrapper(const VulkanOpticalFlowSessionNVWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::OpticalFlowSessionNVWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, opticalFlowSessionNV_map_);
     }
-    bool RemoveWrapper(const VulkanPerformanceConfigurationINTELWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::PerformanceConfigurationINTELWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, performanceConfigurationINTEL_map_);
     }
-    bool RemoveWrapper(const VulkanPhysicalDeviceWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::PhysicalDeviceWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, physicalDevice_map_);
     }
-    bool RemoveWrapper(const VulkanPipelineWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::PipelineWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, pipeline_map_);
     }
-    bool RemoveWrapper(const VulkanPipelineCacheWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::PipelineCacheWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, pipelineCache_map_);
     }
-    bool RemoveWrapper(const VulkanPipelineLayoutWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::PipelineLayoutWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, pipelineLayout_map_);
     }
-    bool RemoveWrapper(const VulkanPrivateDataSlotWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::PrivateDataSlotWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, privateDataSlot_map_);
     }
-    bool RemoveWrapper(const VulkanQueryPoolWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::QueryPoolWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, queryPool_map_);
     }
-    bool RemoveWrapper(const VulkanQueueWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::QueueWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, queue_map_);
     }
-    bool RemoveWrapper(const VulkanRenderPassWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::RenderPassWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, renderPass_map_);
     }
-    bool RemoveWrapper(const VulkanSamplerWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::SamplerWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, sampler_map_);
     }
-    bool RemoveWrapper(const VulkanSamplerYcbcrConversionWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::SamplerYcbcrConversionWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, samplerYcbcrConversion_map_);
     }
-    bool RemoveWrapper(const VulkanSemaphoreWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::SemaphoreWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, semaphore_map_);
     }
-    bool RemoveWrapper(const VulkanShaderEXTWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::ShaderEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, shaderEXT_map_);
     }
-    bool RemoveWrapper(const VulkanShaderModuleWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::ShaderModuleWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, shaderModule_map_);
     }
-    bool RemoveWrapper(const VulkanSurfaceKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::SurfaceKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, surfaceKHR_map_);
     }
-    bool RemoveWrapper(const VulkanSwapchainKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::SwapchainKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, swapchainKHR_map_);
     }
-    bool RemoveWrapper(const VulkanValidationCacheEXTWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::ValidationCacheEXTWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, validationCacheEXT_map_);
     }
-    bool RemoveWrapper(const VulkanVideoSessionKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::VideoSessionKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, videoSessionKHR_map_);
     }
-    bool RemoveWrapper(const VulkanVideoSessionParametersKHRWrapper* wrapper) {
+    bool RemoveWrapper(const vulkan_wrappers::VideoSessionParametersKHRWrapper* wrapper) {
          if (wrapper == nullptr) return false;
          return RemoveEntry(wrapper->handle, videoSessionParametersKHR_map_);
     }
@@ -558,144 +558,144 @@ class VulkanStateHandleTable : VulkanStateTableBase
     template<typename Wrapper> Wrapper* GetWrapper(typename Wrapper::HandleType handle) { return nullptr; }
 
   private:
-    std::unordered_map<VkAccelerationStructureKHR, VulkanAccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
-    std::unordered_map<VkAccelerationStructureNV, VulkanAccelerationStructureNVWrapper*> accelerationStructureNV_map_;
-    std::unordered_map<VkBuffer, VulkanBufferWrapper*> buffer_map_;
-    std::unordered_map<VkBufferView, VulkanBufferViewWrapper*> bufferView_map_;
-    std::unordered_map<VkCommandBuffer, VulkanCommandBufferWrapper*> commandBuffer_map_;
-    std::unordered_map<VkCommandPool, VulkanCommandPoolWrapper*> commandPool_map_;
-    std::unordered_map<VkDebugReportCallbackEXT, VulkanDebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
-    std::unordered_map<VkDebugUtilsMessengerEXT, VulkanDebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
-    std::unordered_map<VkDeferredOperationKHR, VulkanDeferredOperationKHRWrapper*> deferredOperationKHR_map_;
-    std::unordered_map<VkDescriptorPool, VulkanDescriptorPoolWrapper*> descriptorPool_map_;
-    std::unordered_map<VkDescriptorSet, VulkanDescriptorSetWrapper*> descriptorSet_map_;
-    std::unordered_map<VkDescriptorSetLayout, VulkanDescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
-    std::unordered_map<VkDescriptorUpdateTemplate, VulkanDescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
-    std::unordered_map<VkDevice, VulkanDeviceWrapper*> device_map_;
-    std::unordered_map<VkDeviceMemory, VulkanDeviceMemoryWrapper*> deviceMemory_map_;
-    std::unordered_map<VkDisplayKHR, VulkanDisplayKHRWrapper*> displayKHR_map_;
-    std::unordered_map<VkDisplayModeKHR, VulkanDisplayModeKHRWrapper*> displayModeKHR_map_;
-    std::unordered_map<VkEvent, VulkanEventWrapper*> event_map_;
-    std::unordered_map<VkFence, VulkanFenceWrapper*> fence_map_;
-    std::unordered_map<VkFramebuffer, VulkanFramebufferWrapper*> framebuffer_map_;
-    std::unordered_map<VkImage, VulkanImageWrapper*> image_map_;
-    std::unordered_map<VkImageView, VulkanImageViewWrapper*> imageView_map_;
-    std::unordered_map<VkIndirectCommandsLayoutNV, VulkanIndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
-    std::unordered_map<VkInstance, VulkanInstanceWrapper*> instance_map_;
-    std::unordered_map<VkMicromapEXT, VulkanMicromapEXTWrapper*> micromapEXT_map_;
-    std::unordered_map<VkOpticalFlowSessionNV, VulkanOpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
-    std::unordered_map<VkPerformanceConfigurationINTEL, VulkanPerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
-    std::unordered_map<VkPhysicalDevice, VulkanPhysicalDeviceWrapper*> physicalDevice_map_;
-    std::unordered_map<VkPipeline, VulkanPipelineWrapper*> pipeline_map_;
-    std::unordered_map<VkPipelineCache, VulkanPipelineCacheWrapper*> pipelineCache_map_;
-    std::unordered_map<VkPipelineLayout, VulkanPipelineLayoutWrapper*> pipelineLayout_map_;
-    std::unordered_map<VkPrivateDataSlot, VulkanPrivateDataSlotWrapper*> privateDataSlot_map_;
-    std::unordered_map<VkQueryPool, VulkanQueryPoolWrapper*> queryPool_map_;
-    std::unordered_map<VkQueue, VulkanQueueWrapper*> queue_map_;
-    std::unordered_map<VkRenderPass, VulkanRenderPassWrapper*> renderPass_map_;
-    std::unordered_map<VkSampler, VulkanSamplerWrapper*> sampler_map_;
-    std::unordered_map<VkSamplerYcbcrConversion, VulkanSamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
-    std::unordered_map<VkSemaphore, VulkanSemaphoreWrapper*> semaphore_map_;
-    std::unordered_map<VkShaderEXT, VulkanShaderEXTWrapper*> shaderEXT_map_;
-    std::unordered_map<VkShaderModule, VulkanShaderModuleWrapper*> shaderModule_map_;
-    std::unordered_map<VkSurfaceKHR, VulkanSurfaceKHRWrapper*> surfaceKHR_map_;
-    std::unordered_map<VkSwapchainKHR, VulkanSwapchainKHRWrapper*> swapchainKHR_map_;
-    std::unordered_map<VkValidationCacheEXT, VulkanValidationCacheEXTWrapper*> validationCacheEXT_map_;
-    std::unordered_map<VkVideoSessionKHR, VulkanVideoSessionKHRWrapper*> videoSessionKHR_map_;
-    std::unordered_map<VkVideoSessionParametersKHR, VulkanVideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
+    std::unordered_map<VkAccelerationStructureKHR, vulkan_wrappers::AccelerationStructureKHRWrapper*> accelerationStructureKHR_map_;
+    std::unordered_map<VkAccelerationStructureNV, vulkan_wrappers::AccelerationStructureNVWrapper*> accelerationStructureNV_map_;
+    std::unordered_map<VkBuffer, vulkan_wrappers::BufferWrapper*> buffer_map_;
+    std::unordered_map<VkBufferView, vulkan_wrappers::BufferViewWrapper*> bufferView_map_;
+    std::unordered_map<VkCommandBuffer, vulkan_wrappers::CommandBufferWrapper*> commandBuffer_map_;
+    std::unordered_map<VkCommandPool, vulkan_wrappers::CommandPoolWrapper*> commandPool_map_;
+    std::unordered_map<VkDebugReportCallbackEXT, vulkan_wrappers::DebugReportCallbackEXTWrapper*> debugReportCallbackEXT_map_;
+    std::unordered_map<VkDebugUtilsMessengerEXT, vulkan_wrappers::DebugUtilsMessengerEXTWrapper*> debugUtilsMessengerEXT_map_;
+    std::unordered_map<VkDeferredOperationKHR, vulkan_wrappers::DeferredOperationKHRWrapper*> deferredOperationKHR_map_;
+    std::unordered_map<VkDescriptorPool, vulkan_wrappers::DescriptorPoolWrapper*> descriptorPool_map_;
+    std::unordered_map<VkDescriptorSet, vulkan_wrappers::DescriptorSetWrapper*> descriptorSet_map_;
+    std::unordered_map<VkDescriptorSetLayout, vulkan_wrappers::DescriptorSetLayoutWrapper*> descriptorSetLayout_map_;
+    std::unordered_map<VkDescriptorUpdateTemplate, vulkan_wrappers::DescriptorUpdateTemplateWrapper*> descriptorUpdateTemplate_map_;
+    std::unordered_map<VkDevice, vulkan_wrappers::DeviceWrapper*> device_map_;
+    std::unordered_map<VkDeviceMemory, vulkan_wrappers::DeviceMemoryWrapper*> deviceMemory_map_;
+    std::unordered_map<VkDisplayKHR, vulkan_wrappers::DisplayKHRWrapper*> displayKHR_map_;
+    std::unordered_map<VkDisplayModeKHR, vulkan_wrappers::DisplayModeKHRWrapper*> displayModeKHR_map_;
+    std::unordered_map<VkEvent, vulkan_wrappers::EventWrapper*> event_map_;
+    std::unordered_map<VkFence, vulkan_wrappers::FenceWrapper*> fence_map_;
+    std::unordered_map<VkFramebuffer, vulkan_wrappers::FramebufferWrapper*> framebuffer_map_;
+    std::unordered_map<VkImage, vulkan_wrappers::ImageWrapper*> image_map_;
+    std::unordered_map<VkImageView, vulkan_wrappers::ImageViewWrapper*> imageView_map_;
+    std::unordered_map<VkIndirectCommandsLayoutNV, vulkan_wrappers::IndirectCommandsLayoutNVWrapper*> indirectCommandsLayoutNV_map_;
+    std::unordered_map<VkInstance, vulkan_wrappers::InstanceWrapper*> instance_map_;
+    std::unordered_map<VkMicromapEXT, vulkan_wrappers::MicromapEXTWrapper*> micromapEXT_map_;
+    std::unordered_map<VkOpticalFlowSessionNV, vulkan_wrappers::OpticalFlowSessionNVWrapper*> opticalFlowSessionNV_map_;
+    std::unordered_map<VkPerformanceConfigurationINTEL, vulkan_wrappers::PerformanceConfigurationINTELWrapper*> performanceConfigurationINTEL_map_;
+    std::unordered_map<VkPhysicalDevice, vulkan_wrappers::PhysicalDeviceWrapper*> physicalDevice_map_;
+    std::unordered_map<VkPipeline, vulkan_wrappers::PipelineWrapper*> pipeline_map_;
+    std::unordered_map<VkPipelineCache, vulkan_wrappers::PipelineCacheWrapper*> pipelineCache_map_;
+    std::unordered_map<VkPipelineLayout, vulkan_wrappers::PipelineLayoutWrapper*> pipelineLayout_map_;
+    std::unordered_map<VkPrivateDataSlot, vulkan_wrappers::PrivateDataSlotWrapper*> privateDataSlot_map_;
+    std::unordered_map<VkQueryPool, vulkan_wrappers::QueryPoolWrapper*> queryPool_map_;
+    std::unordered_map<VkQueue, vulkan_wrappers::QueueWrapper*> queue_map_;
+    std::unordered_map<VkRenderPass, vulkan_wrappers::RenderPassWrapper*> renderPass_map_;
+    std::unordered_map<VkSampler, vulkan_wrappers::SamplerWrapper*> sampler_map_;
+    std::unordered_map<VkSamplerYcbcrConversion, vulkan_wrappers::SamplerYcbcrConversionWrapper*> samplerYcbcrConversion_map_;
+    std::unordered_map<VkSemaphore, vulkan_wrappers::SemaphoreWrapper*> semaphore_map_;
+    std::unordered_map<VkShaderEXT, vulkan_wrappers::ShaderEXTWrapper*> shaderEXT_map_;
+    std::unordered_map<VkShaderModule, vulkan_wrappers::ShaderModuleWrapper*> shaderModule_map_;
+    std::unordered_map<VkSurfaceKHR, vulkan_wrappers::SurfaceKHRWrapper*> surfaceKHR_map_;
+    std::unordered_map<VkSwapchainKHR, vulkan_wrappers::SwapchainKHRWrapper*> swapchainKHR_map_;
+    std::unordered_map<VkValidationCacheEXT, vulkan_wrappers::ValidationCacheEXTWrapper*> validationCacheEXT_map_;
+    std::unordered_map<VkVideoSessionKHR, vulkan_wrappers::VideoSessionKHRWrapper*> videoSessionKHR_map_;
+    std::unordered_map<VkVideoSessionParametersKHR, vulkan_wrappers::VideoSessionParametersKHRWrapper*> videoSessionParametersKHR_map_;
 };
 
-template<> inline const VulkanAccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
-template<> inline const VulkanAccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
-template<> inline const VulkanBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferWrapper>(VkBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
-template<> inline const VulkanBufferViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferViewWrapper>(VkBufferView handle) const { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
-template<> inline const VulkanCommandBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandBufferWrapper>(VkCommandBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
-template<> inline const VulkanCommandPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandPoolWrapper>(VkCommandPool handle) const { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
-template<> inline const VulkanDebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
-template<> inline const VulkanDebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
-template<> inline const VulkanDeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
-template<> inline const VulkanDescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorPoolWrapper>(VkDescriptorPool handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
-template<> inline const VulkanDescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetWrapper>(VkDescriptorSet handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
-template<> inline const VulkanDescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
-template<> inline const VulkanDescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
-template<> inline const VulkanDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceWrapper>(VkDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
-template<> inline const VulkanDeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceMemoryWrapper>(VkDeviceMemory handle) const { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
-template<> inline const VulkanDisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayKHRWrapper>(VkDisplayKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
-template<> inline const VulkanDisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayModeKHRWrapper>(VkDisplayModeKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
-template<> inline const VulkanEventWrapper* VulkanStateHandleTable::GetWrapper<VulkanEventWrapper>(VkEvent handle) const { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
-template<> inline const VulkanFenceWrapper* VulkanStateHandleTable::GetWrapper<VulkanFenceWrapper>(VkFence handle) const { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
-template<> inline const VulkanFramebufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanFramebufferWrapper>(VkFramebuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
-template<> inline const VulkanImageWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageWrapper>(VkImage handle) const { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
-template<> inline const VulkanImageViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageViewWrapper>(VkImageView handle) const { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
-template<> inline const VulkanIndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) const { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
-template<> inline const VulkanInstanceWrapper* VulkanStateHandleTable::GetWrapper<VulkanInstanceWrapper>(VkInstance handle) const { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
-template<> inline const VulkanMicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanMicromapEXTWrapper>(VkMicromapEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
-template<> inline const VulkanOpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanOpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) const { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
-template<> inline const VulkanPerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) const { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
-template<> inline const VulkanPhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanPhysicalDeviceWrapper>(VkPhysicalDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
-template<> inline const VulkanPipelineWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineWrapper>(VkPipeline handle) const { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
-template<> inline const VulkanPipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineCacheWrapper>(VkPipelineCache handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
-template<> inline const VulkanPipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineLayoutWrapper>(VkPipelineLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
-template<> inline const VulkanPrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<VulkanPrivateDataSlotWrapper>(VkPrivateDataSlot handle) const { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
-template<> inline const VulkanQueryPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueryPoolWrapper>(VkQueryPool handle) const { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
-template<> inline const VulkanQueueWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueueWrapper>(VkQueue handle) const { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
-template<> inline const VulkanRenderPassWrapper* VulkanStateHandleTable::GetWrapper<VulkanRenderPassWrapper>(VkRenderPass handle) const { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
-template<> inline const VulkanSamplerWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerWrapper>(VkSampler handle) const { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
-template<> inline const VulkanSamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) const { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
-template<> inline const VulkanSemaphoreWrapper* VulkanStateHandleTable::GetWrapper<VulkanSemaphoreWrapper>(VkSemaphore handle) const { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
-template<> inline const VulkanShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderEXTWrapper>(VkShaderEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
-template<> inline const VulkanShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderModuleWrapper>(VkShaderModule handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
-template<> inline const VulkanSurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSurfaceKHRWrapper>(VkSurfaceKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
-template<> inline const VulkanSwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSwapchainKHRWrapper>(VkSwapchainKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
-template<> inline const VulkanValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanValidationCacheEXTWrapper>(VkValidationCacheEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
-template<> inline const VulkanVideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionKHRWrapper>(VkVideoSessionKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
-template<> inline const VulkanVideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
+template<> inline const vulkan_wrappers::AccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
+template<> inline const vulkan_wrappers::AccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::AccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) const { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
+template<> inline const vulkan_wrappers::BufferWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::BufferWrapper>(VkBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
+template<> inline const vulkan_wrappers::BufferViewWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::BufferViewWrapper>(VkBufferView handle) const { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
+template<> inline const vulkan_wrappers::CommandBufferWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(VkCommandBuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
+template<> inline const vulkan_wrappers::CommandPoolWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::CommandPoolWrapper>(VkCommandPool handle) const { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
+template<> inline const vulkan_wrappers::DebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
+template<> inline const vulkan_wrappers::DebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
+template<> inline const vulkan_wrappers::DeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
+template<> inline const vulkan_wrappers::DescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorPoolWrapper>(VkDescriptorPool handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
+template<> inline const vulkan_wrappers::DescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorSetWrapper>(VkDescriptorSet handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
+template<> inline const vulkan_wrappers::DescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
+template<> inline const vulkan_wrappers::DescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) const { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
+template<> inline const vulkan_wrappers::DeviceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DeviceWrapper>(VkDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
+template<> inline const vulkan_wrappers::DeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DeviceMemoryWrapper>(VkDeviceMemory handle) const { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
+template<> inline const vulkan_wrappers::DisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DisplayKHRWrapper>(VkDisplayKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
+template<> inline const vulkan_wrappers::DisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DisplayModeKHRWrapper>(VkDisplayModeKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
+template<> inline const vulkan_wrappers::EventWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::EventWrapper>(VkEvent handle) const { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
+template<> inline const vulkan_wrappers::FenceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::FenceWrapper>(VkFence handle) const { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
+template<> inline const vulkan_wrappers::FramebufferWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::FramebufferWrapper>(VkFramebuffer handle) const { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
+template<> inline const vulkan_wrappers::ImageWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ImageWrapper>(VkImage handle) const { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
+template<> inline const vulkan_wrappers::ImageViewWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ImageViewWrapper>(VkImageView handle) const { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
+template<> inline const vulkan_wrappers::IndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) const { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
+template<> inline const vulkan_wrappers::InstanceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::InstanceWrapper>(VkInstance handle) const { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
+template<> inline const vulkan_wrappers::MicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::MicromapEXTWrapper>(VkMicromapEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
+template<> inline const vulkan_wrappers::OpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::OpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) const { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
+template<> inline const vulkan_wrappers::PerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) const { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
+template<> inline const vulkan_wrappers::PhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(VkPhysicalDevice handle) const { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
+template<> inline const vulkan_wrappers::PipelineWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PipelineWrapper>(VkPipeline handle) const { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
+template<> inline const vulkan_wrappers::PipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PipelineCacheWrapper>(VkPipelineCache handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
+template<> inline const vulkan_wrappers::PipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PipelineLayoutWrapper>(VkPipelineLayout handle) const { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
+template<> inline const vulkan_wrappers::PrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PrivateDataSlotWrapper>(VkPrivateDataSlot handle) const { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
+template<> inline const vulkan_wrappers::QueryPoolWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::QueryPoolWrapper>(VkQueryPool handle) const { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
+template<> inline const vulkan_wrappers::QueueWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::QueueWrapper>(VkQueue handle) const { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
+template<> inline const vulkan_wrappers::RenderPassWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::RenderPassWrapper>(VkRenderPass handle) const { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
+template<> inline const vulkan_wrappers::SamplerWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SamplerWrapper>(VkSampler handle) const { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
+template<> inline const vulkan_wrappers::SamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) const { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
+template<> inline const vulkan_wrappers::SemaphoreWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SemaphoreWrapper>(VkSemaphore handle) const { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
+template<> inline const vulkan_wrappers::ShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ShaderEXTWrapper>(VkShaderEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
+template<> inline const vulkan_wrappers::ShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(VkShaderModule handle) const { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
+template<> inline const vulkan_wrappers::SurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SurfaceKHRWrapper>(VkSurfaceKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
+template<> inline const vulkan_wrappers::SwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SwapchainKHRWrapper>(VkSwapchainKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
+template<> inline const vulkan_wrappers::ValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ValidationCacheEXTWrapper>(VkValidationCacheEXT handle) const { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
+template<> inline const vulkan_wrappers::VideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::VideoSessionKHRWrapper>(VkVideoSessionKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
+template<> inline const vulkan_wrappers::VideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::VideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) const { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
 
-template<> inline VulkanAccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
-template<> inline VulkanAccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanAccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
-template<> inline VulkanBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferWrapper>(VkBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
-template<> inline VulkanBufferViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanBufferViewWrapper>(VkBufferView handle) { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
-template<> inline VulkanCommandBufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandBufferWrapper>(VkCommandBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
-template<> inline VulkanCommandPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanCommandPoolWrapper>(VkCommandPool handle) { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
-template<> inline VulkanDebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
-template<> inline VulkanDebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanDebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
-template<> inline VulkanDeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
-template<> inline VulkanDescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorPoolWrapper>(VkDescriptorPool handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
-template<> inline VulkanDescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetWrapper>(VkDescriptorSet handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
-template<> inline VulkanDescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
-template<> inline VulkanDescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<VulkanDescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
-template<> inline VulkanDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceWrapper>(VkDevice handle) { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
-template<> inline VulkanDeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<VulkanDeviceMemoryWrapper>(VkDeviceMemory handle) { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
-template<> inline VulkanDisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayKHRWrapper>(VkDisplayKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
-template<> inline VulkanDisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanDisplayModeKHRWrapper>(VkDisplayModeKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
-template<> inline VulkanEventWrapper* VulkanStateHandleTable::GetWrapper<VulkanEventWrapper>(VkEvent handle) { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
-template<> inline VulkanFenceWrapper* VulkanStateHandleTable::GetWrapper<VulkanFenceWrapper>(VkFence handle) { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
-template<> inline VulkanFramebufferWrapper* VulkanStateHandleTable::GetWrapper<VulkanFramebufferWrapper>(VkFramebuffer handle) { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
-template<> inline VulkanImageWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageWrapper>(VkImage handle) { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
-template<> inline VulkanImageViewWrapper* VulkanStateHandleTable::GetWrapper<VulkanImageViewWrapper>(VkImageView handle) { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
-template<> inline VulkanIndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanIndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
-template<> inline VulkanInstanceWrapper* VulkanStateHandleTable::GetWrapper<VulkanInstanceWrapper>(VkInstance handle) { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
-template<> inline VulkanMicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanMicromapEXTWrapper>(VkMicromapEXT handle) { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
-template<> inline VulkanOpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<VulkanOpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
-template<> inline VulkanPerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<VulkanPerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
-template<> inline VulkanPhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<VulkanPhysicalDeviceWrapper>(VkPhysicalDevice handle) { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
-template<> inline VulkanPipelineWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineWrapper>(VkPipeline handle) { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
-template<> inline VulkanPipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineCacheWrapper>(VkPipelineCache handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
-template<> inline VulkanPipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<VulkanPipelineLayoutWrapper>(VkPipelineLayout handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
-template<> inline VulkanPrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<VulkanPrivateDataSlotWrapper>(VkPrivateDataSlot handle) { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
-template<> inline VulkanQueryPoolWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueryPoolWrapper>(VkQueryPool handle) { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
-template<> inline VulkanQueueWrapper* VulkanStateHandleTable::GetWrapper<VulkanQueueWrapper>(VkQueue handle) { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
-template<> inline VulkanRenderPassWrapper* VulkanStateHandleTable::GetWrapper<VulkanRenderPassWrapper>(VkRenderPass handle) { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
-template<> inline VulkanSamplerWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerWrapper>(VkSampler handle) { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
-template<> inline VulkanSamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<VulkanSamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
-template<> inline VulkanSemaphoreWrapper* VulkanStateHandleTable::GetWrapper<VulkanSemaphoreWrapper>(VkSemaphore handle) { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
-template<> inline VulkanShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderEXTWrapper>(VkShaderEXT handle) { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
-template<> inline VulkanShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<VulkanShaderModuleWrapper>(VkShaderModule handle) { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
-template<> inline VulkanSurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSurfaceKHRWrapper>(VkSurfaceKHR handle) { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
-template<> inline VulkanSwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanSwapchainKHRWrapper>(VkSwapchainKHR handle) { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
-template<> inline VulkanValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<VulkanValidationCacheEXTWrapper>(VkValidationCacheEXT handle) { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
-template<> inline VulkanVideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionKHRWrapper>(VkVideoSessionKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
-template<> inline VulkanVideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<VulkanVideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
+template<> inline vulkan_wrappers::AccelerationStructureKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::AccelerationStructureKHRWrapper>(VkAccelerationStructureKHR handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureKHR_map_); }
+template<> inline vulkan_wrappers::AccelerationStructureNVWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::AccelerationStructureNVWrapper>(VkAccelerationStructureNV handle) { return VulkanStateTableBase::GetWrapper(handle, accelerationStructureNV_map_); }
+template<> inline vulkan_wrappers::BufferWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::BufferWrapper>(VkBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, buffer_map_); }
+template<> inline vulkan_wrappers::BufferViewWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::BufferViewWrapper>(VkBufferView handle) { return VulkanStateTableBase::GetWrapper(handle, bufferView_map_); }
+template<> inline vulkan_wrappers::CommandBufferWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::CommandBufferWrapper>(VkCommandBuffer handle) { return VulkanStateTableBase::GetWrapper(handle, commandBuffer_map_); }
+template<> inline vulkan_wrappers::CommandPoolWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::CommandPoolWrapper>(VkCommandPool handle) { return VulkanStateTableBase::GetWrapper(handle, commandPool_map_); }
+template<> inline vulkan_wrappers::DebugReportCallbackEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DebugReportCallbackEXTWrapper>(VkDebugReportCallbackEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugReportCallbackEXT_map_); }
+template<> inline vulkan_wrappers::DebugUtilsMessengerEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DebugUtilsMessengerEXTWrapper>(VkDebugUtilsMessengerEXT handle) { return VulkanStateTableBase::GetWrapper(handle, debugUtilsMessengerEXT_map_); }
+template<> inline vulkan_wrappers::DeferredOperationKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DeferredOperationKHRWrapper>(VkDeferredOperationKHR handle) { return VulkanStateTableBase::GetWrapper(handle, deferredOperationKHR_map_); }
+template<> inline vulkan_wrappers::DescriptorPoolWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorPoolWrapper>(VkDescriptorPool handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorPool_map_); }
+template<> inline vulkan_wrappers::DescriptorSetWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorSetWrapper>(VkDescriptorSet handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSet_map_); }
+template<> inline vulkan_wrappers::DescriptorSetLayoutWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorSetLayoutWrapper>(VkDescriptorSetLayout handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorSetLayout_map_); }
+template<> inline vulkan_wrappers::DescriptorUpdateTemplateWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(VkDescriptorUpdateTemplate handle) { return VulkanStateTableBase::GetWrapper(handle, descriptorUpdateTemplate_map_); }
+template<> inline vulkan_wrappers::DeviceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DeviceWrapper>(VkDevice handle) { return VulkanStateTableBase::GetWrapper(handle, device_map_); }
+template<> inline vulkan_wrappers::DeviceMemoryWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DeviceMemoryWrapper>(VkDeviceMemory handle) { return VulkanStateTableBase::GetWrapper(handle, deviceMemory_map_); }
+template<> inline vulkan_wrappers::DisplayKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DisplayKHRWrapper>(VkDisplayKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayKHR_map_); }
+template<> inline vulkan_wrappers::DisplayModeKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::DisplayModeKHRWrapper>(VkDisplayModeKHR handle) { return VulkanStateTableBase::GetWrapper(handle, displayModeKHR_map_); }
+template<> inline vulkan_wrappers::EventWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::EventWrapper>(VkEvent handle) { return VulkanStateTableBase::GetWrapper(handle, event_map_); }
+template<> inline vulkan_wrappers::FenceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::FenceWrapper>(VkFence handle) { return VulkanStateTableBase::GetWrapper(handle, fence_map_); }
+template<> inline vulkan_wrappers::FramebufferWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::FramebufferWrapper>(VkFramebuffer handle) { return VulkanStateTableBase::GetWrapper(handle, framebuffer_map_); }
+template<> inline vulkan_wrappers::ImageWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ImageWrapper>(VkImage handle) { return VulkanStateTableBase::GetWrapper(handle, image_map_); }
+template<> inline vulkan_wrappers::ImageViewWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ImageViewWrapper>(VkImageView handle) { return VulkanStateTableBase::GetWrapper(handle, imageView_map_); }
+template<> inline vulkan_wrappers::IndirectCommandsLayoutNVWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(VkIndirectCommandsLayoutNV handle) { return VulkanStateTableBase::GetWrapper(handle, indirectCommandsLayoutNV_map_); }
+template<> inline vulkan_wrappers::InstanceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::InstanceWrapper>(VkInstance handle) { return VulkanStateTableBase::GetWrapper(handle, instance_map_); }
+template<> inline vulkan_wrappers::MicromapEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::MicromapEXTWrapper>(VkMicromapEXT handle) { return VulkanStateTableBase::GetWrapper(handle, micromapEXT_map_); }
+template<> inline vulkan_wrappers::OpticalFlowSessionNVWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::OpticalFlowSessionNVWrapper>(VkOpticalFlowSessionNV handle) { return VulkanStateTableBase::GetWrapper(handle, opticalFlowSessionNV_map_); }
+template<> inline vulkan_wrappers::PerformanceConfigurationINTELWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PerformanceConfigurationINTELWrapper>(VkPerformanceConfigurationINTEL handle) { return VulkanStateTableBase::GetWrapper(handle, performanceConfigurationINTEL_map_); }
+template<> inline vulkan_wrappers::PhysicalDeviceWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PhysicalDeviceWrapper>(VkPhysicalDevice handle) { return VulkanStateTableBase::GetWrapper(handle, physicalDevice_map_); }
+template<> inline vulkan_wrappers::PipelineWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PipelineWrapper>(VkPipeline handle) { return VulkanStateTableBase::GetWrapper(handle, pipeline_map_); }
+template<> inline vulkan_wrappers::PipelineCacheWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PipelineCacheWrapper>(VkPipelineCache handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineCache_map_); }
+template<> inline vulkan_wrappers::PipelineLayoutWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PipelineLayoutWrapper>(VkPipelineLayout handle) { return VulkanStateTableBase::GetWrapper(handle, pipelineLayout_map_); }
+template<> inline vulkan_wrappers::PrivateDataSlotWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::PrivateDataSlotWrapper>(VkPrivateDataSlot handle) { return VulkanStateTableBase::GetWrapper(handle, privateDataSlot_map_); }
+template<> inline vulkan_wrappers::QueryPoolWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::QueryPoolWrapper>(VkQueryPool handle) { return VulkanStateTableBase::GetWrapper(handle, queryPool_map_); }
+template<> inline vulkan_wrappers::QueueWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::QueueWrapper>(VkQueue handle) { return VulkanStateTableBase::GetWrapper(handle, queue_map_); }
+template<> inline vulkan_wrappers::RenderPassWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::RenderPassWrapper>(VkRenderPass handle) { return VulkanStateTableBase::GetWrapper(handle, renderPass_map_); }
+template<> inline vulkan_wrappers::SamplerWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SamplerWrapper>(VkSampler handle) { return VulkanStateTableBase::GetWrapper(handle, sampler_map_); }
+template<> inline vulkan_wrappers::SamplerYcbcrConversionWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SamplerYcbcrConversionWrapper>(VkSamplerYcbcrConversion handle) { return VulkanStateTableBase::GetWrapper(handle, samplerYcbcrConversion_map_); }
+template<> inline vulkan_wrappers::SemaphoreWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SemaphoreWrapper>(VkSemaphore handle) { return VulkanStateTableBase::GetWrapper(handle, semaphore_map_); }
+template<> inline vulkan_wrappers::ShaderEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ShaderEXTWrapper>(VkShaderEXT handle) { return VulkanStateTableBase::GetWrapper(handle, shaderEXT_map_); }
+template<> inline vulkan_wrappers::ShaderModuleWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ShaderModuleWrapper>(VkShaderModule handle) { return VulkanStateTableBase::GetWrapper(handle, shaderModule_map_); }
+template<> inline vulkan_wrappers::SurfaceKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SurfaceKHRWrapper>(VkSurfaceKHR handle) { return VulkanStateTableBase::GetWrapper(handle, surfaceKHR_map_); }
+template<> inline vulkan_wrappers::SwapchainKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::SwapchainKHRWrapper>(VkSwapchainKHR handle) { return VulkanStateTableBase::GetWrapper(handle, swapchainKHR_map_); }
+template<> inline vulkan_wrappers::ValidationCacheEXTWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::ValidationCacheEXTWrapper>(VkValidationCacheEXT handle) { return VulkanStateTableBase::GetWrapper(handle, validationCacheEXT_map_); }
+template<> inline vulkan_wrappers::VideoSessionKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::VideoSessionKHRWrapper>(VkVideoSessionKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionKHR_map_); }
+template<> inline vulkan_wrappers::VideoSessionParametersKHRWrapper* VulkanStateHandleTable::GetWrapper<vulkan_wrappers::VideoSessionParametersKHRWrapper>(VkVideoSessionParametersKHR handle) { return VulkanStateTableBase::GetWrapper(handle, videoSessionParametersKHR_map_); }
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -1167,7 +1167,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryBarrier& value)
     encoder->EncodeFlagsValue(value.dstAccessMask);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -1215,7 +1215,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value)
     encoder->EncodeEnumValue(value.newLayout);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
     EncodeStruct(encoder, value.subresourceRange);
 }
 
@@ -1547,19 +1547,19 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSubmitInfo& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
-    encoder->EncodeHandleArray<SemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
+    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeFlagsArray(value.pWaitDstStageMask, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.commandBufferCount);
-    encoder->EncodeHandleArray<CommandBufferWrapper>(value.pCommandBuffers, value.commandBufferCount);
+    encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(value.pCommandBuffers, value.commandBufferCount);
     encoder->EncodeUInt32Value(value.signalSemaphoreCount);
-    encoder->EncodeHandleArray<SemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
+    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMappedMemoryRange& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -1583,21 +1583,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSparseMemoryBind& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.resourceOffset);
     encoder->EncodeVkDeviceSizeValue(value.size);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeFlagsValue(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseBufferMemoryBindInfo& value)
 {
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeUInt32Value(value.bindCount);
     EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageOpaqueMemoryBindInfo& value)
 {
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
     encoder->EncodeUInt32Value(value.bindCount);
     EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
@@ -1614,14 +1614,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBind& valu
     EncodeStruct(encoder, value.subresource);
     EncodeStruct(encoder, value.offset);
     EncodeStruct(encoder, value.extent);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeFlagsValue(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBindInfo& value)
 {
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
     encoder->EncodeUInt32Value(value.bindCount);
     EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
@@ -1631,7 +1631,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindSparseInfo& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
-    encoder->EncodeHandleArray<SemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
+    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.bufferBindCount);
     EncodeStructArray(encoder, value.pBufferBinds, value.bufferBindCount);
     encoder->EncodeUInt32Value(value.imageOpaqueBindCount);
@@ -1639,7 +1639,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindSparseInfo& value)
     encoder->EncodeUInt32Value(value.imageBindCount);
     EncodeStructArray(encoder, value.pImageBinds, value.imageBindCount);
     encoder->EncodeUInt32Value(value.signalSemaphoreCount);
-    encoder->EncodeHandleArray<SemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
+    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageFormatProperties& value)
@@ -1706,7 +1706,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferViewCreateInfo& value
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.range);
@@ -1753,7 +1753,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageViewCreateInfo& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
     encoder->EncodeEnumValue(value.viewType);
     encoder->EncodeEnumValue(value.format);
     EncodeStruct(encoder, value.components);
@@ -1799,7 +1799,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineShaderStageCreateIn
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.stage);
-    encoder->EncodeHandleValue<ShaderModuleWrapper>(value.module);
+    encoder->EncodeHandleValue<VulkanShaderModuleWrapper>(value.module);
     encoder->EncodeString(value.pName);
     EncodeStructPtr(encoder, value.pSpecializationInfo);
 }
@@ -1810,8 +1810,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkComputePipelineCreateInfo& 
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     EncodeStruct(encoder, value.stage);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
@@ -1985,10 +1985,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGraphicsPipelineCreateInfo&
     EncodeStructPtr(encoder, value.pDepthStencilState);
     EncodeStructPtr(encoder, value.pColorBlendState);
     EncodeStructPtr(encoder, value.pDynamicState);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<RenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
     encoder->EncodeUInt32Value(value.subpass);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
@@ -2005,7 +2005,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLayoutCreateInfo& v
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.setLayoutCount);
-    encoder->EncodeHandleArray<DescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
+    encoder->EncodeHandleArray<VulkanDescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
     encoder->EncodeUInt32Value(value.pushConstantRangeCount);
     EncodeStructArray(encoder, value.pPushConstantRanges, value.pushConstantRangeCount);
 }
@@ -2036,10 +2036,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DescriptorSetWrapper>(value.srcSet);
+    encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(value.srcSet);
     encoder->EncodeUInt32Value(value.srcBinding);
     encoder->EncodeUInt32Value(value.srcArrayElement);
-    encoder->EncodeHandleValue<DescriptorSetWrapper>(value.dstSet);
+    encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(value.dstSet);
     encoder->EncodeUInt32Value(value.dstBinding);
     encoder->EncodeUInt32Value(value.dstArrayElement);
     encoder->EncodeUInt32Value(value.descriptorCount);
@@ -2047,7 +2047,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorBufferInfo& value)
 {
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.range);
 }
@@ -2072,9 +2072,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetAllocateInfo& 
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DescriptorPoolWrapper>(value.descriptorPool);
+    encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(value.descriptorPool);
     encoder->EncodeUInt32Value(value.descriptorSetCount);
-    encoder->EncodeHandleArray<DescriptorSetLayoutWrapper>(value.pSetLayouts, value.descriptorSetCount);
+    encoder->EncodeHandleArray<VulkanDescriptorSetLayoutWrapper>(value.pSetLayouts, value.descriptorSetCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding& value)
@@ -2083,7 +2083,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding&
     encoder->EncodeEnumValue(value.descriptorType);
     encoder->EncodeUInt32Value(value.descriptorCount);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleArray<SamplerWrapper>(value.pImmutableSamplers, value.descriptorCount);
+    encoder->EncodeHandleArray<VulkanSamplerWrapper>(value.pImmutableSamplers, value.descriptorCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutCreateInfo& value)
@@ -2119,9 +2119,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFramebufferCreateInfo& valu
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<RenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
     encoder->EncodeUInt32Value(value.attachmentCount);
-    encoder->EncodeHandleArray<ImageViewWrapper>(value.pAttachments, value.attachmentCount);
+    encoder->EncodeHandleArray<VulkanImageViewWrapper>(value.pAttachments, value.attachmentCount);
     encoder->EncodeUInt32Value(value.width);
     encoder->EncodeUInt32Value(value.height);
     encoder->EncodeUInt32Value(value.layers);
@@ -2177,7 +2177,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferAllocateInfo& 
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<CommandPoolWrapper>(value.commandPool);
+    encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(value.commandPool);
     encoder->EncodeEnumValue(value.level);
     encoder->EncodeUInt32Value(value.commandBufferCount);
 }
@@ -2186,9 +2186,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferInheritanceInf
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<RenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
     encoder->EncodeUInt32Value(value.subpass);
-    encoder->EncodeHandleValue<FramebufferWrapper>(value.framebuffer);
+    encoder->EncodeHandleValue<VulkanFramebufferWrapper>(value.framebuffer);
     encoder->EncodeVkBool32Value(value.occlusionQueryEnable);
     encoder->EncodeFlagsValue(value.queryFlags);
     encoder->EncodeFlagsValue(value.pipelineStatistics);
@@ -2277,8 +2277,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<RenderPassWrapper>(value.renderPass);
-    encoder->EncodeHandleValue<FramebufferWrapper>(value.framebuffer);
+    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<VulkanFramebufferWrapper>(value.framebuffer);
     EncodeStruct(encoder, value.renderArea);
     encoder->EncodeUInt32Value(value.clearValueCount);
     EncodeStructArray(encoder, value.pClearValues, value.clearValueCount);
@@ -2298,8 +2298,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindBufferMemoryInfo& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
 }
 
@@ -2307,8 +2307,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemoryInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
 }
 
@@ -2334,8 +2334,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryDedicatedAllocateInfo
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryAllocateFlagsInfo& value)
@@ -2405,7 +2405,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperti
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
-    encoder->EncodeHandleArray<PhysicalDeviceWrapper>(value.physicalDevices, value.physicalDeviceCount);
+    encoder->EncodeHandleArray<VulkanPhysicalDeviceWrapper>(value.physicalDevices, value.physicalDeviceCount);
     encoder->EncodeVkBool32Value(value.subsetAllocation);
 }
 
@@ -2414,28 +2414,28 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupDeviceCreateInfo
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
-    encoder->EncodeHandleArray<PhysicalDeviceWrapper>(value.pPhysicalDevices, value.physicalDeviceCount);
+    encoder->EncodeHandleArray<VulkanPhysicalDeviceWrapper>(value.pPhysicalDevices, value.physicalDeviceCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImageSparseMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryRequirements2& value)
@@ -2644,7 +2644,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionInfo&
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SamplerYcbcrConversionWrapper>(value.conversion);
+    encoder->EncodeHandleValue<VulkanSamplerYcbcrConversionWrapper>(value.conversion);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindImagePlaneMemoryInfo& value)
@@ -2693,9 +2693,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCre
     encoder->EncodeUInt32Value(value.descriptorUpdateEntryCount);
     EncodeStructArray(encoder, value.pDescriptorUpdateEntries, value.descriptorUpdateEntryCount);
     encoder->EncodeEnumValue(value.templateType);
-    encoder->EncodeHandleValue<DescriptorSetLayoutWrapper>(value.descriptorSetLayout);
+    encoder->EncodeHandleValue<VulkanDescriptorSetLayoutWrapper>(value.descriptorSetLayout);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.pipelineLayout);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.pipelineLayout);
     encoder->EncodeUInt32Value(value.set);
 }
 
@@ -3311,7 +3311,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassAttachmentBeginIn
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.attachmentCount);
-    encoder->EncodeHandleArray<ImageViewWrapper>(value.pAttachments, value.attachmentCount);
+    encoder->EncodeHandleArray<VulkanImageViewWrapper>(value.pAttachments, value.attachmentCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceUniformBufferStandardLayoutFeatures& value)
@@ -3395,7 +3395,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreWaitInfo& value)
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.semaphoreCount);
-    encoder->EncodeHandleArray<SemaphoreWrapper>(value.pSemaphores, value.semaphoreCount);
+    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pSemaphores, value.semaphoreCount);
     encoder->EncodeUInt64Array(value.pValues, value.semaphoreCount);
 }
 
@@ -3403,7 +3403,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreSignalInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeUInt64Value(value.value);
 }
 
@@ -3420,7 +3420,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfo& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferOpaqueCaptureAddressCreateInfo& value)
@@ -3441,7 +3441,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDeviceMemoryOpaqueCaptureAd
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVulkan13Features& value)
@@ -3604,7 +3604,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryBarrier2& value
     encoder->EncodeFlags64Value(value.dstAccessMask);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -3621,7 +3621,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier2& value)
     encoder->EncodeEnumValue(value.newLayout);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
     EncodeStruct(encoder, value.subresourceRange);
 }
 
@@ -3642,7 +3642,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreSubmitInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeUInt64Value(value.value);
     encoder->EncodeFlags64Value(value.stageMask);
     encoder->EncodeUInt32Value(value.deviceIndex);
@@ -3652,7 +3652,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferSubmitInfo& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<CommandBufferWrapper>(value.commandBuffer);
+    encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(value.commandBuffer);
     encoder->EncodeUInt32Value(value.deviceMask);
 }
 
@@ -3703,8 +3703,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.srcBuffer);
-    encoder->EncodeHandleValue<BufferWrapper>(value.dstBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.srcBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.dstBuffer);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
 }
@@ -3724,9 +3724,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<ImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3748,8 +3748,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferToImageInfo2& val
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.srcBuffer);
-    encoder->EncodeHandleValue<ImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.srcBuffer);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3759,9 +3759,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToBufferInfo2& val
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<BufferWrapper>(value.dstBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.dstBuffer);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
 }
@@ -3780,9 +3780,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBlitImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<ImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3804,9 +3804,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkResolveImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<ImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3882,10 +3882,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderingAttachmentInfo& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.imageLayout);
     encoder->EncodeEnumValue(value.resolveMode);
-    encoder->EncodeHandleValue<ImageViewWrapper>(value.resolveImageView);
+    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.resolveImageView);
     encoder->EncodeEnumValue(value.resolveImageLayout);
     encoder->EncodeEnumValue(value.loadOp);
     encoder->EncodeEnumValue(value.storeOp);
@@ -4053,7 +4053,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& val
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<SurfaceKHRWrapper>(value.surface);
+    encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(value.surface);
     encoder->EncodeUInt32Value(value.minImageCount);
     encoder->EncodeEnumValue(value.imageFormat);
     encoder->EncodeEnumValue(value.imageColorSpace);
@@ -4067,7 +4067,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& val
     encoder->EncodeEnumValue(value.compositeAlpha);
     encoder->EncodeEnumValue(value.presentMode);
     encoder->EncodeVkBool32Value(value.clipped);
-    encoder->EncodeHandleValue<SwapchainKHRWrapper>(value.oldSwapchain);
+    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.oldSwapchain);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPresentInfoKHR& value)
@@ -4075,9 +4075,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPresentInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
-    encoder->EncodeHandleArray<SemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
+    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.swapchainCount);
-    encoder->EncodeHandleArray<SwapchainKHRWrapper>(value.pSwapchains, value.swapchainCount);
+    encoder->EncodeHandleArray<VulkanSwapchainKHRWrapper>(value.pSwapchains, value.swapchainCount);
     encoder->EncodeUInt32Array(value.pImageIndices, value.swapchainCount);
     encoder->EncodeEnumArray(value.pResults, value.swapchainCount);
 }
@@ -4086,14 +4086,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageSwapchainCreateInfoKHR
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemorySwapchainInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt32Value(value.imageIndex);
 }
 
@@ -4101,10 +4101,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt64Value(value.timeout);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
-    encoder->EncodeHandleValue<FenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
     encoder->EncodeUInt32Value(value.deviceMask);
 }
 
@@ -4148,7 +4148,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeCreateInfoKHR& v
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModePropertiesKHR& value)
 {
-    encoder->EncodeHandleValue<DisplayModeKHRWrapper>(value.displayMode);
+    encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(value.displayMode);
     EncodeStruct(encoder, value.parameters);
 }
 
@@ -4167,13 +4167,13 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilitiesKHR
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlanePropertiesKHR& value)
 {
-    encoder->EncodeHandleValue<DisplayKHRWrapper>(value.currentDisplay);
+    encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(value.currentDisplay);
     encoder->EncodeUInt32Value(value.currentStackIndex);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPropertiesKHR& value)
 {
-    encoder->EncodeHandleValue<DisplayKHRWrapper>(value.display);
+    encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(value.display);
     encoder->EncodeString(value.displayName);
     EncodeStruct(encoder, value.physicalDimensions);
     EncodeStruct(encoder, value.physicalResolution);
@@ -4187,7 +4187,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKHR
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<DisplayModeKHRWrapper>(value.displayMode);
+    encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(value.displayMode);
     encoder->EncodeUInt32Value(value.planeIndex);
     encoder->EncodeUInt32Value(value.planeStackIndex);
     encoder->EncodeEnumValue(value.transform);
@@ -4322,7 +4322,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoPictureResourceInfoKHR
     EncodeStruct(encoder, value.codedOffset);
     EncodeStruct(encoder, value.codedExtent);
     encoder->EncodeUInt32Value(value.baseArrayLayer);
-    encoder->EncodeHandleValue<ImageViewWrapper>(value.imageViewBinding);
+    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageViewBinding);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoReferenceSlotInfoKHR& value)
@@ -4346,7 +4346,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindVideoSessionMemoryInfoK
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryBindIndex);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeVkDeviceSizeValue(value.memorySize);
 }
@@ -4371,8 +4371,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoSessionParametersCreat
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VideoSessionParametersKHRWrapper>(value.videoSessionParametersTemplate);
-    encoder->EncodeHandleValue<VideoSessionKHRWrapper>(value.videoSession);
+    encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(value.videoSessionParametersTemplate);
+    encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(value.videoSession);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoSessionParametersUpdateInfoKHR& value)
@@ -4387,8 +4387,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoBeginCodingInfoKHR& va
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VideoSessionKHRWrapper>(value.videoSession);
-    encoder->EncodeHandleValue<VideoSessionParametersKHRWrapper>(value.videoSessionParameters);
+    encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(value.videoSession);
+    encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(value.videoSessionParameters);
     encoder->EncodeUInt32Value(value.referenceSlotCount);
     EncodeStructArray(encoder, value.pReferenceSlots, value.referenceSlotCount);
 }
@@ -4426,7 +4426,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoDecodeInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<BufferWrapper>(value.srcBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.srcBuffer);
     encoder->EncodeVkDeviceSizeValue(value.srcBufferOffset);
     encoder->EncodeVkDeviceSizeValue(value.srcBufferRange);
     EncodeStruct(encoder, value.dstPictureResource);
@@ -4813,7 +4813,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderingFragmentShadingRat
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.imageLayout);
     EncodeStruct(encoder, value.shadingRateAttachmentTexelSize);
 }
@@ -4822,7 +4822,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderingFragmentDensityMap
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.imageLayout);
 }
 
@@ -4872,7 +4872,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -4895,7 +4895,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -4904,11 +4904,11 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRelea
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.acquireCount);
-    encoder->EncodeHandleArray<DeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
+    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
     encoder->EncodeUInt64Array(value.pAcquireKeys, value.acquireCount);
     encoder->EncodeUInt32Array(value.pAcquireTimeouts, value.acquireCount);
     encoder->EncodeUInt32Value(value.releaseCount);
-    encoder->EncodeHandleArray<DeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
+    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
 
@@ -4916,7 +4916,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleI
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeVoidPtr(value.handle);
@@ -4946,7 +4946,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfo
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -4954,7 +4954,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& v
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeInt32Value(value.fd);
@@ -4964,7 +4964,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& valu
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -5007,7 +5007,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoK
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<FenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeVoidPtr(value.handle);
@@ -5027,7 +5027,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR&
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<FenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -5035,7 +5035,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<FenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeInt32Value(value.fd);
@@ -5045,7 +5045,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<FenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -5112,7 +5112,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSurfaceInfo2K
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SurfaceKHRWrapper>(value.surface);
+    encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(value.surface);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2KHR& value)
@@ -5154,7 +5154,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DisplayModeKHRWrapper>(value.mode);
+    encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(value.mode);
     encoder->EncodeUInt32Value(value.planeIndex);
 }
 
@@ -5388,7 +5388,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutablePropertiesKHR& value)
@@ -5405,7 +5405,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableInfoKHR& 
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
     encoder->EncodeUInt32Value(value.executableIndex);
 }
 
@@ -5435,7 +5435,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryMapInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -5445,7 +5445,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryUnmapInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLibraryCreateInfoKHR& value)
@@ -5453,7 +5453,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLibraryCreateInfoKH
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.libraryCount);
-    encoder->EncodeHandleArray<PipelineWrapper>(value.pLibraries, value.libraryCount);
+    encoder->EncodeHandleArray<VulkanPipelineWrapper>(value.pLibraries, value.libraryCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPresentIdKHR& value)
@@ -5476,7 +5476,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<BufferWrapper>(value.dstBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.dstBuffer);
     encoder->EncodeVkDeviceSizeValue(value.dstBufferOffset);
     encoder->EncodeVkDeviceSizeValue(value.dstBufferRange);
     EncodeStruct(encoder, value.srcPictureResource);
@@ -5564,7 +5564,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeSessionParameter
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VideoSessionParametersKHRWrapper>(value.videoSessionParameters);
+    encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(value.videoSessionParameters);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeSessionParametersFeedbackInfoKHR& value)
@@ -5816,7 +5816,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoInlineQueryInfoKHR& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<QueryPoolWrapper>(value.queryPool);
+    encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(value.queryPool);
     encoder->EncodeUInt32Value(value.firstQuery);
     encoder->EncodeUInt32Value(value.queryCount);
 }
@@ -5936,10 +5936,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindDescriptorSetsInfoKHR& 
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.firstSet);
     encoder->EncodeUInt32Value(value.descriptorSetCount);
-    encoder->EncodeHandleArray<DescriptorSetWrapper>(value.pDescriptorSets, value.descriptorSetCount);
+    encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(value.pDescriptorSets, value.descriptorSetCount);
     encoder->EncodeUInt32Value(value.dynamicOffsetCount);
     encoder->EncodeUInt32Array(value.pDynamicOffsets, value.dynamicOffsetCount);
 }
@@ -5948,7 +5948,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPushConstantsInfoKHR& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
     encoder->EncodeFlagsValue(value.stageFlags);
     encoder->EncodeUInt32Value(value.offset);
     encoder->EncodeUInt32Value(value.size);
@@ -5960,7 +5960,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetInfoKHR& v
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.set);
     encoder->EncodeUInt32Value(value.descriptorWriteCount);
     EncodeStructArray(encoder, value.pDescriptorWrites, value.descriptorWriteCount);
@@ -5970,8 +5970,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetWithTempla
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DescriptorUpdateTemplateWrapper>(value.descriptorUpdateTemplate);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(value.descriptorUpdateTemplate);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.set);
     encoder->EncodeVoidPtr(value.pData);
 }
@@ -5981,7 +5981,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSetDescriptorBufferOffsetsI
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.firstSet);
     encoder->EncodeUInt32Value(value.setCount);
     encoder->EncodeUInt32Array(value.pBufferIndices, value.setCount);
@@ -5993,7 +5993,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindDescriptorBufferEmbedde
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.set);
 }
 
@@ -6059,8 +6059,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationMemoryAl
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackFeaturesEXT& value)
@@ -6099,9 +6099,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageViewHandleInfoNVX& val
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.descriptorType);
-    encoder->EncodeHandleValue<SamplerWrapper>(value.sampler);
+    encoder->EncodeHandleValue<VulkanSamplerWrapper>(value.sampler);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImageViewAddressPropertiesNVX& value)
@@ -6197,11 +6197,11 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRelea
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.acquireCount);
-    encoder->EncodeHandleArray<DeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
+    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
     encoder->EncodeUInt64Array(value.pAcquireKeys, value.acquireCount);
     encoder->EncodeUInt32Array(value.pAcquireTimeoutMilliseconds, value.acquireCount);
     encoder->EncodeUInt32Value(value.releaseCount);
-    encoder->EncodeHandleArray<DeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
+    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
 
@@ -6266,7 +6266,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkConditionalRenderingBeginIn
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeFlagsValue(value.flags);
 }
@@ -6592,7 +6592,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBuf
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkExternalFormatANDROID& value)
@@ -6820,7 +6820,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleValidationCache
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ValidationCacheEXTWrapper>(value.validationCache);
+    encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(value.validationCache);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkShadingRatePaletteNV& value)
@@ -6900,8 +6900,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInf
     encoder->EncodeUInt32Value(value.groupCount);
     EncodeStructArray(encoder, value.pGroups, value.groupCount);
     encoder->EncodeUInt32Value(value.maxRecursionDepth);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
@@ -6909,16 +6909,16 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.vertexData);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.vertexData);
     encoder->EncodeVkDeviceSizeValue(value.vertexOffset);
     encoder->EncodeUInt32Value(value.vertexCount);
     encoder->EncodeVkDeviceSizeValue(value.vertexStride);
     encoder->EncodeEnumValue(value.vertexFormat);
-    encoder->EncodeHandleValue<BufferWrapper>(value.indexData);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.indexData);
     encoder->EncodeVkDeviceSizeValue(value.indexOffset);
     encoder->EncodeUInt32Value(value.indexCount);
     encoder->EncodeEnumValue(value.indexType);
-    encoder->EncodeHandleValue<BufferWrapper>(value.transformData);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.transformData);
     encoder->EncodeVkDeviceSizeValue(value.transformOffset);
 }
 
@@ -6926,7 +6926,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeometryAABBNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<BufferWrapper>(value.aabbData);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.aabbData);
     encoder->EncodeUInt32Value(value.numAABBs);
     encoder->EncodeUInt32Value(value.stride);
     encoder->EncodeVkDeviceSizeValue(value.offset);
@@ -6970,8 +6970,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindAccelerationStructureMe
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(value.accelerationStructure);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(value.accelerationStructure);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeUInt32Value(value.deviceIndexCount);
     encoder->EncodeUInt32Array(value.pDeviceIndices, value.deviceIndexCount);
@@ -6982,7 +6982,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerat
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.accelerationStructureCount);
-    encoder->EncodeHandleArray<AccelerationStructureNVWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
+    encoder->EncodeHandleArray<VulkanAccelerationStructureNVWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureMemoryRequirementsInfoNV& value)
@@ -6990,7 +6990,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureMemory
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
-    encoder->EncodeHandleValue<AccelerationStructureNVWrapper>(value.accelerationStructure);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(value.accelerationStructure);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPropertiesNV& value)
@@ -7597,7 +7597,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToImageInfoEXT& v
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<ImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -7608,7 +7608,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToMemoryInfoEXT& v
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<ImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -7619,9 +7619,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToImageInfoEXT& va
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<ImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<ImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -7631,7 +7631,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkHostImageLayoutTransitionIn
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
     encoder->EncodeEnumValue(value.oldLayout);
     encoder->EncodeEnumValue(value.newLayout);
     EncodeStruct(encoder, value.subresourceRange);
@@ -7731,7 +7731,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainPresentFenceInfoEX
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.swapchainCount);
-    encoder->EncodeHandleArray<FenceWrapper>(value.pFences, value.swapchainCount);
+    encoder->EncodeHandleArray<VulkanFenceWrapper>(value.pFences, value.swapchainCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainPresentModesCreateInfoEXT& value)
@@ -7763,7 +7763,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkReleaseSwapchainImagesInfoE
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt32Value(value.imageIndexCount);
     encoder->EncodeUInt32Array(value.pImageIndices, value.imageIndexCount);
 }
@@ -7807,7 +7807,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGraphicsPipelineShaderGroup
     encoder->EncodeUInt32Value(value.groupCount);
     EncodeStructArray(encoder, value.pGroups, value.groupCount);
     encoder->EncodeUInt32Value(value.pipelineCount);
-    encoder->EncodeHandleArray<PipelineWrapper>(value.pPipelines, value.pipelineCount);
+    encoder->EncodeHandleArray<VulkanPipelineWrapper>(value.pPipelines, value.pipelineCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindShaderGroupIndirectCommandNV& value)
@@ -7836,7 +7836,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSetStateFlagsIndirectComman
 
 void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsStreamNV& value)
 {
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
 }
 
@@ -7849,7 +7849,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutToken
     encoder->EncodeUInt32Value(value.offset);
     encoder->EncodeUInt32Value(value.vertexBindingUnit);
     encoder->EncodeVkBool32Value(value.vertexDynamicStride);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.pushconstantPipelineLayout);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.pushconstantPipelineLayout);
     encoder->EncodeFlagsValue(value.pushconstantShaderStageFlags);
     encoder->EncodeUInt32Value(value.pushconstantOffset);
     encoder->EncodeUInt32Value(value.pushconstantSize);
@@ -7876,17 +7876,17 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsInfoNV& va
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.pipeline);
-    encoder->EncodeHandleValue<IndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<VulkanIndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
     encoder->EncodeUInt32Value(value.streamCount);
     EncodeStructArray(encoder, value.pStreams, value.streamCount);
     encoder->EncodeUInt32Value(value.sequencesCount);
-    encoder->EncodeHandleValue<BufferWrapper>(value.preprocessBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.preprocessBuffer);
     encoder->EncodeVkDeviceSizeValue(value.preprocessOffset);
     encoder->EncodeVkDeviceSizeValue(value.preprocessSize);
-    encoder->EncodeHandleValue<BufferWrapper>(value.sequencesCountBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.sequencesCountBuffer);
     encoder->EncodeVkDeviceSizeValue(value.sequencesCountOffset);
-    encoder->EncodeHandleValue<BufferWrapper>(value.sequencesIndexBuffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.sequencesIndexBuffer);
     encoder->EncodeVkDeviceSizeValue(value.sequencesIndexOffset);
 }
 
@@ -7895,8 +7895,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsMemoryRequ
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.pipeline);
-    encoder->EncodeHandleValue<IndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<VulkanIndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
     encoder->EncodeUInt32Value(value.maxSequencesCount);
 }
 
@@ -8464,7 +8464,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetZirconHandleInfoFU
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -8472,7 +8472,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreZirconHandle
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeUInt32Value(value.zirconHandle);
@@ -8482,7 +8482,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetZirconHandleInf
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -8497,7 +8497,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetRemoteAddressInfoN
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -8522,9 +8522,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFrameBoundaryEXT& value)
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt64Value(value.frameID);
     encoder->EncodeUInt32Value(value.imageCount);
-    encoder->EncodeHandleArray<ImageWrapper>(value.pImages, value.imageCount);
+    encoder->EncodeHandleArray<VulkanImageWrapper>(value.pImages, value.imageCount);
     encoder->EncodeUInt32Value(value.bufferCount);
-    encoder->EncodeHandleArray<BufferWrapper>(value.pBuffers, value.bufferCount);
+    encoder->EncodeHandleArray<VulkanBufferWrapper>(value.pBuffers, value.bufferCount);
     encoder->EncodeUInt64Value(value.tagName);
     encoder->EncodeSizeTValue(value.tagSize);
     encoder->EncodeVoidArray(value.pTag, value.tagSize);
@@ -8675,7 +8675,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMicromapBuildInfoEXT& value
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.mode);
-    encoder->EncodeHandleValue<MicromapEXTWrapper>(value.dstMicromap);
+    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.dstMicromap);
     encoder->EncodeUInt32Value(value.usageCountsCount);
     EncodeStructArray(encoder, value.pUsageCounts, value.usageCountsCount);
     EncodeStructArray2D(encoder, value.ppUsageCounts, value.usageCountsCount, 1);
@@ -8690,7 +8690,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMicromapCreateInfoEXT& valu
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.createFlags);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
     encoder->EncodeEnumValue(value.type);
@@ -8725,7 +8725,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapToMemoryInfoEXT
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<MicromapEXTWrapper>(value.src);
+    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.src);
     EncodeStruct(encoder, value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
@@ -8735,7 +8735,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToMicromapInfoEXT
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     EncodeStruct(encoder, value.src);
-    encoder->EncodeHandleValue<MicromapEXTWrapper>(value.dst);
+    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -8743,8 +8743,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<MicromapEXTWrapper>(value.src);
-    encoder->EncodeHandleValue<MicromapEXTWrapper>(value.dst);
+    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.src);
+    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -8768,7 +8768,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureTriang
     encoder->EncodeUInt32Value(value.usageCountsCount);
     EncodeStructArray(encoder, value.pUsageCounts, value.usageCountsCount);
     EncodeStructArray2D(encoder, value.ppUsageCounts, value.usageCountsCount, 1);
-    encoder->EncodeHandleValue<MicromapEXTWrapper>(value.micromap);
+    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.micromap);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMicromapTriangleEXT& value)
@@ -8811,7 +8811,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureTriang
     encoder->EncodeUInt32Value(value.usageCountsCount);
     EncodeStructArray(encoder, value.pUsageCounts, value.usageCountsCount);
     EncodeStructArray2D(encoder, value.ppUsageCounts, value.usageCountsCount, 1);
-    encoder->EncodeHandleValue<MicromapEXTWrapper>(value.micromap);
+    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.micromap);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI& value)
@@ -8918,7 +8918,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetBindingReferen
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<DescriptorSetLayoutWrapper>(value.descriptorSetLayout);
+    encoder->EncodeHandleValue<VulkanDescriptorSetLayoutWrapper>(value.descriptorSetLayout);
     encoder->EncodeUInt32Value(value.binding);
 }
 
@@ -9027,7 +9027,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineIndirectDeviceAddre
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindPipelineIndirectCommandNV& value)
@@ -9385,7 +9385,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkShaderCreateInfoEXT& value)
     encoder->EncodeVoidArray(value.pCode, value.codeSize);
     encoder->EncodeString(value.pName);
     encoder->EncodeUInt32Value(value.setLayoutCount);
-    encoder->EncodeHandleArray<DescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
+    encoder->EncodeHandleArray<VulkanDescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
     encoder->EncodeUInt32Value(value.pushConstantRangeCount);
     EncodeStructArray(encoder, value.pPushConstantRanges, value.pushConstantRangeCount);
     EncodeStructPtr(encoder, value.pSpecializationInfo);
@@ -9762,8 +9762,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureBuildG
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.mode);
-    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(value.srcAccelerationStructure);
-    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(value.dstAccelerationStructure);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.srcAccelerationStructure);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.dstAccelerationStructure);
     encoder->EncodeUInt32Value(value.geometryCount);
     EncodeStructArray(encoder, value.pGeometries, value.geometryCount);
     EncodeStructArray2D(encoder, value.ppGeometries, value.geometryCount, 1);
@@ -9775,7 +9775,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureCreate
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.createFlags);
-    encoder->EncodeHandleValue<BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
     encoder->EncodeEnumValue(value.type);
@@ -9787,7 +9787,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerat
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.accelerationStructureCount);
-    encoder->EncodeHandleArray<AccelerationStructureKHRWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
+    encoder->EncodeHandleArray<VulkanAccelerationStructureKHRWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceAccelerationStructureFeaturesKHR& value)
@@ -9819,7 +9819,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureDevice
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(value.accelerationStructure);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.accelerationStructure);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureVersionInfoKHR& value)
@@ -9833,7 +9833,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureTo
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(value.src);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.src);
     EncodeStruct(encoder, value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
@@ -9843,7 +9843,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToAccelerationStr
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     EncodeStruct(encoder, value.src);
-    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(value.dst);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -9851,8 +9851,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureIn
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(value.src);
-    encoder->EncodeHandleValue<AccelerationStructureKHRWrapper>(value.dst);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.src);
+    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -9898,8 +9898,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInf
     EncodeStructPtr(encoder, value.pLibraryInfo);
     EncodeStructPtr(encoder, value.pLibraryInterface);
     EncodeStructPtr(encoder, value.pDynamicState);
-    encoder->EncodeHandleValue<PipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<PipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -9519,7 +9519,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkLatencySleepInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<SemaphoreWrapper>(value.signalSemaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.signalSemaphore);
     encoder->EncodeUInt64Value(value.value);
 }
 

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -1167,7 +1167,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryBarrier& value)
     encoder->EncodeFlagsValue(value.dstAccessMask);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -1215,7 +1215,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value)
     encoder->EncodeEnumValue(value.newLayout);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
     EncodeStruct(encoder, value.subresourceRange);
 }
 
@@ -1547,19 +1547,19 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSubmitInfo& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
-    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeFlagsArray(value.pWaitDstStageMask, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.commandBufferCount);
-    encoder->EncodeHandleArray<VulkanCommandBufferWrapper>(value.pCommandBuffers, value.commandBufferCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::CommandBufferWrapper>(value.pCommandBuffers, value.commandBufferCount);
     encoder->EncodeUInt32Value(value.signalSemaphoreCount);
-    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMappedMemoryRange& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -1583,21 +1583,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSparseMemoryBind& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.resourceOffset);
     encoder->EncodeVkDeviceSizeValue(value.size);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeFlagsValue(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseBufferMemoryBindInfo& value)
 {
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeUInt32Value(value.bindCount);
     EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageOpaqueMemoryBindInfo& value)
 {
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
     encoder->EncodeUInt32Value(value.bindCount);
     EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
@@ -1614,14 +1614,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBind& valu
     EncodeStruct(encoder, value.subresource);
     EncodeStruct(encoder, value.offset);
     EncodeStruct(encoder, value.extent);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeFlagsValue(value.flags);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBindInfo& value)
 {
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
     encoder->EncodeUInt32Value(value.bindCount);
     EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
@@ -1631,7 +1631,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindSparseInfo& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
-    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.bufferBindCount);
     EncodeStructArray(encoder, value.pBufferBinds, value.bufferBindCount);
     encoder->EncodeUInt32Value(value.imageOpaqueBindCount);
@@ -1639,7 +1639,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindSparseInfo& value)
     encoder->EncodeUInt32Value(value.imageBindCount);
     EncodeStructArray(encoder, value.pImageBinds, value.imageBindCount);
     encoder->EncodeUInt32Value(value.signalSemaphoreCount);
-    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SemaphoreWrapper>(value.pSignalSemaphores, value.signalSemaphoreCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageFormatProperties& value)
@@ -1706,7 +1706,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferViewCreateInfo& value
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.range);
@@ -1753,7 +1753,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageViewCreateInfo& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
     encoder->EncodeEnumValue(value.viewType);
     encoder->EncodeEnumValue(value.format);
     EncodeStruct(encoder, value.components);
@@ -1799,7 +1799,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineShaderStageCreateIn
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.stage);
-    encoder->EncodeHandleValue<VulkanShaderModuleWrapper>(value.module);
+    encoder->EncodeHandleValue<vulkan_wrappers::ShaderModuleWrapper>(value.module);
     encoder->EncodeString(value.pName);
     EncodeStructPtr(encoder, value.pSpecializationInfo);
 }
@@ -1810,8 +1810,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkComputePipelineCreateInfo& 
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     EncodeStruct(encoder, value.stage);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
@@ -1985,10 +1985,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGraphicsPipelineCreateInfo&
     EncodeStructPtr(encoder, value.pDepthStencilState);
     EncodeStructPtr(encoder, value.pColorBlendState);
     EncodeStructPtr(encoder, value.pDynamicState);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::RenderPassWrapper>(value.renderPass);
     encoder->EncodeUInt32Value(value.subpass);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
@@ -2005,7 +2005,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLayoutCreateInfo& v
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.setLayoutCount);
-    encoder->EncodeHandleArray<VulkanDescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
     encoder->EncodeUInt32Value(value.pushConstantRangeCount);
     EncodeStructArray(encoder, value.pPushConstantRanges, value.pushConstantRangeCount);
 }
@@ -2036,10 +2036,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(value.srcSet);
+    encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetWrapper>(value.srcSet);
     encoder->EncodeUInt32Value(value.srcBinding);
     encoder->EncodeUInt32Value(value.srcArrayElement);
-    encoder->EncodeHandleValue<VulkanDescriptorSetWrapper>(value.dstSet);
+    encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetWrapper>(value.dstSet);
     encoder->EncodeUInt32Value(value.dstBinding);
     encoder->EncodeUInt32Value(value.dstArrayElement);
     encoder->EncodeUInt32Value(value.descriptorCount);
@@ -2047,7 +2047,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorBufferInfo& value)
 {
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.range);
 }
@@ -2072,9 +2072,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetAllocateInfo& 
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDescriptorPoolWrapper>(value.descriptorPool);
+    encoder->EncodeHandleValue<vulkan_wrappers::DescriptorPoolWrapper>(value.descriptorPool);
     encoder->EncodeUInt32Value(value.descriptorSetCount);
-    encoder->EncodeHandleArray<VulkanDescriptorSetLayoutWrapper>(value.pSetLayouts, value.descriptorSetCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DescriptorSetLayoutWrapper>(value.pSetLayouts, value.descriptorSetCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding& value)
@@ -2083,7 +2083,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding&
     encoder->EncodeEnumValue(value.descriptorType);
     encoder->EncodeUInt32Value(value.descriptorCount);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleArray<VulkanSamplerWrapper>(value.pImmutableSamplers, value.descriptorCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SamplerWrapper>(value.pImmutableSamplers, value.descriptorCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutCreateInfo& value)
@@ -2119,9 +2119,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFramebufferCreateInfo& valu
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<vulkan_wrappers::RenderPassWrapper>(value.renderPass);
     encoder->EncodeUInt32Value(value.attachmentCount);
-    encoder->EncodeHandleArray<VulkanImageViewWrapper>(value.pAttachments, value.attachmentCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::ImageViewWrapper>(value.pAttachments, value.attachmentCount);
     encoder->EncodeUInt32Value(value.width);
     encoder->EncodeUInt32Value(value.height);
     encoder->EncodeUInt32Value(value.layers);
@@ -2177,7 +2177,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferAllocateInfo& 
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanCommandPoolWrapper>(value.commandPool);
+    encoder->EncodeHandleValue<vulkan_wrappers::CommandPoolWrapper>(value.commandPool);
     encoder->EncodeEnumValue(value.level);
     encoder->EncodeUInt32Value(value.commandBufferCount);
 }
@@ -2186,9 +2186,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferInheritanceInf
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<vulkan_wrappers::RenderPassWrapper>(value.renderPass);
     encoder->EncodeUInt32Value(value.subpass);
-    encoder->EncodeHandleValue<VulkanFramebufferWrapper>(value.framebuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::FramebufferWrapper>(value.framebuffer);
     encoder->EncodeVkBool32Value(value.occlusionQueryEnable);
     encoder->EncodeFlagsValue(value.queryFlags);
     encoder->EncodeFlagsValue(value.pipelineStatistics);
@@ -2277,8 +2277,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanRenderPassWrapper>(value.renderPass);
-    encoder->EncodeHandleValue<VulkanFramebufferWrapper>(value.framebuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::RenderPassWrapper>(value.renderPass);
+    encoder->EncodeHandleValue<vulkan_wrappers::FramebufferWrapper>(value.framebuffer);
     EncodeStruct(encoder, value.renderArea);
     encoder->EncodeUInt32Value(value.clearValueCount);
     EncodeStructArray(encoder, value.pClearValues, value.clearValueCount);
@@ -2298,8 +2298,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindBufferMemoryInfo& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
 }
 
@@ -2307,8 +2307,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemoryInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
 }
 
@@ -2334,8 +2334,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryDedicatedAllocateInfo
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryAllocateFlagsInfo& value)
@@ -2405,7 +2405,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperti
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
-    encoder->EncodeHandleArray<VulkanPhysicalDeviceWrapper>(value.physicalDevices, value.physicalDeviceCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::PhysicalDeviceWrapper>(value.physicalDevices, value.physicalDeviceCount);
     encoder->EncodeVkBool32Value(value.subsetAllocation);
 }
 
@@ -2414,28 +2414,28 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupDeviceCreateInfo
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
-    encoder->EncodeHandleArray<VulkanPhysicalDeviceWrapper>(value.pPhysicalDevices, value.physicalDeviceCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::PhysicalDeviceWrapper>(value.pPhysicalDevices, value.physicalDeviceCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImageSparseMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryRequirements2& value)
@@ -2644,7 +2644,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionInfo&
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSamplerYcbcrConversionWrapper>(value.conversion);
+    encoder->EncodeHandleValue<vulkan_wrappers::SamplerYcbcrConversionWrapper>(value.conversion);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindImagePlaneMemoryInfo& value)
@@ -2693,9 +2693,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCre
     encoder->EncodeUInt32Value(value.descriptorUpdateEntryCount);
     EncodeStructArray(encoder, value.pDescriptorUpdateEntries, value.descriptorUpdateEntryCount);
     encoder->EncodeEnumValue(value.templateType);
-    encoder->EncodeHandleValue<VulkanDescriptorSetLayoutWrapper>(value.descriptorSetLayout);
+    encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetLayoutWrapper>(value.descriptorSetLayout);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.pipelineLayout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.pipelineLayout);
     encoder->EncodeUInt32Value(value.set);
 }
 
@@ -3311,7 +3311,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassAttachmentBeginIn
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.attachmentCount);
-    encoder->EncodeHandleArray<VulkanImageViewWrapper>(value.pAttachments, value.attachmentCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::ImageViewWrapper>(value.pAttachments, value.attachmentCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceUniformBufferStandardLayoutFeatures& value)
@@ -3395,7 +3395,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreWaitInfo& value)
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.semaphoreCount);
-    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pSemaphores, value.semaphoreCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SemaphoreWrapper>(value.pSemaphores, value.semaphoreCount);
     encoder->EncodeUInt64Array(value.pValues, value.semaphoreCount);
 }
 
@@ -3403,7 +3403,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreSignalInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeUInt64Value(value.value);
 }
 
@@ -3420,7 +3420,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfo& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferOpaqueCaptureAddressCreateInfo& value)
@@ -3441,7 +3441,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDeviceMemoryOpaqueCaptureAd
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVulkan13Features& value)
@@ -3604,7 +3604,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryBarrier2& value
     encoder->EncodeFlags64Value(value.dstAccessMask);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -3621,7 +3621,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier2& value)
     encoder->EncodeEnumValue(value.newLayout);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
     EncodeStruct(encoder, value.subresourceRange);
 }
 
@@ -3642,7 +3642,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreSubmitInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeUInt64Value(value.value);
     encoder->EncodeFlags64Value(value.stageMask);
     encoder->EncodeUInt32Value(value.deviceIndex);
@@ -3652,7 +3652,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferSubmitInfo& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanCommandBufferWrapper>(value.commandBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::CommandBufferWrapper>(value.commandBuffer);
     encoder->EncodeUInt32Value(value.deviceMask);
 }
 
@@ -3703,8 +3703,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.srcBuffer);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.dstBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.srcBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.dstBuffer);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
 }
@@ -3724,9 +3724,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3748,8 +3748,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyBufferToImageInfo2& val
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.srcBuffer);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.srcBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3759,9 +3759,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToBufferInfo2& val
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.dstBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.dstBuffer);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
 }
@@ -3780,9 +3780,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBlitImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3804,9 +3804,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkResolveImageInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -3882,10 +3882,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderingAttachmentInfo& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.imageLayout);
     encoder->EncodeEnumValue(value.resolveMode);
-    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.resolveImageView);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(value.resolveImageView);
     encoder->EncodeEnumValue(value.resolveImageLayout);
     encoder->EncodeEnumValue(value.loadOp);
     encoder->EncodeEnumValue(value.storeOp);
@@ -4053,7 +4053,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& val
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(value.surface);
+    encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(value.surface);
     encoder->EncodeUInt32Value(value.minImageCount);
     encoder->EncodeEnumValue(value.imageFormat);
     encoder->EncodeEnumValue(value.imageColorSpace);
@@ -4067,7 +4067,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& val
     encoder->EncodeEnumValue(value.compositeAlpha);
     encoder->EncodeEnumValue(value.presentMode);
     encoder->EncodeVkBool32Value(value.clipped);
-    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.oldSwapchain);
+    encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(value.oldSwapchain);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPresentInfoKHR& value)
@@ -4075,9 +4075,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPresentInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
-    encoder->EncodeHandleArray<VulkanSemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SemaphoreWrapper>(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.swapchainCount);
-    encoder->EncodeHandleArray<VulkanSwapchainKHRWrapper>(value.pSwapchains, value.swapchainCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::SwapchainKHRWrapper>(value.pSwapchains, value.swapchainCount);
     encoder->EncodeUInt32Array(value.pImageIndices, value.swapchainCount);
     encoder->EncodeEnumArray(value.pResults, value.swapchainCount);
 }
@@ -4086,14 +4086,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageSwapchainCreateInfoKHR
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(value.swapchain);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemorySwapchainInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt32Value(value.imageIndex);
 }
 
@@ -4101,10 +4101,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt64Value(value.timeout);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
-    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeUInt32Value(value.deviceMask);
 }
 
@@ -4148,7 +4148,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeCreateInfoKHR& v
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModePropertiesKHR& value)
 {
-    encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(value.displayMode);
+    encoder->EncodeHandleValue<vulkan_wrappers::DisplayModeKHRWrapper>(value.displayMode);
     EncodeStruct(encoder, value.parameters);
 }
 
@@ -4167,13 +4167,13 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilitiesKHR
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlanePropertiesKHR& value)
 {
-    encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(value.currentDisplay);
+    encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(value.currentDisplay);
     encoder->EncodeUInt32Value(value.currentStackIndex);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPropertiesKHR& value)
 {
-    encoder->EncodeHandleValue<VulkanDisplayKHRWrapper>(value.display);
+    encoder->EncodeHandleValue<vulkan_wrappers::DisplayKHRWrapper>(value.display);
     encoder->EncodeString(value.displayName);
     EncodeStruct(encoder, value.physicalDimensions);
     EncodeStruct(encoder, value.physicalResolution);
@@ -4187,7 +4187,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKHR
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(value.displayMode);
+    encoder->EncodeHandleValue<vulkan_wrappers::DisplayModeKHRWrapper>(value.displayMode);
     encoder->EncodeUInt32Value(value.planeIndex);
     encoder->EncodeUInt32Value(value.planeStackIndex);
     encoder->EncodeEnumValue(value.transform);
@@ -4322,7 +4322,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoPictureResourceInfoKHR
     EncodeStruct(encoder, value.codedOffset);
     EncodeStruct(encoder, value.codedExtent);
     encoder->EncodeUInt32Value(value.baseArrayLayer);
-    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageViewBinding);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(value.imageViewBinding);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoReferenceSlotInfoKHR& value)
@@ -4346,7 +4346,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindVideoSessionMemoryInfoK
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryBindIndex);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeVkDeviceSizeValue(value.memorySize);
 }
@@ -4371,8 +4371,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoSessionParametersCreat
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(value.videoSessionParametersTemplate);
-    encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(value.videoSession);
+    encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionParametersKHRWrapper>(value.videoSessionParametersTemplate);
+    encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionKHRWrapper>(value.videoSession);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoSessionParametersUpdateInfoKHR& value)
@@ -4387,8 +4387,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoBeginCodingInfoKHR& va
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanVideoSessionKHRWrapper>(value.videoSession);
-    encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(value.videoSessionParameters);
+    encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionKHRWrapper>(value.videoSession);
+    encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionParametersKHRWrapper>(value.videoSessionParameters);
     encoder->EncodeUInt32Value(value.referenceSlotCount);
     EncodeStructArray(encoder, value.pReferenceSlots, value.referenceSlotCount);
 }
@@ -4426,7 +4426,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoDecodeInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.srcBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.srcBuffer);
     encoder->EncodeVkDeviceSizeValue(value.srcBufferOffset);
     encoder->EncodeVkDeviceSizeValue(value.srcBufferRange);
     EncodeStruct(encoder, value.dstPictureResource);
@@ -4813,7 +4813,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderingFragmentShadingRat
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.imageLayout);
     EncodeStruct(encoder, value.shadingRateAttachmentTexelSize);
 }
@@ -4822,7 +4822,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRenderingFragmentDensityMap
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.imageLayout);
 }
 
@@ -4872,7 +4872,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -4895,7 +4895,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -4904,11 +4904,11 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRelea
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.acquireCount);
-    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
     encoder->EncodeUInt64Array(value.pAcquireKeys, value.acquireCount);
     encoder->EncodeUInt32Array(value.pAcquireTimeouts, value.acquireCount);
     encoder->EncodeUInt32Value(value.releaseCount);
-    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
 
@@ -4916,7 +4916,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleI
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeVoidPtr(value.handle);
@@ -4946,7 +4946,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfo
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -4954,7 +4954,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& v
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeInt32Value(value.fd);
@@ -4964,7 +4964,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& valu
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -5007,7 +5007,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoK
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeVoidPtr(value.handle);
@@ -5027,7 +5027,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR&
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -5035,7 +5035,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeInt32Value(value.fd);
@@ -5045,7 +5045,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanFenceWrapper>(value.fence);
+    encoder->EncodeHandleValue<vulkan_wrappers::FenceWrapper>(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -5112,7 +5112,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSurfaceInfo2K
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSurfaceKHRWrapper>(value.surface);
+    encoder->EncodeHandleValue<vulkan_wrappers::SurfaceKHRWrapper>(value.surface);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2KHR& value)
@@ -5154,7 +5154,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDisplayModeKHRWrapper>(value.mode);
+    encoder->EncodeHandleValue<vulkan_wrappers::DisplayModeKHRWrapper>(value.mode);
     encoder->EncodeUInt32Value(value.planeIndex);
 }
 
@@ -5388,7 +5388,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutablePropertiesKHR& value)
@@ -5405,7 +5405,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineExecutableInfoKHR& 
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
     encoder->EncodeUInt32Value(value.executableIndex);
 }
 
@@ -5435,7 +5435,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryMapInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
@@ -5445,7 +5445,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryUnmapInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLibraryCreateInfoKHR& value)
@@ -5453,7 +5453,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLibraryCreateInfoKH
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.libraryCount);
-    encoder->EncodeHandleArray<VulkanPipelineWrapper>(value.pLibraries, value.libraryCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::PipelineWrapper>(value.pLibraries, value.libraryCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPresentIdKHR& value)
@@ -5476,7 +5476,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeInfoKHR& value)
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.dstBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.dstBuffer);
     encoder->EncodeVkDeviceSizeValue(value.dstBufferOffset);
     encoder->EncodeVkDeviceSizeValue(value.dstBufferRange);
     EncodeStruct(encoder, value.srcPictureResource);
@@ -5564,7 +5564,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeSessionParameter
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanVideoSessionParametersKHRWrapper>(value.videoSessionParameters);
+    encoder->EncodeHandleValue<vulkan_wrappers::VideoSessionParametersKHRWrapper>(value.videoSessionParameters);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkVideoEncodeSessionParametersFeedbackInfoKHR& value)
@@ -5816,7 +5816,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkVideoInlineQueryInfoKHR& va
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanQueryPoolWrapper>(value.queryPool);
+    encoder->EncodeHandleValue<vulkan_wrappers::QueryPoolWrapper>(value.queryPool);
     encoder->EncodeUInt32Value(value.firstQuery);
     encoder->EncodeUInt32Value(value.queryCount);
 }
@@ -5936,10 +5936,10 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindDescriptorSetsInfoKHR& 
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.firstSet);
     encoder->EncodeUInt32Value(value.descriptorSetCount);
-    encoder->EncodeHandleArray<VulkanDescriptorSetWrapper>(value.pDescriptorSets, value.descriptorSetCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DescriptorSetWrapper>(value.pDescriptorSets, value.descriptorSetCount);
     encoder->EncodeUInt32Value(value.dynamicOffsetCount);
     encoder->EncodeUInt32Array(value.pDynamicOffsets, value.dynamicOffsetCount);
 }
@@ -5948,7 +5948,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPushConstantsInfoKHR& value
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
     encoder->EncodeFlagsValue(value.stageFlags);
     encoder->EncodeUInt32Value(value.offset);
     encoder->EncodeUInt32Value(value.size);
@@ -5960,7 +5960,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetInfoKHR& v
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.set);
     encoder->EncodeUInt32Value(value.descriptorWriteCount);
     EncodeStructArray(encoder, value.pDescriptorWrites, value.descriptorWriteCount);
@@ -5970,8 +5970,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetWithTempla
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDescriptorUpdateTemplateWrapper>(value.descriptorUpdateTemplate);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(value.descriptorUpdateTemplate);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.set);
     encoder->EncodeVoidPtr(value.pData);
 }
@@ -5981,7 +5981,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSetDescriptorBufferOffsetsI
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.firstSet);
     encoder->EncodeUInt32Value(value.setCount);
     encoder->EncodeUInt32Array(value.pBufferIndices, value.setCount);
@@ -5993,7 +5993,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindDescriptorBufferEmbedde
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stageFlags);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
     encoder->EncodeUInt32Value(value.set);
 }
 
@@ -6018,7 +6018,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEX
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(GetWrappedId(value.object, value.objectType));
+    encoder->EncodeUInt64Value(GetVulkanWrappedId(value.object, value.objectType));
     encoder->EncodeString(value.pObjectName);
 }
 
@@ -6027,7 +6027,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(GetWrappedId(value.object, value.objectType));
+    encoder->EncodeUInt64Value(GetVulkanWrappedId(value.object, value.objectType));
     encoder->EncodeUInt64Value(value.tagName);
     encoder->EncodeSizeTValue(value.tagSize);
     encoder->EncodeVoidArray(value.pTag, value.tagSize);
@@ -6059,8 +6059,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationMemoryAl
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackFeaturesEXT& value)
@@ -6099,9 +6099,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImageViewHandleInfoNVX& val
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageViewWrapper>(value.imageView);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageViewWrapper>(value.imageView);
     encoder->EncodeEnumValue(value.descriptorType);
-    encoder->EncodeHandleValue<VulkanSamplerWrapper>(value.sampler);
+    encoder->EncodeHandleValue<vulkan_wrappers::SamplerWrapper>(value.sampler);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImageViewAddressPropertiesNVX& value)
@@ -6197,11 +6197,11 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRelea
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.acquireCount);
-    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DeviceMemoryWrapper>(value.pAcquireSyncs, value.acquireCount);
     encoder->EncodeUInt64Array(value.pAcquireKeys, value.acquireCount);
     encoder->EncodeUInt32Array(value.pAcquireTimeoutMilliseconds, value.acquireCount);
     encoder->EncodeUInt32Value(value.releaseCount);
-    encoder->EncodeHandleArray<VulkanDeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DeviceMemoryWrapper>(value.pReleaseSyncs, value.releaseCount);
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
 
@@ -6266,7 +6266,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkConditionalRenderingBeginIn
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeFlagsValue(value.flags);
 }
@@ -6510,7 +6510,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(GetWrappedId(value.objectHandle, value.objectType));
+    encoder->EncodeUInt64Value(GetVulkanWrappedId(value.objectHandle, value.objectType));
     encoder->EncodeString(value.pObjectName);
 }
 
@@ -6546,7 +6546,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT&
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(GetWrappedId(value.objectHandle, value.objectType));
+    encoder->EncodeUInt64Value(GetVulkanWrappedId(value.objectHandle, value.objectType));
     encoder->EncodeUInt64Value(value.tagName);
     encoder->EncodeSizeTValue(value.tagSize);
     encoder->EncodeVoidArray(value.pTag, value.tagSize);
@@ -6592,7 +6592,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBuf
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkExternalFormatANDROID& value)
@@ -6820,7 +6820,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleValidationCache
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanValidationCacheEXTWrapper>(value.validationCache);
+    encoder->EncodeHandleValue<vulkan_wrappers::ValidationCacheEXTWrapper>(value.validationCache);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkShadingRatePaletteNV& value)
@@ -6900,8 +6900,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInf
     encoder->EncodeUInt32Value(value.groupCount);
     EncodeStructArray(encoder, value.pGroups, value.groupCount);
     encoder->EncodeUInt32Value(value.maxRecursionDepth);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
@@ -6909,16 +6909,16 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.vertexData);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.vertexData);
     encoder->EncodeVkDeviceSizeValue(value.vertexOffset);
     encoder->EncodeUInt32Value(value.vertexCount);
     encoder->EncodeVkDeviceSizeValue(value.vertexStride);
     encoder->EncodeEnumValue(value.vertexFormat);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.indexData);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.indexData);
     encoder->EncodeVkDeviceSizeValue(value.indexOffset);
     encoder->EncodeUInt32Value(value.indexCount);
     encoder->EncodeEnumValue(value.indexType);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.transformData);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.transformData);
     encoder->EncodeVkDeviceSizeValue(value.transformOffset);
 }
 
@@ -6926,7 +6926,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeometryAABBNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.aabbData);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.aabbData);
     encoder->EncodeUInt32Value(value.numAABBs);
     encoder->EncodeUInt32Value(value.stride);
     encoder->EncodeVkDeviceSizeValue(value.offset);
@@ -6970,8 +6970,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindAccelerationStructureMe
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(value.accelerationStructure);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(value.accelerationStructure);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeUInt32Value(value.deviceIndexCount);
     encoder->EncodeUInt32Array(value.pDeviceIndices, value.deviceIndexCount);
@@ -6982,7 +6982,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerat
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.accelerationStructureCount);
-    encoder->EncodeHandleArray<VulkanAccelerationStructureNVWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::AccelerationStructureNVWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureMemoryRequirementsInfoNV& value)
@@ -6990,7 +6990,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureMemory
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureNVWrapper>(value.accelerationStructure);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureNVWrapper>(value.accelerationStructure);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPropertiesNV& value)
@@ -7597,7 +7597,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToImageInfoEXT& v
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -7608,7 +7608,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToMemoryInfoEXT& v
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -7619,9 +7619,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyImageToImageInfoEXT& va
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.srcImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.srcImage);
     encoder->EncodeEnumValue(value.srcImageLayout);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.dstImage);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.dstImage);
     encoder->EncodeEnumValue(value.dstImageLayout);
     encoder->EncodeUInt32Value(value.regionCount);
     EncodeStructArray(encoder, value.pRegions, value.regionCount);
@@ -7631,7 +7631,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkHostImageLayoutTransitionIn
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanImageWrapper>(value.image);
+    encoder->EncodeHandleValue<vulkan_wrappers::ImageWrapper>(value.image);
     encoder->EncodeEnumValue(value.oldLayout);
     encoder->EncodeEnumValue(value.newLayout);
     EncodeStruct(encoder, value.subresourceRange);
@@ -7731,7 +7731,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainPresentFenceInfoEX
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.swapchainCount);
-    encoder->EncodeHandleArray<VulkanFenceWrapper>(value.pFences, value.swapchainCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::FenceWrapper>(value.pFences, value.swapchainCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainPresentModesCreateInfoEXT& value)
@@ -7763,7 +7763,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkReleaseSwapchainImagesInfoE
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSwapchainKHRWrapper>(value.swapchain);
+    encoder->EncodeHandleValue<vulkan_wrappers::SwapchainKHRWrapper>(value.swapchain);
     encoder->EncodeUInt32Value(value.imageIndexCount);
     encoder->EncodeUInt32Array(value.pImageIndices, value.imageIndexCount);
 }
@@ -7807,7 +7807,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGraphicsPipelineShaderGroup
     encoder->EncodeUInt32Value(value.groupCount);
     EncodeStructArray(encoder, value.pGroups, value.groupCount);
     encoder->EncodeUInt32Value(value.pipelineCount);
-    encoder->EncodeHandleArray<VulkanPipelineWrapper>(value.pPipelines, value.pipelineCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::PipelineWrapper>(value.pPipelines, value.pipelineCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindShaderGroupIndirectCommandNV& value)
@@ -7836,7 +7836,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSetStateFlagsIndirectComman
 
 void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsStreamNV& value)
 {
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
 }
 
@@ -7849,7 +7849,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutToken
     encoder->EncodeUInt32Value(value.offset);
     encoder->EncodeUInt32Value(value.vertexBindingUnit);
     encoder->EncodeVkBool32Value(value.vertexDynamicStride);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.pushconstantPipelineLayout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.pushconstantPipelineLayout);
     encoder->EncodeFlagsValue(value.pushconstantShaderStageFlags);
     encoder->EncodeUInt32Value(value.pushconstantOffset);
     encoder->EncodeUInt32Value(value.pushconstantSize);
@@ -7876,17 +7876,17 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsInfoNV& va
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
-    encoder->EncodeHandleValue<VulkanIndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
     encoder->EncodeUInt32Value(value.streamCount);
     EncodeStructArray(encoder, value.pStreams, value.streamCount);
     encoder->EncodeUInt32Value(value.sequencesCount);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.preprocessBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.preprocessBuffer);
     encoder->EncodeVkDeviceSizeValue(value.preprocessOffset);
     encoder->EncodeVkDeviceSizeValue(value.preprocessSize);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.sequencesCountBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.sequencesCountBuffer);
     encoder->EncodeVkDeviceSizeValue(value.sequencesCountOffset);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.sequencesIndexBuffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.sequencesIndexBuffer);
     encoder->EncodeVkDeviceSizeValue(value.sequencesIndexOffset);
 }
 
@@ -7895,8 +7895,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkGeneratedCommandsMemoryRequ
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
-    encoder->EncodeHandleValue<VulkanIndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<vulkan_wrappers::IndirectCommandsLayoutNVWrapper>(value.indirectCommandsLayout);
     encoder->EncodeUInt32Value(value.maxSequencesCount);
 }
 
@@ -8464,7 +8464,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetZirconHandleInfoFU
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -8472,7 +8472,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreZirconHandle
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeUInt32Value(value.zirconHandle);
@@ -8482,7 +8482,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetZirconHandleInf
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanSemaphoreWrapper>(value.semaphore);
+    encoder->EncodeHandleValue<vulkan_wrappers::SemaphoreWrapper>(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -8497,7 +8497,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetRemoteAddressInfoN
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDeviceMemoryWrapper>(value.memory);
+    encoder->EncodeHandleValue<vulkan_wrappers::DeviceMemoryWrapper>(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
@@ -8522,9 +8522,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkFrameBoundaryEXT& value)
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt64Value(value.frameID);
     encoder->EncodeUInt32Value(value.imageCount);
-    encoder->EncodeHandleArray<VulkanImageWrapper>(value.pImages, value.imageCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::ImageWrapper>(value.pImages, value.imageCount);
     encoder->EncodeUInt32Value(value.bufferCount);
-    encoder->EncodeHandleArray<VulkanBufferWrapper>(value.pBuffers, value.bufferCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::BufferWrapper>(value.pBuffers, value.bufferCount);
     encoder->EncodeUInt64Value(value.tagName);
     encoder->EncodeSizeTValue(value.tagSize);
     encoder->EncodeVoidArray(value.pTag, value.tagSize);
@@ -8675,7 +8675,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMicromapBuildInfoEXT& value
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.mode);
-    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.dstMicromap);
+    encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.dstMicromap);
     encoder->EncodeUInt32Value(value.usageCountsCount);
     EncodeStructArray(encoder, value.pUsageCounts, value.usageCountsCount);
     EncodeStructArray2D(encoder, value.ppUsageCounts, value.usageCountsCount, 1);
@@ -8690,7 +8690,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMicromapCreateInfoEXT& valu
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.createFlags);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
     encoder->EncodeEnumValue(value.type);
@@ -8725,7 +8725,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapToMemoryInfoEXT
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.src);
+    encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.src);
     EncodeStruct(encoder, value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
@@ -8735,7 +8735,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToMicromapInfoEXT
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     EncodeStruct(encoder, value.src);
-    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.dst);
+    encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -8743,8 +8743,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMicromapInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.src);
-    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.dst);
+    encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.src);
+    encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -8768,7 +8768,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureTriang
     encoder->EncodeUInt32Value(value.usageCountsCount);
     EncodeStructArray(encoder, value.pUsageCounts, value.usageCountsCount);
     EncodeStructArray2D(encoder, value.ppUsageCounts, value.usageCountsCount, 1);
-    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.micromap);
+    encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.micromap);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkMicromapTriangleEXT& value)
@@ -8811,7 +8811,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureTriang
     encoder->EncodeUInt32Value(value.usageCountsCount);
     EncodeStructArray(encoder, value.pUsageCounts, value.usageCountsCount);
     EncodeStructArray2D(encoder, value.ppUsageCounts, value.usageCountsCount, 1);
-    encoder->EncodeHandleValue<VulkanMicromapEXTWrapper>(value.micromap);
+    encoder->EncodeHandleValue<vulkan_wrappers::MicromapEXTWrapper>(value.micromap);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI& value)
@@ -8918,7 +8918,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetBindingReferen
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanDescriptorSetLayoutWrapper>(value.descriptorSetLayout);
+    encoder->EncodeHandleValue<vulkan_wrappers::DescriptorSetLayoutWrapper>(value.descriptorSetLayout);
     encoder->EncodeUInt32Value(value.binding);
 }
 
@@ -9027,7 +9027,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineIndirectDeviceAddre
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.pipeline);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.pipeline);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkBindPipelineIndirectCommandNV& value)
@@ -9385,7 +9385,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkShaderCreateInfoEXT& value)
     encoder->EncodeVoidArray(value.pCode, value.codeSize);
     encoder->EncodeString(value.pName);
     encoder->EncodeUInt32Value(value.setLayoutCount);
-    encoder->EncodeHandleArray<VulkanDescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::DescriptorSetLayoutWrapper>(value.pSetLayouts, value.setLayoutCount);
     encoder->EncodeUInt32Value(value.pushConstantRangeCount);
     EncodeStructArray(encoder, value.pPushConstantRanges, value.pushConstantRangeCount);
     EncodeStructPtr(encoder, value.pSpecializationInfo);
@@ -9762,8 +9762,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureBuildG
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.mode);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.srcAccelerationStructure);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.dstAccelerationStructure);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.srcAccelerationStructure);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.dstAccelerationStructure);
     encoder->EncodeUInt32Value(value.geometryCount);
     EncodeStructArray(encoder, value.pGeometries, value.geometryCount);
     EncodeStructArray2D(encoder, value.ppGeometries, value.geometryCount, 1);
@@ -9775,7 +9775,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureCreate
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.createFlags);
-    encoder->EncodeHandleValue<VulkanBufferWrapper>(value.buffer);
+    encoder->EncodeHandleValue<vulkan_wrappers::BufferWrapper>(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
     encoder->EncodeEnumValue(value.type);
@@ -9787,7 +9787,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerat
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.accelerationStructureCount);
-    encoder->EncodeHandleArray<VulkanAccelerationStructureKHRWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
+    encoder->EncodeHandleArray<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.pAccelerationStructures, value.accelerationStructureCount);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceAccelerationStructureFeaturesKHR& value)
@@ -9819,7 +9819,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureDevice
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.accelerationStructure);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.accelerationStructure);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureVersionInfoKHR& value)
@@ -9833,7 +9833,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureTo
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.src);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.src);
     EncodeStruct(encoder, value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
@@ -9843,7 +9843,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyMemoryToAccelerationStr
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     EncodeStruct(encoder, value.src);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.dst);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -9851,8 +9851,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkCopyAccelerationStructureIn
 {
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.src);
-    encoder->EncodeHandleValue<VulkanAccelerationStructureKHRWrapper>(value.dst);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.src);
+    encoder->EncodeHandleValue<vulkan_wrappers::AccelerationStructureKHRWrapper>(value.dst);
     encoder->EncodeEnumValue(value.mode);
 }
 
@@ -9898,8 +9898,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInf
     EncodeStructPtr(encoder, value.pLibraryInfo);
     EncodeStructPtr(encoder, value.pLibraryInterface);
     EncodeStructPtr(encoder, value.pDynamicState);
-    encoder->EncodeHandleValue<VulkanPipelineLayoutWrapper>(value.layout);
-    encoder->EncodeHandleValue<VulkanPipelineWrapper>(value.basePipelineHandle);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeHandleValue<vulkan_wrappers::PipelineWrapper>(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -393,7 +393,7 @@ void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent,
 {
     if (value != nullptr)
     {
-        CreateWrappedHandles<VulkanParentWrapper, VulkanCoParentWrapper, VulkanPhysicalDeviceWrapper>(parent, co_parent, value->physicalDevices, value->physicalDeviceCount, get_id);
+        CreateWrappedVulkanHandles<VulkanParentWrapper, VulkanCoParentWrapper, vulkan_wrappers::PhysicalDeviceWrapper>(parent, co_parent, value->physicalDevices, value->physicalDeviceCount, get_id);
     }
 }
 
@@ -402,7 +402,7 @@ void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent,
 {
     if (value != nullptr)
     {
-        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, VulkanDisplayKHRWrapper>(parent, co_parent, &value->display, get_id);
+        CreateWrappedVulkanHandle<VulkanParentWrapper, VulkanCoParentWrapper, vulkan_wrappers::DisplayKHRWrapper>(parent, co_parent, &value->display, get_id);
     }
 }
 
@@ -411,7 +411,7 @@ void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent,
 {
     if (value != nullptr)
     {
-        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, VulkanDisplayKHRWrapper>(parent, co_parent, &value->currentDisplay, get_id);
+        CreateWrappedVulkanHandle<VulkanParentWrapper, VulkanCoParentWrapper, vulkan_wrappers::DisplayKHRWrapper>(parent, co_parent, &value->currentDisplay, get_id);
     }
 }
 
@@ -420,7 +420,7 @@ void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent,
 {
     if (value != nullptr)
     {
-        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, VulkanDisplayModeKHRWrapper>(parent, co_parent, &value->displayMode, get_id);
+        CreateWrappedVulkanHandle<VulkanParentWrapper, VulkanCoParentWrapper, vulkan_wrappers::DisplayModeKHRWrapper>(parent, co_parent, &value->displayMode, get_id);
     }
 }
 

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -388,77 +388,77 @@ VkBaseInStructure* CopyPNextStruct(const VkBaseInStructure* base, HandleUnwrapMe
 
 const void* UnwrapPNextStructHandles(const void* value, HandleUnwrapMemory* unwrap_memory);
 
-template <typename ParentWrapper, typename CoParentWrapper>
-void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, VkPhysicalDeviceGroupProperties* value, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>
+void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, VkPhysicalDeviceGroupProperties* value, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
-        CreateWrappedHandles<ParentWrapper, CoParentWrapper, PhysicalDeviceWrapper>(parent, co_parent, value->physicalDevices, value->physicalDeviceCount, get_id);
+        CreateWrappedHandles<VulkanParentWrapper, VulkanCoParentWrapper, VulkanPhysicalDeviceWrapper>(parent, co_parent, value->physicalDevices, value->physicalDeviceCount, get_id);
     }
 }
 
-template <typename ParentWrapper, typename CoParentWrapper>
-void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, VkDisplayPropertiesKHR* value, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>
+void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, VkDisplayPropertiesKHR* value, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
-        CreateWrappedHandle<ParentWrapper, CoParentWrapper, DisplayKHRWrapper>(parent, co_parent, &value->display, get_id);
+        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, VulkanDisplayKHRWrapper>(parent, co_parent, &value->display, get_id);
     }
 }
 
-template <typename ParentWrapper, typename CoParentWrapper>
-void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, VkDisplayPlanePropertiesKHR* value, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>
+void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, VkDisplayPlanePropertiesKHR* value, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
-        CreateWrappedHandle<ParentWrapper, CoParentWrapper, DisplayKHRWrapper>(parent, co_parent, &value->currentDisplay, get_id);
+        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, VulkanDisplayKHRWrapper>(parent, co_parent, &value->currentDisplay, get_id);
     }
 }
 
-template <typename ParentWrapper, typename CoParentWrapper>
-void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, VkDisplayModePropertiesKHR* value, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>
+void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, VkDisplayModePropertiesKHR* value, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
-        CreateWrappedHandle<ParentWrapper, CoParentWrapper, DisplayModeKHRWrapper>(parent, co_parent, &value->displayMode, get_id);
+        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, VulkanDisplayModeKHRWrapper>(parent, co_parent, &value->displayMode, get_id);
     }
 }
 
-template <typename ParentWrapper, typename CoParentWrapper>
-void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, VkDisplayProperties2KHR* value, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>
+void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, VkDisplayProperties2KHR* value, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
-        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value->displayProperties, get_id);
+        CreateWrappedStructHandles<VulkanParentWrapper, VulkanCoParentWrapper>(parent, co_parent, &value->displayProperties, get_id);
     }
 }
 
-template <typename ParentWrapper, typename CoParentWrapper>
-void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, VkDisplayPlaneProperties2KHR* value, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>
+void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, VkDisplayPlaneProperties2KHR* value, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
-        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value->displayPlaneProperties, get_id);
+        CreateWrappedStructHandles<VulkanParentWrapper, VulkanCoParentWrapper>(parent, co_parent, &value->displayPlaneProperties, get_id);
     }
 }
 
-template <typename ParentWrapper, typename CoParentWrapper>
-void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, VkDisplayModeProperties2KHR* value, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>
+void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, VkDisplayModeProperties2KHR* value, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
-        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value->displayModeProperties, get_id);
+        CreateWrappedStructHandles<VulkanParentWrapper, VulkanCoParentWrapper>(parent, co_parent, &value->displayModeProperties, get_id);
     }
 }
 
-template <typename ParentWrapper, typename CoParentWrapper, typename T>
-void CreateWrappedStructArrayHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, T* value, size_t len, PFN_GetHandleId get_id)
+template <typename VulkanParentWrapper, typename VulkanCoParentWrapper, typename T>
+void CreateWrappedStructArrayHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, T* value, size_t len, PFN_GetHandleId get_id)
 {
     if (value != nullptr)
     {
         for (size_t i = 0; i < len; ++i)
         {
-            CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value[i], get_id);
+            CreateWrappedStructHandles<VulkanParentWrapper, VulkanCoParentWrapper>(parent, co_parent, &value[i], get_id);
         }
     }
 }

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1471,7 +1471,7 @@ class BaseGenerator(OutputGenerator):
 
         if (method_call == 'encoder->EncodeHandleValue' or method_call == 'encoder->EncodeHandleArray' 
             or method_call == 'encoder->EncodeHandlePtr'):
-            method_call += '<{}>'.format(value.base_type[2:] + 'Wrapper')
+            method_call += '<{}>'.format('Vulkan' + value.base_type[2:] + 'Wrapper')
 
         if self.is_output_parameter(value) and omit_output_param:
             args.append(omit_output_param)

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1417,7 +1417,7 @@ class BaseGenerator(OutputGenerator):
                     arg_name, handle_type_name
                 )
             else:
-                arg_name = 'GetWrappedId({}, {})'.format(
+                arg_name = 'GetVulkanWrappedId({}, {})'.format(
                     arg_name, handle_type_name
                 )
 
@@ -1471,7 +1471,7 @@ class BaseGenerator(OutputGenerator):
 
         if (method_call == 'encoder->EncodeHandleValue' or method_call == 'encoder->EncodeHandleArray' 
             or method_call == 'encoder->EncodeHandlePtr'):
-            method_call += '<{}>'.format('Vulkan' + value.base_type[2:] + 'Wrapper')
+            method_call += '<{}>'.format('vulkan_wrappers::' + value.base_type[2:] + 'Wrapper')
 
         if self.is_output_parameter(value) and omit_output_param:
             args.append(omit_output_param)

--- a/framework/generated/vulkan_generators/layer_func_table_generator.py
+++ b/framework/generated/vulkan_generators/layer_func_table_generator.py
@@ -106,7 +106,7 @@ class LayerFuncTableGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         self.newline()
         write(
-            'const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {',
+            'const std::unordered_map<std::string, PFN_vkVoidFunction> vulkan_func_table = {',
             file=self.outFile
         )
 

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -210,13 +210,13 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
         call_setup_expr = []
         object_name = values[0].name
         if self.use_instance_table(name, values[0].base_type):
-            dispatchfunc = 'GetInstanceTable'
+            dispatchfunc = 'GetVulkanInstanceTable'
             if values[0].base_type == 'VkDevice':
                 object_name = 'physical_device'
                 call_setup_expr.append("auto device_wrapper = GetWrapper<DeviceWrapper>({});".format(values[0].name))
                 call_setup_expr.append("auto physical_device = device_wrapper->physical_device->handle;")
         else:
-            dispatchfunc = 'GetDeviceTable'
+            dispatchfunc = 'GetVulkanDeviceTable'
 
         return [call_setup_expr, '{}({})->{}({})'.format(dispatchfunc, object_name, name[2:], arg_list)]
 

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -213,7 +213,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
             dispatchfunc = 'GetVulkanInstanceTable'
             if values[0].base_type == 'VkDevice':
                 object_name = 'physical_device'
-                call_setup_expr.append("auto device_wrapper = GetWrapper<DeviceWrapper>({});".format(values[0].name))
+                call_setup_expr.append("auto device_wrapper = GetWrapper<VulkanDeviceWrapper>({});".format(values[0].name))
                 call_setup_expr.append("auto physical_device = device_wrapper->physical_device->handle;")
         else:
             dispatchfunc = 'GetVulkanDeviceTable'
@@ -478,7 +478,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
 
                 if 'pAllocateInfo->' in length_name:
                     # This is a pool allocation call, which receives one allocate info structure that is shared by all object being allocated.
-                    decl += 'EndPoolCreateApiCallCapture<{}, {}Wrapper, {}>({}, {}, {}, {}, {})'.format(
+                    decl += 'EndPoolCreateApiCallCapture<{}, Vulkan{}Wrapper, {}>({}, {}, {}, {}, {})'.format(
                         parent_handle.base_type, handle.base_type[2:],
                         info_base_type, return_value, parent_handle.name,
                         length_name, handle.name, info_name
@@ -497,27 +497,27 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                         )
 
                         if not member_array_length:
-                            unwrap_handle_def = '[]({}* handle_struct)->{wrapper}Wrapper* {{ return GetWrapper<{wrapper}Wrapper>(handle_struct->{}); }}'.format(
+                            unwrap_handle_def = '[]({}* handle_struct)->Vulkan{wrapper}Wrapper* {{ return GetWrapper<Vulkan{wrapper}Wrapper>(handle_struct->{}); }}'.format(
                                 handle.base_type,
                                 member_handle_name,
                                 wrapper=member_handle_type[2:]
                             )
 
-                        decl += 'EndStructGroupCreateApiCallCapture<{}, {}Wrapper, {}>({}, {}, {}, {}, {})'.format(
+                        decl += 'EndStructGroupCreateApiCallCapture<{}, Vulkan{}Wrapper, {}>({}, {}, {}, {}, {})'.format(
                             parent_handle.base_type, member_handle_type[2:],
                             handle.base_type, return_value, parent_handle.name,
                             length_name, handle.name, unwrap_handle_def
                         )
                     elif self.is_handle(values[1].base_type):
                         second_handle = values[1]
-                        decl += 'EndGroupCreateApiCallCapture<{}, {}, {}Wrapper, {}>({}, {}, {}, {}, {}, {})'.format(
+                        decl += 'EndGroupCreateApiCallCapture<{}, {}, Vulkan{}Wrapper, {}>({}, {}, {}, {}, {}, {})'.format(
                             parent_handle.base_type, second_handle.base_type,
                             handle.base_type[2:], info_base_type, return_value,
                             parent_handle.name, second_handle.name,
                             length_name, handle.name, info_name
                         )
                     else:
-                        decl += 'EndGroupCreateApiCallCapture<{}, void*, {}Wrapper, {}>({}, {}, nullptr, {}, {}, {})'.format(
+                        decl += 'EndGroupCreateApiCallCapture<{}, void*, Vulkan{}Wrapper, {}>({}, {}, nullptr, {}, {}, {})'.format(
                             parent_handle.base_type, handle.base_type[2:],
                             info_base_type, return_value, parent_handle.name,
                             length_name, handle.name, info_name
@@ -528,14 +528,14 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     # TODO: No cases in current Vulkan spec of handle inside non-array output structure
                     raise NotImplementedError
                 elif parent_handle:
-                    decl += 'EndCreateApiCallCapture<{}, {}Wrapper, {}>({}, {}, {}, {})'.format(
+                    decl += 'EndCreateApiCallCapture<{}, Vulkan{}Wrapper, {}>({}, {}, {}, {})'.format(
                         parent_handle.base_type, handle.base_type[2:],
                         info_base_type, return_value, parent_handle.name,
                         handle.name, info_name
                     )
                 else:
                     # Instance creation does not have a parent handle; set the parent handle type to 'void*'.
-                    decl += 'EndCreateApiCallCapture<const void*, {}Wrapper, {}>({}, nullptr, {}, {})'.format(
+                    decl += 'EndCreateApiCallCapture<const void*, Vulkan{}Wrapper, {}>({}, nullptr, {}, {})'.format(
                         handle.base_type[2:], info_base_type, return_value,
                         handle.name, info_name
                     )
@@ -554,11 +554,11 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     handle = values[3]
 
             if handle.is_array:
-                decl += 'EndDestroyApiCallCapture<{}Wrapper>({}, {})'.format(
+                decl += 'EndDestroyApiCallCapture<Vulkan{}Wrapper>({}, {})'.format(
                     handle.base_type[2:], handle.array_length, handle.name
                 )
             else:
-                decl += 'EndDestroyApiCallCapture<{}Wrapper>({})'.format(
+                decl += 'EndDestroyApiCallCapture<Vulkan{}Wrapper>({})'.format(
                     handle.base_type[2:], handle.name
                 )
 
@@ -589,18 +589,18 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
             ):
                 # The VkInstance handle does not have parent, so the 'unused'
                 # values will be provided to the wrapper creation function.
-                parent_type = 'NoParentWrapper'
-                parent_value = 'NoParentWrapper::kHandleValue'
+                parent_type = 'VulkanNoParentWrapper'
+                parent_value = 'VulkanNoParentWrapper::kHandleValue'
                 if self.is_handle(values[0].base_type):
-                    parent_type = values[0].base_type[2:] + 'Wrapper'
+                    parent_type = 'Vulkan' + values[0].base_type[2:] + 'Wrapper'
                     parent_value = values[0].name
 
                 # Some handles have two parent handles, such as swapchain images and display modes,
                 # or command buffers and descriptor sets allocated from pools.
-                co_parent_type = 'NoParentWrapper'
-                co_parent_value = 'NoParentWrapper::kHandleValue'
+                co_parent_type = 'VulkanNoParentWrapper'
+                co_parent_value = 'VulkanNoParentWrapper::kHandleValue'
                 if self.is_handle(values[1].base_type):
-                    co_parent_type = values[1].base_type[2:] + 'Wrapper'
+                    co_parent_type = 'Vulkan' + values[1].base_type[2:] + 'Wrapper'
                     co_parent_value = values[1].name
                 elif values[1].base_type.endswith(
                     'AllocateInfo'
@@ -610,7 +610,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     members = self.structs_with_handles[values[1].base_type]
                     for member in members:
                         if self.is_handle(member.base_type):
-                            co_parent_type = member.base_type[2:] + 'Wrapper'
+                            co_parent_type = 'Vulkan' + member.base_type[2:] + 'Wrapper'
                             co_parent_value = values[
                                 1].name + '->' + member.name
                             break
@@ -624,7 +624,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                             )
                             break
                     if self.is_handle(value.base_type):
-                        expr += indent + 'CreateWrappedHandles<{}, {}, {}Wrapper>({}, {}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
+                        expr += indent + 'CreateWrappedHandles<{}, {}, Vulkan{}Wrapper>({}, {}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
                             parent_type, co_parent_type, value.base_type[2:],
                             parent_value, co_parent_value, value.name,
                             length_name
@@ -639,7 +639,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                         )
                 else:
                     if self.is_handle(value.base_type):
-                        expr += indent + 'CreateWrappedHandle<{}, {}, {}Wrapper>({}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
+                        expr += indent + 'CreateWrappedHandle<{}, {}, Vulkan{}Wrapper>({}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
                             parent_type, co_parent_type, value.base_type[2:],
                             parent_value, co_parent_value, value.name
                         )
@@ -702,11 +702,11 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     handle = values[3]
 
             if handle.is_array:
-                expr += indent + 'DestroyWrappedHandles<{}Wrapper>({}, {});\n'.format(
+                expr += indent + 'DestroyWrappedHandles<Vulkan{}Wrapper>({}, {});\n'.format(
                     handle.base_type[2:], handle.name, handle.array_length
                 )
             else:
-                expr += indent + 'DestroyWrappedHandle<{}Wrapper>({});\n'.format(
+                expr += indent + 'DestroyWrappedHandle<Vulkan{}Wrapper>({});\n'.format(
                     handle.base_type[2:], handle.name
                 )
         return expr

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -213,7 +213,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
             dispatchfunc = 'GetVulkanInstanceTable'
             if values[0].base_type == 'VkDevice':
                 object_name = 'physical_device'
-                call_setup_expr.append("auto device_wrapper = GetWrapper<VulkanDeviceWrapper>({});".format(values[0].name))
+                call_setup_expr.append("auto device_wrapper = GetVulkanWrapper<vulkan_wrappers::DeviceWrapper>({});".format(values[0].name))
                 call_setup_expr.append("auto physical_device = device_wrapper->physical_device->handle;")
         else:
             dispatchfunc = 'GetVulkanDeviceTable'
@@ -478,7 +478,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
 
                 if 'pAllocateInfo->' in length_name:
                     # This is a pool allocation call, which receives one allocate info structure that is shared by all object being allocated.
-                    decl += 'EndPoolCreateApiCallCapture<{}, Vulkan{}Wrapper, {}>({}, {}, {}, {}, {})'.format(
+                    decl += 'EndPoolCreateApiCallCapture<{}, vulkan_wrappers::{}Wrapper, {}>({}, {}, {}, {}, {})'.format(
                         parent_handle.base_type, handle.base_type[2:],
                         info_base_type, return_value, parent_handle.name,
                         length_name, handle.name, info_name
@@ -497,27 +497,27 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                         )
 
                         if not member_array_length:
-                            unwrap_handle_def = '[]({}* handle_struct)->Vulkan{wrapper}Wrapper* {{ return GetWrapper<Vulkan{wrapper}Wrapper>(handle_struct->{}); }}'.format(
+                            unwrap_handle_def = '[]({}* handle_struct)->vulkan_wrappers::{wrapper}Wrapper* {{ return GetVulkanWrapper<vulkan_wrappers::{wrapper}Wrapper>(handle_struct->{}); }}'.format(
                                 handle.base_type,
                                 member_handle_name,
                                 wrapper=member_handle_type[2:]
                             )
 
-                        decl += 'EndStructGroupCreateApiCallCapture<{}, Vulkan{}Wrapper, {}>({}, {}, {}, {}, {})'.format(
+                        decl += 'EndStructGroupCreateApiCallCapture<{}, vulkan_wrappers::{}Wrapper, {}>({}, {}, {}, {}, {})'.format(
                             parent_handle.base_type, member_handle_type[2:],
                             handle.base_type, return_value, parent_handle.name,
                             length_name, handle.name, unwrap_handle_def
                         )
                     elif self.is_handle(values[1].base_type):
                         second_handle = values[1]
-                        decl += 'EndGroupCreateApiCallCapture<{}, {}, Vulkan{}Wrapper, {}>({}, {}, {}, {}, {}, {})'.format(
+                        decl += 'EndGroupCreateApiCallCapture<{}, {}, vulkan_wrappers::{}Wrapper, {}>({}, {}, {}, {}, {}, {})'.format(
                             parent_handle.base_type, second_handle.base_type,
                             handle.base_type[2:], info_base_type, return_value,
                             parent_handle.name, second_handle.name,
                             length_name, handle.name, info_name
                         )
                     else:
-                        decl += 'EndGroupCreateApiCallCapture<{}, void*, Vulkan{}Wrapper, {}>({}, {}, nullptr, {}, {}, {})'.format(
+                        decl += 'EndGroupCreateApiCallCapture<{}, void*, vulkan_wrappers::{}Wrapper, {}>({}, {}, nullptr, {}, {}, {})'.format(
                             parent_handle.base_type, handle.base_type[2:],
                             info_base_type, return_value, parent_handle.name,
                             length_name, handle.name, info_name
@@ -528,14 +528,14 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     # TODO: No cases in current Vulkan spec of handle inside non-array output structure
                     raise NotImplementedError
                 elif parent_handle:
-                    decl += 'EndCreateApiCallCapture<{}, Vulkan{}Wrapper, {}>({}, {}, {}, {})'.format(
+                    decl += 'EndCreateApiCallCapture<{}, vulkan_wrappers::{}Wrapper, {}>({}, {}, {}, {})'.format(
                         parent_handle.base_type, handle.base_type[2:],
                         info_base_type, return_value, parent_handle.name,
                         handle.name, info_name
                     )
                 else:
                     # Instance creation does not have a parent handle; set the parent handle type to 'void*'.
-                    decl += 'EndCreateApiCallCapture<const void*, Vulkan{}Wrapper, {}>({}, nullptr, {}, {})'.format(
+                    decl += 'EndCreateApiCallCapture<const void*, vulkan_wrappers::{}Wrapper, {}>({}, nullptr, {}, {})'.format(
                         handle.base_type[2:], info_base_type, return_value,
                         handle.name, info_name
                     )
@@ -554,11 +554,11 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     handle = values[3]
 
             if handle.is_array:
-                decl += 'EndDestroyApiCallCapture<Vulkan{}Wrapper>({}, {})'.format(
+                decl += 'EndDestroyApiCallCapture<vulkan_wrappers::{}Wrapper>({}, {})'.format(
                     handle.base_type[2:], handle.array_length, handle.name
                 )
             else:
-                decl += 'EndDestroyApiCallCapture<Vulkan{}Wrapper>({})'.format(
+                decl += 'EndDestroyApiCallCapture<vulkan_wrappers::{}Wrapper>({})'.format(
                     handle.base_type[2:], handle.name
                 )
 
@@ -592,7 +592,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                 parent_type = 'VulkanNoParentWrapper'
                 parent_value = 'VulkanNoParentWrapper::kHandleValue'
                 if self.is_handle(values[0].base_type):
-                    parent_type = 'Vulkan' + values[0].base_type[2:] + 'Wrapper'
+                    parent_type = 'vulkan_wrappers::' + values[0].base_type[2:] + 'Wrapper'
                     parent_value = values[0].name
 
                 # Some handles have two parent handles, such as swapchain images and display modes,
@@ -600,7 +600,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                 co_parent_type = 'VulkanNoParentWrapper'
                 co_parent_value = 'VulkanNoParentWrapper::kHandleValue'
                 if self.is_handle(values[1].base_type):
-                    co_parent_type = 'Vulkan' + values[1].base_type[2:] + 'Wrapper'
+                    co_parent_type = 'vulkan_wrappers::' + values[1].base_type[2:] + 'Wrapper'
                     co_parent_value = values[1].name
                 elif values[1].base_type.endswith(
                     'AllocateInfo'
@@ -610,7 +610,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     members = self.structs_with_handles[values[1].base_type]
                     for member in members:
                         if self.is_handle(member.base_type):
-                            co_parent_type = 'Vulkan' + member.base_type[2:] + 'Wrapper'
+                            co_parent_type = 'vulkan_wrappers::' + member.base_type[2:] + 'Wrapper'
                             co_parent_value = values[
                                 1].name + '->' + member.name
                             break
@@ -624,7 +624,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                             )
                             break
                     if self.is_handle(value.base_type):
-                        expr += indent + 'CreateWrappedHandles<{}, {}, Vulkan{}Wrapper>({}, {}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
+                        expr += indent + 'CreateWrappedVulkanHandles<{}, {}, vulkan_wrappers::{}Wrapper>({}, {}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
                             parent_type, co_parent_type, value.base_type[2:],
                             parent_value, co_parent_value, value.name,
                             length_name
@@ -639,7 +639,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                         )
                 else:
                     if self.is_handle(value.base_type):
-                        expr += indent + 'CreateWrappedHandle<{}, {}, Vulkan{}Wrapper>({}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
+                        expr += indent + 'CreateWrappedVulkanHandle<{}, {}, vulkan_wrappers::{}Wrapper>({}, {}, {}, VulkanCaptureManager::GetUniqueId);\n'.format(
                             parent_type, co_parent_type, value.base_type[2:],
                             parent_value, co_parent_value, value.name
                         )
@@ -702,11 +702,11 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                     handle = values[3]
 
             if handle.is_array:
-                expr += indent + 'DestroyWrappedHandles<Vulkan{}Wrapper>({}, {});\n'.format(
+                expr += indent + 'DestroyWrappedVulkanHandles<vulkan_wrappers::{}Wrapper>({}, {});\n'.format(
                     handle.base_type[2:], handle.name, handle.array_length
                 )
             else:
-                expr += indent + 'DestroyWrappedHandle<Vulkan{}Wrapper>({});\n'.format(
+                expr += indent + 'DestroyWrappedVulkanHandle<vulkan_wrappers::{}Wrapper>({});\n'.format(
                     handle.base_type[2:], handle.name
                 )
         return expr

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
@@ -114,7 +114,7 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                     if (handles):
                         # Generate a function to build a list of handle types and values.
                         cmddef = '\n'
-                        cmddef += 'void Track{}Handles(VulkanCommandBufferWrapper* wrapper, {})\n'.format(
+                        cmddef += 'void Track{}Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, {})\n'.format(
                             cmd[2:], self.get_arg_list(handles)
                         )
                         cmddef += '{\n'
@@ -215,8 +215,8 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                 value_name = '{}[{}]'.format(value_name, index_name)
             elif value.is_pointer:
                 value_name = '(*{})'.format(value_name)
-            body += indent + 'if({} != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::{}].insert(GetWrappedId<{}>({}));\n'.format(
-                value_name, type_enum_value, 'Vulkan' + value.base_type[2:] + 'Wrapper' ,value_name
+            body += indent + 'if({} != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::{}].insert(GetVulkanWrappedId<{}>({}));\n'.format(
+                value_name, type_enum_value, 'vulkan_wrappers::' + value.base_type[2:] + 'Wrapper' ,value_name
             )
 
         elif self.is_struct(

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
@@ -114,7 +114,7 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                     if (handles):
                         # Generate a function to build a list of handle types and values.
                         cmddef = '\n'
-                        cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {})\n'.format(
+                        cmddef += 'void Track{}Handles(VulkanCommandBufferWrapper* wrapper, {})\n'.format(
                             cmd[2:], self.get_arg_list(handles)
                         )
                         cmddef += '{\n'
@@ -216,7 +216,7 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
             elif value.is_pointer:
                 value_name = '(*{})'.format(value_name)
             body += indent + 'if({} != VK_NULL_HANDLE) wrapper->command_handles[CommandHandleType::{}].insert(GetWrappedId<{}>({}));\n'.format(
-                value_name, type_enum_value, value.base_type[2:] + 'Wrapper' ,value_name
+                value_name, type_enum_value, 'Vulkan' + value.base_type[2:] + 'Wrapper' ,value_name
             )
 
         elif self.is_struct(

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
@@ -127,7 +127,7 @@ class VulkanCommandBufferUtilHeaderGenerator(BaseGenerator):
                 if (handles):
                     # Generate a function to build a list of handle types and values.
                     cmddef = '\n'
-                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {});'.format(
+                    cmddef += 'void Track{}Handles(VulkanCommandBufferWrapper* wrapper, {});'.format(
                         cmd[2:], self.get_arg_list(handles)
                     )
                     write(cmddef, file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
@@ -127,7 +127,7 @@ class VulkanCommandBufferUtilHeaderGenerator(BaseGenerator):
                 if (handles):
                     # Generate a function to build a list of handle types and values.
                     cmddef = '\n'
-                    cmddef += 'void Track{}Handles(VulkanCommandBufferWrapper* wrapper, {});'.format(
+                    cmddef += 'void Track{}Handles(vulkan_wrappers::CommandBufferWrapper* wrapper, {});'.format(
                         cmd[2:], self.get_arg_list(handles)
                     )
                     write(cmddef, file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
@@ -136,7 +136,7 @@ class VulkanDispatchTableGenerator(BaseGenerator):
         self.generate_no_op_funcs()
         self.newline()
 
-        write('struct LayerTable', file=self.outFile)
+        write('struct VulkanLayerTable', file=self.outFile)
         write('{', file=self.outFile)
         write(
             '    PFN_vkCreateInstance CreateInstance{ nullptr };',
@@ -219,7 +219,7 @@ class VulkanDispatchTableGenerator(BaseGenerator):
 
     def generate_instance_cmd_table(self):
         """Generate instance dispatch table structure."""
-        write('struct InstanceTable', file=self.outFile)
+        write('struct VulkanInstanceTable', file=self.outFile)
         write('{', file=self.outFile)
 
         for name in self.instance_cmd_names:
@@ -232,7 +232,7 @@ class VulkanDispatchTableGenerator(BaseGenerator):
 
     def generate_device_cmd_table(self):
         """Generate device dispatch table structure."""
-        write('struct DeviceTable', file=self.outFile)
+        write('struct VulkanDeviceTable', file=self.outFile)
         write('{', file=self.outFile)
 
         for name in self.device_cmd_names:
@@ -260,7 +260,7 @@ class VulkanDispatchTableGenerator(BaseGenerator):
     def generate_load_instance_table_func(self):
         """Generate function to set the instance table's functions with a getprocaddress routine."""
         write(
-            'static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, InstanceTable* table)',
+            'static void LoadVulkanInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, VulkanInstanceTable* table)',
             file=self.outFile
         )
         write('{', file=self.outFile)
@@ -283,7 +283,7 @@ class VulkanDispatchTableGenerator(BaseGenerator):
     def generate_load_device_table_func(self):
         """Generate function to set the device table's functions with a getprocaddress routine."""
         write(
-            'static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, DeviceTable* table)',
+            'static void LoadVulkanDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, VulkanDeviceTable* table)',
             file=self.outFile
         )
         write('{', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
@@ -106,7 +106,7 @@ class VulkanStateTableHeaderGenerator(BaseGenerator):
             if vkhandle_name in self.DUPLICATE_HANDLE_TYPES:
                 continue
             handle_name = vkhandle_name[2:]
-            handle_wrapper = handle_name + 'Wrapper'
+            handle_wrapper = 'Vulkan' + handle_name + 'Wrapper'
             handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'
             insert_code += '    bool InsertWrapper(format::HandleId id, {0}* wrapper) {{ return InsertEntry(id, wrapper, {1}); }}\n'.format(handle_wrapper, handle_map)
             remove_code += '    bool RemoveWrapper(const {0}* wrapper) {{ return RemoveEntry(wrapper, {1}); }}\n'.format(handle_wrapper, handle_map)

--- a/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
@@ -106,22 +106,23 @@ class VulkanStateTableHeaderGenerator(BaseGenerator):
             if vkhandle_name in self.DUPLICATE_HANDLE_TYPES:
                 continue
             handle_name = vkhandle_name[2:]
-            handle_wrapper = 'Vulkan' + handle_name + 'Wrapper'
+            handle_wrapper_func = handle_name + 'Wrapper'
+            handle_wrapper_type = 'vulkan_wrappers::' + handle_name + 'Wrapper'
             handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'
-            insert_code += '    bool InsertWrapper(format::HandleId id, {0}* wrapper) {{ return InsertEntry(id, wrapper, {1}); }}\n'.format(handle_wrapper, handle_map)
-            remove_code += '    bool RemoveWrapper(const {0}* wrapper) {{ return RemoveEntry(wrapper, {1}); }}\n'.format(handle_wrapper, handle_map)
-            visit_code += '    void VisitWrappers(std::function<void({0}*)> visitor) const {{ for (auto entry : {1}) {{ visitor(entry.second); }} }}\n'.format(handle_wrapper, handle_map)
-            get_code += '    {0}* Get{0}(format::HandleId id) {{ return GetWrapper<{0}>(id, {1}); }}\n'.format(handle_wrapper, handle_map)
-            const_get_code += '    const {0}* Get{0}(format::HandleId id) const {{ return GetWrapper<{0}>(id, {1}); }}\n'.format(handle_wrapper, handle_map)
-            map_code += '    std::map<format::HandleId, {0}*> {1};\n'.format(handle_wrapper, handle_map)
-            vk_insert_code += '    bool InsertWrapper({0}* wrapper) {{ return InsertEntry(wrapper->handle, wrapper, {1}); }}\n'.format(handle_wrapper, handle_map)
-            vk_remove_code += '    bool RemoveWrapper(const {}* wrapper) {{\n'.format(handle_wrapper)
+            insert_code += '    bool InsertWrapper(format::HandleId id, {0}* wrapper) {{ return InsertEntry(id, wrapper, {1}); }}\n'.format(handle_wrapper_type, handle_map)
+            remove_code += '    bool RemoveWrapper(const {0}* wrapper) {{ return RemoveEntry(wrapper, {1}); }}\n'.format(handle_wrapper_type, handle_map)
+            visit_code += '    void VisitWrappers(std::function<void({0}*)> visitor) const {{ for (auto entry : {1}) {{ visitor(entry.second); }} }}\n'.format(handle_wrapper_type, handle_map)
+            get_code += '    {0}* Get{1}(format::HandleId id) {{ return GetWrapper<{0}>(id, {2}); }}\n'.format(handle_wrapper_type, handle_wrapper_func, handle_map)
+            const_get_code += '    const {0}* Get{1}(format::HandleId id) const {{ return GetWrapper<{0}>(id, {2}); }}\n'.format(handle_wrapper_type, handle_wrapper_func, handle_map)
+            map_code += '    std::map<format::HandleId, {0}*> {1};\n'.format(handle_wrapper_type, handle_map)
+            vk_insert_code += '    bool InsertWrapper({0}* wrapper) {{ return InsertEntry(wrapper->handle, wrapper, {1}); }}\n'.format(handle_wrapper_type, handle_map)
+            vk_remove_code += '    bool RemoveWrapper(const {}* wrapper) {{\n'.format(handle_wrapper_type)
             vk_remove_code += '         if (wrapper == nullptr) return false;\n'
             vk_remove_code += '         return RemoveEntry(wrapper->handle, {});\n'.format(handle_map)
             vk_remove_code += '    }\n'
-            vk_get_code += 'template<> inline {0}* VulkanStateHandleTable::GetWrapper<{0}>({1} handle) {{ return VulkanStateTableBase::GetWrapper(handle, {2}); }}\n'.format(handle_wrapper, vkhandle_name, handle_map)
-            vk_const_get_code += 'template<> inline const {0}* VulkanStateHandleTable::GetWrapper<{0}>({1} handle) const {{ return VulkanStateTableBase::GetWrapper(handle, {2}); }}\n'.format(handle_wrapper, vkhandle_name, handle_map)
-            vk_map_code += '    std::unordered_map<{0}, {1}*> {2};\n'.format(vkhandle_name, handle_wrapper, handle_map)
+            vk_get_code += 'template<> inline {0}* VulkanStateHandleTable::GetWrapper<{0}>({1} handle) {{ return VulkanStateTableBase::GetWrapper(handle, {2}); }}\n'.format(handle_wrapper_type, vkhandle_name, handle_map)
+            vk_const_get_code += 'template<> inline const {0}* VulkanStateHandleTable::GetWrapper<{0}>({1} handle) const {{ return VulkanStateTableBase::GetWrapper(handle, {2}); }}\n'.format(handle_wrapper_type, vkhandle_name, handle_map)
+            vk_map_code += '    std::unordered_map<{0}, {1}*> {2};\n'.format(vkhandle_name, handle_wrapper_type, handle_map)
 
         self.newline()
         code = 'class VulkanStateTable : VulkanStateTableBase\n'

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
@@ -290,16 +290,16 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
                         )
                 else:
                     if member.is_array:
-                        body += '        CreateWrappedHandles<VulkanParentWrapper, VulkanCoParentWrapper, Vulkan{}Wrapper>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedVulkanHandles<VulkanParentWrapper, VulkanCoParentWrapper, vulkan_wrappers::{}Wrapper>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
                             member.base_type[2:], member.name,
                             member.array_length
                         )
                     elif member.is_pointer:
-                        body += '        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, Vulkan{}Wrapper>(parent, co_parent, value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedVulkanHandle<VulkanParentWrapper, VulkanCoParentWrapper, vulkan_wrappers::{}Wrapper>(parent, co_parent, value->{}, get_id);\n'.format(
                             member.base_type[2:], member.name
                         )
                     else:
-                        body += '        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, Vulkan{}Wrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedVulkanHandle<VulkanParentWrapper, VulkanCoParentWrapper, vulkan_wrappers::{}Wrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
                             member.base_type[2:], member.name
                         )
 

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
@@ -115,11 +115,11 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
         self.newline()
         self.generate_create_wrapper_funcs()
         write(
-            'template <typename ParentWrapper, typename CoParentWrapper, typename T>',
+            'template <typename VulkanParentWrapper, typename VulkanCoParentWrapper, typename T>',
             file=self.outFile
         )
         write(
-            'void CreateWrappedStructArrayHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, T* value, size_t len, PFN_GetHandleId get_id)',
+            'void CreateWrappedStructArrayHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, T* value, size_t len, PFN_GetHandleId get_id)',
             file=self.outFile
         )
         write('{', file=self.outFile)
@@ -128,7 +128,7 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
         write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
         write('        {', file=self.outFile)
         write(
-            '            CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value[i], get_id);',
+            '            CreateWrappedStructHandles<VulkanParentWrapper, VulkanCoParentWrapper>(parent, co_parent, &value[i], get_id);',
             file=self.outFile
         )
         write('        }', file=self.outFile)
@@ -265,8 +265,8 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
     def generate_create_wrapper_funcs(self):
         """Generates functions that wrap struct handle members."""
         for struct in self.output_structs:
-            body = 'template <typename ParentWrapper, typename CoParentWrapper>\n'
-            body += 'void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, {}* value, PFN_GetHandleId get_id)\n'.format(
+            body = 'template <typename VulkanParentWrapper, typename VulkanCoParentWrapper>\n'
+            body += 'void CreateWrappedStructHandles(typename VulkanParentWrapper::HandleType parent, typename VulkanCoParentWrapper::HandleType co_parent, {}* value, PFN_GetHandleId get_id)\n'.format(
                 struct
             )
             body += '{\n'
@@ -277,29 +277,29 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
             for member in members:
                 if self.is_struct(member.base_type):
                     if member.is_array:
-                        body += '        CreateWrappedStructArrayHandles<ParentWrapper, CoParentWrapper, {}>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedStructArrayHandles<VulkanParentWrapper, VulkanCoParentWrapper, {}>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
                             member.base_type, member.name, member.array_length
                         )
                     elif member.is_pointer:
-                        body += '        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedStructHandles<VulkanParentWrapper, VulkanCoParentWrapper>(parent, co_parent, value->{}, get_id);\n'.format(
                             member.name
                         )
                     else:
-                        body += '        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedStructHandles<VulkanParentWrapper, VulkanCoParentWrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
                             member.name
                         )
                 else:
                     if member.is_array:
-                        body += '        CreateWrappedHandles<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedHandles<VulkanParentWrapper, VulkanCoParentWrapper, Vulkan{}Wrapper>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
                             member.base_type[2:], member.name,
                             member.array_length
                         )
                     elif member.is_pointer:
-                        body += '        CreateWrappedHandle<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, Vulkan{}Wrapper>(parent, co_parent, value->{}, get_id);\n'.format(
                             member.base_type[2:], member.name
                         )
                     else:
-                        body += '        CreateWrappedHandle<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
+                        body += '        CreateWrappedHandle<VulkanParentWrapper, VulkanCoParentWrapper, Vulkan{}Wrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
                             member.base_type[2:], member.name
                         )
 

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -31,10 +31,10 @@ GFXRECON_BEGIN_NAMESPACE(graphics)
 // Requires Vulkan version >= 1.1 or VK_KHR_get_physical_device_properties2
 // feature_struct sType must be set, pNext must be nullptr
 template <typename T>
-static void GetPhysicalDeviceFeatures(uint32_t                     instance_api_version,
-                                      const encode::InstanceTable* instance_table,
-                                      const VkPhysicalDevice       physical_device,
-                                      T&                           feature_struct)
+static void GetPhysicalDeviceFeatures(uint32_t                           instance_api_version,
+                                      const encode::VulkanInstanceTable* instance_table,
+                                      const VkPhysicalDevice             physical_device,
+                                      T&                                 feature_struct)
 {
     assert((feature_struct.sType != 0) && (feature_struct.pNext == nullptr));
     feature_struct.pNext = nullptr;
@@ -54,10 +54,10 @@ static void GetPhysicalDeviceFeatures(uint32_t                     instance_api_
 // Requires Vulkan version >= 1.1 or VK_KHR_get_physical_device_properties2
 // properties_struct sType must be set, pNext must be nullptr
 template <typename T>
-static void GetPhysicalDeviceProperties(uint32_t                     instance_api_version,
-                                        const encode::InstanceTable* instance_table,
-                                        const VkPhysicalDevice       physical_device,
-                                        T&                           properties_struct)
+static void GetPhysicalDeviceProperties(uint32_t                           instance_api_version,
+                                        const encode::VulkanInstanceTable* instance_table,
+                                        const VkPhysicalDevice             physical_device,
+                                        T&                                 properties_struct)
 {
     assert((properties_struct.sType != 0) && (properties_struct.pNext == nullptr));
     properties_struct.pNext = nullptr;
@@ -74,10 +74,10 @@ static void GetPhysicalDeviceProperties(uint32_t                     instance_ap
 }
 
 template <typename T>
-VkBool32 VulkanDeviceUtil::EnableRequiredBufferDeviceAddressFeatures(uint32_t                     instance_api_version,
-                                                                     const encode::InstanceTable* instance_table,
-                                                                     const VkPhysicalDevice       physical_device,
-                                                                     T*                           feature_struct)
+VkBool32 VulkanDeviceUtil::EnableRequiredBufferDeviceAddressFeatures(uint32_t instance_api_version,
+                                                                     const encode::VulkanInstanceTable* instance_table,
+                                                                     const VkPhysicalDevice             physical_device,
+                                                                     T*                                 feature_struct)
 {
     // Type must be feature struct type that contains bufferDeviceAddress and bufferDeviceAddressCaptureReplay
     static_assert(std::is_same<T, VkPhysicalDeviceVulkan12Features>::value ||
@@ -115,10 +115,10 @@ VkBool32 VulkanDeviceUtil::EnableRequiredBufferDeviceAddressFeatures(uint32_t   
 }
 
 VulkanDevicePropertyFeatureInfo
-VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                     instance_api_version,
-                                                       const encode::InstanceTable* instance_table,
-                                                       const VkPhysicalDevice       physical_device,
-                                                       const VkDeviceCreateInfo*    create_info)
+VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                           instance_api_version,
+                                                       const encode::VulkanInstanceTable* instance_table,
+                                                       const VkPhysicalDevice             physical_device,
+                                                       const VkDeviceCreateInfo*          create_info)
 {
     VulkanDevicePropertyFeatureInfo result;
     VkBaseOutStructure*             current_struct = reinterpret_cast<const VkBaseOutStructure*>(create_info)->pNext;

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -47,20 +47,21 @@ class VulkanDeviceUtil
     // Incoming create_info data will be modified. Use RestoreModifiedPhysicalDeviceFeatures
     // to revert incoming data to original values (e.g., prior to writing to the capture file).
     // feature_* property_* members store the state of the features/properties after this call.
-    VulkanDevicePropertyFeatureInfo EnableRequiredPhysicalDeviceFeatures(uint32_t instance_api_version,
-                                                                         const encode::InstanceTable* instance_table,
-                                                                         const VkPhysicalDevice       physical_device,
-                                                                         const VkDeviceCreateInfo*    create_info);
+    VulkanDevicePropertyFeatureInfo
+    EnableRequiredPhysicalDeviceFeatures(uint32_t                           instance_api_version,
+                                         const encode::VulkanInstanceTable* instance_table,
+                                         const VkPhysicalDevice             physical_device,
+                                         const VkDeviceCreateInfo*          create_info);
 
     // Restore any incoming values that were modified in EnableRequiredPhysicalDeviceFeatures
     void RestoreModifiedPhysicalDeviceFeatures();
 
   private:
     template <typename T>
-    VkBool32 EnableRequiredBufferDeviceAddressFeatures(uint32_t                     instance_api_version,
-                                                       const encode::InstanceTable* instance_table,
-                                                       const VkPhysicalDevice       physical_device,
-                                                       T*                           feature_struct);
+    VkBool32 EnableRequiredBufferDeviceAddressFeatures(uint32_t                           instance_api_version,
+                                                       const encode::VulkanInstanceTable* instance_table,
+                                                       const VkPhysicalDevice             physical_device,
+                                                       T*                                 feature_struct);
 
   private:
     // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -45,7 +45,7 @@ class VulkanResourcesUtil
     VulkanResourcesUtil() = delete;
 
     VulkanResourcesUtil(VkDevice                                device,
-                        const encode::DeviceTable&              device_table,
+                        const encode::VulkanDeviceTable&        device_table,
                         const VkPhysicalDeviceMemoryProperties& memory_properties) :
         device_(device),
         device_table_(device_table), memory_properties_(memory_properties), queue_family_index_(UINT32_MAX),
@@ -243,7 +243,7 @@ class VulkanResourcesUtil
     };
 
     VkDevice                                device_;
-    const encode::DeviceTable&              device_table_;
+    const encode::VulkanDeviceTable&        device_table_;
     const VkPhysicalDeviceMemoryProperties& memory_properties_;
     uint32_t                                queue_family_index_;
     VkCommandPool                           command_pool_;

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -279,7 +279,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
     // Check for implementation in the next level
     if (instance != VK_NULL_HANDLE)
     {
-        auto table = encode::GetInstanceTable(instance);
+        auto table = encode::GetVulkanInstanceTable(instance);
         if ((table != nullptr) && (table->GetInstanceProcAddr != nullptr))
         {
             has_implementation = (table->GetInstanceProcAddr(instance, pName) != nullptr);
@@ -304,9 +304,9 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
     // the instance handle is null and we can't determine if it is available from the next level.
     if (has_implementation || (instance == VK_NULL_HANDLE))
     {
-        const auto entry = func_table.find(pName);
+        const auto entry = vulkan_func_table.find(pName);
 
-        if (entry != func_table.end())
+        if (entry != vulkan_func_table.end())
         {
             result = entry->second;
         }
@@ -335,7 +335,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, cons
         bool has_implementation = false;
 
         // Check for implementation in the next level
-        auto table = encode::GetDeviceTable(device);
+        auto table = encode::GetVulkanDeviceTable(device);
         if ((table != nullptr) && (table->GetDeviceProcAddr != nullptr))
         {
             has_implementation = (table->GetDeviceProcAddr(device, pName) != nullptr);
@@ -358,8 +358,8 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, cons
         // Only intercept the requested function if there is an implementation available
         if (has_implementation)
         {
-            const auto entry = func_table.find(pName);
-            if (entry != func_table.end())
+            const auto entry = vulkan_func_table.find(pName);
+            if (entry != vulkan_func_table.end())
             {
                 result = entry->second;
             }
@@ -432,7 +432,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevi
         // provided extensions.
         // In order to screen out unsupported extensions, we always query the chain
         // twice, and remove those that are present from the count.
-        auto     instance_table            = encode::GetInstanceTable(physicalDevice);
+        auto     instance_table            = encode::GetVulkanInstanceTable(physicalDevice);
         uint32_t downstream_property_count = 0;
 
         result = instance_table->EnumerateDeviceExtensionProperties(


### PR DESCRIPTION
Since GFXR started as a Vulkan project, many of the items have no clear identifier in their name.  But now that GFXR supports DX and may support other APIs in the future, we should clarify Vulkan-specific items.