### PR TITLE
Resolving user message conflict between Optimizer and Replay

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -3844,15 +3844,24 @@ void Dx12ReplayConsumerBase::ApplyFillMemoryResourceValueCommand(uint64_t       
 
 void Dx12ReplayConsumerBase::PostReplay()
 {
-    if (ContainsDxrWorkload() || ContainsEiWorkload())
+    if (ContainsOptFillMem() == false)
     {
-        if (ContainsOptFillMem() == false)
+        bool rv_mappings_performed = false;
+        if (GetResourceValueMapper() != nullptr)
+        {
+            rv_mappings_performed = GetResourceValueMapper()->PerformedRvMapping();
+        }
+        if ((ContainsDxrWorkload() || ContainsEiWorkload()) && rv_mappings_performed)
         {
             GFXRECON_LOG_INFO_ONCE(
                 "This capture contains DXR and/or ExecuteIndirect workloads, but has not been optimized.");
-            GFXRECON_LOG_INFO_ONCE(
-                "Use gfxrecon-optimize to obtain an optimized capture with improved playback performance.");
         }
+        else
+        {
+            GFXRECON_LOG_INFO_ONCE("This capture has not been optimized.")
+        }
+        GFXRECON_LOG_INFO_ONCE(
+            "Use gfxrecon-optimize to obtain an optimized capture with improved playback performance.");
     }
 }
 

--- a/framework/decode/dx12_resource_value_mapper.cpp
+++ b/framework/decode/dx12_resource_value_mapper.cpp
@@ -1349,6 +1349,18 @@ void Dx12ResourceValueMapper::MapResources(const ResourceValueInfoMap&          
             bool write_back = false;
             for (const auto& value_info : value_infos)
             {
+                if (performed_rv_mapping_ == false)
+                {
+                    if ((value_info.type == ResourceValueType::kGpuVirtualAddress) ||
+                        (value_info.type == ResourceValueType::kGpuDescriptorHandle) ||
+                        (value_info.type == ResourceValueType::kShaderIdentifier) ||
+                        (value_info.type == ResourceValueType::kIndirectArgumentDispatchRays))
+                    {
+                        // condition for DXR/EI optimization really being done in gfxrecon-optimize
+                        performed_rv_mapping_ = true;
+                    }
+                }
+
                 if (MapValue(value_info,
                              temp_resource_data,
                              resource_object_info->capture_id,

--- a/framework/decode/dx12_resource_value_mapper.h
+++ b/framework/decode/dx12_resource_value_mapper.h
@@ -148,6 +148,8 @@ class Dx12ResourceValueMapper
 
     void RemoveGpuDescriptorHeap(uint64_t capture_gpu_start);
 
+    bool PerformedRvMapping() { return performed_rv_mapping_; };
+
   private:
     struct ProcessResourceMappingsArgs
     {
@@ -224,6 +226,7 @@ class Dx12ResourceValueMapper
 
     std::unique_ptr<graphics::Dx12ResourceDataUtil> resource_data_util_;
     std::unique_ptr<Dx12ResourceValueTracker>       resource_value_tracker_;
+    bool                                            performed_rv_mapping_{ false };
 
     const graphics::Dx12GpuVaMap&    gpu_va_map_;
     const decode::Dx12DescriptorMap& descriptor_map_;


### PR DESCRIPTION
**Problem**
The replay checks only DXR and EI related calls without checking whether there are resources involved for outputting the DXR/EI optimization console message. gfxrecon-optimize on the other hand tracks the related resources in order to show proper console messages. 

**Solution**
In the replay, we add the checking on whether gfxrecon-optimize will obtain a list of tracked resources without really tracking the DXR/EI related resources. We won't mention "DXR/EI workloads" in the console INFO message if there are only DXR/EI calls with no related resources involved. 

**Result**
Tested the change with applications with DXR and without DXR. The console  message will depend on whether DXR/EI optimization will really happen with gfxrecon-optimize. The message will be either "This capture has not been optimized" or "This capture contains DXR and/or ExecuteIndirect workloads, but has not been optimized."   