### PR TITLE
Fix compilation for Apple clang version 15.0.0

### DIFF
--- a/framework/util/json_util.cpp
+++ b/framework/util/json_util.cpp
@@ -27,9 +27,6 @@
 #include "util/strings.h"
 #include "format/format_json.h"
 
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #include <codecvt> // For encoding wstring_view to utf8.
 
 #if defined(D3D12_SUPPORT)
@@ -182,7 +179,14 @@ void FieldToJson(nlohmann::ordered_json& jdata, const std::string_view data, con
 
 void FieldToJson(nlohmann::ordered_json& jdata, const std::wstring_view data, const util::JsonOptions& options)
 {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
     std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
     jdata = utf8_conv.to_bytes(data.data(), data.data() + data.length());
 }
 

--- a/framework/util/json_util.cpp
+++ b/framework/util/json_util.cpp
@@ -27,6 +27,9 @@
 #include "util/strings.h"
 #include "format/format_json.h"
 
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <codecvt> // For encoding wstring_view to utf8.
 
 #if defined(D3D12_SUPPORT)


### PR DESCRIPTION
Fix compilation for Apple clang version 15.0.0 by ignoring `<codecvt> `deprecation-warnings for clang.

the reasoning behind simply silencing the warning is the current absence of any stl-alternative
and a generous timeframe for transitioning to something else.

- deprecation in c++17: https://isocpp.org/files/papers/p0636r0.html
- proposal to remove in c++26: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2871r3.pdf 