### PR TITLE
clean up tocpp platform

### DIFF
--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -1342,11 +1342,12 @@ static void BuildInstanceCreateInfo(std::ostream&                       out,
     if (struct_info->enabledExtensionCount > 0)
     {
         GfxToCppPlatform cur_platform = consumer.GetPlatform();
-        std::string cur_extension_name = kTargetPlatforms.at(cur_platform).wsiSurfaceExtName;
+        std::string      cur_extension_name = kTargetPlatforms.at(cur_platform).wsiSurfaceExtName;
 
         // Generate a map of WSI extensions to the new extension for this current platform
         std::map<std::string, std::string> replace_map;
-        for(const auto& [platform_enum, info] : kTargetPlatforms) {
+        for (const auto& [platform_enum, info] : kTargetPlatforms)
+        {
             replace_map[info.wsiSurfaceExtName] = cur_extension_name;
         }
 

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -42,7 +42,6 @@ struct GfxToCppPlatformMap
 
 const GfxToCppPlatform GetGfxToCppPlatform(const std::string& format_str);
 const std::string      GfxToCppPlatformToString(GfxToCppPlatform platform);
-bool                   GfxToCppPlatformIsValid(const GfxToCppPlatform& platform);
 
 VulkanCppConsumerBase::VulkanCppConsumerBase() :
     frame_file_(nullptr), global_file_(nullptr), main_file_(nullptr), pfn_loader_()
@@ -95,15 +94,6 @@ void VulkanCppConsumerBase::WriteMainHeader()
         case GfxToCppPlatform::PLATFORM_XCB:
             fprintf(main_file_, "%s", sXcbOutputMainStart);
             break;
-        case GfxToCppPlatform::PLATFORM_COUNT:
-        default:
-        {
-            fprintf(main_file_,
-                    "// Nothing to generate for unknown platform: %s\n",
-                    GfxToCppPlatformToString(platform_).c_str());
-            assert(false);
-            break;
-        }
     }
 }
 
@@ -120,15 +110,6 @@ void VulkanCppConsumerBase::WriteMainFooter()
         case GfxToCppPlatform::PLATFORM_XCB:
             fprintf(main_file_, "%s", sXcbOutputMainEnd);
             break;
-        case GfxToCppPlatform::PLATFORM_COUNT:
-        default:
-        {
-            fprintf(main_file_,
-                    "// Nothing to generate for unknown platform: %s\n",
-                    GfxToCppPlatformToString(platform_).c_str());
-            assert(false);
-            break;
-        }
     }
 }
 
@@ -165,15 +146,6 @@ bool VulkanCppConsumerBase::WriteGlobalHeaderFile()
                         sXcbOutputHeader,
                         sCommonOutputHeaderFunctions);
                 break;
-            case GfxToCppPlatform::PLATFORM_COUNT:
-            default:
-            {
-                fprintf(header_file,
-                        "// Nothing to generate for unknown platform: %s\n",
-                        GfxToCppPlatformToString(platform_).c_str());
-                assert(false);
-                break;
-            }
         }
 
         PrintToFile(header_file, "extern %s;\n", GfxToCppVariable::GenerateStringVec(variable_data_));
@@ -216,13 +188,6 @@ void VulkanCppConsumerBase::PrintOutCMakeFile()
             case GfxToCppPlatform::PLATFORM_XCB:
                 fprintf(cmake_file, "%s", sXcbCMakeFile);
                 break;
-            case GfxToCppPlatform::PLATFORM_COUNT:
-            default:
-            {
-                fprintf(stderr, "Error while opening file: %s\n", filename.c_str());
-                assert(false);
-                break;
-            }
         }
         util::platform::FileClose(cmake_file);
     }
@@ -307,14 +272,6 @@ void VulkanCppConsumerBase::PrintOutGlobalVar()
                 fputs(formatted_output_override_method, global_file);
                 delete[] formatted_output_override_method;
                 break;
-            }
-            case GfxToCppPlatform::PLATFORM_COUNT:
-            default:
-            {
-                fprintf(main_file_,
-                        "// Nothing to generate for unknown platform: %s\n",
-                        GfxToCppPlatformToString(platform_).c_str());
-                return;
             }
         }
 
