### PR TITLE
Dont call vkWaitForFences with fenceCount 0

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3180,7 +3180,10 @@ VkResult VulkanReplayConsumerBase::OverrideWaitForFences(PFN_vkWaitForFences    
     {
         // Ensure that wait for fences waits until the fences have been signaled (or error occurs) by changing the
         // timeout to UINT64_MAX.
-        result = func(device, modified_fence_count, modified_fences, waitAll, std::numeric_limits<uint64_t>::max());
+        if (modified_fence_count > 0)
+        {
+            result = func(device, modified_fence_count, modified_fences, waitAll, std::numeric_limits<uint64_t>::max());
+        }
     }
     else
     {


### PR DESCRIPTION
If a shadow fence is already signaled then it is erased from modified_fences, and if modified_fence_count is 0 the call to vkWaitForFences should be skipped because that is not valid according to VUID-vkWaitForFences-fenceCount-arrayLength