### PR TITLE
Add .cache in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ __pycache__/
 *.pyc
 *.rdbg
 ._*
+.cache
 .DS_Store
 external/wayland-protocols/


### PR DESCRIPTION
This folder is used by clangd vs code extension and can be ignored