### PR TITLE
Uniform behavior for measurements in `FpsInfo`

### DIFF
--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -26,37 +26,13 @@
 #include "util/date_time.h"
 #include "util/logging.h"
 #include "util/platform.h"
+#include "nlohmann/json.hpp"
 #include "util/json_util.h"
 
-#include "nlohmann/json.hpp"
 #include <cinttypes>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
-
-static double GetElapsedSeconds(uint64_t start_time, uint64_t end_time)
-{
-    return util::datetime::ConvertTimestampToSeconds(
-        util::datetime::DiffTimestamps(static_cast<int64_t>(start_time), static_cast<int64_t>(end_time)));
-}
-
-static void
-WriteFpsToConsole(const char* prefix, uint64_t start_frame, uint64_t end_frame, int64_t start_time, int64_t end_time)
-{
-    assert(end_frame >= start_frame && end_time >= start_time);
-
-    double   diff_time_sec = GetElapsedSeconds(static_cast<uint64_t>(start_time), static_cast<uint64_t>(end_time));
-    uint64_t total_frames  = (end_frame - start_frame) + 1;
-    double   fps           = (diff_time_sec > 0.0) ? (static_cast<double>(total_frames) / diff_time_sec) : 0.0;
-    GFXRECON_WRITE_CONSOLE("%s %f fps, %f seconds, %" PRIu64 " frame%s, framerange %" PRIu64 "-%" PRIu64,
-                           prefix,
-                           fps,
-                           diff_time_sec,
-                           total_frames,
-                           total_frames > 1 ? "s" : "",
-                           start_frame,
-                           end_frame);
-}
 
 FpsInfo::FpsInfo(uint64_t               measurement_start_frame,
                  uint64_t               measurement_end_frame,
@@ -68,17 +44,25 @@ FpsInfo::FpsInfo(uint64_t               measurement_start_frame,
                  const std::string_view measurement_file_name,
                  bool                   quit_after_frame,
                  uint64_t               quit_frame) :
-    measurement_start_frame_(measurement_start_frame),
-    measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
-    has_measurement_range_(has_measurement_range), quit_after_range_(quit_after_range),
-    flush_measurement_range_(flush_measurement_range), flush_inside_measurement_range_(flush_inside_measurement_range),
-    started_measurement_(false), ended_measurement_(false), frame_start_time_(0), frame_durations_(),
-    measurement_file_name_(measurement_file_name), preload_measurement_range_(preload_measurement_range),
+    start_time_(0),
+    replay_start_time_(0), replay_end_time_(0), measurement_start_time_(0), measurement_end_time_(0),
+    measurement_start_boot_time_(0), measurement_end_boot_time_(0), measurement_start_process_time_(0),
+    measurement_end_process_time_(0), has_measurement_range_(has_measurement_range), replay_start_frame_(0),
+    measurement_start_frame_(measurement_start_frame), measurement_end_frame_(measurement_end_frame),
+    quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range),
+    flush_inside_measurement_range_(flush_inside_measurement_range), started_measurement_(false),
+    ended_measurement_(false), preload_measurement_range_(preload_measurement_range),
+    measurement_file_name_(measurement_file_name), frame_start_time_(0), frame_durations_(),
     quit_after_frame_(quit_after_frame), quit_frame_(quit_frame)
 {
     if (has_measurement_range_)
     {
-        GFXRECON_ASSERT(!measurement_file_name_.empty());
+        if (util::filepath::IsFile(measurement_file_name_))
+        {
+            GFXRECON_LOG_WARNING("Removing existing file at measurement file location: %s",
+                                 measurement_file_name_.c_str());
+            std::remove(measurement_file_name_.c_str());
+        }
     }
 }
 
@@ -105,8 +89,11 @@ void FpsInfo::BeginFrame(uint64_t frame)
     {
         if (frame >= measurement_start_frame_)
         {
-            measurement_start_time_ = util::datetime::GetTimestamp();
-            started_measurement_    = true;
+            measurement_start_boot_time_    = util::datetime::GetBootTime();
+            measurement_start_time_         = util::datetime::GetTimestamp();
+            measurement_start_process_time_ = util::datetime::GetProcessTime();
+            started_measurement_            = true;
+            GFXRECON_WRITE_CONSOLE("================== Start timer (Frame: %llu) ==================", frame);
             frame_durations_.clear();
         }
     }
