### PR TITLE
Alpha channel is discarded in screenshots before writing to disk #1455

### DIFF
--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -58,14 +58,14 @@ inline void WriteImageFile(const std::string&     filename,
             GFXRECON_LOG_ERROR("Screenshot format invalid!  Expected BMP or PNG, falling back to BMP.");
             // Intentional fall-through
         case util::ScreenshotFormat::kBmp:
-            if (!util::imagewriter::WriteBmpImage(filename + ".bmp", width, height, size, data))
+            if (!util::imagewriter::WriteBmpImageNoAlpha(filename + ".bmp", width, height, size, data))
             {
                 GFXRECON_LOG_ERROR("Screenshot could not be created: failed to write BMP file %s", filename.c_str());
             }
             break;
 #ifdef GFXRECON_ENABLE_PNG_SCREENSHOT
         case util::ScreenshotFormat::kPng:
-            if (!util::imagewriter::WritePngImage(filename + ".png", width, height, size, data))
+            if (!util::imagewriter::WritePngImageNoAlpha(filename + ".png", width, height, size, data))
             {
                 GFXRECON_LOG_ERROR("Screenshot could not be created: failed to write PNG file %s", filename.c_str());
             }

--- a/framework/graphics/dx12_util.cpp
+++ b/framework/graphics/dx12_util.cpp
@@ -114,12 +114,13 @@ void TakeScreenshot(std::unique_ptr<graphics::DX12ImageRenderer>& image_renderer
                                         "Screenshot format invalid!  Expected BMP or PNG, falling back to BMP.");
                                     // Intentional fall-through
                                 case gfxrecon::util::ScreenshotFormat::kBmp:
-                                    if (!util::imagewriter::WriteBmpImage(filename + ".bmp",
-                                                                          static_cast<unsigned int>(fb_desc.Width),
-                                                                          static_cast<unsigned int>(fb_desc.Height),
-                                                                          datasize,
-                                                                          std::data(captured_image.data),
-                                                                          static_cast<unsigned int>(pitch)))
+                                    if (!util::imagewriter::WriteBmpImageNoAlpha(
+                                            filename + ".bmp",
+                                            static_cast<unsigned int>(fb_desc.Width),
+                                            static_cast<unsigned int>(fb_desc.Height),
+                                            datasize,
+                                            std::data(captured_image.data),
+                                            static_cast<unsigned int>(pitch)))
                                     {
                                         GFXRECON_LOG_ERROR(
                                             "Screenshot could not be created: failed to write BMP file %s",
@@ -127,12 +128,13 @@ void TakeScreenshot(std::unique_ptr<graphics::DX12ImageRenderer>& image_renderer
                                     }
                                     break;
                                 case gfxrecon::util::ScreenshotFormat::kPng:
-                                    if (!util::imagewriter::WritePngImage(filename + ".png",
-                                                                          static_cast<unsigned int>(fb_desc.Width),
-                                                                          static_cast<unsigned int>(fb_desc.Height),
-                                                                          datasize,
-                                                                          std::data(captured_image.data),
-                                                                          static_cast<unsigned int>(pitch)))
+                                    if (!util::imagewriter::WritePngImageNoAlpha(
+                                            filename + ".png",
+                                            static_cast<unsigned int>(fb_desc.Width),
+                                            static_cast<unsigned int>(fb_desc.Height),
+                                            datasize,
+                                            std::data(captured_image.data),
+                                            static_cast<unsigned int>(pitch)))
                                     {
                                         GFXRECON_LOG_ERROR(
                                             "Screenshot could not be created: failed to write PNG file %s",
@@ -1102,9 +1104,10 @@ bool IsDepthStencilFormat(const DXGI_FORMAT format)
         case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
         case DXGI_FORMAT_D24_UNORM_S8_UINT:
         case DXGI_FORMAT_D16_UNORM:
-        return true;
+            return true;
 
-        // Assumed colour formats listed explicitly so a new format added to the enum would trigger a compiler warning to update this:
+        // Assumed colour formats listed explicitly so a new format added to the enum would trigger a compiler warning
+        // to update this:
         case DXGI_FORMAT_R32G32B32A32_TYPELESS:
         case DXGI_FORMAT_R32G32B32A32_FLOAT:
         case DXGI_FORMAT_R32G32B32A32_UINT:
@@ -1221,7 +1224,7 @@ bool IsDepthStencilFormat(const DXGI_FORMAT format)
         case DXGI_FORMAT_V408:
         case DXGI_FORMAT_SAMPLER_FEEDBACK_MIN_MIP_OPAQUE:
         case DXGI_FORMAT_SAMPLER_FEEDBACK_MIP_REGION_USED_OPAQUE:
-        return false;
+            return false;
     }
     // Log the error if a new format shows up but on balance of probabilities assume it isn't depth:
     GFXRECON_LOG_ERROR("Unknown DXGI_FORMAT value: %u.", static_cast<unsigned>(format));

--- a/framework/util/image_writer.cpp
+++ b/framework/util/image_writer.cpp
@@ -149,7 +149,7 @@ bool WriteBmpImageNoAlpha(
     // BMP image data requires row to be a multiple of 4 bytes
     // Round-up row size to next multiple of 4, if it isn't already
     const uint32_t rowSizeNoAlpha = ((width * kImageBppNoAlpha) + 3u) & (~0x03);
-    uint32_t bmp_image_size = height * rowSizeNoAlpha;
+    uint32_t       bmp_image_size = height * rowSizeNoAlpha;
     if (bmp_image_size <= data_size)
     {
         FILE*   file   = nullptr;
@@ -216,7 +216,7 @@ bool WritePngImage(
     bool success = false;
 
 #ifdef GFXRECON_ENABLE_PNG_SCREENSHOT
-    uint32_t row_pitch = pitch == 0 ? width * kImageBpp : pitch;
+    uint32_t row_pitch               = pitch == 0 ? width * kImageBpp : pitch;
     stbi_write_png_compression_level = 4;
     if (1 == stbi_write_png(filename.c_str(), width, height, kImageBpp, data, row_pitch))
     {

--- a/framework/util/image_writer.cpp
+++ b/framework/util/image_writer.cpp
@@ -66,6 +66,9 @@ GFXRECON_BEGIN_NAMESPACE(imagewriter)
 const uint16_t kBmpBitCount = 32; // Expecting 32-bit BGRA bitmap data.
 const uint32_t kImageBpp    = 4;  // Expecting 4 bytes per pixel for 32-bit BGRA bitmap data.
 
+const uint16_t kBmpBitCountNoAlpha = 24; // Expecting 24-bit BGR bitmap data.
+const uint32_t kImageBppNoAlpha    = 3;  // Expecting 3 bytes per pixel for 32-bit BGRA bitmap data; alpha removed.
+
 bool WriteBmpImage(
     const std::string& filename, uint32_t width, uint32_t height, uint64_t data_size, const void* data, uint32_t pitch)
 {
@@ -132,6 +135,80 @@ bool WriteBmpImage(
     return success;
 }
 
+bool WriteBmpImageNoAlpha(
+    const std::string& filename, uint32_t width, uint32_t height, uint64_t data_size, const void* data, uint32_t pitch)
+{
+    bool     success   = false;
+    uint32_t row_pitch = width * kImageBpp;
+
+    if (pitch != 0)
+    {
+        row_pitch = pitch;
+    }
+
+    // BMP image data doesn't require row padding, so compute size with height * width * kImageBppNoAlpha, not row_pitch
+    // * height.
+    uint32_t bmp_image_size = height * width * kImageBppNoAlpha;
+    if (bmp_image_size <= data_size)
+    {
+        FILE*   file   = nullptr;
+        int32_t result = util::platform::FileOpen(&file, filename.c_str(), "wb");
+
+        if ((result == 0) && (file != nullptr))
+        {
+            BmpFileHeader file_header;
+            BmpInfoHeader info_header;
+
+            file_header.type      = ('M' << 8) | 'B';
+            file_header.reserved1 = 0;
+            file_header.reserved2 = 0;
+            file_header.off_bits  = sizeof(file_header) + sizeof(info_header);
+            file_header.size      = bmp_image_size + file_header.off_bits;
+
+            info_header.size             = sizeof(info_header);
+            info_header.width            = width;
+            info_header.height           = height;
+            info_header.planes           = 1;
+            info_header.bit_count        = kBmpBitCountNoAlpha;
+            info_header.compression      = 0;
+            info_header.size_image       = 0;
+            info_header.x_pels_per_meter = 0;
+            info_header.y_pels_per_meter = 0;
+            info_header.clr_used         = 0;
+            info_header.clr_important    = 0;
+
+            util::platform::FileWrite(&file_header, sizeof(file_header), 1, file);
+            util::platform::FileWrite(&info_header, sizeof(info_header), 1, file);
+
+            // Y needs to be inverted when writing the bitmap data.
+            auto height_1 = height - 1;
+            auto bytes    = reinterpret_cast<const uint8_t*>(data);
+
+            // Row data without alpha
+            uint8_t* rowBytes = new uint8_t[width * kImageBppNoAlpha];
+            for (uint32_t i = 0; i < height; ++i)
+            {
+                const uint32_t bytesOffset = (height_1 - i) * row_pitch;
+                for (uint32_t j = 0; j < width; j++)
+                {
+                    memcpy(&rowBytes[j * kImageBppNoAlpha], &bytes[bytesOffset + (j * kImageBpp)], kImageBppNoAlpha);
+                }
+                util::platform::FileWrite(rowBytes, 1, width * kImageBppNoAlpha, file);
+            }
+            delete[] rowBytes;
+
+            if (!ferror(file))
+            {
+                success = true;
+            }
+
+            util::platform::FileClose(file);
+        }
+    }
+
+    return success;
+}
+
 bool WritePngImage(
     const std::string& filename, uint32_t width, uint32_t height, uint64_t data_size, const void* data, uint32_t pitch)
 {
@@ -146,6 +223,38 @@ bool WritePngImage(
     }
 #endif
 
+    return success;
+}
+
+bool WritePngImageNoAlpha(
+    const std::string& filename, uint32_t width, uint32_t height, uint64_t data_size, const void* data, uint32_t pitch)
+{
+    bool success = false;
+
+#ifdef GFXRECON_ENABLE_PNG_SCREENSHOT
+    uint32_t row_pitch               = pitch == 0 ? width * kImageBpp : pitch;
+    stbi_write_png_compression_level = 4;
+
+    const uint32_t row_pitch_no_alpha = (row_pitch * kImageBppNoAlpha) / kImageBpp;
+    uint8_t*       dataNoAlpha        = new uint8_t[height * kImageBppNoAlpha * row_pitch_no_alpha];
+    auto           dataWithAlpha      = reinterpret_cast<const uint8_t*>(data);
+    for (uint32_t i = 0; i < height; i++)
+    {
+        const uint32_t offset_with_alpha = i * row_pitch;
+        const uint32_t offset_no_alpha   = i * row_pitch_no_alpha;
+        for (uint32_t j = 0; j < width; j++)
+        {
+            memcpy(&dataNoAlpha[offset_no_alpha + (j * kImageBppNoAlpha)],
+                   &dataWithAlpha[offset_with_alpha + (j * kImageBpp)],
+                   kImageBppNoAlpha);
+        }
+    }
+    if (1 == stbi_write_png(filename.c_str(), width, height, kImageBppNoAlpha, dataNoAlpha, row_pitch_no_alpha))
+    {
+        success = true;
+    }
+    delete[] dataNoAlpha;
+#endif
     return success;
 }
 

--- a/framework/util/image_writer.h
+++ b/framework/util/image_writer.h
@@ -68,12 +68,26 @@ bool WriteBmpImage(const std::string& filename,
                    const void*        data,
                    uint32_t           pitch = 0);
 
+bool WriteBmpImageNoAlpha(const std::string& filename,
+                          uint32_t           width,
+                          uint32_t           height,
+                          uint64_t           data_size,
+                          const void*        data,
+                          uint32_t           pitch = 0);
+
 bool WritePngImage(const std::string& filename,
                    uint32_t           width,
                    uint32_t           height,
                    uint64_t           data_size,
                    const void*        data,
                    uint32_t           pitch = 0);
+
+bool WritePngImageNoAlpha(const std::string& filename,
+                          uint32_t           width,
+                          uint32_t           height,
+                          uint64_t           data_size,
+                          const void*        data,
+                          uint32_t           pitch = 0);
 
 GFXRECON_END_NAMESPACE(imagewriter)
 GFXRECON_END_NAMESPACE(util)


### PR DESCRIPTION
Fixes #1455 

Added `util::imagewriter::WriteBmpImageNoAlpha()` and `util::imagewriter::WritePngImageNoAlpha()`.
Kept previous versions in case the output of alpha channel becomes a command-line option.