### PR TITLE
Add macOS x86_64 config to github-actions / CI-builds

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -132,6 +132,14 @@ jobs:
             type: "debug",
             build_dir: "dbuild"
           }
+        - {
+          name: "macOS Release (macOS-13, x86_64)",
+          os: macos-13,
+          artifact: "gfxreconstruct-dev-macOS-x86_64-release",
+          target: x86_64-apple-darwin,
+          type: "release",
+          build_dir: "build"
+        }
     steps:
     - name: Clone repository
       uses: actions/checkout@v1


### PR DESCRIPTION
- runner is set explicitely to macOS-13, target x86_64-apple-darwin
-  closes #1516