@@ -403,16 +360,13 @@ bool VulkanCppConsumerBase::Initialize(const std::string&      filename,
         int32_t result = util::platform::FileOpen(&main_file_, filename.c_str(), "w");
         if (result == 0)
         {
-            if (platform != GfxToCppPlatform::PLATFORM_COUNT)
-            {
-                filename_    = filename;
-                platform_    = platform;
-                out_dir_     = outputDir;
-                bin_out_dir_ = "bin";
-                spv_out_dir_ = "spv";
-                src_out_dir_ = "src";
-                success      = true;
-            }
+            filename_    = filename;
+            platform_    = platform;
+            out_dir_     = outputDir;
+            bin_out_dir_ = "bin";
+            spv_out_dir_ = "spv";
+            src_out_dir_ = "src";
+            success      = true;
 
             WriteMainHeader();
         }
@@ -1387,17 +1341,13 @@ static void BuildInstanceCreateInfo(std::ostream&                       out,
     std::string              enabled_extensions_names = "NULL";
     if (struct_info->enabledExtensionCount > 0)
     {
-        // The array should be setup so that the enum could be used as an index.  Just verify it
         GfxToCppPlatform cur_platform = consumer.GetPlatform();
-        assert(kValidTargetPlatforms[static_cast<uint32_t>(cur_platform)].platformEnum == cur_platform);
-        std::string cur_extension_name = kValidTargetPlatforms[static_cast<uint32_t>(cur_platform)].wsiSurfaceExtName;
+        std::string cur_extension_name = kTargetPlatforms.at(cur_platform).wsiSurfaceExtName;
 
         // Generate a map of WSI extensions to the new extension for this current platform
         std::map<std::string, std::string> replace_map;
-        const uint32_t max_count = static_cast<uint32_t>(sizeof(kValidTargetPlatforms) / sizeof(PlatformTargets));
-        for (uint32_t ii = 0; ii < max_count; ++ii)
-        {
-            replace_map[kValidTargetPlatforms[ii].wsiSurfaceExtName] = cur_extension_name;
+        for(const auto& [platform_enum, info] : kTargetPlatforms) {
+            replace_map[info.wsiSurfaceExtName] = cur_extension_name;
         }
 
         extension_names =
@@ -1750,12 +1700,6 @@ void VulkanCppConsumerBase::GenerateSurfaceCreation(GfxToCppPlatform        plat
             create_info_struct_var_name = GenerateStruct_VkXcbSurfaceCreateInfoKHR(
                 stream_create_info, &xcb_struct_info, &decoded_xcb_info, *this);
             surface_create_func_call = "vkCreateXcbSurfaceKHR";
-            break;
-        }
-        case GfxToCppPlatform::PLATFORM_COUNT:
-        default:
-        {
-            assert(false);
             break;
         }
     }
@@ -2952,33 +2896,12 @@ std::string VulkanCppConsumerBase::BuildValue(const StdVideoAV1FrameRestorationT
 
 const GfxToCppPlatform getGfxToCppPlatform(const std::string& format_str)
 {
-    for (const PlatformTargets& entry : kValidTargetPlatforms)
-    {
-        if (format_str == entry.platformName)
-        {
-            return entry.platformEnum;
-        }
-    }
-
-    return GfxToCppPlatform::PLATFORM_COUNT;
+    return kTargetPlatformByName.at(format_str);
 }
 
 const std::string GfxToCppPlatformToString(GfxToCppPlatform platform)
 {
-    for (const PlatformTargets& entry : kValidTargetPlatforms)
-    {
-        if (platform == entry.platformEnum)
-        {
-            return entry.platformName;
-        }
-    }
-
-    return "<unknown platform>";
-}
-
-bool GfxToCppPlatformIsValid(const GfxToCppPlatform& platform)
-{
-    return platform != GfxToCppPlatform::PLATFORM_COUNT;
+    return kTargetPlatforms.at(platform).platformName;
 }
 
 std::string VulkanCppConsumerBase::AddStruct(const std::stringstream& content, const std::string& var_namePrefix)

--- a/framework/decode/vulkan_cpp_loader_generator.cpp
+++ b/framework/decode/vulkan_cpp_loader_generator.cpp
@@ -59,23 +59,24 @@ void VulkanCppLoaderGenerator::WriteOutLoaderGenerator(const std::string& outDir
             case GfxToCppPlatform::PLATFORM_ANDROID:
                 fprintf(pfn_src_file, "#define VK_USE_PLATFORM_ANDROID_KHR\n");
                 break;
-            case GfxToCppPlatform::PLATFORM_MACOS:
-                fprintf(pfn_src_file, "#define VK_USE_PLATFORM_METAL_EXT\n");
-                break;
-            case GfxToCppPlatform::PLATFORM_WAYLAND:
-                fprintf(pfn_src_file, "#define VK_USE_PLATFORM_WAYLAND_KHR\n");
-                break;
             case GfxToCppPlatform::PLATFORM_WIN32:
                 fprintf(pfn_src_file, "#define VK_USE_PLATFORM_WIN32_KHR\n");
                 break;
             case GfxToCppPlatform::PLATFORM_XCB:
                 fprintf(pfn_src_file, "#define VK_USE_PLATFORM_XCB_KHR\n");
                 break;
+#if 0
+            // TODO: implement these platforms
+            case GfxToCppPlatform::PLATFORM_MACOS:
+                fprintf(pfn_src_file, "#define VK_USE_PLATFORM_METAL_EXT\n");
+                break;
+            case GfxToCppPlatform::PLATFORM_WAYLAND:
+                fprintf(pfn_src_file, "#define VK_USE_PLATFORM_WAYLAND_KHR\n");
+                break;
             case GfxToCppPlatform::PLATFORM_XLIB:
                 fprintf(pfn_src_file, "#define VK_USE_PLATFORM_XLIB_KHR\n");
                 break;
-            default:
-                break;
+#endif
         }
 
         fprintf(pfn_src_file, "#include \"loader.h\"\n\n");

--- a/framework/decode/vulkan_cpp_utilities.h
+++ b/framework/decode/vulkan_cpp_utilities.h
@@ -43,25 +43,25 @@ enum class GfxToCppPlatform
 
 struct PlatformTargetInfo
 {
-    std::string                               platformName;
-    std::string                               wsiSurfaceExtName;
+    std::string platformName;
+    std::string wsiSurfaceExtName;
 };
 
-const std::map<gfxrecon::decode::GfxToCppPlatform,PlatformTargetInfo> kTargetPlatforms = {
-    { GfxToCppPlatform::PLATFORM_ANDROID, {"android", VK_KHR_ANDROID_SURFACE_EXTENSION_NAME } },
+const std::map<gfxrecon::decode::GfxToCppPlatform, PlatformTargetInfo> kTargetPlatforms = {
+    { GfxToCppPlatform::PLATFORM_ANDROID, { "android", VK_KHR_ANDROID_SURFACE_EXTENSION_NAME } },
     //{ GfxToCppPlatform::PLATFORM_MACOS, {"macos", VK_EXT_METAL_SURFACE_EXTENSION_NAME } },
     //{ GfxToCppPlatform::PLATFORM_WAYLAND, {"wayland", VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME } },
-    { GfxToCppPlatform::PLATFORM_WIN32, {"win32", VK_KHR_WIN32_SURFACE_EXTENSION_NAME } },
-    { GfxToCppPlatform::PLATFORM_XCB, {"xcb", VK_KHR_XCB_SURFACE_EXTENSION_NAME } },
+    { GfxToCppPlatform::PLATFORM_WIN32, { "win32", VK_KHR_WIN32_SURFACE_EXTENSION_NAME } },
+    { GfxToCppPlatform::PLATFORM_XCB, { "xcb", VK_KHR_XCB_SURFACE_EXTENSION_NAME } },
     //{ GfxToCppPlatform::PLATFORM_XLIB, {"xlib", VK_KHR_XLIB_SURFACE_EXTENSION_NAME } },
 };
 
-const std::map<std::string,GfxToCppPlatform> kTargetPlatformByName = {
-    { "android", GfxToCppPlatform::PLATFORM_ANDROID},
+const std::map<std::string, GfxToCppPlatform> kTargetPlatformByName = {
+    { "android", GfxToCppPlatform::PLATFORM_ANDROID },
     //{ "macos", GfxToCppPlatform::PLATFORM_MACOS},
     //{ "wayland", GfxToCppPlatform::PLATFORM_WAYLAND},
-    { "win32", GfxToCppPlatform::PLATFORM_WIN32},
-    { "xcb", GfxToCppPlatform::PLATFORM_XCB},
+    { "win32", GfxToCppPlatform::PLATFORM_WIN32 },
+    { "xcb", GfxToCppPlatform::PLATFORM_XCB },
     //{ "xlib", GfxToCppPlatform::PLATFORM_XLIB},
 };
 

--- a/framework/decode/vulkan_cpp_utilities.h
+++ b/framework/decode/vulkan_cpp_utilities.h
@@ -34,28 +34,35 @@ const uint32_t MAX_FRAME_CAPACITY = 1000;
 enum class GfxToCppPlatform
 {
     PLATFORM_ANDROID,
-    PLATFORM_MACOS,
-    PLATFORM_WAYLAND,
+    // PLATFORM_MACOS,
+    // PLATFORM_WAYLAND,
     PLATFORM_WIN32,
     PLATFORM_XCB,
-    PLATFORM_XLIB,
-    PLATFORM_COUNT // MUST BE LAST
+    // PLATFORM_XLIB,
 };
 
-struct PlatformTargets
+struct PlatformTargetInfo
 {
-    gfxrecon::decode::GfxToCppPlatform platformEnum;
-    char                               platformName[32];
-    char                               wsiSurfaceExtName[32];
+    std::string                               platformName;
+    std::string                               wsiSurfaceExtName;
 };
 
-const PlatformTargets kValidTargetPlatforms[] = {
-    { GfxToCppPlatform::PLATFORM_ANDROID, "android", VK_KHR_ANDROID_SURFACE_EXTENSION_NAME },
-    { GfxToCppPlatform::PLATFORM_MACOS, "macos", VK_EXT_METAL_SURFACE_EXTENSION_NAME },
-    { GfxToCppPlatform::PLATFORM_WAYLAND, "wayland", VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME },
-    { GfxToCppPlatform::PLATFORM_WIN32, "win32", VK_KHR_WIN32_SURFACE_EXTENSION_NAME },
-    { GfxToCppPlatform::PLATFORM_XCB, "xcb", VK_KHR_XCB_SURFACE_EXTENSION_NAME },
-    { GfxToCppPlatform::PLATFORM_XLIB, "xlib", VK_KHR_XLIB_SURFACE_EXTENSION_NAME }
+const std::map<gfxrecon::decode::GfxToCppPlatform,PlatformTargetInfo> kTargetPlatforms = {
+    { GfxToCppPlatform::PLATFORM_ANDROID, {"android", VK_KHR_ANDROID_SURFACE_EXTENSION_NAME } },
+    //{ GfxToCppPlatform::PLATFORM_MACOS, {"macos", VK_EXT_METAL_SURFACE_EXTENSION_NAME } },
+    //{ GfxToCppPlatform::PLATFORM_WAYLAND, {"wayland", VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME } },
+    { GfxToCppPlatform::PLATFORM_WIN32, {"win32", VK_KHR_WIN32_SURFACE_EXTENSION_NAME } },
+    { GfxToCppPlatform::PLATFORM_XCB, {"xcb", VK_KHR_XCB_SURFACE_EXTENSION_NAME } },
+    //{ GfxToCppPlatform::PLATFORM_XLIB, {"xlib", VK_KHR_XLIB_SURFACE_EXTENSION_NAME } },
+};
+
+const std::map<std::string,GfxToCppPlatform> kTargetPlatformByName = {
+    { "android", GfxToCppPlatform::PLATFORM_ANDROID},
+    //{ "macos", GfxToCppPlatform::PLATFORM_MACOS},
+    //{ "wayland", GfxToCppPlatform::PLATFORM_WAYLAND},
+    { "win32", GfxToCppPlatform::PLATFORM_WIN32},
+    { "xcb", GfxToCppPlatform::PLATFORM_XCB},
+    //{ "xlib", GfxToCppPlatform::PLATFORM_XLIB},
 };
 
 struct GfxToCppVariable

--- a/tools/tocpp/main.cpp
+++ b/tools/tocpp/main.cpp
@@ -223,7 +223,7 @@ static gfxrecon::decode::GfxToCppPlatform GetCppTargetPlatform(const gfxrecon::u
 
         return gfxrecon::decode::kTargetPlatformByName.at(platform);
     }
-    else 
+    else
     {
         GFXRECON_LOG_INFO("Platform not specified, defaulting to XCB.");
         return gfxrecon::decode::GfxToCppPlatform::PLATFORM_XCB;

--- a/tools/tocpp/main.cpp
+++ b/tools/tocpp/main.cpp
@@ -63,13 +63,7 @@ CommandLineArgument g_target_argument = { true,
                                           "-t",
                                           "--target",
                                           "<platform>\t\t\t",
-#if defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__) || defined(__MINGW64__)
-                                          " (Defaults to win32)",
-#elif defined(__APPLE__)
-                                          " (Defaults to macos)",
-#else
                                           " (Defaults to xcb)",
-#endif
                                           "The type of platform for the intended target Vulkan source.\n"
                                           "\t\t\t\t\t\t\t  Available Platforms:\n"
                                           "\t\t\t\t\t\t\t     android    Generate for Android.\n"
@@ -212,7 +206,6 @@ static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::Ar
 
 static gfxrecon::decode::GfxToCppPlatform GetCppTargetPlatform(const gfxrecon::util::ArgumentParser& arg_parser)
 {
-    gfxrecon::decode::GfxToCppPlatform platform_enum = gfxrecon::decode::GfxToCppPlatform::PLATFORM_COUNT;
     std::string                        platform;
 
     // We can just check for the short argument because the argument parser will assign even
@@ -221,40 +214,20 @@ static gfxrecon::decode::GfxToCppPlatform GetCppTargetPlatform(const gfxrecon::u
     {
         platform = arg_parser.GetArgumentValue(g_target_argument.short_option);
         printf("Platform set to %s\n", platform.c_str());
-    }
 
-    if (platform.length() > 0)
-    {
-        // Choose the appropriate platform
-        const uint32_t max_count = static_cast<uint32_t>(sizeof(gfxrecon::decode::kValidTargetPlatforms) /
-                                                         sizeof(gfxrecon::decode::PlatformTargets));
-        for (uint32_t ii = 0; ii < max_count; ++ii)
+        if (gfxrecon::decode::kTargetPlatformByName.count(platform) == 0)
         {
-            if (gfxrecon::util::platform::StringCompare(gfxrecon::decode::kValidTargetPlatforms[ii].platformName,
-                                                        platform.c_str()) == 0)
-            {
-                platform_enum = gfxrecon::decode::kValidTargetPlatforms[ii].platformEnum;
-                break;
-            }
+            GFXRECON_LOG_ERROR("The specified platform \"%s\" is not known!", platform.c_str());
+            exit(1);
         }
-    }
 
-    // If no platform was found, default to a given one for the platform
-    if (platform_enum >= gfxrecon::decode::GfxToCppPlatform::PLATFORM_COUNT)
+        return gfxrecon::decode::kTargetPlatformByName.at(platform);
+    }
+    else 
     {
-#if defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__) || defined(__MINGW64__)
-        GFXRECON_LOG_INFO("Target platform is not specified or invalid, fall back to 'win32'.");
-        platform_enum = gfxrecon::decode::GfxToCppPlatform::PLATFORM_WIN32;
-#elif defined(__APPLE__)
-        GFXRECON_LOG_INFO("Target platform is not specified or invalid, fall back to 'macos'.");
-        platform_enum = gfxrecon::decode::GfxToCppPlatform::PLATFORM_MACOS;
-#else
-        GFXRECON_LOG_INFO("Target platform is not specified or invalid, fall back to 'xcb'.");
-        platform_enum = gfxrecon::decode::GfxToCppPlatform::PLATFORM_XCB;
-#endif
+        GFXRECON_LOG_INFO("Platform not specified, defaulting to XCB.");
+        return gfxrecon::decode::GfxToCppPlatform::PLATFORM_XCB;
     }
-
-    return platform_enum;
 }
 
 static bool OutputDirectoryIsValid(std::string& out_dir)


### PR DESCRIPTION
Clean up code regarding tocpp platform

* remove a COUNT enum that is unnecessary
* use map to and from platform enums
* remove unsupported or partial platforms WIN32, XLIB, MACOS
* make XCB the default since WIN32, XLIB, and MACOS are unsupported and Android requires the template file dir