### PR TITLE
Add missing code-path for VK_EXT_inline_uniform_block

### DIFF
--- a/framework/decode/custom_vulkan_struct_to_json.cpp
+++ b/framework/decode/custom_vulkan_struct_to_json.cpp
@@ -393,6 +393,14 @@ void FieldToJson(nlohmann::ordered_json&                      jdata,
                          acceleration_structure_count,
                          options);
         }
+
+        const size_t inline_uniform_block_num_bytes = pData->GetInlineUniformBlockCount();
+        if (inline_uniform_block_num_bytes > 0)
+        {
+            jdata["inlineUniformBlock"] =
+                std::vector<uint8_t>(pData->GetInlineUniformBlockPointer(),
+                                     pData->GetInlineUniformBlockPointer() + inline_uniform_block_num_bytes);
+        }
     }
     else
     {

--- a/framework/decode/descriptor_update_template_decoder.cpp
+++ b/framework/decode/descriptor_update_template_decoder.cpp
@@ -40,13 +40,16 @@ DescriptorUpdateTemplateDecoder::DescriptorUpdateTemplateDecoder() :
     decoded_texel_buffer_view_handle_ids_(nullptr), image_info_count_(0), buffer_info_count_(0),
     texel_buffer_view_count_(0), image_info_(nullptr), buffer_info_(nullptr), texel_buffer_views_(nullptr),
     decoded_acceleration_structure_khr_handle_ids_(nullptr), acceleration_structure_khr_count_(0),
-    acceleration_structures_khr_(nullptr)
+    acceleration_structures_khr_(nullptr), inline_uniform_block_count_(0), inline_uniform_block_(nullptr)
 {}
 
 DescriptorUpdateTemplateDecoder::~DescriptorUpdateTemplateDecoder() {}
 
 size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buffer_size)
 {
+    // account for the encoded array's metadata
+    constexpr size_t array_meta_size = sizeof(format::PointerAttributes) + sizeof(size_t) + sizeof(void*);
+
     size_t bytes_read = DecodeAttributes(buffer, buffer_size);
 
     // The update template should identify as a struct pointer.
@@ -131,6 +134,16 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
                         required_read_memory_size  = sizeof(format::HandleId) * cur_type.count;
                         required_alloc_memory_size = sizeof(VkAccelerationStructureKHR) * cur_type.count;
                         break;
+                    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+                    {
+                        cur_type.offset    = total_size;
+                        uint32_t num_bytes = cur_type.count + array_meta_size;
+
+                        // We will read/write raw bytes in the allocated memory block, they should be the same
+                        required_read_memory_size  = num_bytes;
+                        required_alloc_memory_size = num_bytes;
+                        break;
+                    }
                     default:
                         invalid_optional_desc = true;
                         // If descriptor_type is not recognized, it is possible the capture file was created with a
@@ -152,12 +165,11 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
                 // Update the total size of what we need to allocate
                 total_size += required_alloc_memory_size;
 
-                // Upate the bytes to read to include this block of data so we can get to the next
-                // block.
+                // Update the bytes to read to include this block of data so we can get to the next block.
                 bytes_to_read += optional_read_len + required_read_memory_size;
 
                 // Save the new optional info to the end of the vector so it stays in order
-                optional_info.push_back(std::move(cur_type));
+                optional_info.push_back(cur_type);
             }
         }
 
@@ -200,54 +212,63 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
                                                             texel_buffer_view_count_);
         }
 
