### PR TITLE
Use static liblz4-flavour on Apple-platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,12 @@ if(WIN32)
 find_package(Detours)
 endif() # WIN32
 
+if(APPLE)
+    set(LZ4_USE_STATIC_LIBRARY TRUE)
+else()
+    set(LZ4_USE_STATIC_LIBRARY ${BUILD_STATIC})
+endif()
+
 find_package(LZ4)
 find_package(ZSTD)
 

--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -40,7 +40,7 @@ unset(_LZ4_x86)
 list(APPEND _LZ4_SEARCH_PATH _LZ4_SEARCH_NORMAL)
 
 set(LZ4_NAMES lz4 lz4_static liblz4 liblz4_static)
-if(BUILD_STATIC)
+if(LZ4_USE_STATIC_LIBRARY)
     set(LZ4_NAMES liblz4.a ${LZ4_NAMES})
 endif()
 set(LZ4_NAMES_DEBUG lz4d lz4_staticd liblz4d liblz4_staticd)


### PR DESCRIPTION
we normally link dynamically against liblz4,
but that causes trouble on macOS (and iOS) w.r.t. code signatures.
this PR makes minor changes in our toplevel-CMakeLists and FindLZ4.cmake, in order to use a static liblz4 instead