### PR TITLE
Add missed "is_fullscreen" value in DxgiSwapchainInfo

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -2473,6 +2473,7 @@ void Dx12ReplayConsumerBase::SetSwapchainInfo(DxObjectInfo* info,
             swapchain_info->window  = window;
             swapchain_info->hwnd_id = hwnd_id;
             swapchain_info->image_ids.resize(image_count);
+            swapchain_info->is_fullscreen = !windowed;
             std::fill(swapchain_info->image_ids.begin(), swapchain_info->image_ids.end(), format::kNullHandleId);
 
             // Get the ID3D12CommandQueue from the IUnknown queue object.


### PR DESCRIPTION
**Problem**
Some trim traces won't go through the replayer or optimizer successfully. If an application is in full-screen state, it should be set back to windowed state at the end of the replay. Currently, for some trim traces, the debug layer also complains with "DXGI ERROR: IDXGISwapChain::Release: Swapchain Released while fullscreen. Switch it to the windowed state first. [ MISCELLANEOUS ERROR https://github.amd.com/Developer-Solutions/gfxreconstruct/pull/66: ]."

**Solution** 
Fixed this bug in Dx12ReplayConsumerBase::SetSwapchainInfo() function. 

**Result**
The error can be avoided. 