### PR TITLE
Fix mapped memory image data update issue

### DIFF
--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2020 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -327,7 +327,7 @@ VkDeviceSize VulkanRealignAllocator::FindMatchingResourceOffset(const TrackedDev
 //         which is got from trace file without any adjustment for replay memory requirement difference.
 //
 // VkDeviceSize image_data_start_replay_time,
-//         The copied subresource belong to an image which is in a mapped memory, the parameter is the offset of
+//         The copied subresource belongs to an image which is in a mapped memory, the parameter is the offset of
 //         the image data start which is relative to the mapped memory, and the offset is the image replay time
 //         binding offset which is already after adjustment for replay time memory requirement difference.
 //
@@ -335,7 +335,7 @@ VkDeviceSize VulkanRealignAllocator::FindMatchingResourceOffset(const TrackedDev
 //         These parameters are the create info of the image which has the subresource to be copied.
 //
 // MemoryData allocator_data,
-//         The info of the memory object for which the subresource data will be copied to, include its id and memory
+//         The info of the memory object for which the subresource data will be copied to, including its id and memory
 //         type.
 //
 // uint64_t offset,size,
@@ -392,11 +392,11 @@ VkResult VulkanRealignAllocator::CopyImageSubresourceDataAccordingToLayoutInfo(
         // on subresource layout change between capture and replay time.
         //
         // Note: multi-planar format is not supported in the following handling, and for depth/stencil format,
-        //       we cannot handle the case that depth and stencil aspects is stored separately by driver
+        //       we cannot handle the case that depth and stencil aspects are stored separately by driver
         //       implementation.
 
         // TODO: add handling for multi-planar and the case for depth/stencil format that depth and stencil
-        //      aspects is stored separately by driver implementation.
+        //      aspects are stored separately by driver implementation.
 
         VkDeviceSize texel_size = 0;
         bool         is_texel_block_size;
@@ -419,7 +419,7 @@ VkResult VulkanRealignAllocator::CopyImageSubresourceDataAccordingToLayoutInfo(
                      copy_subresource_info.image_subresource_layout_replay_time.rowPitch);
 
         // This is the subresource data range to be copied, the start and end of the range are capture time offset which
-        // is relative to the start of subresource data;
+        // is relative to the start of subresource data.
         VkDeviceSize copy_range_limit_start_to_subresource_start =
                          copy_subresource_info.subresource_data_offset -
                          copy_subresource_info.image_subresource_layout_capture_time.offset,
@@ -427,7 +427,7 @@ VkResult VulkanRealignAllocator::CopyImageSubresourceDataAccordingToLayoutInfo(
                          copy_subresource_info.subresource_data_offset + copy_subresource_info.subresource_data_size -
                          copy_subresource_info.image_subresource_layout_capture_time.offset;
 
-        // we'll copy the subresource data range to replay time corresponding location from
+        // We'll copy the subresource data range to replay time corresponding location from
         // capture_time_row_data_offset_to_subresource_data_start. This is the capture time offset which is relative to
         // the start of the subresource data. We call it capture time location because this is the location in (or
         // determined by) trace file which is without any consideration of cross-GPU/Driver handling such as binding
@@ -637,14 +637,14 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
         }
         else
         {
-            // The resource is image and it bind to a mapped memory, the full or part image data within the range
+            // The resource is image and it binds to a mapped memory, the full or part image data within the range
             // (offset,size) will be updated by the following handling. According to the tiling of the image, there are
             // the following cases:
             //
             // 1. The tiling is VK_IMAGE_TILING_OPTIMAL
             //
             //    In general, target application should not select the tiling if uploading data to an image from host
-            //    because how texels are laid out in memory is opaque and depend on driver implementation. In the
+            //    because how texels are laid out in memory is opaque and depends on driver implementation. In the
             //    following code, if graphic hardware or driver is different with capture-time, an error message will be
             //    output for this case and image data update will be skipped. if graphic hardware and driver is same
             //    with capture-time, image data will be updated directly without any adjustment to memory location.
@@ -681,10 +681,10 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
 
                 if (create_info.tiling == VK_IMAGE_TILING_OPTIMAL)
                 {
-                    // How texels are laid out in memory is opaque and depend on driver implementation. The case is not
+                    // How texels are laid out in memory is opaque and depends on driver implementation. The case is not
                     // supported by the following handling, The image data update will be skipped with an error message
                     // output. Note, even the image subresource layout from vkGetImageSubresourceLayout is same with
-                    // capture time, still no garentee that the actual memory layout of this image is same.
+                    // capture time, still no guarantee that the actual memory layout of this image is same.
 
                     skip_update = true;
                     GFXRECON_LOG_WARNING_ONCE("Skip uploading data to VK_IMAGE_TILING_OPTIMAL image in mapped memory, "
@@ -758,7 +758,7 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
                     // the image subresource data so we can update the image. The following is why and what
                     // we need to do during the process.
                     //
-                    // During capture-time, target application update a mapped memory range (offset, size) with
+                    // During capture-time, target application updates a mapped memory range (offset, size) with
                     // a data block (data, size). Assume there's an image for which its image data is located within
                     // (the case for partly overlapping is same) the range (offset,size), the image data range is
                     // (imgae_data_capture_time_start, image_data_capture_time_size). Note it's the offset

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -691,7 +691,7 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
                 }
                 else if (create_info.tiling == VK_IMAGE_TILING_LINEAR)
                 {
-                    // Target application update image data for lenear titling image
+                    // Target application update image data for linear titling image
                     if (entry->GetImageSubresourceLayoutSize() == 0)
                     {
                         update_data_without_change_memory_location = true;
@@ -714,10 +714,10 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
                 }
                 else if (create_info.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)
                 {
-                    // It's lenear image if match the condition that Linux DRM format modifier is
+                    // It's linear image if match the condition that Linux DRM format modifier is
                     // DRM_FORMAT_MOD_LINEAR.
 
-                    // TODO: Add process for the following lenear image:
+                    // TODO: Add process for the following linear image:
                     //       VkImage created with VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT and whose Linux DRM format
                     //       modifier is DRM_FORMAT_MOD_LINEAR.
 
@@ -743,7 +743,7 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
                     }
 
                     VkDeviceSize copy_range_start = std::max(resource_start, copy_data_start);
-                    VkDeviceSize copy_range_end   = std::max(resource_end, copy_data_end);
+                    VkDeviceSize copy_range_end   = std::min(resource_end, copy_data_end);
                     copy_size                     = copy_range_end - copy_range_start;
                     mapped_memory_offset          = entry->GetReplayBindOffset() + copy_range_start - resource_start;
                     data_offset                   = copy_range_start - copy_data_start;

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -27,6 +27,7 @@
 #include "decode/vulkan_object_info.h"
 #include "generated/generated_vulkan_struct_decoders.h"
 #include "util/logging.h"
+#include "graphics/vulkan_resources_util.h"
 
 #include <algorithm>
 #include <cassert>
@@ -304,6 +305,264 @@ VkDeviceSize VulkanRealignAllocator::FindMatchingResourceOffset(const TrackedDev
     return offset;
 }
 
+// Copy part or whole data of one image subresource to target mapped memory according to its subresource layout
+// info of both capture time and replay time. During the copy process, the function may adjust subresource texel
+// data location according to the subresource layout difference between capture time and replay time. The function
+// is used by UpdateResourceData function. The image must be a linear tiling image.
+// Note:
+//     multi-planar format is not supported in the following handling, and for depth/stencil format, it cannot handle
+//     the case that depth and stencil aspects is stored separately by driver implementation.
+//
+// const SubresourceLayoutInfo& copy_subresource_info,
+//         The info of the target subresource which includes the range of subresource data to be copied , it also
+//         includes capture-time and replay-time subresource layout. The data range of this subresource to be copied is
+//         (copy_subresource_info.subresource_data_offset, copy_subresource_info.subresource_data_size), the start of
+//         the range is capture time offset which is relative to the start of image data. This range could be part or
+//         whole subresource data.
+//
+//
+// VkDeviceSize image_data_start_capture_time,
+//         The copied subresource belong to an image which is in mapped memory, the parameter is the offset of the
+//         image data start which is relative to the mapped memory, and the offset is capture time binding offset
+//         which is got from trace file without any adjustment for replay memory requirement difference.
+//
+// VkDeviceSize image_data_start_replay_time,
+//         The copied subresource belong to an image which is in a mapped memory, the parameter is the offset of
+//         the image data start which is relative to the mapped memory, and the offset is the image replay time
+//         binding offset which is already after adjustment for replay time memory requirement difference.
+//
+// VkImageType image_type, uint32_t image_arraylayers, VkFormat image_format, VkExtent3D image_extent,
+//         These parameters are the create info of the image which has the subresource to be copied.
+//
+// MemoryData allocator_data,
+//         The info of the memory object for which the subresource data will be copied to, include its id and memory
+//         type.
+//
+// uint64_t offset,size,
+//         The offset and size of the mapped memory range, the offset is relative to mapped memory, it's the capture
+//         time value. The three values (offset, size, data) indicate that during capture time, for mapped memory
+//         range (offset, size), the content of the range is data block which is pointed by data pointer.The copied
+//         subresource data is from the data block.
+//
+// const uint8_t* data,
+//         pointer to the buffer which is data used to copy to the mapped memory range (offset, size).
+
+VkResult VulkanRealignAllocator::CopyImageSubresourceDataAccordingToLayoutInfo(
+    const SubresourceLayoutInfo& copy_subresource_info,
+    VkDeviceSize                 image_data_start_capture_time,
+    VkDeviceSize                 image_data_start_replay_time,
+    VkImageType                  image_type,
+    uint32_t                     image_arraylayers,
+    VkFormat                     image_format,
+    VkExtent3D                   image_extent,
+    MemoryData                   allocator_data,
+    uint64_t                     offset,
+    uint64_t                     size,
+    const uint8_t*               data)
+{
+    VkResult result                  = VK_ERROR_MEMORY_MAP_FAILED;
+    bool     same_subresource_layout = (copy_subresource_info.image_subresource_layout_capture_time.offset ==
+                                    copy_subresource_info.image_subresource_layout_replay_time.offset) &&
+                                   (copy_subresource_info.image_subresource_layout_capture_time.size ==
+                                    copy_subresource_info.image_subresource_layout_replay_time.size) &&
+                                   (copy_subresource_info.image_subresource_layout_capture_time.arrayPitch ==
+                                    copy_subresource_info.image_subresource_layout_replay_time.arrayPitch) &&
+                                   (copy_subresource_info.image_subresource_layout_capture_time.depthPitch ==
+                                    copy_subresource_info.image_subresource_layout_replay_time.depthPitch) &&
+                                   (copy_subresource_info.image_subresource_layout_capture_time.rowPitch ==
+                                    copy_subresource_info.image_subresource_layout_replay_time.rowPitch);
+
+    if (same_subresource_layout)
+    {
+        // The layout for this subresource is same between capture time and replay time. So we don't need to
+        // adjust the location of texel data relative to image data start because location and size for this
+        // subresource and all texel data layout within the subresource keep same between capture and replay
+        // time. We just need to consider the replay time image data start is image_data_start_replay_time.
+
+        result = VulkanDefaultAllocator::WriteMappedMemoryRange(
+            allocator_data,
+            image_data_start_replay_time + copy_subresource_info.subresource_data_offset,
+            copy_subresource_info.subresource_data_size,
+            data + image_data_start_capture_time + copy_subresource_info.subresource_data_offset - offset);
+    }
+    else
+    {
+        // The layout for this subresource is different between capture time and replay time. In the following
+        // handling, we'll copy the rows of the subresource data one by one with memory location adjustment based
+        // on subresource layout change between capture and replay time.
+        //
+        // Note: multi-planar format is not supported in the following handling, and for depth/stencil format,
+        //       we cannot handle the case that depth and stencil aspects is stored separately by driver
+        //       implementation.
+
+        // TODO: add handling for multi-planar and the case for depth/stencil format that depth and stencil
+        //      aspects is stored separately by driver implementation.
+
+        VkDeviceSize texel_size = 0;
+        bool         is_texel_block_size;
+        uint16_t     block_width, block_height;
+
+        bool is_format_supported = gfxrecon::graphics::GetImageTexelSize(
+            image_format, &texel_size, &is_texel_block_size, &block_width, &block_height);
+
+        if (!is_format_supported)
+        { // The image format is not supported.
+            return result;
+        }
+
+        VkDeviceSize offset_in_texel; // offset (< texel size) which is relative to texel start.
+        uint32_t     x, y, z, layer;
+        bool         compressed_texel_block_coordinates, padding_location;
+
+        VkDeviceSize copyable_row_pitch_memory_size =
+            std::min(copy_subresource_info.image_subresource_layout_capture_time.rowPitch,
+                     copy_subresource_info.image_subresource_layout_replay_time.rowPitch);
+
+        // This is the subresource data range to be copied, the start and end of the range are capture time offset which
+        // is relative to the start of subresource data;
+        VkDeviceSize copy_range_limit_start_to_subresource_start =
+                         copy_subresource_info.subresource_data_offset -
+                         copy_subresource_info.image_subresource_layout_capture_time.offset,
+                     copy_range_limit_end_to_subresource_start =
+                         copy_subresource_info.subresource_data_offset + copy_subresource_info.subresource_data_size -
+                         copy_subresource_info.image_subresource_layout_capture_time.offset;
+
+        // we'll copy the subresource data range to replay time corresponding location from
+        // capture_time_row_data_offset_to_subresource_data_start. This is the capture time offset which is relative to
+        // the start of the subresource data. We call it capture time location because this is the location in (or
+        // determined by) trace file which is without any consideration of cross-GPU/Driver handling such as binding
+        // offset adjustment for memory requirement difference or texel data location adjustment for subresource layout
+        // difference.
+        VkDeviceSize current_row_left_size = 0, capture_time_row_data_offset_to_subresource_data_start =
+                                                    copy_range_limit_start_to_subresource_start;
+
+        // In the following handling, we first get the texel coordicates corresponding to the capture time location
+        // capture_time_row_data_offset_to_subresource_data_start, then calculate the replay time offset according to
+        // the texel coordicates.
+        bool result_capture_time_offset_to_coordinates = gfxrecon::graphics::GetTexelCoordinatesFromOffset(
+            image_type,
+            image_arraylayers,
+            image_format,
+            image_extent,
+            copy_subresource_info.image_subresource_layout_capture_time,
+            capture_time_row_data_offset_to_subresource_data_start,
+            &compressed_texel_block_coordinates,
+            &x,
+            &y,
+            &z,
+            &layer,
+            &offset_in_texel,
+            &padding_location,
+            &current_row_left_size);
+
+        VkDeviceSize replay_time_row_data_offset_to_subresource_data_start;
+        bool         result_coordinates_to_replay_time_offset = gfxrecon::graphics::GetOffsetFromTexelCoordinates(
+            image_type,
+            image_arraylayers,
+            image_format,
+            image_extent,
+            copy_subresource_info.image_subresource_layout_replay_time,
+            compressed_texel_block_coordinates,
+            x,
+            y,
+            z,
+            layer,
+            offset_in_texel,
+            padding_location,
+            &replay_time_row_data_offset_to_subresource_data_start);
+
+        bool is_valid_row = result_capture_time_offset_to_coordinates && result_coordinates_to_replay_time_offset;
+
+        bool result_coordinates_to_capture_time_offset = false;
+
+        while (is_valid_row)
+        {
+            if (!padding_location)
+            {
+                result = VulkanDefaultAllocator::WriteMappedMemoryRange(
+                    allocator_data,
+                    image_data_start_replay_time + copy_subresource_info.image_subresource_layout_replay_time.offset +
+                        replay_time_row_data_offset_to_subresource_data_start,
+                    current_row_left_size,
+                    data + image_data_start_capture_time +
+                        copy_subresource_info.image_subresource_layout_capture_time.offset +
+                        capture_time_row_data_offset_to_subresource_data_start - offset);
+
+                if (result != VK_SUCCESS)
+                {
+                    GFXRECON_LOG_ERROR("Failed to upload data to image subresource in mapped memory!");
+                    break;
+                }
+            }
+
+            is_valid_row = gfxrecon::graphics::NextRowTexelCoordinates(
+                image_type, image_arraylayers, image_format, image_extent, y, z, layer);
+
+            if (is_valid_row)
+            {
+                padding_location = false; // After call NextRowTexelCoordinatesAndOffset, the location we will handle is
+                                          // the start of next row, it's the location of valid texel data.
+
+                current_row_left_size = copyable_row_pitch_memory_size;
+
+                result_coordinates_to_replay_time_offset = gfxrecon::graphics::GetOffsetFromTexelCoordinates(
+                    image_type,
+                    image_arraylayers,
+                    image_format,
+                    image_extent,
+                    copy_subresource_info.image_subresource_layout_replay_time,
+                    compressed_texel_block_coordinates,
+                    0,
+                    y,
+                    z,
+                    layer,
+                    0,
+                    false,
+                    &replay_time_row_data_offset_to_subresource_data_start);
+
+                result_coordinates_to_capture_time_offset = gfxrecon::graphics::GetOffsetFromTexelCoordinates(
+                    image_type,
+                    image_arraylayers,
+                    image_format,
+                    image_extent,
+                    copy_subresource_info.image_subresource_layout_capture_time,
+                    compressed_texel_block_coordinates,
+                    0,
+                    y,
+                    z,
+                    layer,
+                    0,
+                    false,
+                    &capture_time_row_data_offset_to_subresource_data_start);
+
+                is_valid_row = result_coordinates_to_capture_time_offset && result_coordinates_to_replay_time_offset;
+
+                if (is_valid_row)
+                {
+                    if ((capture_time_row_data_offset_to_subresource_data_start + current_row_left_size) >
+                        copy_range_limit_end_to_subresource_start)
+                    {
+                        if (capture_time_row_data_offset_to_subresource_data_start >=
+                            copy_range_limit_end_to_subresource_start)
+                        {
+                            // The row is out of copy range limit;
+                            break;
+                        }
+                        else
+                        {
+                            // Part of the row is out of copy range limit;
+                            current_row_left_size = copy_range_limit_end_to_subresource_start -
+                                                    capture_time_row_data_offset_to_subresource_data_start;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
 VkResult VulkanRealignAllocator::UpdateResourceData(
     format::HandleId capture_id, MemoryData allocator_data, uint64_t offset, uint64_t size, const uint8_t* data)
 {
@@ -378,10 +637,226 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
         }
         else
         {
-            // TODO: Handle copy image subresources.
-            GFXRECON_LOG_ERROR(
-                "VulkanRealignAllocator::WriteMappedMemoryRange does not support updates to mapped image resources");
-            result = VK_ERROR_MEMORY_MAP_FAILED;
+            // The resource is image and it bind to a mapped memory, the full or part image data within the range
+            // (offset,size) will be updated by the following handling. According to the tiling of the image, there are
+            // the following cases:
+            //
+            // 1. The tiling is VK_IMAGE_TILING_OPTIMAL
+            //
+            //    In general, target application should not select the tiling if uploading data to an image from host
+            //    because how texels are laid out in memory is opaque and depend on driver implementation. In the
+            //    following code, if graphic hardware or driver is different with capture-time, an error message will be
+            //    output for this case and image data update will be skipped. if graphic hardware and driver is same
+            //    with capture-time, image data will be updated directly without any adjustment to memory location.
+            //
+            // 2. The tiling is VK_IMAGE_TILING_LINEAR:
+            //
+            //    This is the way supported by Vulkan doc for uploading data to image in mapped memory. In the following
+            //    code, if graphic hardware and driver is same with capture-time, image data will be updated directly
+            //    without any adjustment to memory location. if graphic hardware and driver is different with
+            //    capture-time, we'll adjust the memory location of the upload image data according to the difference of
+            //    subresource memory layout between capture and replay time.
+            //
+            // 3. The tiling is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT
+            //
+            //    If Linux DRM format modifier is DRM_FORMAT_MOD_LINEAR, the image is a linear resource, We leave a TODO
+            //    comment for this case. Otherwise, an error message will be output for this case and image data update
+            //    will be skipped.
+
+            auto create_info = entry->GetImageCreateInfo();
+            bool skip_update = false, update_data_without_change_memory_location = false;
+            auto tracked_device_info = tracked_object_table_->GetTrackedDeviceInfo(entry->GetCaptureDeviceId());
+            auto tracked_physical_device_info =
+                tracked_object_table_->GetTrackedPhysicalDeviceInfo(tracked_device_info->GetCapturePhysicalDeviceId());
+
+            if (!tracked_physical_device_info->IsGpuDriverChanged())
+            {
+                // Playback on same hardware/driver, the memory layout of the image is same, just update data according
+                // to the memory location info in the trace file.
+                update_data_without_change_memory_location = true;
+            }
+            else
+            {
+                // Playback on different hardware/driver, we need to consider how texels are laid out in memory.
+
+                if (create_info.tiling == VK_IMAGE_TILING_OPTIMAL)
+                {
+                    // How texels are laid out in memory is opaque and depend on driver implementation. The case is not
+                    // supported by the following handling, The image data update will be skipped with an error message
+                    // output. Note, even the image subresource layout from vkGetImageSubresourceLayout is same with
+                    // capture time, still no garentee that the actual memory layout of this image is same.
+
+                    skip_update = true;
+                    GFXRECON_LOG_WARNING_ONCE("Skip uploading data to VK_IMAGE_TILING_OPTIMAL image in mapped memory, "
+                                              "playback may fail or show corruption!");
+                }
+                else if (create_info.tiling == VK_IMAGE_TILING_LINEAR)
+                {
+                    // Target application update image data for lenear titling image
+                    if (entry->ImageSubresourceLayoutAmount() == 0)
+                    {
+                        update_data_without_change_memory_location = true;
+                        GFXRECON_LOG_WARNING_ONCE("GPU or driver is different between capture time and replay time, no "
+                                                  "image subresource layout info can be used when uploading data to "
+                                                  "VK_IMAGE_TILING_LINEAR image in mapped memory, "
+                                                  "playback may fail or show corruption!");
+                    }
+                    else
+                    {
+                        if (!entry->IsImageSubresourceLayoutChanged())
+                        {
+                            // There's no change with the subresource layout between capture and playback time, and
+                            // because it's linear tiling, so how texels are laid out in memory is exactly same with
+                            // capture-time. We just need to update the image data with the memory location info in
+                            // trace file plus replat-time binding offset adjustment for memory requirement change.
+                            update_data_without_change_memory_location = true;
+                        }
+                    }
+                }
+                else if (create_info.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)
+                {
+                    // It's lenear image if match the condition that Linux DRM format modifier is
+                    // DRM_FORMAT_MOD_LINEAR.
+
+                    // TODO: Add process for the following lenear image:
+                    //       VkImage created with VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT and whose Linux DRM format
+                    //       modifier is DRM_FORMAT_MOD_LINEAR.
+
+                    skip_update = true;
+                    GFXRECON_LOG_WARNING_ONCE("Upload data to image in mapped memory is not supported if the image "
+                                              "tiling is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT!");
+                }
+            }
+
+            if (!skip_update)
+            {
+                if (update_data_without_change_memory_location)
+                {
+                    VkDeviceSize resource_start  = entry->GetTraceBindOffset();
+                    VkDeviceSize resource_end    = entry->GetTraceBindOffset() + entry->GetReplayResourceSize();
+                    uint64_t     copy_data_start = offset;
+                    uint64_t     copy_data_end   = offset + size;
+
+                    // Ignore the resource that is outside the copy range.
+                    if ((copy_data_start >= resource_end) || (resource_start >= copy_data_end))
+                    {
+                        continue;
+                    }
+
+                    VkDeviceSize copy_range_start = std::max(resource_start, copy_data_start);
+                    VkDeviceSize copy_range_end   = std::max(resource_end, copy_data_end);
+                    copy_size                     = copy_range_end - copy_range_start;
+                    mapped_memory_offset          = entry->GetReplayBindOffset() + copy_range_start - resource_start;
+                    data_offset                   = copy_range_start - copy_data_start;
+
+                    result = VulkanDefaultAllocator::WriteMappedMemoryRange(
+                        allocator_data, mapped_memory_offset, copy_size, data + data_offset);
+                }
+                else
+                {
+                    // The image subresource layout changed, we need to calculate the new memory location for
+                    // the image subresource data so we can update the image. The following is why and what
+                    // we need to do during the process.
+                    //
+                    // During capture-time, target application update a mapped memory range (offset, size) with
+                    // a data block (data, size). Assume there's an image for which its image data is located within
+                    // (the case for partly overlapping is same) the range (offset,size), the image data range is
+                    // (imgae_data_capture_time_start, image_data_capture_time_size). Note it's the offset
+                    // relative to mapped memory start for imgae_data_capture_time_start.
+                    //
+                    // If without considering any memory requirement change, we can assume the image data range
+                    // will keep same as capture_time. If considering the memory requirement change, we know
+                    // that the binding offset for resource may have some change, assume the replay-time image
+                    // data range for the image is (imgae_data_replay_time_start,
+                    // image_data_replay_time_size), note it's the offset relative to mapped memory start for
+                    // imgae_data_replay_time_start.
+                    //
+                    // So far, we only considered memory requirement change, let's further consider the
+                    // subresource layout change. For the image. Image may have lots of subresource, assume one
+                    // of them located at (subresource_capture_time_start,
+                    // subresource_capture_time-size), during replay-time, the range is
+                    // (subresource_replay_time_start, subresource_replay_time-size), please note, the
+                    // offset here is relative to image data start, not relative to memory start.
+                    //
+                    // So far, we considered offset/size change with subresource layout, that's not enough
+                    // because we also need to consider the inside of subresource: the change for rowPitch,
+                    // depthPitch, arrayPitch. For one row data without any padding, it's same between
+                    // capture-time and replay-time, but rowPitch, depthPitch, arrayPitch may include padding,
+                    // so the location for row data may be changed between capture time and replay time. But the
+                    // corresponding texel coordinates is same, in the following process, for row data, we
+                    // first get its first texel coordinate from capture-time offset, then from texel
+                    // coordinates to calculate its replay-time offset, then we copy the row data to its
+                    // replay-time location one by one. The case for depthPitch, arrayPitch is similar.
+                    //
+                    // In the above info about handling, we ignored the case about part of image data
+                    // and part of subresource data. The way for this tool to capture target application
+                    // updating mapped memory is by page guard or memory write-watch, it's based on memory not
+                    // resource, considering target application may update resource in multiple threads, it's
+                    // very possible that the captured mapped memory range only include part of image data or
+                    // part of subresource data, the case is also included in the following handling.
+
+                    // imgae_data_capture_time_start and imgae_data_capture_time_end is the offset relative to
+                    // memory start and the range is the whole data range of the image.
+                    VkDeviceSize imgae_data_capture_time_start = entry->GetTraceBindOffset();
+                    VkDeviceSize imgae_data_capture_time_end =
+                        entry->GetTraceBindOffset() + entry->GetTraceResourceSize();
+
+                    // copy_data_start and copy_data_end is the offset relative to memory start and the range
+                    // define the aera the mapped memory data to be copied. Note, the image data could be
+                    // outside/inside/overlaping the range and the range may also include other buffer/image
+                    // data.
+                    uint64_t copy_data_start = offset;
+                    uint64_t copy_data_end   = offset + size;
+
+                    // Get the copy destination offset which is relative to memory start. This is the replay
+                    // time location which is adjusted according to replay time image/buffer memory requirement.
+                    VkDeviceSize imgae_data_replay_time_start = entry->GetReplayBindOffset();
+
+                    // Ignore the image that is outside the copy range.
+                    if ((copy_data_start >= imgae_data_capture_time_end) ||
+                        (imgae_data_capture_time_start >= copy_data_end))
+                    {
+                        continue;
+                    }
+
+                    // The image copy data range (image_copy_data_start, image_copy_data_size) is the data of this
+                    // image within the memory range (offset, size). Note: the range may be full or part data of the
+                    // image.
+                    uint64_t image_copy_data_start = std::max(copy_data_start, imgae_data_capture_time_start);
+                    uint64_t image_copy_data_size =
+                        std::min(copy_data_end, imgae_data_capture_time_end) - image_copy_data_start;
+
+                    // Get the offset of image_copy_data_start which is relative to imgae_data_capture_time_start,
+                    // it should be zero if the image copy data range is from beginning of whole image data.
+                    VkDeviceSize image_copy_data_start_offset_to_image_start =
+                        image_copy_data_start - imgae_data_capture_time_start;
+
+                    // Search and get all subresources which is inside or overlapped with the image copy data range
+                    // (image_copy_data_start, image_copy_data_size)
+                    std::vector<SubresourceLayoutInfo> subresource_layouts;
+                    bool                               search_result = entry->GetImageSubresourceLayoutsInRange(
+                        image_copy_data_start_offset_to_image_start, image_copy_data_size, subresource_layouts);
+
+                    if (search_result)
+                    {
+                        for (auto& copy_subresource_info : subresource_layouts)
+                        {
+                            result =
+                                CopyImageSubresourceDataAccordingToLayoutInfo(copy_subresource_info,
+                                                                              imgae_data_capture_time_start,
+                                                                              imgae_data_replay_time_start,
+                                                                              entry->GetImageCreateInfo().imageType,
+                                                                              entry->GetImageCreateInfo().arrayLayers,
+                                                                              entry->GetImageCreateInfo().format,
+                                                                              entry->GetImageCreateInfo().extent,
+                                                                              allocator_data,
+                                                                              offset,
+                                                                              size,
+                                                                              data);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -693,7 +693,7 @@ VkResult VulkanRealignAllocator::UpdateResourceData(
                 else if (create_info.tiling == VK_IMAGE_TILING_LINEAR)
                 {
                     // Target application update image data for lenear titling image
-                    if (entry->ImageSubresourceLayoutAmount() == 0)
+                    if (entry->GetImageSubresourceLayoutSize() == 0)
                     {
                         update_data_without_change_memory_location = true;
                         GFXRECON_LOG_WARNING_ONCE("GPU or driver is different between capture time and replay time, no "

--- a/framework/decode/vulkan_realign_allocator.h
+++ b/framework/decode/vulkan_realign_allocator.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 ** Copyright (c) 2020 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a

--- a/framework/decode/vulkan_realign_allocator.h
+++ b/framework/decode/vulkan_realign_allocator.h
@@ -103,10 +103,10 @@ class VulkanRealignAllocator : public VulkanDefaultAllocator
         format::HandleId capture_id, MemoryData allocator_data, uint64_t offset, uint64_t size, const uint8_t* data);
 
     VkResult CopyImageSubresourceDataAccordingToLayoutInfo(const SubresourceLayoutInfo& copy_subresource_info,
-                                                           VkDeviceSize                 image_data_start_capture_time,
-                                                           VkDeviceSize                 image_data_start_replay_time,
-                                                           VkImageType                  imageType,
-                                                           uint32_t                     arrayLayers,
+                                                           VkDeviceSize                 capture_image_data_start,
+                                                           VkDeviceSize                 replay_image_data_start,
+                                                           VkImageType                  image_type,
+                                                           uint32_t                     array_layers,
                                                            VkFormat                     format,
                                                            VkExtent3D                   extent,
                                                            MemoryData                   allocator_data,

--- a/framework/decode/vulkan_realign_allocator.h
+++ b/framework/decode/vulkan_realign_allocator.h
@@ -102,6 +102,18 @@ class VulkanRealignAllocator : public VulkanDefaultAllocator
     VkResult UpdateResourceData(
         format::HandleId capture_id, MemoryData allocator_data, uint64_t offset, uint64_t size, const uint8_t* data);
 
+    VkResult CopyImageSubresourceDataAccordingToLayoutInfo(const SubresourceLayoutInfo& copy_subresource_info,
+                                                           VkDeviceSize                 image_data_start_capture_time,
+                                                           VkDeviceSize                 image_data_start_replay_time,
+                                                           VkImageType                  imageType,
+                                                           uint32_t                     arrayLayers,
+                                                           VkFormat                     format,
+                                                           VkExtent3D                   extent,
+                                                           MemoryData                   allocator_data,
+                                                           uint64_t                     offset,
+                                                           uint64_t                     size,
+                                                           const uint8_t*               data);
+
     std::unique_ptr<VkMappedMemoryRange[]> UpdateMappedMemoryOffsets(uint32_t                   memory_range_count,
                                                                      const VkMappedMemoryRange* memory_ranges,
                                                                      const MemoryData*          allocator_datas) const;

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_resource_tracking_consumer.h
+++ b/framework/decode/vulkan_resource_tracking_consumer.h
@@ -173,6 +173,41 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
 
     void CalculateReplayBindingOffsetAndMemoryAllocationSize();
 
+    void Process_vkGetImageSubresourceLayout(const ApiCallInfo&                                 call_info,
+                                             format::HandleId                                   device,
+                                             format::HandleId                                   image,
+                                             StructPointerDecoder<Decoded_VkImageSubresource>*  pSubresource,
+                                             StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) override;
+
+    void
+    Process_vkGetImageSubresourceLayout2KHR(const ApiCallInfo&                                     call_info,
+                                            format::HandleId                                       device,
+                                            format::HandleId                                       image,
+                                            StructPointerDecoder<Decoded_VkImageSubresource2KHR>*  pSubresource,
+                                            StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout) override;
+
+    void
+    Process_vkGetImageSubresourceLayout2EXT(const ApiCallInfo&                                     call_info,
+                                            format::HandleId                                       device,
+                                            format::HandleId                                       image,
+                                            StructPointerDecoder<Decoded_VkImageSubresource2KHR>*  pSubresource,
+                                            StructPointerDecoder<Decoded_VkSubresourceLayout2KHR>* pLayout) override;
+
+    void Process_vkGetPhysicalDeviceProperties(
+        const ApiCallInfo&                                        call_info,
+        format::HandleId                                          physicalDevice,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties) override;
+
+    void Process_vkGetPhysicalDeviceProperties2(
+        const ApiCallInfo&                                         call_info,
+        format::HandleId                                           physicalDevice,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) override;
+
+    void Process_vkGetPhysicalDeviceProperties2KHR(
+        const ApiCallInfo&                                         call_info,
+        format::HandleId                                           physicalDevice,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) override;
+
   protected:
     VulkanTrackedObjectInfoTable* GetTrackedObjectInfoTable() { return tracked_object_info_table_; }
 

--- a/framework/decode/vulkan_resource_tracking_consumer.h
+++ b/framework/decode/vulkan_resource_tracking_consumer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_tracked_object_info.h
+++ b/framework/decode/vulkan_tracked_object_info.h
@@ -29,6 +29,7 @@
 #include "vulkan/vulkan.h"
 
 #include <vector>
+#include <map>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -86,6 +87,26 @@ class TrackedPhysicalDeviceInfo
     VkPhysicalDeviceMemoryProperties*       GetReplayDevicePhysicalMemoryProperties();
     const VkPhysicalDeviceMemoryProperties* GetReplayDevicePhysicalMemoryProperties() const;
 
+    // Set capture device physical properties
+    void SetCaptureDevicePhysicalProperties(VkPhysicalDeviceProperties properties) { capture_properties_ = properties; }
+
+    // Get capture device physical properties
+    VkPhysicalDeviceProperties* GetCaptureDevicePhysicalProperties() { return &capture_properties_; }
+
+    // Set replay device physical properties
+    void SetReplayDevicePhysicalProperties(VkPhysicalDeviceProperties properties) { replay_properties_ = properties; }
+
+    // Get replay device physical properties
+    VkPhysicalDeviceProperties* GetReplayDevicePhysicalProperties() { return &replay_properties_; }
+
+    bool IsGpuDriverChanged() const
+    {
+        bool is_gpu_or_driver_changed = (capture_properties_.vendorID != replay_properties_.vendorID) ||
+                                        (capture_properties_.deviceID != replay_properties_.deviceID) ||
+                                        (capture_properties_.driverVersion != replay_properties_.driverVersion);
+        return is_gpu_or_driver_changed;
+    };
+
   private:
     // ID assigned to the object at capture.
     format::HandleId capture_id_{ 0 };
@@ -95,6 +116,9 @@ class TrackedPhysicalDeviceInfo
 
     VkPhysicalDeviceMemoryProperties capture_memory_properties_{};
     VkPhysicalDeviceMemoryProperties replay_memory_properties_{};
+
+    VkPhysicalDeviceProperties capture_properties_{};
+    VkPhysicalDeviceProperties replay_properties_{};
 };
 
 // This class stores the tracked device information
@@ -133,6 +157,12 @@ class TrackedDeviceInfo
     // Get replay device physical memory properties
     const VkPhysicalDeviceMemoryProperties* GetReplayDevicePhysicalMemoryProperties() const;
 
+    // Set capture device ID
+    void SetCapturePhysicalDeviceId(format::HandleId capture_id) { capture_physical_device_id_ = capture_id; }
+
+    // Get capture device ID
+    format::HandleId GetCapturePhysicalDeviceId() const { return capture_physical_device_id_; }
+
   private:
     // ID assigned to the object at capture.
     format::HandleId capture_id_{ 0 };
@@ -143,7 +173,23 @@ class TrackedDeviceInfo
     // capture device and replay device physical memory properties
     const VkPhysicalDeviceMemoryProperties* capture_memory_properties_{ nullptr };
     const VkPhysicalDeviceMemoryProperties* replay_memory_properties_{ nullptr };
+
+    format::HandleId capture_physical_device_id_{ 0 };
 };
+
+typedef struct SubresourceLayoutInfo
+{
+    VkImageSubresource  image_subresource;
+    bool                valid_capture_time = false;
+    VkSubresourceLayout image_subresource_layout_capture_time;
+    bool                valid_replay_time = false;
+    VkSubresourceLayout image_subresource_layout_replay_time;
+
+    // The range is defined for the image subresource data related handling,
+    // It specify the actual data range which may not be whole subresource data.
+    VkDeviceSize subresource_data_offset;
+    VkDeviceSize subresource_data_size;
+} SubresourceLayoutInfo;
 
 // This class stores the tracked resources (buffer and image) information
 // during the first pass of the replay.
@@ -254,6 +300,187 @@ class TrackedResourceInfo
     // Get image flag
     bool GetImageFlag() const { return is_image; };
 
+    bool IsSameImageSubresourceLayout(VkSubresourceLayout* image_subresource_layout_capture_time,
+                                      VkSubresourceLayout* image_subresource_layout_playback_time)
+    {
+        bool result = false;
+        if ((image_subresource_layout_capture_time->arrayPitch == image_subresource_layout_playback_time->arrayPitch) &&
+            (image_subresource_layout_capture_time->depthPitch == image_subresource_layout_playback_time->depthPitch) &&
+            (image_subresource_layout_capture_time->offset == image_subresource_layout_playback_time->offset) &&
+            (image_subresource_layout_capture_time->rowPitch == image_subresource_layout_playback_time->rowPitch) &&
+            (image_subresource_layout_capture_time->size == image_subresource_layout_playback_time->size))
+        {
+            result = true;
+        }
+        return result;
+    }
+
+    // Set image subresource layout
+    void SetImageSubresourceLayout(VkImageSubresource*  image_subresource,
+                                   VkSubresourceLayout* image_subresource_layout_capture_time,
+                                   VkSubresourceLayout* image_subresource_layout_replay_time)
+    {
+        if ((image_subresource != nullptr) && (image_subresource_layout_capture_time != nullptr))
+        {
+            SubresourceLayoutInfo subresource_layout_info;
+            subresource_layout_info.image_subresource                     = *image_subresource;
+            subresource_layout_info.image_subresource_layout_capture_time = *image_subresource_layout_capture_time;
+            subresource_layout_info.valid_capture_time                    = true;
+            subresource_layout_info.subresource_data_offset = image_subresource_layout_capture_time->offset;
+            subresource_layout_info.subresource_data_size   = image_subresource_layout_capture_time->size;
+
+            if (image_subresource_layout_replay_time != nullptr)
+            {
+                subresource_layout_info.image_subresource_layout_replay_time = *image_subresource_layout_replay_time;
+                subresource_layout_info.valid_replay_time                    = true;
+                if (!IsSameImageSubresourceLayout(image_subresource_layout_capture_time,
+                                                  image_subresource_layout_replay_time))
+                {
+                    image_subresource_layout_changed_ = true;
+                }
+            }
+
+            image_subresource_layouts_[image_subresource_layout_capture_time->offset] =
+                std::move(subresource_layout_info);
+        }
+    };
+
+    // Check and get intersected range for test_range (test_range_offset, test_range_size) and range (range_offset,
+    // range_size) Return true if two ranges are intersected, and if corresponding pointer is not nullptr, return
+    // intersect range and the intersect range is full test range or not.
+    bool IsIntersected(VkDeviceSize  test_range_offset,
+                       VkDeviceSize  test_range_size,
+                       VkDeviceSize  range_offset,
+                       VkDeviceSize  range_size,
+                       bool*         is_test_range_covered,
+                       VkDeviceSize* intersect_offset_in,
+                       VkDeviceSize* intersect_size_in)
+    {
+        bool         test_range_covered = false, result = false;
+        VkDeviceSize intersect_offset = 0, intersect_size = 0;
+        bool         outside_of_range = (test_range_offset >= (range_offset + range_size)) ||
+                                ((test_range_offset + test_range_size) <= range_offset);
+
+        if (!outside_of_range)
+        {
+            result           = true;
+            intersect_offset = std::max(test_range_offset, range_offset);
+            intersect_size =
+                std::min(test_range_offset + test_range_size, range_offset + range_size) - intersect_offset;
+            test_range_covered = (intersect_size == test_range_size);
+        }
+
+        if (is_test_range_covered != nullptr)
+        {
+            *is_test_range_covered = test_range_covered;
+        }
+
+        if (intersect_offset_in != nullptr)
+        {
+            *intersect_offset_in = intersect_offset;
+        }
+
+        if (intersect_size_in != nullptr)
+        {
+            *intersect_size_in = intersect_size;
+        }
+
+        return result;
+    }
+
+    // Get all image subresource layouts for which its part or whole subresource data is located in target image data
+    // range.
+    //
+    // VkDeviceSize  offset_to_image_data_start
+    //         The start offset of the target image data range.
+    //
+    // VkDeviceSize size,
+    //         The size of the target image data range.
+    //
+    // std::vector<SubresourceLayoutInfo>& subresource_layouts
+    //         The matched image subresource layouts. For any subresource X in the returned vector,
+    //         X.subresource_data_offset and X.subresource_data_size is the actual range of the subresource data, the
+    //         actual range may be part or whole subresource data. The whole subresource data range is
+    //         (X.image_subresource_layout_capture_time.offset, X.image_subresource_layout_capture_time.size) for
+    //         capture-time or (X.image_subresource_layout_replay_time.offset,
+    //         X.image_subresource_layout_replay_time.size) for replay-time.
+    //
+    bool GetImageSubresourceLayoutsInRange(VkDeviceSize                        offset_to_image_data_start,
+                                           VkDeviceSize                        size,
+                                           std::vector<SubresourceLayoutInfo>& subresource_layouts)
+    {
+        bool result = false;
+        if (image_subresource_layouts_.size() != 0)
+        {
+            // For all items at or after iterator_subresource_for_range_begin, the key >=offset_to_image_data_start,
+            // for all items at or after iterator_subresource_for_range_end, the key >=
+            // (offset_to_image_data_start+size), so for any subresource in the range from
+            // iterator_subresource_for_range_begin to the item just before iterator_subresource_for_range_end, its part
+            // or whole subresource data is located in target image data range.
+            auto iterator_subresource_for_range_begin =
+                image_subresource_layouts_.lower_bound(offset_to_image_data_start);
+            auto iterator_subresource_for_range_end =
+                image_subresource_layouts_.lower_bound(offset_to_image_data_start + size);
+
+            //  we need to consider the boundary conditions for iterator_subresource_for_range_begin and check if the
+            //  previous subresource data range overlapping the target range, so we include the subresource into the
+            //  searching scope. we don't need to care about iterator_subresource_for_range_begin is end() or not.
+            if (iterator_subresource_for_range_begin != image_subresource_layouts_.begin())
+            {
+                iterator_subresource_for_range_begin--;
+            }
+
+            bool         full_subresource_data = false, is_intersected = false;
+            VkDeviceSize intersect_offset = 0, intersect_size = 0;
+
+            while (iterator_subresource_for_range_begin != image_subresource_layouts_.end())
+            {
+                if (iterator_subresource_for_range_begin != iterator_subresource_for_range_end)
+                {
+                    is_intersected = IsIntersected(iterator_subresource_for_range_begin->second.subresource_data_offset,
+                                                   iterator_subresource_for_range_begin->second.subresource_data_size,
+                                                   offset_to_image_data_start,
+                                                   size,
+                                                   &full_subresource_data,
+                                                   &intersect_offset,
+                                                   &intersect_size);
+                    if (is_intersected)
+                    {
+                        result = true;
+                        subresource_layouts.push_back(iterator_subresource_for_range_begin->second);
+
+                        // If target range only include part data of the subresource, we need to
+                        // adjust the layout info to describe the part data.
+                        if (!full_subresource_data)
+                        {
+                            auto& target_layout_info                   = subresource_layouts.back();
+                            target_layout_info.subresource_data_offset = intersect_offset;
+                            target_layout_info.subresource_data_size   = intersect_size;
+                        }
+                    }
+
+                    iterator_subresource_for_range_begin++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    size_t ImageSubresourceLayoutAmount() { return image_subresource_layouts_.size(); }
+
+    bool IsImageSubresourceLayoutChanged() { return image_subresource_layout_changed_; }
+
+    // Set capture device ID
+    void SetCaptureDeviceId(format::HandleId capture_id) { capture_device_id_ = capture_id; }
+
+    // Get capture device ID
+    format::HandleId GetCaptureDeviceId() const { return capture_device_id_; }
+
   private:
     // ID assigned to the object at capture.
     format::HandleId capture_id_{ 0 };
@@ -289,6 +516,12 @@ class TrackedResourceInfo
 
     // Flag to indicate if this resource is an image (true) or a buffer (false)
     bool is_image{ false };
+
+    format::HandleId capture_device_id_{ 0 };
+
+    bool image_subresource_layout_changed_ = false;
+
+    std::map<VkDeviceSize, SubresourceLayoutInfo> image_subresource_layouts_;
 };
 
 // This class stores the tracked device memory information

--- a/framework/decode/vulkan_tracked_object_info.h
+++ b/framework/decode/vulkan_tracked_object_info.h
@@ -471,7 +471,7 @@ class TrackedResourceInfo
         return result;
     }
 
-    size_t ImageSubresourceLayoutAmount() { return image_subresource_layouts_.size(); }
+    size_t GetImageSubresourceLayoutSize() { return image_subresource_layouts_.size(); }
 
     bool IsImageSubresourceLayoutChanged() { return image_subresource_layout_changed_; }
 

--- a/framework/decode/vulkan_tracked_object_info.h
+++ b/framework/decode/vulkan_tracked_object_info.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/decode/vulkan_tracked_object_info_table.cpp
+++ b/framework/decode/vulkan_tracked_object_info_table.cpp
@@ -80,6 +80,11 @@ TrackedDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedDeviceInfo(format::Ha
     return GetTrackedObjectInfo<TrackedDeviceInfo>(id, &tracked_device_map_);
 }
 
+const TrackedDeviceInfo* VulkanTrackedObjectInfoTable::GetTrackedDeviceInfo(format::HandleId id) const
+{
+    return GetTrackedObjectInfo<TrackedDeviceInfo>(id, &tracked_device_map_);
+}
+
 // Return specified handle ID's device memory information from the tracked memories information table map
 TrackedDeviceMemoryInfo* VulkanTrackedObjectInfoTable::GetTrackedDeviceMemoryInfo(format::HandleId id)
 {

--- a/framework/decode/vulkan_tracked_object_info_table.cpp
+++ b/framework/decode/vulkan_tracked_object_info_table.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2023 LunarG, Inc.
+** Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/graphics/vulkan_resources_util.h
+++ b/framework/graphics/vulkan_resources_util.h
@@ -263,6 +263,49 @@ bool FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& memory_properti
                          uint32_t*                               found_index,
                          VkMemoryPropertyFlags*                  found_flags);
 
+bool GetImageTexelSize(VkFormat      format,
+                       VkDeviceSize* texel_size,
+                       bool*         is_texel_block_size,
+                       uint16_t*     block_width_pointer,
+                       uint16_t*     block_height_pointer);
+
+bool GetTexelCoordinatesFromOffset(VkImageType                imageType,
+                                   uint32_t                   arrayLayers,
+                                   VkFormat                   format,
+                                   const VkExtent3D&          extent,
+                                   const VkSubresourceLayout& subresource_layout,
+                                   VkDeviceSize               offset_to_subresource_data_start,
+                                   bool*                      pointer_texel_rectangle_block_coordinates,
+                                   uint32_t*                  pointer_x,
+                                   uint32_t*                  pointer_y,
+                                   uint32_t*                  pointer_z,
+                                   uint32_t*                  pointer_layer,
+                                   VkDeviceSize*              pointer_offset_in_texel_or_padding,
+                                   bool*                      pointer_padding_location,
+                                   VkDeviceSize*              pointer_current_row_left_size);
+
+bool GetOffsetFromTexelCoordinates(VkImageType         imageType,
+                                   uint32_t            arrayLayers,
+                                   VkFormat            format,
+                                   const VkExtent3D&   extent,
+                                   VkSubresourceLayout subresource_layout,
+                                   bool                compressed_texel_block_coordinates,
+                                   uint32_t            x,
+                                   uint32_t            y,
+                                   uint32_t            z,
+                                   uint32_t            layer,
+                                   VkDeviceSize        offset_in_texel_or_padding,
+                                   bool                padding_location,
+                                   VkDeviceSize*       offset_to_subresource_data_start);
+
+bool NextRowTexelCoordinates(VkImageType       imageType,
+                             uint32_t          arrayLayers,
+                             VkFormat          format,
+                             const VkExtent3D& extent,
+                             uint32_t&         y,
+                             uint32_t&         z,
+                             uint32_t&         layer);
+
 GFXRECON_END_NAMESPACE(gfxrecon)
 GFXRECON_END_NAMESPACE(encode)
 


### PR DESCRIPTION
**The problem**
   
Some applications update data of images which is in mapped memory. For such application, it shows corruption if replaying the captured trace file with -m realign option.

**The solution**

The root cause of the problem is related process doesn't have the handling for updating mapped memory image data. The commit added the handling.

**Result**

Tested the target application with the build of the pull request on the same or different GPU/Driver system with -m realign option, it fixed the issue.
