### PR TITLE
Track AHB buffers with userfaultfd

### DIFF
--- a/framework/util/page_guard_manager_uffd.cpp
+++ b/framework/util/page_guard_manager_uffd.cpp
@@ -546,6 +546,22 @@ bool PageGuardManager::UffdRegisterMemory(const void* address, size_t length)
 {
     assert(uffd_fd_ != -1);
 
+    if (!length || (length % system_page_size_))
+    {
+        GFXRECON_LOG_ERROR(
+            "Attempting to register a memory region with a non page aligned length (%zu) (system's page size %zu).",
+            length,
+            system_page_size_);
+    }
+
+    if (!util::platform::IsAddressAligned(address, system_page_size_))
+    {
+        GFXRECON_LOG_ERROR("Attempting to register a memory region with non page aligned base address (%zu) (system's "
+                           "page size: %zu).",
+                           address,
+                           system_page_size_);
+    }
+
     struct uffdio_register uffdio_register;
     uffdio_register.range.start = GFXRECON_PTR_TO_UINT64(address);
     uffdio_register.range.len   = length;

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -558,6 +558,12 @@ inline size_t GetAlignedSize(size_t size, size_t align_to)
     return size;
 }
 
+inline bool IsAddressAligned(const void* address, size_t alignment)
+{
+    uintptr_t uint_addr = reinterpret_cast<uintptr_t>(address);
+    return (uint_addr % alignment) == 0;
+}
+
 inline LibraryHandle OpenLibrary(const std::vector<std::string>& name_list)
 {
     for (const auto& name : name_list)


### PR DESCRIPTION
Although original page guard memory tracking method (mprotect) is tracking imported AHB buffers, the initial userfaultfd commit did not add support for them.

With this commit imported AHB buffer are now tracked with the userfaultfd method too.

However there is a caveat:
Userfaultfd requires that both base address and length of registered memory regions to be paged aligned. Since in the case of imported buffers we cannot back the regions with a shadow memory (we cannot intercept their allocation and return a shadow pointer instead of the original one), when registering the buffer to uffd we need to page align both base address and length. This can effectively extend the tracking to memory that is not inside the actual buffer and can lead to undefined behavior. A warning message is printed if such a case is detected.