### PR TITLE
Update log msg for empty accel struct vert data

### DIFF
--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -349,7 +349,11 @@ void GetAccelerationStructureInputsBufferEntries(D3D12_BUILD_RAYTRACING_ACCELERA
                 }
                 else
                 {
-                    GFXRECON_LOG_ERROR("D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC's vertex data has 0 byte size.");
+                    GFXRECON_LOG_DEBUG("D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC's vertex data has 0 byte size. "
+                                       "(vertex count: %u, vertex stride in bytes: %" PRIu64
+                                       "). Skipping acceleration structure input data for this desc.",
+                                       triangles_desc.VertexCount,
+                                       triangles_desc.VertexBuffer.StrideInBytes);
                 }
             }
             else if (geom_desc->Type == D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS)


### PR DESCRIPTION
Reduce the severity from "error" to "debug" and indicate that no input entry data is saved for the geometry desc.