### PR TITLE
Add support for VK_EXT_inline_uniform_block 

### DIFF
--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -98,12 +98,11 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
                 value->pTexelBufferView = handle_mapping::MapHandleArray<BufferViewInfo>(
                     &wrapper->pTexelBufferView, object_mapper, &VulkanObjectInfoTable::GetBufferViewInfo);
                 break;
-            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-                // TODO
-                break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
                 // TODO
                 break;
+            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+                // Handles are mapped in the VkWriteDescriptorSetInlineUniformBlock structure in the pNext chain
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
                 // Handles are mapped in the VkWriteDescriptorSetAccelerationStructureKHR structure in the pNext chain
                 break;

--- a/framework/decode/custom_vulkan_struct_to_json.cpp
+++ b/framework/decode/custom_vulkan_struct_to_json.cpp
@@ -246,10 +246,10 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkWriteDescriptorS
                 HandleToJson(jdata["pTexelBufferView"], &meta_struct.pTexelBufferView, options);
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-                // Nothing to do here for acceleration structures as the rest of the data is stored
-                // in the pNext chain
-                break;
             case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+                // Nothing to do here for acceleration-structures and inline-uniform-blocks,
+                // as the rest of the data is stored in the pNext chain
+                break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
             case VK_DESCRIPTOR_TYPE_MUTABLE_EXT:
                 GFXRECON_LOG_WARNING("Descriptor type not supported at " __FILE__ ", line: %d.", __LINE__);

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -2332,10 +2332,9 @@ void VulkanCppConsumerBase::GenerateDescriptorUpdateTemplateData(DescriptorUpdat
                         struct_define_stream << "\t\t\tVkAccelerationStructureKHR descAccelInfo" << cur_count++ << "["
                                              << var.count << "];\n";
                         break;
-                    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-                        // Not handled
-                        assert(false);
-                        struct_define_stream << "INLINE UNIFORM BLOCK not handled,";
+                    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+                        struct_define_stream << "\t\t\tInlineUniformBlock descInlineUniformInfo" << cur_count++ << "["
+                                             << var.count << "];\n";
                         break;
                     default:
                         assert(false);

--- a/framework/decode/vulkan_cpp_structs.cpp
+++ b/framework/decode/vulkan_cpp_structs.cpp
@@ -169,7 +169,7 @@ std::string GenerateStruct_VkWriteDescriptorSet(std::ostream&                 ou
             break;
         }
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
         case VK_DESCRIPTOR_TYPE_MAX_ENUM:
         {
             // Nothing to do.

--- a/framework/decode/vulkan_cpp_utilities.cpp
+++ b/framework/decode/vulkan_cpp_utilities.cpp
@@ -70,8 +70,8 @@ std::string DescriptorCreateInfoTypeToString(VkDescriptorType descriptorType)
         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
         case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
             return "VkBufferView";
-        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-            return "VkWriteDescriptorSetInlineUniformBlockEXT";
+        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+            return "VkWriteDescriptorSetInlineUniformBlock";
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
             return "VkWriteDescriptorSetAccelerationStructureKHR";
         default:
@@ -99,7 +99,7 @@ DescriptorBaseType GetDescriptorBaseType(VkDescriptorType descriptorType)
         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
         case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
             return DESCRIPTOR_BASE_TYPE_TEXEL;
-        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
             return DESCRIPTOR_BASE_TYPE_INLINE_UNIFORM_BLOCK;
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
             return DESCRIPTOR_BASE_TYPE_ACCELERATION_STRUCTURE;

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -501,7 +501,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSets(
             switch (writes[i].descriptorType)
             {
                 case VK_DESCRIPTOR_TYPE_SAMPLER:
-                case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+                case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
                     // Descriptor types that do not need to be tracked.
                     break;
                 case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -105,6 +105,11 @@ static const void* UnwrapDescriptorUpdateTemplateInfoHandles(const UpdateTemplat
             }
         }
 
+        // Process VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK data
+        for (const auto& entry_info : info->inline_uniform_block)
+        {
+            memcpy(unwrapped_data + entry_info.offset, bytes + entry_info.offset, entry_info.count);
+        }
         return unwrapped_data;
     }
 

--- a/framework/encode/custom_vulkan_command_buffer_util.cpp
+++ b/framework/encode/custom_vulkan_command_buffer_util.cpp
@@ -186,12 +186,7 @@ void TrackCmdPushDescriptorSetKHRHandles(vulkan_wrappers::CommandBufferWrapper* 
                     }
                 }
                 break;
-                case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-                {
-                    assert(false && "Maintentance required to support pushed inline uniform block descriptors when "
-                                    "creating trimmed captures");
-                }
-                break;
+                case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
                 case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
                 case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
                 case VK_DESCRIPTOR_TYPE_MUTABLE_VALVE:

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -145,12 +145,11 @@ void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
         case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
             omit_texel_buffer_data = false;
             break;
-        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-            // TODO
-            break;
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
             // TODO
             break;
+        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+            // Handles are encoded in the VkWriteDescriptorSetInlineUniformBlock structure in the pNext chain
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
             // Handles are encoded in the VkWriteDescriptorSetAccelerationStructureKHR structure in the pNext chain
             break;

--- a/framework/encode/descriptor_update_template_info.h
+++ b/framework/encode/descriptor_update_template_info.h
@@ -46,8 +46,10 @@ struct UpdateTemplateInfo
 {
     // The counts are the sum of the total descriptorCount for each update template entry type. When written to the
     // capture file, the update template data will be written as tightly packed arrays of VkDescriptorImageInfo,
-    // VkDescriptorBufferInfo, VkBufferView, and VkAccelerationStructureKHR types.  There will be one array per
-    // descriptor update entry, so the counts are pre-computed for the file encoding process to know the total number of
+    // VkDescriptorBufferInfo, VkBufferView, VkAccelerationStructureKHR or byte-arrays
+    // in case of VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK.
+    // There will be one array per descriptor update entry,
+    // so the counts are pre-computed for the file encoding process to know the total number of
     // items to encode prior to processing the individual UpdateTemplateEntry structures.
     size_t                               max_size{ 0 };
     size_t                               image_info_count{ 0 };
@@ -58,6 +60,7 @@ struct UpdateTemplateInfo
     std::vector<UpdateTemplateEntryInfo> buffer_info;
     std::vector<UpdateTemplateEntryInfo> texel_buffer_view;
     std::vector<UpdateTemplateEntryInfo> acceleration_structure_khr;
+    std::vector<UpdateTemplateEntryInfo> inline_uniform_block;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -76,6 +76,7 @@ struct DescriptorInfo
     std::unique_ptr<VkDescriptorBufferInfo[]>     buffers;
     std::unique_ptr<VkBufferView[]>               texel_buffer_views;
     std::unique_ptr<VkAccelerationStructureKHR[]> acceleration_structures;
+    std::unique_ptr<uint8_t[]>                    inline_uniform_block;
     std::unique_ptr<VkDescriptorType[]>           mutable_type;
 };
 

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -864,8 +864,8 @@ inline void InitializePoolObjectState(VkDevice                               par
             case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                 descriptor_info.texel_buffer_views = std::make_unique<VkBufferView[]>(binding_info.count);
                 break;
-            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-                // TODO
+            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+                descriptor_info.inline_uniform_block = std::make_unique<uint8_t[]>(binding_info.count);
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
                 // TODO


### PR DESCRIPTION
overall a low-hanging fruit, adding into existing infrastructure:
- tracking of a binary blob `inline_uniform_block` in DescriptorInfo
- add-hoc (re-)creation of associated pNext-structure for `VkWriteDescriptorSet`
- adapt places skipping over the feature or labeling it unsupported
- gfxrecon-convert: remove a warning about the feature being unsupported

tested successfully with a capture/replay of Sascha's corresponding sample:
https://github.com/SaschaWillems/Vulkan/blob/master/examples/inlineuniformblocks/inlineuniformblocks.cpp