-        // If we discovered valid optional descriptor types after the standard ones, handle them appropriately
-        if (optional_info.size() > 0)
+        // If we discovered valid optional descriptor types after the standard ones, handle them appropriately.
+        // They have to be in order because if the above code hits an invalid one, it and anything after
+        // the invalid block will not be appended to the vector.
+        for (auto& cur_type : optional_info)
         {
-            // They have to be in order because if the above code hits an invalid one, it and anything after
-            // the invalid block will not be appended to the vector.
-            for (auto& cur_type : optional_info)
+            // Read the descriptor count and type again and verify it matches what was pre-read.
+            // This is just to make sure the previous read actual read the data properly.
+            size_t current_count = 0;
+            bytes_read +=
+                ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &current_count);
+            VkDescriptorType current_descriptor_type;
+            bytes_read += ValueDecoder::DecodeEnumValue(
+                (buffer + bytes_read), (buffer_size - bytes_read), &current_descriptor_type);
+            assert(current_count == cur_type.count);
+            assert(current_descriptor_type == cur_type.type);
+
+            switch (cur_type.type)
             {
-                // Read the descriptor count and type again and verify it matches what was pre-read.
-                // This is just to make sure the previous read actual read the data properly.
-                size_t current_count = 0;
-                bytes_read +=
-                    ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &current_count);
-                VkDescriptorType current_descriptor_type;
-                bytes_read += ValueDecoder::DecodeEnumValue(
-                    (buffer + bytes_read), (buffer_size - bytes_read), &current_descriptor_type);
-                assert(current_count == cur_type.count);
-                assert(current_descriptor_type == cur_type.type);
-
-                switch (cur_type.type)
+                case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
                 {
-                    case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-                    {
-                        // Just double check that we haven't already created an acceleration struct section
-                        assert(acceleration_structure_khr_count_ == 0);
+                    // Just double check that we haven't already created an acceleration struct section
+                    assert(acceleration_structure_khr_count_ == 0);
 
-                        acceleration_structure_khr_count_ = cur_type.count;
-                        acceleration_structures_khr_ =
-                            reinterpret_cast<VkAccelerationStructureKHR*>(template_memory_ + cur_type.offset);
-                        decoded_acceleration_structure_khr_handle_ids_ =
-                            DecodeAllocator::Allocate<format::HandleId>(acceleration_structure_khr_count_);
+                    acceleration_structure_khr_count_ = cur_type.count;
+                    acceleration_structures_khr_ =
+                        reinterpret_cast<VkAccelerationStructureKHR*>(template_memory_ + cur_type.offset);
+                    decoded_acceleration_structure_khr_handle_ids_ =
+                        DecodeAllocator::Allocate<format::HandleId>(acceleration_structure_khr_count_);
 
-                        bytes_read += ValueDecoder::DecodeHandleIdArray((buffer + bytes_read),
-                                                                        (buffer_size - bytes_read),
-                                                                        decoded_acceleration_structure_khr_handle_ids_,
-                                                                        acceleration_structure_khr_count_);
-                        break;
-                    }
-                    default:
-                        // This should only trigger if someone added a type to the above while loop and not down here.
-                        assert(false);
-                        break;
+                    bytes_read += ValueDecoder::DecodeHandleIdArray((buffer + bytes_read),
+                                                                    (buffer_size - bytes_read),
+                                                                    decoded_acceleration_structure_khr_handle_ids_,
+                                                                    acceleration_structure_khr_count_);
+                    break;
                 }
+                case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
+                {
+                    // double check that we haven't already created an inline-uniform-block section
+                    assert(inline_uniform_block_count_ == 0);
+                    inline_uniform_block_count_ = cur_type.count;
+                    inline_uniform_block_       = template_memory_ + cur_type.offset;
+
+                    bytes_read += array_meta_size;
+                    bytes_read += ValueDecoder::DecodeUInt8Array((buffer + bytes_read),
+                                                                 (buffer_size - bytes_read),
+                                                                 inline_uniform_block_,
+                                                                 inline_uniform_block_count_);
+                    break;
+                }
+                default:
+                    // This should only trigger if someone added a type to the above while loop and not down here.
+                    assert(false);
+                    break;
             }
         }
-
-        assert(bytes_read <= buffer_size);
     }
-
+    assert(bytes_read <= buffer_size);
     return bytes_read;
 }
 

