### PR TITLE
Use GetDeviceQueue2 for the queue that has flags.

### DIFF
--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -25,6 +25,7 @@
 #include "util/image_writer.h"
 #include "util/logging.h"
 #include "util/platform.h"
+#include "decode/decoder_util.h"
 
 #include <condition_variable>
 #include <limits>
@@ -75,7 +76,7 @@ inline void WriteImageFile(const std::string&     filename,
 }
 
 void ScreenshotHandler::WriteImage(const std::string&                      filename_prefix,
-                                   VkDevice                                device,
+                                   const DeviceInfo*                       device_info,
                                    const encode::VulkanDeviceTable*        device_table,
                                    const VkPhysicalDeviceMemoryProperties& memory_properties,
                                    VulkanResourceAllocator*                allocator,
@@ -104,7 +105,7 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
     }
 
     VkResult result = VK_SUCCESS;
-
+    auto     device = device_info->handle;
     // TODO: Improved queue selection; ensure queue supports transfer operations.
 
     // Get a command pool for the device.
@@ -137,7 +138,7 @@ void ScreenshotHandler::WriteImage(const std::string&                      filen
         VkQueue queue         = VK_NULL_HANDLE;
 
         // Get a queue.
-        device_table->GetDeviceQueue(device, kDefaultQueueFamilyIndex, kDefaultQueueIndex, &queue);
+        queue = GetDeviceQueue(device_table, device_info, kDefaultQueueFamilyIndex, kDefaultQueueIndex);
 
         // Get a buffer size.
         VkDeviceSize buffer_size     = copy_resource.buffer_size;

--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -24,6 +24,7 @@
 #define GFXRECON_DECODE_SCREENSHOT_HANDLER_H
 
 #include "decode/screenshot_handler_base.h"
+#include "decode/vulkan_object_info.h"
 #include "decode/vulkan_replay_options.h"
 #include "decode/vulkan_resource_allocator.h"
 #include "generated/generated_vulkan_dispatch_table.h"
@@ -52,7 +53,7 @@ class ScreenshotHandler : public ScreenshotHandlerBase
     {}
 
     void WriteImage(const std::string&                      filename_prefix,
-                    VkDevice                                device,
+                    const DeviceInfo*                       device_info,
                     const encode::VulkanDeviceTable*        device_table,
                     const VkPhysicalDeviceMemoryProperties& memory_properties,
                     VulkanResourceAllocator*                allocator,

--- a/framework/decode/vulkan_captured_swapchain.cpp
+++ b/framework/decode/vulkan_captured_swapchain.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "decode/vulkan_captured_swapchain.h"
+#include "decode/decoder_util.h"
 
 #include "util/logging.h"
 
@@ -343,7 +344,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStatePreAcquire(
     uint32_t        queue_family_index = swapchain_info->queue_family_indices[0];
 
     // TODO: Improved queue selection?
-    device_table_->GetDeviceQueue(device, queue_family_index, 0, &transition_queue);
+    transition_queue = GetDeviceQueue(device_table_, device_info, queue_family_index, 0);
 
     VkCommandPoolCreateInfo pool_create_info = { VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO };
     pool_create_info.pNext                   = nullptr;
@@ -547,19 +548,7 @@ void VulkanCapturedSwapchain::ProcessSetSwapchainImageStateQueueSubmit(
     pool_create_info.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     pool_create_info.queueFamilyIndex        = queue_family_index;
 
-    const auto queue_family_flags = device_info->queue_family_creation_flags.find(queue_family_index);
-    assert(queue_family_flags != device_info->queue_family_creation_flags.end());
-    if (queue_family_flags->second != 0)
-    {
-        const VkDeviceQueueInfo2 queue_info = {
-            VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2, nullptr, queue_family_flags->second, queue_family_index, 0
-        };
-        device_table_->GetDeviceQueue2(device, &queue_info, &queue);
-    }
-    else
-    {
-        device_table_->GetDeviceQueue(device, queue_family_index, 0, &queue);
-    }
+    queue = GetDeviceQueue(device_table_, device_info, queue_family_index, 0);
 
     result = device_table_->CreateCommandPool(device, &pool_create_info, nullptr, &pool);
 

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -1007,7 +1007,7 @@ void VulkanCppConsumerBase::Generate_vkAllocateMemory(VkResult                  
     fprintf(file, "\t{\n");
 
     // Check to see if we need to worry about opaque memory here.
-    DeviceInfo* dev_info = nullptr;
+    VkDeviceInfo* dev_info = nullptr;
     if (device_info_map_.find(device) != device_info_map_.end())
     {
         dev_info                       = device_info_map_[device];
@@ -1097,7 +1097,7 @@ void VulkanCppConsumerBase::Generate_vkCreateBuffer(VkResult                    
     FILE* file = GetFrameFile();
     fprintf(file, "\t{\n");
 
-    DeviceInfo*      dev_info      = nullptr;
+    VkDeviceInfo*    dev_info      = nullptr;
     format::HandleId buffer_handle = *pBuffer->GetPointer();
     if (device_info_map_.find(device) != device_info_map_.end())
     {
@@ -1341,7 +1341,7 @@ static void BuildInstanceCreateInfo(std::ostream&                       out,
     std::string              enabled_extensions_names = "NULL";
     if (struct_info->enabledExtensionCount > 0)
     {
-        GfxToCppPlatform cur_platform = consumer.GetPlatform();
+        GfxToCppPlatform cur_platform       = consumer.GetPlatform();
         std::string      cur_extension_name = kTargetPlatforms.at(cur_platform).wsiSurfaceExtName;
 
         // Generate a map of WSI extensions to the new extension for this current platform
@@ -1417,7 +1417,7 @@ void VulkanCppConsumerBase::Generate_vkCreateDevice(VkResult                    
 {
     FILE* file = GetFrameFile();
 
-    DeviceInfo* new_dev_info                 = new DeviceInfo();
+    VkDeviceInfo* new_dev_info               = new VkDeviceInfo();
     new_dev_info->parent                     = physicalDevice;
     device_info_map_[*pDevice->GetPointer()] = new_dev_info;
 
@@ -1468,7 +1468,7 @@ void VulkanCppConsumerBase::Generate_vkDestroyDevice(format::HandleId           
 
     if (device_info_map_.find(device) != device_info_map_.end())
     {
-        DeviceInfo* dev_info = device_info_map_[device];
+        VkDeviceInfo* dev_info = device_info_map_[device];
         delete dev_info;
         device_info_map_.erase(device);
     }
@@ -3304,7 +3304,7 @@ void VulkanCppConsumerBase::ProcessSetOpaqueAddressCommand(format::HandleId devi
 {
     if (device_info_map_.find(device_id) != device_info_map_.end())
     {
-        DeviceInfo* dev_info = device_info_map_[device_id];
+        VkDeviceInfo* dev_info = device_info_map_[device_id];
         // Store the opaque address to use at object creation.
         dev_info->opaque_addresses[object_id] = address;
     }

--- a/framework/decode/vulkan_cpp_consumer_base.h
+++ b/framework/decode/vulkan_cpp_consumer_base.h
@@ -50,7 +50,7 @@ struct DescriptorUpdateTemplateEntries
 };
 
 // Track items that are specific to a given device
-struct DeviceInfo
+struct VkDeviceInfo
 {
     format::HandleId                               parent{ 0 };
     std::unordered_map<format::HandleId, uint64_t> opaque_addresses;
@@ -700,7 +700,7 @@ class VulkanCppConsumerBase : public VulkanConsumer
     std::unordered_map<VkObjectType, uint32_t>                            counters_;
     VulkanCppLoaderGenerator                                              pfn_loader_;
     std::unordered_map<format::HandleId, std::string>                     handle_id_map_;
-    std::unordered_map<format::HandleId, DeviceInfo*>                     device_info_map_;
+    std::unordered_map<format::HandleId, VkDeviceInfo*>                   device_info_map_;
     std::vector<std::string>                                              func_data_;
     std::unordered_map<uint64_t, std::string>                             memory_id_map_;
     std::unordered_map<uint64_t, VulkanCppAndroidBufferInfo>              android_buffer_id_map_;

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -22,6 +22,7 @@
 
 #include "decode/vulkan_offscreen_swapchain.h"
 #include "encode/vulkan_handle_wrapper_util.h"
+#include "decode/decoder_util.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -92,6 +93,7 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
 
     const format::HandleId* id               = swapchain->GetPointer();
     VkSwapchainKHR*         replay_swapchain = swapchain->GetHandlePointer();
+    VkDevice                device           = device_info->handle;
 
     // Give swapchain a fake handle. It's handle id.
     *replay_swapchain = UINT64_TO_VK_HANDLE(VkSwapchainKHR, *id);
@@ -100,8 +102,7 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    VkDevice device = device_info->handle;
-    device_table_->GetDeviceQueue(device, default_queue_family_index_, 0, &default_queue_);
+    default_queue_ = GetDeviceQueue(device_table_, device_info, default_queue_family_index_, 0);
 
     // If this option is set, a command buffer submission with a `VkFrameBoundaryEXT` must be called each time
     // `vkQueuePresentKHR` should have been called by the offscreen swapchain. So a maximum of work must be done at

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2116,7 +2116,7 @@ void VulkanReplayConsumerBase::WriteScreenshots(const Decoded_VkPresentInfoKHR* 
                         : (options_.screenshot_height ? options_.screenshot_height : swapchain_info->height);
 
                 screenshot_handler_->WriteImage(filename_prefix,
-                                                device_info->handle,
+                                                device_info,
                                                 GetDeviceTable(device_info->handle),
                                                 memory_properties,
                                                 device_info->allocator.get(),
@@ -2193,7 +2193,7 @@ bool VulkanReplayConsumerBase::CheckCommandBufferInfoForFrameBoundary(const Comm
                             : (options_.screenshot_height ? options_.screenshot_height : image_info->extent.height);
 
                     screenshot_handler_->WriteImage(filename_prefix,
-                                                    device_info->handle,
+                                                    device_info,
                                                     GetDeviceTable(device_info->handle),
                                                     memory_properties,
                                                     device_info->allocator.get(),
@@ -2249,7 +2249,7 @@ bool VulkanReplayConsumerBase::CheckPNextChainForFrameBoundary(const DeviceInfo*
                     : (options_.screenshot_height ? options_.screenshot_height : image_info->extent.height);
 
             screenshot_handler_->WriteImage(filename_prefix,
-                                            device_info->handle,
+                                            device_info,
                                             GetDeviceTable(device_info->handle),
                                             memory_properties,
                                             device_info->allocator.get(),

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -24,6 +24,7 @@
 #include "decode/vulkan_object_info.h"
 
 #include "decode/copy_shaders.h"
+#include "decode/decoder_util.h"
 #include "util/platform.h"
 
 #include <algorithm>
@@ -318,22 +319,7 @@ VkResult VulkanResourceInitializer::GetCommandExecObjects(uint32_t         queue
 
             if (result == VK_SUCCESS)
             {
-                const auto queue_family_flags = device_info_->queue_family_creation_flags.find(queue_family_index);
-                assert(queue_family_flags != device_info_->queue_family_creation_flags.end());
-                if (queue_family_flags->second != 0)
-                {
-                    const VkDeviceQueueInfo2 queue_info = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2,
-                                                            nullptr,
-                                                            queue_family_flags->second,
-                                                            queue_family_index,
-                                                            0 };
-                    device_table_->GetDeviceQueue2(device_, &queue_info, queue);
-                }
-                else
-                {
-                    device_table_->GetDeviceQueue(device_, queue_family_index, 0, queue);
-                }
-
+                *queue = GetDeviceQueue(device_table_, device_info_, queue_family_index, 0);
                 command_exec_objects_.emplace(queue_family_index,
                                               CommandExecObjects{ *queue, command_pool, *command_buffer });
             }
@@ -657,7 +643,7 @@ VkResult VulkanResourceInitializer::CreateDrawObjects(VkFormat              form
             input_assembly_info.primitiveRestartEnable = VK_FALSE;
 
             VkViewport viewport     = { 0.0f, 0.0f, static_cast<float>(extent.width), static_cast<float>(extent.height),
-                                    0.0f, 1.0f };
+                                        0.0f, 1.0f };
             VkRect2D   scissor_rect = { { 0, 0 }, { extent.width, extent.height } };
 
             VkPipelineViewportStateCreateInfo viewport_info = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -23,6 +23,7 @@
 #include "decode/vulkan_virtual_swapchain.h"
 
 #include "decode/vulkan_resource_allocator.h"
+#include "decode/decoder_util.h"
 
 #include <array>
 
@@ -235,21 +236,7 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainResourceData(const DeviceInfo*  
                           swapchain_info->capture_id);
     }
 
-    const auto queue_family_flags = device_info->queue_family_creation_flags.find(copy_queue_family_index);
-    assert(queue_family_flags != device_info->queue_family_creation_flags.end());
-    // If the queue has flags, it has to use GetDeviceQueue2 to get it.
-    if (queue_family_flags->second != 0)
-    {
-        const VkDeviceQueueInfo2 queue_info = {
-            VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2, nullptr, queue_family_flags->second, copy_queue_family_index, 0
-        };
-        device_table_->GetDeviceQueue2(device, &queue_info, &initial_copy_queue);
-    }
-    else
-    {
-        device_table_->GetDeviceQueue(device, copy_queue_family_index, 0, &initial_copy_queue);
-    }
-
+    initial_copy_queue = GetDeviceQueue(device_table_, device_info, copy_queue_family_index, 0);
     if (initial_copy_queue == VK_NULL_HANDLE)
     {
         GFXRECON_LOG_ERROR("Virtual swapchain failed getting device queue %d to create initial virtual swapchain "


### PR DESCRIPTION
close: https://github.com/LunarG/gfxreconstruct/issues/1471

1.  If the queue has flags, it has to use `GetDeviceQueue2` to get it.  

2. Add `GetDeviceQueue()` to replace all  `device_table->GetDeviceQueue2` and `device_table->GetDeviceQueue`. To ensure using the correct way to get queue.