### PR TITLE
Fix VK_EXT_frame_boundary extension activation

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2477,31 +2477,31 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
             }
         }
 
+        if (options_.offscreen_swapchain_frame_boundary)
+        {
+            bool frameBoundaryExtensionFound = false;
+
+            for (const char* extensionName : filtered_extensions)
+            {
+                if (gfxrecon::util::platform::StringCompareNoCase(extensionName, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
+                {
+                    frameBoundaryExtensionFound = true;
+                    break;
+                }
+            }
+
+            if (!frameBoundaryExtensionFound)
+            {
+                filtered_extensions.push_back(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
+            }
+        }
+
         modified_create_info.enabledExtensionCount   = static_cast<uint32_t>(filtered_extensions.size());
         modified_create_info.ppEnabledExtensionNames = filtered_extensions.data();
     }
     else
     {
         GFXRECON_LOG_WARNING("The vkCreateInstance parameter pCreateInfo is NULL.");
-    }
-
-    if (options_.offscreen_swapchain_frame_boundary)
-    {
-        bool frameBoundaryExtensionFound = false;
-
-        for (const char* extensionName : filtered_extensions)
-        {
-            if (gfxrecon::util::platform::StringCompareNoCase(extensionName, VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME))
-            {
-                frameBoundaryExtensionFound = true;
-                break;
-            }
-        }
-
-        if (!frameBoundaryExtensionFound)
-        {
-            filtered_extensions.push_back(VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME);
-        }
     }
 
     // Disable layers; any layers needed for replay should be enabled for the replay app with the VK_INSTANCE_LAYERS


### PR DESCRIPTION
In `OverrideCreateInstance`, the extension name was added to `filtered_extensions` AFTER the vector size was saved in the create info structure.

This is obviously an error (it still worked because this option is mainly used when capturing the replay, and that the capture layer ALWAYS support the extension even if not activated).

The bug was introduced by #1354 