@@ -118,64 +105,17 @@ void FpsInfo::EndFrame(uint64_t frame)
 {
     if (started_measurement_ && !ended_measurement_)
     {
-        frame_durations_.push_back(util::datetime::DiffTimestamps(frame_start_time_, util::datetime::GetTimestamp()));
+        int64_t frame_end_time = util::datetime::GetTimestamp();
+        frame_durations_.push_back(util::datetime::DiffTimestamps(frame_start_time_, frame_end_time));
 
         // Measurement frame range end is non-inclusive, as opposed to trim frame range
         if (frame >= measurement_end_frame_ - 1)
         {
-            measurement_end_time_ = util::datetime::GetTimestamp();
-            ended_measurement_    = true;
-
-            // Save measurements to file
-            if (!measurement_file_name_.empty())
-            {
-                double   start_time   = util::datetime::ConvertTimestampToSeconds(measurement_start_time_);
-                double   end_time     = util::datetime::ConvertTimestampToSeconds(measurement_end_time_);
-                double   diff_time    = GetElapsedSeconds(static_cast<uint64_t>(measurement_start_time_),
-                                                     static_cast<uint64_t>(measurement_end_time_));
-                uint64_t total_frames = measurement_end_frame_ - measurement_start_frame_;
-                double   fps          = static_cast<double>(total_frames) / diff_time;
-
-                nlohmann::json file_content = { { "frame_range",
-                                                  { { "start_frame", measurement_start_frame_ },
-                                                    { "end_frame", measurement_end_frame_ },
-                                                    { "frame_count", total_frames },
-                                                    { "start_time_monotonic", start_time },
-                                                    { "end_time_monotonic", end_time },
-                                                    { "duration", diff_time },
-                                                    { "fps", fps },
-                                                    { "frame_durations", frame_durations_ } } } };
-
-                FILE*   file_pointer = nullptr;
-                int32_t result       = util::platform::FileOpen(&file_pointer, measurement_file_name_.c_str(), "w");
-                if (result == 0)
-                {
-                    const std::string json_string = file_content.dump(util::kJsonIndentWidth);
-
-                    // It either writes a fully valid file, or it doesn't write anything !
-                    if (!util::platform::FileWrite(json_string.data(), json_string.size(), file_pointer))
-                    {
-                        GFXRECON_LOG_ERROR("Failed to write to measurements file '%s'.",
-                                           measurement_file_name_.c_str());
-
-                        // Try to delete the partial file from disk using <cstdio>
-                        const int remove_result = std::remove(measurement_file_name_.c_str());
-                        if (remove_result != 0)
-                        {
-                            GFXRECON_LOG_ERROR("Failed to remove measurements file '%s' (Error %i).",
-                                               measurement_file_name_.c_str(),
-                                               remove_result);
-                        }
-                    }
-                    util::platform::FileClose(file_pointer);
-                }
-                else
-                {
-                    GFXRECON_LOG_ERROR(
-                        "Failed to open measurements file '%s' (Error %i).", measurement_file_name_.c_str(), result);
-                    GFXRECON_LOG_ERROR("%s", std::strerror(result));
-                }
-            }
+            measurement_end_boot_time_    = util::datetime::GetBootTime();
+            measurement_end_process_time_ = util::datetime::GetProcessTime();
+            measurement_end_time_         = frame_end_time;
+            ended_measurement_            = true;
+            GFXRECON_WRITE_CONSOLE("================== End timer (Frame: %llu) ==================", frame);
         }
     }
 }
@@ -189,54 +129,93 @@ bool FpsInfo::ShouldWaitIdleAfterFrame(uint64_t frame)
 
 void FpsInfo::EndFile(uint64_t frame)
 {
+    replay_end_time_ = gfxrecon::util::datetime::GetTimestamp();
+
     if (!ended_measurement_)
     {
-        measurement_end_time_  = gfxrecon::util::datetime::GetTimestamp();
-        measurement_end_frame_ = frame;
+        measurement_end_boot_time_    = util::datetime::GetBootTime();
+        measurement_end_process_time_ = util::datetime::GetProcessTime();
+        measurement_end_time_         = replay_end_time_;
+        measurement_end_frame_        = frame;
+        GFXRECON_WRITE_CONSOLE("================== End timer (Frame: %llu) ==================", frame);
     }
 }
 
 void FpsInfo::ProcessStateEndMarker(uint64_t frame_number)
 {
-    replay_start_frame_ = static_cast<int64_t>(frame_number);
-    replay_start_time_  = static_cast<uint64_t>(util::datetime::GetTimestamp());
+    replay_start_frame_  = static_cast<int64_t>(frame_number);
+    replay_start_time_   = static_cast<uint64_t>(util::datetime::GetTimestamp());
+    started_measurement_ = false; // End of loading trimmed state, so we reset the measurement if it started too soon
 }
 