--- a/framework/decode/descriptor_update_template_decoder.cpp
+++ b/framework/decode/descriptor_update_template_decoder.cpp
@@ -47,7 +47,7 @@ DescriptorUpdateTemplateDecoder::~DescriptorUpdateTemplateDecoder() {}
 
 size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buffer_size)
 {
-    // account for the encoded array's metadata
+    // account for an encoded array's metadata (inline-uniform-block encoded using ParameterEncoder::EncodeUInt8Array)
     constexpr size_t array_meta_size = sizeof(format::PointerAttributes) + sizeof(size_t) + sizeof(void*);
 
     size_t bytes_read = DecodeAttributes(buffer, buffer_size);

--- a/framework/decode/descriptor_update_template_decoder.h
+++ b/framework/decode/descriptor_update_template_decoder.h
@@ -48,6 +48,7 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     size_t GetBufferInfoCount() const { return buffer_info_count_; }
     size_t GetTexelBufferViewCount() const { return texel_buffer_view_count_; }
     size_t GetAccelerationStructureKHRCount() const { return acceleration_structure_khr_count_; }
+    size_t GetInlineUniformBlockCount() const { return acceleration_structure_khr_count_; }
 
     Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() { return decoded_image_info_; }
     Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() { return decoded_buffer_info_; }
@@ -69,6 +70,7 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     VkDescriptorBufferInfo*     GetBufferInfoPointer() { return buffer_info_; }
     VkBufferView*               GetTexelBufferViewPointer() { return texel_buffer_views_; }
     VkAccelerationStructureKHR* GetAccelerationStructureKHRPointer() { return acceleration_structures_khr_; }
+    uint8_t*                    GetInlineUniformBlockPointer() { return inline_uniform_block_; }
 
     const VkDescriptorImageInfo*      GetImageInfoPointer() const { return image_info_; }
     const VkDescriptorBufferInfo*     GetBufferInfoPointer() const { return buffer_info_; }
@@ -77,6 +79,7 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     {
         return acceleration_structures_khr_;
     }
+    const uint8_t* GetInlineUniformBlockPointer() const { return inline_uniform_block_; }
 
     size_t Decode(const uint8_t* buffer, size_t buffer_size);
 
@@ -98,6 +101,10 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     format::HandleId*           decoded_acceleration_structure_khr_handle_ids_;
     size_t                      acceleration_structure_khr_count_;
     VkAccelerationStructureKHR* acceleration_structures_khr_;
+
+    // inline uniform blocks
+    size_t   inline_uniform_block_count_;
+    uint8_t* inline_uniform_block_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/descriptor_update_template_decoder.h
+++ b/framework/decode/descriptor_update_template_decoder.h
@@ -48,7 +48,7 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     size_t GetBufferInfoCount() const { return buffer_info_count_; }
     size_t GetTexelBufferViewCount() const { return texel_buffer_view_count_; }
     size_t GetAccelerationStructureKHRCount() const { return acceleration_structure_khr_count_; }
-    size_t GetInlineUniformBlockCount() const { return acceleration_structure_khr_count_; }
+    size_t GetInlineUniformBlockCount() const { return inline_uniform_block_count_; }
 
     Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() { return decoded_image_info_; }
     Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() { return decoded_buffer_info_; }

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -2158,11 +2158,13 @@ void VulkanCppConsumerBase::GenerateDescriptorUpdateTemplateData(DescriptorUpdat
     std::vector<std::string>    buffer_desc_info_variables;
     std::vector<std::string>    texel_desc_info_variables;
     std::vector<std::string>    accel_desc_info_variables;
+    std::vector<std::string>    inline_uniform_block_info_variables;
 
-    uint32_t image_info_count        = static_cast<uint32_t>(decoder->GetImageInfoCount());
-    uint32_t buffer_info_count       = static_cast<uint32_t>(decoder->GetBufferInfoCount());
-    uint32_t texel_buffer_view_count = static_cast<uint32_t>(decoder->GetTexelBufferViewCount());
-    uint32_t accel_struct_count      = static_cast<uint32_t>(decoder->GetAccelerationStructureKHRCount());
+    uint32_t image_info_count           = static_cast<uint32_t>(decoder->GetImageInfoCount());
+    uint32_t buffer_info_count          = static_cast<uint32_t>(decoder->GetBufferInfoCount());
+    uint32_t texel_buffer_view_count    = static_cast<uint32_t>(decoder->GetTexelBufferViewCount());
+    uint32_t accel_struct_count         = static_cast<uint32_t>(decoder->GetAccelerationStructureKHRCount());
+    uint32_t inline_uniform_block_count = static_cast<uint32_t>(decoder->GetInlineUniformBlockCount());
 
     assert(descriptor_update_template_entry_map_.find(descriptor_update_template) !=
            descriptor_update_template_entry_map_.end());
@@ -2303,8 +2305,14 @@ void VulkanCppConsumerBase::GenerateDescriptorUpdateTemplateData(DescriptorUpdat
             }
             case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
             {
-                // TODO: VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK
+                // TODO: needs testing, unsure when/how we'll use this
                 assert(false);
+
+                VariableOffset offset = {
+                    inline_uniform_block_info_variables[0], entry.descriptorType, entry.descriptorCount, entry.offset
+                };
+                inline_uniform_block_info_variables.erase(inline_uniform_block_info_variables.begin());
+                variables.push_back(std::move(offset));
                 break;
             }
             default:

--- a/framework/decode/vulkan_cpp_consumer_base.h
+++ b/framework/decode/vulkan_cpp_consumer_base.h
@@ -47,6 +47,7 @@ struct DescriptorUpdateTemplateEntries
     std::vector<VkDescriptorUpdateTemplateEntry> buffers;
     std::vector<VkDescriptorUpdateTemplateEntry> texels;
     std::vector<VkDescriptorUpdateTemplateEntry> accelerations;
+    std::vector<VkDescriptorUpdateTemplateEntry> inline_uniform_blocks;
 };
 
 // Track items that are specific to a given device
@@ -554,11 +555,11 @@ class VulkanCppConsumerBase : public VulkanConsumer
                                             format::HandleId   device,
                                             format::HandleId   operation) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
