### PR TITLE
Fix OverrideCreateInstance and OverrideCreateDevice

### DIFF
--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -146,6 +146,21 @@ bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, 
     return false;
 }
 
+bool IsSupportedExtension(const std::vector<const char*>& extensions_names, const char* extension)
+{
+    assert(extension != nullptr);
+
+    for (const auto name : extensions_names)
+    {
+        if (util::platform::StringCompare(name, extension) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool IsIgnorableExtension(const char* extension)
 {
     return kIgnorableExtensions.count(extension) > 0;

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -46,6 +46,7 @@ VkResult GetDeviceExtensions(VkPhysicalDevice                         physical_d
                              std::vector<VkExtensionProperties>*      properties);
 
 bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, const char* extension);
+bool IsSupportedExtension(const std::vector<const char*>& extensions_names, const char* extension);
 
 void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
                                  std::vector<const char*>*                 extensions);


### PR DESCRIPTION
These two functions have become very hard to read and modify, and full of small edge-case bugs because of this. With this commit I propose to clean a little these two functions, by:
- Removing some unnecessary nested if that should belong in a validation layer, and eventually replacing them with an assert
- Uniformizing variable names between these two functions as they perform a lot of very similar operations
- Adding VK_EXT_frame_boundary as a DEVICE extension, and not an instance extension, which it has never been (and also doing so before setting the modified_extensions in the create info, not after)
- Adding fake support for VK_EXT_frame_boundary
- Removing unsupported device features should only happen when `--remove-unsupported` option is set