-void FpsInfo::LogToConsole()
+void FpsInfo::LogMeasurements()
 {
-    if (!has_measurement_range_)
-    {
-        // No measurement range or no end limit to range, include trimmed
-        // range load statistics.
+    double start_time_monotonic = util::datetime::ConvertTimestampToSeconds(measurement_start_time_);
+    double end_time_monotonic   = util::datetime::ConvertTimestampToSeconds(measurement_end_time_);
 
-        if (replay_start_time_ != start_time_)
+    double   load_time       = util::datetime::GetElapsedSeconds(start_time_, replay_start_time_);
+    double   total_time      = util::datetime::GetElapsedSeconds(start_time_, replay_end_time_);
+    double   measured_time   = util::datetime::GetElapsedSeconds(measurement_start_time_, measurement_end_time_);
+    uint64_t measured_frames = measurement_end_frame_ - measurement_start_frame_;
+    double   measured_fps    = (measured_time > 0.0) ? static_cast<double>(measured_frames) / measured_time : 0.0;
+
+    GFXRECON_WRITE_CONSOLE("Load time:  %f seconds (frame %lu)", load_time, replay_start_frame_);
+    GFXRECON_WRITE_CONSOLE("Total time: %f seconds", total_time);
+    GFXRECON_WRITE_CONSOLE("Measured FPS: %f fps, %f seconds, %lu frame%s, 1 loop, framerange [%lu-%lu)",
+                           measured_fps,
+                           measured_time,
+                           measured_frames,
+                           measured_frames > 1 ? "s" : "",
+                           measurement_start_frame_,
+                           measurement_end_frame_);
+
+    // Save measurements to file
+    if (has_measurement_range_)
+    {
+        nlohmann::json file_content = { { "frame_range",
+                                          { { "start_frame", measurement_start_frame_ },
+                                            { "end_frame", measurement_end_frame_ },
+                                            { "frame_count", measured_frames },
+                                            { "start_time_boot", measurement_start_boot_time_ },
+                                            { "start_time_process", measurement_start_process_time_ },
+                                            { "start_time_monotonic", start_time_monotonic },
+                                            { "end_time_boot", measurement_end_boot_time_ },
+                                            { "end_time_process", measurement_end_process_time_ },
+                                            { "end_time_monotonic", end_time_monotonic },
+                                            { "duration", measured_time },
+                                            { "fps", measured_fps },
+                                            { "frame_durations", frame_durations_ } } } };
+
+        FILE*   file_pointer = nullptr;
+        int32_t result       = util::platform::FileOpen(&file_pointer, measurement_file_name_.c_str(), "w");
+        if (result == 0)
         {
-            GFXRECON_WRITE_CONSOLE("Load time:  %f seconds", GetElapsedSeconds(start_time_, replay_start_time_));
-        }
-        GFXRECON_WRITE_CONSOLE("Total time: %f seconds",
-                               GetElapsedSeconds(start_time_, static_cast<uint64_t>(measurement_end_time_)));
+            const std::string json_string = file_content.dump(util::kJsonIndentWidth);
 
-        WriteFpsToConsole("Replay FPS:",
-                          static_cast<uint64_t>(replay_start_frame_),
-                          measurement_end_frame_ - 1 + static_cast<uint64_t>(replay_start_frame_) - 1,
-                          static_cast<int64_t>(replay_start_time_),
-                          measurement_end_time_);
-    }
-    else
-    {
-        // There was a measurement range, emit only statistics about the
-        // measurement range
-        double   diff_time_sec = GetElapsedSeconds(static_cast<uint64_t>(measurement_start_time_),
-                                                 static_cast<uint64_t>(measurement_end_time_));
-        uint64_t total_frames  = measurement_end_frame_ - measurement_start_frame_;
-        double   fps           = static_cast<double>(total_frames) / diff_time_sec;
-        GFXRECON_WRITE_CONSOLE("Measurement range FPS: %f fps, %f seconds, %lu frame%s, 1 loop, framerange [%lu-%lu)",
-                               fps,
-                               diff_time_sec,
-                               total_frames,
-                               total_frames > 1 ? "s" : "",
-                               measurement_start_frame_,
-                               measurement_end_frame_);
+            const bool success = util::platform::FileWrite(json_string.data(), json_string.size(), file_pointer);
+            util::platform::FileClose(file_pointer);
+
+            // It either writes a fully valid file, or it doesn't write anything !
+            if (!success)
+            {
+                GFXRECON_LOG_ERROR("Failed to write to measurements file '%s'.", measurement_file_name_.c_str());
+
+                // Try to delete the partial file from disk using <cstdio>
+                const int remove_result = std::remove(measurement_file_name_.c_str());
+                if (remove_result != 0)
+                {
+                    GFXRECON_LOG_ERROR("Failed to remove measurements file '%s' (Error %i).",
+                                       measurement_file_name_.c_str(),
+                                       remove_result);
+                }
+            }
+        }
+        else
+        {
+            GFXRECON_LOG_ERROR(
+                "Failed to open measurements file '%s' (Error %i).", measurement_file_name_.c_str(), result);
+            GFXRECON_LOG_ERROR("%s", std::strerror(result));
+        }
     }
 }
 

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -47,7 +47,7 @@ class FpsInfo
                      bool             quit_after_frame               = false,
                      uint64_t         quit_frame                     = std::numeric_limits<uint64_t>::max());
 
