### PR TITLE
Warn if screenshot indexing change is detected

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -73,6 +73,8 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     virtual void ProcessStateEndMarker(uint64_t frame_number) override;
 
+    virtual void ProcessFrameEndMarker(uint64_t frame_number) override;
+
     virtual void
     ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) override;
 
@@ -906,6 +908,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     util::ScreenshotFormat                                screenshot_format_;
     std::unique_ptr<ScreenshotHandlerBase>                screenshot_handler_;
     std::unordered_map<ID3D12Resource*, ResourceInitInfo> resource_init_infos_;
+    uint64_t                                              frame_end_marker_count_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -263,11 +263,14 @@ int main(int argc, const char** argv)
                 {
 #if defined(D3D12_SUPPORT)
                     dx12_replay_consumer.PostReplay();
-                    if (file_processor.UsesFrameMarkers() == false &&
-                        dx12_replay_consumer.GetDXGITestPresentCount() > 0)
+                    if (!dx_replay_options.screenshot_ranges.empty() && !file_processor.UsesFrameMarkers() &&
+                        (dx12_replay_consumer.GetDXGITestPresentCount() > 0))
                     {
-                        GFXRECON_LOG_WARNING("This capture contains %u test present count.",
-                                             dx12_replay_consumer.GetDXGITestPresentCount());
+                        GFXRECON_LOG_WARNING_ONCE(
+                            "This capture contains %" PRIu32
+                            " calls to IDXGISwapChain::Present with flag DXGI_PRESENT_TEST and no frame end markers. "
+                            "Screenshot frame indexing may have changed since capture.",
+                            dx12_replay_consumer.GetDXGITestPresentCount());
                     }
 #endif
 


### PR DESCRIPTION
GFXR's DX12 frame counting logic changed. In some existing captures, the frame that a screenshot index corresponds to may have changed so log a warning.