### PR TITLE
Write CreateHardwareBufferCmd even without AHB data

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1677,7 +1677,6 @@ bool VulkanCaptureManager::ProcessReferenceToAndroidHardwareBuffer(VkDevice devi
 
         if ((desc.usage & AHARDWAREBUFFER_USAGE_CPU_READ_MASK) != 0)
         {
-
             void* data   = nullptr;
             int   result = -1;
 
@@ -1708,6 +1707,15 @@ bool VulkanCaptureManager::ProcessReferenceToAndroidHardwareBuffer(VkDevice devi
             }
 #endif
 
+            // Only store buffer IDs and reference count if a creation command is written to the capture file.
+            format::HandleId memory_id = GetUniqueId();
+
+            HardwareBufferInfo& ahb_info = hardware_buffers_[hardware_buffer];
+            ahb_info.memory_id           = memory_id;
+            ahb_info.reference_count     = 0;
+
+            WriteCreateHardwareBufferCmd(memory_id, hardware_buffer, plane_info);
+
             if (result != 0)
             {
                 result =
@@ -1725,14 +1733,6 @@ bool VulkanCaptureManager::ProcessReferenceToAndroidHardwareBuffer(VkDevice devi
                     device_unwrapped, hardware_buffer, &properties);
                 if (result == VK_SUCCESS)
                 {
-                    // Only store buffer IDs and reference count if a creation command is written to the capture file.
-                    format::HandleId memory_id = GetUniqueId();
-
-                    HardwareBufferInfo& ahb_info = hardware_buffers_[hardware_buffer];
-                    ahb_info.memory_id           = memory_id;
-                    ahb_info.reference_count     = 0;
-
-                    WriteCreateHardwareBufferCmd(memory_id, hardware_buffer, plane_info);
                     if (data != nullptr)
                     {
                         WriteFillMemoryCmd(memory_id, 0, properties.allocationSize, data);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1323,7 +1323,7 @@ class VulkanCaptureManager : public CaptureManager
     const VkImportAndroidHardwareBufferInfoANDROID*
     FindAllocateMemoryExtensions(const VkMemoryAllocateInfo* allocate_info);
 
-    bool ProcessReferenceToAndroidHardwareBuffer(VkDevice device, AHardwareBuffer* hardware_buffer);
+    void ProcessReferenceToAndroidHardwareBuffer(VkDevice device, AHardwareBuffer* hardware_buffer);
     void ProcessImportAndroidHardwareBuffer(VkDevice device, VkDeviceMemory memory, AHardwareBuffer* hardware_buffer);
     void ReleaseAndroidHardwareBuffer(AHardwareBuffer* hardware_buffer);
     bool CheckBindAlignment(VkDeviceSize memoryOffset);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1230,8 +1230,10 @@ void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
     }
 #endif
 
+    // Write CreateHardwareBufferCmd with or without the AHB payload
     WriteCreateHardwareBufferCmd(memory_id, hardware_buffer, plane_info);
 
+    // If AHardwareBuffer_lockPlanes failed (or is not available) try AHardwareBuffer_lock
     if (result != 0)
     {
         result = AHardwareBuffer_lock(hardware_buffer, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &data);
@@ -1239,13 +1241,17 @@ void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
 
     if (result == 0)
     {
-        if (data != nullptr)
+        if (data == nullptr)
         {
-            WriteFillMemoryCmd(memory_id, 0, allocation_size, data);
+            GFXRECON_LOG_WARNING("AHardwareBuffer_lock returned nullptr for data pointer");
+
+            // Dump zeros for AHB payload.
+            std::vector<uint8_t> zeros(allocation_size, 0);
+            WriteFillMemoryCmd(memory_id, 0, zeros.size(), zeros.data());
         }
         else
         {
-            GFXRECON_LOG_WARNING("AHardwareBuffer_lock returned nullptr for data pointer");
+            WriteFillMemoryCmd(memory_id, 0, allocation_size, data);
         }
 
         result = AHardwareBuffer_unlock(hardware_buffer, nullptr);
@@ -1257,6 +1263,10 @@ void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
     else
     {
         GFXRECON_LOG_ERROR("AHardwareBuffer_lock failed: hardware buffer data will be omitted from the capture file");
+
+        // Dump zeros for AHB payload.
+        std::vector<uint8_t> zeros(allocation_size, 0);
+        WriteFillMemoryCmd(memory_id, 0, zeros.size(), zeros.data());
     }
 #else
     GFXRECON_UNREFERENCED_PARAMETER(memory_id);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1230,6 +1230,8 @@ void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
     }
 #endif
 
+    WriteCreateHardwareBufferCmd(memory_id, hardware_buffer, plane_info);
+
     if (result != 0)
     {
         result = AHardwareBuffer_lock(hardware_buffer, AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, -1, nullptr, &data);
@@ -1237,8 +1239,6 @@ void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
 
     if (result == 0)
     {
-        WriteCreateHardwareBufferCmd(memory_id, hardware_buffer, plane_info);
-
         if (data != nullptr)
         {
             WriteFillMemoryCmd(memory_id, 0, allocation_size, data);


### PR DESCRIPTION
CreateHardwareBufferCmd will now be written to the capture file even when the AHB payload cannot be retrieve at capture time.