-    void LogToConsole();
+    void LogMeasurements();
 
     void                   BeginFile();
     bool                   ShouldWaitIdleBeforeFrame(uint64_t file_processor_frame);
@@ -60,18 +60,27 @@ class FpsInfo
     [[nodiscard]] uint64_t ShouldPreloadFrames(uint64_t current_frame) const;
 
   private:
-    uint64_t start_time_{};
+    uint64_t start_time_;
 
-    uint64_t measurement_start_frame_;
-    uint64_t measurement_end_frame_;
+    int64_t replay_start_time_;
+    int64_t replay_end_time_;
 
     int64_t measurement_start_time_;
     int64_t measurement_end_time_;
 
-    int64_t  replay_start_time_;
+    double measurement_start_boot_time_;
+    double measurement_end_boot_time_;
+
+    double measurement_start_process_time_;
+    double measurement_end_process_time_;
+
     uint64_t replay_start_frame_;
 
+    uint64_t measurement_start_frame_;
+    uint64_t measurement_end_frame_;
+
     bool has_measurement_range_;
+
     bool quit_after_range_;
     bool flush_measurement_range_;
     bool flush_inside_measurement_range_;

--- a/framework/util/date_time.h
+++ b/framework/util/date_time.h
@@ -46,7 +46,7 @@ GFXRECON_BEGIN_NAMESPACE(datetime)
 #if defined(WIN32)
 
 ///@ Retrieve a timestamp, relative to an undefined reference point, suitable for computing time intervals.
-inline uint64_t GetTimestamp()
+inline int64_t GetTimestamp()
 {
     LARGE_INTEGER StartingTime;
     LARGE_INTEGER Frequency;
@@ -99,6 +99,11 @@ inline double ConvertTimestampToSeconds(int64_t timestamp)
     return static_cast<double>(timestamp) / 1000000000.0;
 }
 
+inline double GetElapsedSeconds(int64_t start_timestamp, int64_t end_timestamp)
+{
+    return ConvertTimestampToSeconds(DiffTimestamps(start_timestamp, end_timestamp));
+}
+
 /// @brief Generate a compact representation of the current time.
 /// @param use_gmt Use a location-independent time zone if true, else the local
 /// one.
@@ -112,6 +117,58 @@ std::string UtcString(const time_t seconds_since_epoch);
 /// @brief The current moment in UTC to the second as a string formatted to
 /// rfc3339.
 std::string UtcNowString();
