### PR TITLE
Fix exiting on vkDestroySwapchainKHR on macOS

### DIFF
--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -40,6 +40,7 @@ typedef void(^GFXReconKeyCallback)(gfxrecon::application::Application*);
 
 @implementation GFXReconWindowDelegate
 - (void)windowWillClose:(NSNotification*)notification {
+    GFXRECON_LOG_DEBUG_ONCE("User closed window");
     [NSApp terminate:self];
 }
 @end
@@ -142,6 +143,7 @@ bool MetalWindow::Destroy()
     if (window_)
     {
         [static_cast<GFXReconView*>([window_ contentView]) setApp:nil];
+        [window_ setDelegate:nil];
         [window_ close];
         metal_context_->UnregisterWindow(this);
     }


### PR DESCRIPTION
vkDestroySwapchainKHR closes its window, and we took that to mean the user had closed the window and wanted to exit

Also adds a printout on user close so similar issues are easier to debug in the future