-                                                           format::HandleId                 device,
-                                                           format::HandleId                 descriptorSet,
-                                                           format::HandleId                 descriptorUpdateTemplate,
-                                                           DescriptorUpdateTemplateDecoder* pData) override;
+    void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
+                                                   format::HandleId                 device,
+                                                   format::HandleId                 descriptorSet,
+                                                   format::HandleId                 descriptorUpdateTemplate,
+                                                   DescriptorUpdateTemplateDecoder* pData) override;
 
     virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
                                                                format::HandleId   commandBuffer,

--- a/framework/decode/vulkan_json_consumer_base.cpp
+++ b/framework/decode/vulkan_json_consumer_base.cpp
@@ -204,17 +204,19 @@ void VulkanExportJsonConsumerBase::Process_vkCmdPushConstants(const ApiCallInfo&
     });
 }
 
-void VulkanExportJsonConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
-    const ApiCallInfo&               call_info,
-    format::HandleId                 device,
-    format::HandleId                 descriptorSet,
-    format::HandleId                 descriptorUpdateTemplate,
-    DescriptorUpdateTemplateDecoder* pData)
+void VulkanExportJsonConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo& call_info,
+                                                                             format::HandleId   device,
+                                                                             format::HandleId   descriptorSet,
+                                                                             format::HandleId descriptorUpdateTemplate,
+                                                                             DescriptorUpdateTemplateDecoder* pData,
+                                                                             bool use_KHR_suffix)
 {
     using namespace gfxrecon::util;
     const JsonOptions& json_options = GetJsonOptions();
 
-    auto& function = WriteApiCallStart(call_info, "vkUpdateDescriptorSetWithTemplateKHR");
+    const char* function_name =
+        use_KHR_suffix ? "vkUpdateDescriptorSetWithTemplateKHR" : "vkUpdateDescriptorSetWithTemplate";
+    auto& function = WriteApiCallStart(call_info, function_name);
     auto& args     = function[NameArgs()];
 
     HandleToJson(args["device"], device, json_options);

--- a/framework/decode/vulkan_json_consumer_base.h
+++ b/framework/decode/vulkan_json_consumer_base.h
@@ -91,13 +91,34 @@ class VulkanExportJsonConsumerBase : public VulkanConsumer
                                             uint32_t                 size,
                                             PointerDecoder<uint8_t>* pValues) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo&               call_info,
-                                                              format::HandleId                 device,
-                                                              format::HandleId                 descriptorSet,
-                                                              format::HandleId                 descriptorUpdateTemplate,
-                                                              DescriptorUpdateTemplateDecoder* pData) override;
+    void Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo&               call_info,
+                                                      format::HandleId                 device,
+                                                      format::HandleId                 descriptorSet,
+                                                      format::HandleId                 descriptorUpdateTemplate,
+                                                      DescriptorUpdateTemplateDecoder* pData) override
+    {
+        Process_vkUpdateDescriptorSetWithTemplate(
+            call_info, device, descriptorSet, descriptorUpdateTemplate, pData, true);
+    }
+
+    void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
+                                                   format::HandleId                 device,
+                                                   format::HandleId                 descriptorSet,
+                                                   format::HandleId                 descriptorUpdateTemplate,
+                                                   DescriptorUpdateTemplateDecoder* pData) override
+    {
+        Process_vkUpdateDescriptorSetWithTemplate(
+            call_info, device, descriptorSet, descriptorUpdateTemplate, pData, false);
+    }
 
   protected:
+    void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
+                                                   format::HandleId                 device,
+                                                   format::HandleId                 descriptorSet,
+                                                   format::HandleId                 descriptorUpdateTemplate,
+                                                   DescriptorUpdateTemplateDecoder* pData,
+                                                   bool                             use_KHR_suffix);
+
     const util::JsonOptions& GetJsonOptions() const { return writer_->GetOptions(); }
 
     nlohmann::ordered_json& WriteBlockStart() { return writer_->WriteBlockStart(); }

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -274,6 +274,7 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
         std::vector<UpdateTemplateEntryInfo> buffer_infos;
         std::vector<UpdateTemplateEntryInfo> texel_buffer_view_infos;
         std::vector<UpdateTemplateEntryInfo> acceleration_structure_infos;
+        std::vector<UpdateTemplateEntryInfo> inline_uniform_block_infos;
     };
 
     // Table of descriptor update template info, keyed by VkDescriptorUpdateTemplate ID.

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -190,6 +190,18 @@ static void EncodeDescriptorUpdateTemplateInfo(VulkanCaptureManager*     manager
                 }
             }
         }
+
+        // Process raw byte-arrays for VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK
+        if (info->inline_uniform_block_count > 0)
+        {
+            encoder->EncodeSizeTValue(info->inline_uniform_block_count);
+            encoder->EncodeEnumValue(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK);
+
+            for (const auto& entry_info : info->inline_uniform_block)
+            {
+                encoder->EncodeUInt8Array(bytes + entry_info.offset, entry_info.count);
+            }
+        }
     }
     else
     {

--- a/framework/encode/descriptor_update_template_info.h
+++ b/framework/encode/descriptor_update_template_info.h
@@ -56,6 +56,7 @@ struct UpdateTemplateInfo
     size_t                               buffer_info_count{ 0 };
     size_t                               texel_buffer_view_count{ 0 };
     size_t                               acceleration_structure_khr_count{ 0 };
+    size_t                               inline_uniform_block_count{ 0 };
     std::vector<UpdateTemplateEntryInfo> image_info;
     std::vector<UpdateTemplateEntryInfo> buffer_info;
     std::vector<UpdateTemplateEntryInfo> texel_buffer_view;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -497,6 +497,26 @@ void VulkanCaptureManager::SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTem
 
                 entry_size = sizeof(VkAccelerationStructureKHR);
             }
+            else if (type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK)
+            {
+                constexpr size_t byte_stride = 1;
+                GFXRECON_ASSERT(entry->stride == byte_stride);
+
+                UpdateTemplateEntryInfo inline_uniform_info;
+                inline_uniform_info.binding       = entry->dstBinding;
+                inline_uniform_info.array_element = entry->dstArrayElement;
+
+                // count is interpreted as number of bytes here
+                inline_uniform_info.count  = entry->descriptorCount;
+                inline_uniform_info.offset = entry->offset;
+                inline_uniform_info.stride = entry->stride;
+                inline_uniform_info.type   = type;
+
+                info->inline_uniform_block_count += entry->descriptorCount;
+                info->inline_uniform_block.emplace_back(inline_uniform_info);
+
+                entry_size = byte_stride;
+            }
             else
             {
                 GFXRECON_LOG_ERROR("Unrecognized/unsupported descriptor type in descriptor update template.");

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2357,6 +2357,7 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId           
     write->pBufferInfo      = nullptr;
     write->pImageInfo       = nullptr;
     write->pTexelBufferView = nullptr;
+    write->pNext            = nullptr;
 
     switch (write->descriptorType)
     {


### PR DESCRIPTION
support for `VK_EXT_inline_uniform_block`was added recently. 
this addresses missing things for the combination with `vkUpdateDescriptorSetWithTemplate`.

note:
there are already only few samples for `VK_EXT_inline_uniform_block`, same for `vkUpdateDescriptorSetWithTemplate`.
so I forked Sascha's samples and added a modified version of **raytracingreflections** to cover this scenario, similar to a fork done by @MarkY-LunarG 

used this to verify the changes work:
https://github.com/fabian-lunarg/Vulkan/blob/custom_samples/examples/raytracingreflectionsdesctemplates_inline_uniform/raytracingreflectionsdesctemplates_inline_uniform.cpp

- descriptors are updated per frame via `vkUpdateDescriptorSetWithTemplate` (update after bind is enabled everywhere)
- uniform-buffer was replaced with an inline-uniform-block

with this PR recording&replay of this sample (and hopefully any application combining `VK_EXT_inline_uniform_block` and `vkUpdateDescriptorSetWithTemplate`) works now, both with and without trimming