+
+#if defined(WIN32)
+
+// Time in seconds since boot
+inline double GetBootTime()
+{
+    return ConvertTimestampToSeconds(GetTimestamp());
+}
+
+// Time in seconds consumed by this process
+inline double GetProcessTime()
+{
+    ULONG64 CycleTime;
+
+    // Get time and convert ticks to seconds
+    QueryProcessCycleTime(GetCurrentProcess(), &CycleTime);
+    return (static_cast<double>(CycleTime) / CLOCKS_PER_SEC);
+}
+
+#else // !defined(WIN32)
+
+// Time in seconds since boot
+inline double GetBootTime()
+{
+#if defined(CLOCK_BOOTTIME)
+
+    timespec time;
+    clock_gettime(CLOCK_BOOTTIME, &time);
+    int64_t timestamp = (1000000000 * static_cast<int64_t>(time.tv_sec)) + static_cast<int64_t>(time.tv_nsec);
+    return ConvertTimestampToSeconds(timestamp);
+
+#else
+    return 0.0;
+#endif
+}
+
+// Time in seconds consumed by this process
+inline double GetProcessTime()
+{
+#if defined(CLOCK_PROCESS_CPUTIME_ID)
+
+    timespec time;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &time);
+    int64_t timestamp = (1000000000 * static_cast<int64_t>(time.tv_sec)) + static_cast<int64_t>(time.tv_nsec);
+    return ConvertTimestampToSeconds(timestamp);
+
+#else
+    return 0.0;
+#endif
+}
+
+#endif // WIN32
 
 GFXRECON_END_NAMESPACE(datetime)
 GFXRECON_END_NAMESPACE(util)

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -152,13 +152,13 @@ int main(int argc, const char** argv)
             gfxrecon::decode::VulkanReplayOptions          vulkan_replay_options =
                 GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table);
 
-            uint32_t start_frame = 0;
-            uint32_t end_frame   = 0;
-
             bool     quit_after_frame = false;
             uint32_t quit_frame       = std::numeric_limits<uint32_t>::max();
 
-            bool        has_mfr                            = false;
+            uint32_t measurement_start_frame = 0;
+            uint32_t measurement_end_frame   = 0;
+            bool     has_mfr                 = false;
+
             bool        quit_after_measurement_frame_range = false;
             bool        flush_measurement_frame_range      = false;
             bool        flush_inside_measurement_range     = false;
@@ -167,7 +167,8 @@ int main(int argc, const char** argv)
 
             if (vulkan_replay_options.enable_vulkan)
             {
-                has_mfr                            = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
+                has_mfr = GetMeasurementFrameRange(arg_parser, measurement_start_frame, measurement_end_frame);
+                GetMeasurementFilename(arg_parser, measurement_file_name);
                 quit_after_measurement_frame_range = vulkan_replay_options.quit_after_measurement_frame_range;
                 flush_measurement_frame_range      = vulkan_replay_options.flush_measurement_frame_range;
                 flush_inside_measurement_range     = vulkan_replay_options.flush_inside_measurement_range;
@@ -180,13 +181,8 @@ int main(int argc, const char** argv)
                 }
             }
 
-            if (has_mfr)
-            {
-                GetMeasurementFilename(arg_parser, measurement_file_name);
-            }
-
-            gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(start_frame),
-                                                 static_cast<uint64_t>(end_frame),
+            gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(measurement_start_frame),
+                                                 static_cast<uint64_t>(measurement_end_frame),
                                                  has_mfr,
                                                  quit_after_measurement_frame_range,
                                                  flush_measurement_frame_range,
@@ -296,12 +292,12 @@ int main(int argc, const char** argv)
             if ((file_processor->GetCurrentFrameNumber() > 0) &&
                 (file_processor->GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
             {
-                if (file_processor->GetCurrentFrameNumber() < start_frame)
+                if (file_processor->GetCurrentFrameNumber() < measurement_start_frame)
                 {
                     GFXRECON_LOG_WARNING(
                         "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                         "Measurements were never started, cannot calculate measurement range FPS.",
-                        start_frame,
+                        measurement_start_frame,
                         file_processor->GetCurrentFrameNumber());
                 }
                 else
@@ -319,7 +315,7 @@ int main(int argc, const char** argv)
                     }
 #endif
 
-                    fps_info.LogToConsole();
+                    fps_info.LogMeasurements();
                 }
             }
             else if (file_processor->GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)


### PR DESCRIPTION
Having uniform/standardized log formats/behaviors allow for automation tools to be easier to implement and maintain.

As the measurements done by GFXReconstruct are performance free and were already done on the whole replay if no frame-range was specified, I propose to consider `gfxrecon-replay` as always acquiring measurements, either on the whole replay or on the specified frame-range.

Thus there is no need for special message/behavior depending if a frame-range has been manually specified. That's what this commit implements:
- A measurement file is always created if the replay has been run successfully
- The same log message at the end of the replay is displayed, no matter if a range has been specified or not and no matter how much time the (potentially non-existant) load has taken

In addition, as `CLOCK_MONOTONIC` has an arbitrary starting point, `CLOCK_BOOTTIME` start/end time have been added to the measurement file for time to be coherent between multiple runs of `gfxrecon-replay`