### PR TITLE
Support multiple simultaneous API capture managers

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(gfxrecon_encode STATIC "")
 
 target_sources(gfxrecon_encode
                PRIVATE
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/api_capture_manager.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/api_capture_manager.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/capture_manager.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/capture_manager.cpp               
                    ${GFXRECON_SOURCE_DIR}/framework/encode/capture_settings.h

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(gfxrecon_encode STATIC "")
 
 target_sources(gfxrecon_encode
                PRIVATE
+                    ${CMAKE_CURRENT_LIST_DIR}/api_capture_manager.h
+                    ${CMAKE_CURRENT_LIST_DIR}/api_capture_manager.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/capture_manager.h
                     ${CMAKE_CURRENT_LIST_DIR}/capture_manager.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/capture_settings.h

--- a/framework/encode/api_capture_manager.cpp
+++ b/framework/encode/api_capture_manager.cpp
@@ -1,0 +1,39 @@
+/*
+** Copyright (c) 2018-2022 Valve Corporation
+** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include PROJECT_VERSION_HEADER_FILE
+
+#include "encode/api_capture_manager.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+CaptureSettings::TraceSettings ApiCaptureManager::GetDefaultTraceSettings()
+{
+    // Return default trace settings.
+    return CaptureSettings::TraceSettings();
+}
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/api_capture_manager.h
+++ b/framework/encode/api_capture_manager.h
@@ -1,0 +1,212 @@
+/*
+** Copyright (c) 2018-2022 Valve Corporation
+** Copyright (c) 2018-2024 LunarG, Inc.
+** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_ENCODE_API_CAPTURE_MANAGER_H
+#define GFXRECON_ENCODE_API_CAPTURE_MANAGER_H
+
+#include "encode/capture_manager.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+class ApiCaptureManager
+{
+  public:
+    ApiCaptureManager(format::ApiFamilyId api_family) : api_family_(api_family) {}
+    void SetCommonManager(CommonCaptureManager* common_manager) { common_manager_ = common_manager; }
+
+    // Forwarded Statics
+    static format::HandleId GetUniqueId() { return CommonCaptureManager::GetUniqueId(); }
+    static auto AcquireSharedApiCallLock() { return std::move(CommonCaptureManager::AcquireSharedApiCallLock()); }
+
+    static auto AcquireExclusiveApiCallLock() { return std::move(CommonCaptureManager::AcquireExclusiveApiCallLock()); }
+
+    // Virtual interface
+    virtual void CreateStateTracker()                                                               = 0;
+    virtual void DestroyStateTracker()                                                              = 0;
+    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) = 0;
+    virtual CaptureSettings::TraceSettings GetDefaultTraceSettings();
+
+    format::ApiFamilyId GetApiFamily() const { return api_family_; }
+    bool                IsCaptureModeTrack() const { return common_manager_->IsCaptureModeTrack(); }
+    bool                IsCaptureModeWrite() const { return common_manager_->IsCaptureModeWrite(); }
+
+    bool IsPageGuardMemoryModeDisabled() const
+    {
+        return GetPageGuardMemoryMode() == CommonCaptureManager::kMemoryModeDisabled;
+    }
+    bool IsPageGuardMemoryModeShadowInternal() const
+    {
+        return GetPageGuardMemoryMode() == CommonCaptureManager::kMemoryModeShadowInternal;
+    }
+    bool IsPageGuardMemoryModeShadowPersistent() const
+    {
+        return GetPageGuardMemoryMode() == CommonCaptureManager::kMemoryModeShadowPersistent;
+    }
+    bool IsPageGuardMemoryModeExternal() const
+    {
+        return GetPageGuardMemoryMode() == CommonCaptureManager::kMemoryModeExternal;
+    }
+
+    typedef uint32_t CaptureMode;
+
+    // Forwarded Common Methods
+    HandleUnwrapMemory* GetHandleUnwrapMemory() { return common_manager_->GetHandleUnwrapMemory(); }
+    ParameterEncoder*   BeginTrackedApiCallCapture(format::ApiCallId call_id)
+    {
+        return common_manager_->BeginTrackedApiCallCapture(call_id);
+    }
+    ParameterEncoder* BeginApiCallCapture(format::ApiCallId call_id)
+    {
+        return common_manager_->BeginApiCallCapture(call_id);
+    }
+    ParameterEncoder* BeginTrackedMethodCallCapture(format::ApiCallId call_id, format::HandleId object_id)
+    {
+        return common_manager_->BeginTrackedMethodCallCapture(call_id, object_id);
+    }
+    ParameterEncoder* BeginMethodCallCapture(format::ApiCallId call_id, format::HandleId object_id)
+    {
+        return common_manager_->BeginMethodCallCapture(call_id, object_id);
+    }
+    void EndApiCallCapture() { common_manager_->EndApiCallCapture(); }
+
+    void EndMethodCallCapture() { common_manager_->EndMethodCallCapture(); }
+
+    void WriteFrameMarker(format::MarkerType marker_type) { common_manager_->WriteFrameMarker(marker_type); }
+
+    void EndFrame() { common_manager_->EndFrame(api_family_); }
+
+    // Pre/PostQueueSubmit to be called immediately before and after work is submitted to the GPU by vkQueueSubmit for
+    // Vulkan or by ID3D12CommandQueue::ExecuteCommandLists for DX12.
+    void PreQueueSubmit() { common_manager_->PreQueueSubmit(api_family_); }
+    void PostQueueSubmit() { common_manager_->PostQueueSubmit(api_family_); }
+
+    bool ShouldTriggerScreenshot() { return common_manager_->ShouldTriggerScreenshot(); }
+
+    void CheckContinueCaptureForWriteMode(uint32_t current_boundary_count)
+    {
+        common_manager_->CheckContinueCaptureForWriteMode(api_family_, current_boundary_count);
+    }
+
+    void CheckStartCaptureForTrackMode(uint32_t current_boundary_count)
+    {
+        common_manager_->CheckStartCaptureForTrackMode(api_family_, current_boundary_count);
+    }
+
+    bool IsTrimHotkeyPressed() { return common_manager_->IsTrimHotkeyPressed(); }
+
+    CaptureSettings::RuntimeTriggerState GetRuntimeTriggerState() { return common_manager_->GetRuntimeTriggerState(); }
+
+    bool RuntimeTriggerEnabled() { return common_manager_->RuntimeTriggerEnabled(); }
+
+    bool RuntimeTriggerDisabled() { return common_manager_->RuntimeTriggerDisabled(); }
+
+    void WriteDisplayMessageCmd(const char* message) { common_manager_->WriteDisplayMessageCmd(api_family_, message); }
+
+    void WriteExeFileInfo(const gfxrecon::util::filepath::FileInfo& info)
+    {
+        common_manager_->WriteExeFileInfo(api_family_, info);
+    }
+
+    void ForcedWriteAnnotation(const format::AnnotationType type, const char* label, const char* data)
+    {
+        common_manager_->ForcedWriteAnnotation(type, label, data);
+    }
+
+    /// @brief Inject an Annotation block into the capture file.
+    /// @param type Identifies the contents of data as plain, xml, or json text
+    /// @param label The key or name of the annotation.
+    /// @param data The value or payload text of the annotation.
+    void WriteAnnotation(const format::AnnotationType type, const char* label, const char* data)
+    {
+        common_manager_->WriteAnnotation(type, label, data);
+    }
+
+    bool GetIUnknownWrappingSetting() const { return common_manager_->GetIUnknownWrappingSetting(); }
+    auto GetForceCommandSerialization() const { return common_manager_->GetForceCommandSerialization(); }
+    auto GetQueueZeroOnly() const { return common_manager_->GetQueueZeroOnly(); }
+    auto GetAllowPipelineCompileRequired() const { return common_manager_->GetAllowPipelineCompileRequired(); }
+
+    bool     IsAnnotated() const { return common_manager_->IsAnnotated(); }
+    uint16_t GetGPUVAMask() const { return common_manager_->GetGPUVAMask(); }
+    uint16_t GetDescriptorMask() const { return common_manager_->GetDescriptorMask(); }
+    uint64_t GetShaderIDMask() const { return common_manager_->GetShaderIDMask(); }
+    uint64_t GetBlockIndex() const { return common_manager_->GetBlockIndex(); }
+
+    bool                                GetForceFileFlush() const { return common_manager_->GetForceFileFlush(); }
+    CaptureSettings::MemoryTrackingMode GetMemoryTrackingMode() const
+    {
+        return common_manager_->GetMemoryTrackingMode();
+    }
+    bool GetPageGuardAlignBufferSizes() const { return common_manager_->GetPageGuardAlignBufferSizes(); }
+    bool GetPageGuardTrackAhbMemory() const { return common_manager_->GetPageGuardTrackAhbMemory(); }
+    CommonCaptureManager::PageGuardMemoryMode GetPageGuardMemoryMode() const
+    {
+        return common_manager_->GetPageGuardMemoryMode();
+    }
+    const std::string&                GetTrimKey() const { return common_manager_->GetTrimKey(); }
+    bool                              IsTrimEnabled() const { return common_manager_->IsTrimEnabled(); }
+    uint32_t                          GetCurrentFrame() const { return common_manager_->GetCurrentFrame(); }
+    CommonCaptureManager::CaptureMode GetCaptureMode() const { return common_manager_->GetCaptureMode(); }
+    bool                              GetDebugLayerSetting() const { return common_manager_->GetDebugLayerSetting(); }
+    bool GetDebugDeviceLostSetting() const { return common_manager_->GetDebugDeviceLostSetting(); }
+    bool GetDisableDxrSetting() const { return common_manager_->GetDisableDxrSetting(); }
+    auto GetAccelStructPaddingSetting() const { return common_manager_->GetAccelStructPaddingSetting(); }
+
+    void WriteResizeWindowCmd(format::HandleId surface_id, uint32_t width, uint32_t height)
+    {
+        common_manager_->WriteResizeWindowCmd(api_family_, surface_id, width, height);
+    }
+    void WriteFillMemoryCmd(format::HandleId memory_id, uint64_t offset, uint64_t size, const void* data)
+    {
+        common_manager_->WriteFillMemoryCmd(api_family_, memory_id, offset, size, data);
+    }
+    void WriteCreateHeapAllocationCmd(uint64_t allocation_id, uint64_t allocation_size)
+    {
+        common_manager_->WriteCreateHeapAllocationCmd(api_family_, allocation_id, allocation_size);
+    }
+    void WriteToFile(const void* data, size_t size) { common_manager_->WriteToFile(data, size); }
+
+    template <size_t N>
+    void CombineAndWriteToFile(const std::pair<const void*, size_t> (&buffers)[N])
+    {
+        common_manager_->CombineAndWriteToFile<N>(buffers);
+    }
+
+    CommonCaptureManager::ThreadData* GetThreadData() { return common_manager_->GetThreadData(); }
+    util::Compressor*                 GetCompressor() { return common_manager_->GetCompressor(); }
+    std::mutex&                       GetMappedMemoryLock() { return common_manager_->GetMappedMemoryLock(); }
+    util::Keyboard&                   GetKeyboard() { return common_manager_->GetKeyboard(); }
+    const std::string&                GetScreenshotPrefix() const { return common_manager_->GetScreenshotPrefix(); }
+    util::ScreenshotFormat            GetScreenshotFormat() { return common_manager_->GetScreenshotFormat(); }
+
+  protected:
+    const format::ApiFamilyId api_family_;
+    CommonCaptureManager*     common_manager_ = nullptr;
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_API_CAPTURE_MANAGER_H

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -25,6 +25,7 @@
 #include PROJECT_VERSION_HEADER_FILE
 
 #include "encode/capture_manager.h"
+#include "encode/api_capture_manager.h"
 
 #include "encode/parameter_buffer.h"
 #include "encode/parameter_encoder.h"
@@ -47,19 +48,18 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 const uint32_t kFirstFrame           = 1;
 const size_t   kFileStreamBufferSize = 256 * 1024;
 
-std::mutex                                     CaptureManager::ThreadData::count_lock_;
-format::ThreadId                               CaptureManager::ThreadData::thread_count_ = 0;
-std::unordered_map<uint64_t, format::ThreadId> CaptureManager::ThreadData::id_map_;
+std::mutex                                     CommonCaptureManager::ThreadData::count_lock_;
+format::ThreadId                               CommonCaptureManager::ThreadData::thread_count_ = 0;
+std::unordered_map<uint64_t, format::ThreadId> CommonCaptureManager::ThreadData::id_map_;
 
-uint32_t                                                 CaptureManager::instance_count_ = 0;
-std::mutex                                               CaptureManager::instance_lock_;
-thread_local std::unique_ptr<CaptureManager::ThreadData> CaptureManager::thread_data_;
-CaptureManager::ApiCallMutexT                            CaptureManager::api_call_mutex_;
-std::function<void()>                                    CaptureManager::delete_instance_func_ = nullptr;
+CommonCaptureManager*                                          CommonCaptureManager::singleton_;
+std::mutex                                                     CommonCaptureManager::instance_lock_;
+thread_local std::unique_ptr<CommonCaptureManager::ThreadData> CommonCaptureManager::thread_data_;
+CommonCaptureManager::ApiCallMutexT                            CommonCaptureManager::api_call_mutex_;
 
-std::atomic<format::HandleId> CaptureManager::unique_id_counter_{ format::kNullHandleId };
+std::atomic<format::HandleId> CommonCaptureManager::unique_id_counter_{ format::kNullHandleId };
 
-CaptureManager::ThreadData::ThreadData() :
+CommonCaptureManager::ThreadData::ThreadData() :
     thread_id_(GetThreadId()), object_id_(format::kNullHandleId), call_id_(format::ApiCallId::ApiCall_Unknown),
     block_index_(0)
 {
@@ -67,7 +67,7 @@ CaptureManager::ThreadData::ThreadData() :
     parameter_encoder_ = std::make_unique<ParameterEncoder>(parameter_buffer_.get());
 }
 
-format::ThreadId CaptureManager::ThreadData::GetThreadId()
+format::ThreadId CommonCaptureManager::ThreadData::GetThreadId()
 {
     format::ThreadId id  = 0;
     uint64_t         tid = util::platform::GetCurrentThreadId();
@@ -88,8 +88,8 @@ format::ThreadId CaptureManager::ThreadData::GetThreadId()
     return id;
 }
 
-CaptureManager::CaptureManager(format::ApiFamilyId api_family) :
-    api_family_(api_family), force_file_flush_(false), timestamp_filename_(true),
+CommonCaptureManager::CommonCaptureManager() :
+    force_file_flush_(false), timestamp_filename_(true),
     memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kPageGuard), page_guard_align_buffer_sizes_(false),
     page_guard_track_ahb_memory_(false), page_guard_unblock_sigsegv_(false), page_guard_signal_handler_watcher_(false),
     page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false),
@@ -101,7 +101,7 @@ CaptureManager::CaptureManager(format::ApiFamilyId api_family) :
     allow_pipeline_compile_required_(false), quit_after_frame_ranges_(false), block_index_(0)
 {}
 
-CaptureManager::~CaptureManager()
+CommonCaptureManager::~CommonCaptureManager()
 {
     if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard ||
         memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
@@ -112,27 +112,30 @@ CaptureManager::~CaptureManager()
     util::Log::Release();
 }
 
-bool CaptureManager::CreateInstance(std::function<CaptureManager*()> GetInstanceFunc,
-                                    std::function<void()>            NewInstanceFunc,
-                                    std::function<void()>            DeleteInstanceFunc)
+bool CommonCaptureManager::CreateInstance(ApiCaptureManager*           api_capture_singleton,
+                                          const std::function<void()>& destroyer)
 {
-    bool                        success = true;
     std::lock_guard<std::mutex> instance_lock(instance_lock_);
+
+    if (!singleton_)
+    {
+        singleton_ = new CommonCaptureManager();
+    }
+
+    return singleton_->LockedCreateInstance(api_capture_singleton, destroyer);
+}
+
+bool CommonCaptureManager::LockedCreateInstance(ApiCaptureManager*           api_capture_singleton,
+                                                const std::function<void()>& destroyer)
+{
+    bool success = true;
 
     if (instance_count_ == 0)
     {
-        assert(GetInstanceFunc() == nullptr);
-
-        // Create new instance of capture manager.
-        instance_count_ = 1;
-        NewInstanceFunc();
-        delete_instance_func_ = DeleteInstanceFunc;
-        if (std::atexit(CaptureManager::AtExit))
+        if (std::atexit(CommonCaptureManager::AtExit))
         {
             GFXRECON_LOG_WARNING("Failed registering atexit");
         }
-
-        assert(GetInstanceFunc() != nullptr);
 
         // Initialize logging to report only errors (to stderr).
         util::Log::Settings stderr_only_log_settings;
@@ -140,62 +143,97 @@ bool CaptureManager::CreateInstance(std::function<CaptureManager*()> GetInstance
         stderr_only_log_settings.output_errors_to_stderr = true;
         util::Log::Init(stderr_only_log_settings);
 
-        // Get capture settings which can be different per capture manager.
-        CaptureSettings settings(GetInstanceFunc()->GetDefaultTraceSettings());
+        // NOTE: FIRST Api Instance is used for settings -- actual multiple simulatenous API support will need to
+        // resolve. Get capture settings which can be different per capture manager.
+        default_settings_ = api_capture_singleton->GetDefaultTraceSettings();
+        capture_settings_ = api_capture_singleton->GetDefaultTraceSettings();
 
         // Load log settings.
-        CaptureSettings::LoadLogSettings(&settings);
+        CaptureSettings::LoadLogSettings(&capture_settings_);
 
         // Reinitialize logging with values retrieved from settings.
         util::Log::Release();
-        util::Log::Init(settings.GetLogSettings());
+        util::Log::Init(capture_settings_.GetLogSettings());
 
         // Load all settings with final logging settings active.
-        CaptureSettings::LoadSettings(&settings);
+        CaptureSettings::LoadSettings(&capture_settings_);
 
         GFXRECON_LOG_INFO("Initializing GFXReconstruct capture layer");
         GFXRECON_LOG_INFO("  GFXReconstruct Version %s", GFXRECON_PROJECT_VERSION_STRING);
 
-        CaptureSettings::TraceSettings trace_settings = settings.GetTraceSettings();
+        CaptureSettings::TraceSettings trace_settings = capture_settings_.GetTraceSettings();
         std::string                    base_filename  = trace_settings.capture_file;
 
         // Initialize capture manager with default settings.
-        success = GetInstanceFunc()->Initialize(base_filename, trace_settings);
+        success = Initialize(api_capture_singleton->GetApiFamily(), base_filename, trace_settings);
         if (!success)
         {
-            GFXRECON_LOG_FATAL("Failed to initialize CaptureManager");
+            GFXRECON_LOG_FATAL("Failed to initialize CommonCaptureManager");
+        }
+    }
+
+    // Add the api capture managers to the list
+    GFXRECON_ASSERT(api_capture_singleton != nullptr);
+    auto manager_it = api_capture_managers_.find(api_capture_singleton);
+    if (manager_it == api_capture_managers_.end())
+    {
+        // Add the Api Capture Manager to this list, and point it back to this common manager.
+        auto inserted =
+            api_capture_managers_.insert(std::make_pair(api_capture_singleton, ApiInstanceRecord{ 1, destroyer }));
+        api_capture_singleton->SetCommonManager(this);
+        GFXRECON_ASSERT(inserted.second);
+        manager_it = inserted.first;
+
+        // NOTE: moved here from CaptureTracker::Initialize... DRY'r than putting it into the API specific
+        //       CreateInstances. For actual multiple simulatenous API support we need to ensure all API capture manager
+        //       state trackers are in the correct state given the differing settings that may be present.
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            api_capture_singleton->CreateStateTracker();
         }
     }
     else
     {
-        assert(GetInstanceFunc() != nullptr);
-        ++instance_count_;
+        ++manager_it->second.count;
     }
 
-    GFXRECON_LOG_DEBUG("CaptureManager::CreateInstance(): Current instance count is %u", instance_count_);
+    ++instance_count_;
+
+    GFXRECON_LOG_DEBUG("CommonCaptureManager::CreateInstance(): Current instance count is %u", instance_count_);
 
     return success;
 }
 
-void CaptureManager::DestroyInstance(std::function<const CaptureManager*()> GetInstanceFunc)
+void CommonCaptureManager::DestroyInstance(ApiCaptureManager* api_capture_manager)
 {
     std::lock_guard<std::mutex> instance_lock(instance_lock_);
 
-    if (GetInstanceFunc() != nullptr)
-    {
-        assert(instance_count_ > 0);
+    GFXRECON_ASSERT(instance_count_ > 0);
 
+    auto manager_it = api_capture_managers_.find(api_capture_manager);
+    GFXRECON_ASSERT(manager_it != api_capture_managers_.end());
+
+    if (manager_it != api_capture_managers_.end())
+    {
+        GFXRECON_ASSERT(manager_it->second.count > 0);
+        --manager_it->second.count;
+
+        if (manager_it->second.count == 0)
+        {
+            GFXRECON_ASSERT(manager_it->first);
+            manager_it->second.destroyer();
+            api_capture_managers_.erase(manager_it);
+        }
         --instance_count_;
+        GFXRECON_LOG_DEBUG("CommonCaptureManager::DestroyInstance(): Current instance count is %u", instance_count_);
 
         if (instance_count_ == 0)
         {
-            assert(delete_instance_func_);
-            delete_instance_func_();
-            delete_instance_func_ = nullptr;
-            assert(GetInstanceFunc() == nullptr);
+            // NOTE: This delete is deleting this, so don't touch the object after this is done.
+            GFXRECON_ASSERT(this == singleton_);
+            delete singleton_;
+            singleton_ = nullptr;
         }
-
-        GFXRECON_LOG_DEBUG("CaptureManager::DestroyInstance(): Current instance count is %u", instance_count_);
     }
 }
 
@@ -242,7 +280,9 @@ std::string PrepScreenshotPrefix(const std::string& dir)
     return out;
 }
 
-bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings::TraceSettings& trace_settings)
+bool CommonCaptureManager::Initialize(format::ApiFamilyId                   api_family,
+                                      std::string                           base_filename,
+                                      const CaptureSettings::TraceSettings& trace_settings)
 {
     bool success = true;
 
@@ -329,7 +369,7 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
         trace_settings.runtime_capture_trigger == CaptureSettings::RuntimeTriggerState::kNotUsed)
     {
         // Use default kModeWrite capture mode.
-        success = CreateCaptureFile(base_filename_);
+        success = CreateCaptureFile(api_family, base_filename_);
     }
     else
     {
@@ -358,7 +398,7 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
                     capture_mode_ = kModeWriteAndTrack;
                 }
 
-                success = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_ranges_[0]));
+                success = CreateCaptureFile(api_family, CreateTrimFilename(base_filename_, trim_ranges_[0]));
             }
             else
             {
@@ -383,7 +423,8 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
                 capture_mode_         = kModeWriteAndTrack;
                 trim_key_first_frame_ = current_frame_;
 
-                success = CreateCaptureFile(util::filepath::InsertFilenamePostfix(base_filename_, "_trim_trigger"));
+                success = CreateCaptureFile(api_family,
+                                            util::filepath::InsertFilenamePostfix(base_filename_, "_trim_trigger"));
             }
             else
             {
@@ -426,11 +467,6 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
                                            trace_settings.page_guard_signal_handler_watcher_max_restores,
                                            mem_prot_mode);
         }
-
-        if ((capture_mode_ & kModeTrack) == kModeTrack)
-        {
-            CreateStateTracker();
-        }
     }
     else
     {
@@ -440,7 +476,25 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
     return success;
 }
 
-ParameterEncoder* CaptureManager::InitApiCallCapture(format::ApiCallId call_id)
+CommonCaptureManager::ThreadData* CommonCaptureManager::GetThreadData()
+{
+    if (!thread_data_)
+    {
+        thread_data_ = std::make_unique<ThreadData>();
+    }
+    return thread_data_.get();
+}
+
+bool CommonCaptureManager::IsCaptureModeTrack() const
+{
+    return (GetCaptureMode() & kModeTrack) == kModeTrack;
+}
+bool CommonCaptureManager::IsCaptureModeWrite() const
+{
+    return (GetCaptureMode() & kModeWrite) == kModeWrite;
+}
+
+ParameterEncoder* CommonCaptureManager::InitApiCallCapture(format::ApiCallId call_id)
 {
     auto thread_data      = GetThreadData();
     thread_data->call_id_ = call_id;
@@ -451,7 +505,7 @@ ParameterEncoder* CaptureManager::InitApiCallCapture(format::ApiCallId call_id)
     return thread_data->parameter_encoder_.get();
 }
 
-ParameterEncoder* CaptureManager::InitMethodCallCapture(format::ApiCallId call_id, format::HandleId object_id)
+ParameterEncoder* CommonCaptureManager::InitMethodCallCapture(format::ApiCallId call_id, format::HandleId object_id)
 {
     auto thread_data        = GetThreadData();
     thread_data->call_id_   = call_id;
@@ -463,7 +517,7 @@ ParameterEncoder* CaptureManager::InitMethodCallCapture(format::ApiCallId call_i
     return thread_data->parameter_encoder_.get();
 }
 
-void CaptureManager::EndApiCallCapture()
+void CommonCaptureManager::EndApiCallCapture()
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
@@ -519,7 +573,7 @@ void CaptureManager::EndApiCallCapture()
     }
 }
 
-void CaptureManager::EndMethodCallCapture()
+void CommonCaptureManager::EndMethodCallCapture()
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
@@ -579,7 +633,7 @@ void CaptureManager::EndMethodCallCapture()
     }
 }
 
-bool CaptureManager::IsTrimHotkeyPressed()
+bool CommonCaptureManager::IsTrimHotkeyPressed()
 {
     // Return true when GetKeyState() transitions from false to true
     bool hotkey_state      = keyboard_.GetKeyState(trim_key_);
@@ -588,7 +642,7 @@ bool CaptureManager::IsTrimHotkeyPressed()
     return hotkey_pressed;
 }
 
-CaptureSettings::RuntimeTriggerState CaptureManager::GetRuntimeTriggerState()
+CaptureSettings::RuntimeTriggerState CommonCaptureManager::GetRuntimeTriggerState()
 {
     CaptureSettings settings;
     CaptureSettings::LoadRunTimeEnvVarSettings(&settings);
@@ -596,7 +650,7 @@ CaptureSettings::RuntimeTriggerState CaptureManager::GetRuntimeTriggerState()
     return settings.GetTraceSettings().runtime_capture_trigger;
 }
 
-bool CaptureManager::RuntimeTriggerEnabled()
+bool CommonCaptureManager::RuntimeTriggerEnabled()
 {
     CaptureSettings::RuntimeTriggerState state = GetRuntimeTriggerState();
 
@@ -609,7 +663,7 @@ bool CaptureManager::RuntimeTriggerEnabled()
     return result;
 }
 
-bool CaptureManager::RuntimeTriggerDisabled()
+bool CommonCaptureManager::RuntimeTriggerDisabled()
 {
     CaptureSettings::RuntimeTriggerState state = GetRuntimeTriggerState();
 
@@ -622,7 +676,8 @@ bool CaptureManager::RuntimeTriggerDisabled()
     return result;
 }
 
-void CaptureManager::CheckContinueCaptureForWriteMode(uint32_t current_boundary_count)
+void CommonCaptureManager::CheckContinueCaptureForWriteMode(format::ApiFamilyId api_family,
+                                                            uint32_t            current_boundary_count)
 {
     if (!trim_ranges_.empty())
     {
@@ -640,7 +695,11 @@ void CaptureManager::CheckContinueCaptureForWriteMode(uint32_t current_boundary_
                 trim_enabled_  = false;
                 trim_boundary_ = CaptureSettings::TrimBoundary::kUnknown;
                 capture_mode_  = kModeDisabled;
-                DestroyStateTracker();
+                // Clean up all of the capture manager's state trackers
+                for (auto& manager_it : api_capture_managers_)
+                {
+                    manager_it.first->DestroyStateTracker();
+                }
                 compressor_ = nullptr;
             }
             else if (trim_ranges_[trim_current_range_].first == current_boundary_count)
@@ -648,7 +707,7 @@ void CaptureManager::CheckContinueCaptureForWriteMode(uint32_t current_boundary_
                 // Trimming was configured to capture two consecutive ranges, so we need to start a new capture
                 // file for the current range.
                 const auto& trim_range = trim_ranges_[trim_current_range_];
-                bool        success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
+                bool        success    = CreateCaptureFile(api_family, CreateTrimFilename(base_filename_, trim_range));
                 if (success)
                 {
                     ActivateTrimming();
@@ -672,14 +731,15 @@ void CaptureManager::CheckContinueCaptureForWriteMode(uint32_t current_boundary_
     }
 }
 
-void CaptureManager::CheckStartCaptureForTrackMode(uint32_t current_boundary_count)
+void CommonCaptureManager::CheckStartCaptureForTrackMode(format::ApiFamilyId api_family,
+                                                         uint32_t            current_boundary_count)
 {
     if (!trim_ranges_.empty())
     {
         if (current_boundary_count == trim_ranges_[trim_current_range_].first)
         {
             const auto& trim_range = trim_ranges_[trim_current_range_];
-            bool        success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
+            bool        success    = CreateCaptureFile(api_family, CreateTrimFilename(base_filename_, trim_range));
             if (success)
             {
                 ActivateTrimming();
@@ -694,7 +754,8 @@ void CaptureManager::CheckStartCaptureForTrackMode(uint32_t current_boundary_cou
     }
     else if (IsTrimHotkeyPressed() || RuntimeTriggerEnabled())
     {
-        bool success = CreateCaptureFile(util::filepath::InsertFilenamePostfix(base_filename_, "_trim_trigger"));
+        bool success =
+            CreateCaptureFile(api_family, util::filepath::InsertFilenamePostfix(base_filename_, "_trim_trigger"));
         if (success)
         {
 
@@ -710,7 +771,7 @@ void CaptureManager::CheckStartCaptureForTrackMode(uint32_t current_boundary_cou
     }
 }
 
-bool CaptureManager::ShouldTriggerScreenshot()
+bool CommonCaptureManager::ShouldTriggerScreenshot()
 {
     bool triger_screenshot = false;
 
@@ -738,7 +799,7 @@ bool CaptureManager::ShouldTriggerScreenshot()
     return triger_screenshot;
 }
 
-void CaptureManager::WriteFrameMarker(format::MarkerType marker_type)
+void CommonCaptureManager::WriteFrameMarker(format::MarkerType marker_type)
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
@@ -752,7 +813,7 @@ void CaptureManager::WriteFrameMarker(format::MarkerType marker_type)
     }
 }
 
-void CaptureManager::EndFrame()
+void CommonCaptureManager::EndFrame(format::ApiFamilyId api_family)
 {
     // Write an end-of-frame marker to the capture file.
     WriteFrameMarker(format::MarkerType::kEndMarker);
@@ -765,13 +826,13 @@ void CaptureManager::EndFrame()
         {
             // Currently capturing a frame range.
             // Check for end of range or hotkey trigger to stop capture.
-            CheckContinueCaptureForWriteMode(current_frame_);
+            CheckContinueCaptureForWriteMode(api_family, current_frame_);
         }
         else if ((capture_mode_ & kModeTrack) == kModeTrack)
         {
             // Capture is not active.
             // Check for start of capture frame range or hotkey trigger to start capture
-            CheckStartCaptureForTrackMode(current_frame_);
+            CheckStartCaptureForTrackMode(api_family, current_frame_);
         }
     }
 
@@ -789,7 +850,7 @@ void CaptureManager::EndFrame()
     }
 }
 
-void CaptureManager::PreQueueSubmit()
+void CommonCaptureManager::PreQueueSubmit(format::ApiFamilyId api_family)
 {
     ++queue_submit_count_;
 
@@ -798,24 +859,25 @@ void CaptureManager::PreQueueSubmit()
         if (((capture_mode_ & kModeWrite) != kModeWrite) && ((capture_mode_ & kModeTrack) == kModeTrack))
         {
             // Capture is not active, check for start of capture frame range.
-            CheckStartCaptureForTrackMode(queue_submit_count_);
+            CheckStartCaptureForTrackMode(api_family, queue_submit_count_);
         }
     }
 }
 
-void CaptureManager::PostQueueSubmit()
+void CommonCaptureManager::PostQueueSubmit(format::ApiFamilyId api_family)
 {
     if (trim_enabled_ && (trim_boundary_ == CaptureSettings::TrimBoundary::kQueueSubmits))
     {
         if ((capture_mode_ & kModeWrite) == kModeWrite)
         {
             // Currently capturing a queue submit range, check for end of range.
-            CheckContinueCaptureForWriteMode(queue_submit_count_);
+            CheckContinueCaptureForWriteMode(api_family, queue_submit_count_);
         }
     }
 }
 
-std::string CaptureManager::CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range)
+std::string CommonCaptureManager::CreateTrimFilename(const std::string&     base_filename,
+                                                     const util::UintRange& trim_range)
 {
     GFXRECON_ASSERT(trim_range.last >= trim_range.first);
 
@@ -847,7 +909,7 @@ std::string CaptureManager::CreateTrimFilename(const std::string& base_filename,
     return util::filepath::InsertFilenamePostfix(base_filename, range_string);
 }
 
-bool CaptureManager::CreateCaptureFile(const std::string& base_filename)
+bool CommonCaptureManager::CreateCaptureFile(format::ApiFamilyId api_family, const std::string& base_filename)
 {
     bool        success          = true;
     std::string capture_filename = base_filename;
@@ -866,7 +928,7 @@ bool CaptureManager::CreateCaptureFile(const std::string& base_filename)
 
         gfxrecon::util::filepath::FileInfo info{};
         gfxrecon::util::filepath::GetApplicationInfo(info);
-        WriteExeFileInfo(info);
+        WriteExeFileInfo(api_family, info);
 
         // Save parameters of the capture in an annotation.
         std::string operation_annotation = "{\n"
@@ -904,17 +966,20 @@ bool CaptureManager::CreateCaptureFile(const std::string& base_filename)
     return success;
 }
 
-void CaptureManager::ActivateTrimming()
+void CommonCaptureManager::ActivateTrimming()
 {
     capture_mode_ |= kModeWrite;
 
     auto thread_data = GetThreadData();
     assert(thread_data != nullptr);
 
-    WriteTrackedState(file_stream_.get(), thread_data->thread_id_);
+    for (auto& manager : api_capture_managers_)
+    {
+        manager.first->WriteTrackedState(file_stream_.get(), thread_data->thread_id_);
+    }
 }
 
-void CaptureManager::DeactivateTrimming()
+void CommonCaptureManager::DeactivateTrimming()
 {
     capture_mode_ &= ~kModeWrite;
 
@@ -923,7 +988,7 @@ void CaptureManager::DeactivateTrimming()
     file_stream_ = nullptr;
 }
 
-void CaptureManager::WriteFileHeader()
+void CommonCaptureManager::WriteFileHeader()
 {
     std::vector<format::FileOptionPair> option_list;
 
@@ -946,15 +1011,15 @@ void CaptureManager::WriteFileHeader()
     thread_data->block_index_ = block_index_.load();
 }
 
-void CaptureManager::BuildOptionList(const format::EnabledOptions&        enabled_options,
-                                     std::vector<format::FileOptionPair>* option_list)
+void CommonCaptureManager::BuildOptionList(const format::EnabledOptions&        enabled_options,
+                                           std::vector<format::FileOptionPair>* option_list)
 {
     assert(option_list != nullptr);
 
     option_list->push_back({ format::FileOption::kCompressionType, enabled_options.compression_type });
 }
 
-void CaptureManager::WriteDisplayMessageCmd(const char* message)
+void CommonCaptureManager::WriteDisplayMessageCmd(format::ApiFamilyId api_family, const char* message)
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
@@ -964,15 +1029,19 @@ void CaptureManager::WriteDisplayMessageCmd(const char* message)
 
         message_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
         message_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(message_cmd) + message_length;
+
+        // NOTE: The message output may vary based on the ordering of Instance Creation/Destruction relative to
+        //       message generation. Need to addres for actual multiple simulatenous API support.
         message_cmd.meta_header.meta_data_id =
-            format::MakeMetaDataId(api_family_, format::MetaDataType::kDisplayMessageCommand);
+            format::MakeMetaDataId(api_family, format::MetaDataType::kDisplayMessageCommand);
         message_cmd.thread_id = thread_data->thread_id_;
 
         CombineAndWriteToFile({ { &message_cmd, sizeof(message_cmd) }, { message, message_length } });
     }
 }
 
-void CaptureManager::WriteExeFileInfo(const gfxrecon::util::filepath::FileInfo& info)
+void CommonCaptureManager::WriteExeFileInfo(format::ApiFamilyId                       api_family,
+                                            const gfxrecon::util::filepath::FileInfo& info)
 {
     auto                     thread_data     = GetThreadData();
     size_t                   info_length     = sizeof(format::ExeFileInfoBlock);
@@ -982,13 +1051,13 @@ void CaptureManager::WriteExeFileInfo(const gfxrecon::util::filepath::FileInfo& 
     exe_info_header.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
     exe_info_header.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(exe_info_header);
     exe_info_header.meta_header.meta_data_id =
-        format::MakeMetaDataId(api_family_, format::MetaDataType::kExeFileInfoCommand);
+        format::MakeMetaDataId(api_family, format::MetaDataType::kExeFileInfoCommand);
     exe_info_header.thread_id = thread_data->thread_id_;
 
     WriteToFile(&exe_info_header, sizeof(exe_info_header));
 }
 
-void CaptureManager::ForcedWriteAnnotation(const format::AnnotationType type, const char* label, const char* data)
+void CommonCaptureManager::ForcedWriteAnnotation(const format::AnnotationType type, const char* label, const char* data)
 {
     auto       thread_data  = GetThreadData();
     const auto label_length = util::platform::StringLength(label);
@@ -1005,7 +1074,7 @@ void CaptureManager::ForcedWriteAnnotation(const format::AnnotationType type, co
     CombineAndWriteToFile({ { &annotation, sizeof(annotation) }, { label, label_length }, { data, data_length } });
 }
 
-void CaptureManager::WriteAnnotation(const format::AnnotationType type, const char* label, const char* data)
+void CommonCaptureManager::WriteAnnotation(const format::AnnotationType type, const char* label, const char* data)
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
@@ -1013,7 +1082,10 @@ void CaptureManager::WriteAnnotation(const format::AnnotationType type, const ch
     }
 }
 
-void CaptureManager::WriteResizeWindowCmd(format::HandleId surface_id, uint32_t width, uint32_t height)
+void CommonCaptureManager::WriteResizeWindowCmd(format::ApiFamilyId api_family,
+                                                format::HandleId    surface_id,
+                                                uint32_t            width,
+                                                uint32_t            height)
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
@@ -1022,7 +1094,7 @@ void CaptureManager::WriteResizeWindowCmd(format::HandleId surface_id, uint32_t 
         resize_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
         resize_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(resize_cmd);
         resize_cmd.meta_header.meta_data_id =
-            format::MakeMetaDataId(api_family_, format::MetaDataType::kResizeWindowCommand);
+            format::MakeMetaDataId(api_family, format::MetaDataType::kResizeWindowCommand);
         resize_cmd.thread_id = thread_data->thread_id_;
 
         resize_cmd.surface_id = surface_id;
@@ -1033,7 +1105,8 @@ void CaptureManager::WriteResizeWindowCmd(format::HandleId surface_id, uint32_t 
     }
 }
 
-void CaptureManager::WriteFillMemoryCmd(format::HandleId memory_id, uint64_t offset, uint64_t size, const void* data)
+void CommonCaptureManager::WriteFillMemoryCmd(
+    format::ApiFamilyId api_family, format::HandleId memory_id, uint64_t offset, uint64_t size, const void* data)
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
@@ -1049,7 +1122,7 @@ void CaptureManager::WriteFillMemoryCmd(format::HandleId memory_id, uint64_t off
 
         fill_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
         fill_cmd.meta_header.meta_data_id =
-            format::MakeMetaDataId(api_family_, format::MetaDataType::kFillMemoryCommand);
+            format::MakeMetaDataId(api_family, format::MetaDataType::kFillMemoryCommand);
         fill_cmd.thread_id     = thread_data->thread_id_;
         fill_cmd.memory_id     = memory_id;
         fill_cmd.memory_offset = offset;
@@ -1090,9 +1163,11 @@ void CaptureManager::WriteFillMemoryCmd(format::HandleId memory_id, uint64_t off
     }
 }
 
-void CaptureManager::WriteCreateHeapAllocationCmd(uint64_t allocation_id, uint64_t allocation_size)
+void CommonCaptureManager::WriteCreateHeapAllocationCmd(format::ApiFamilyId api_family,
+                                                        uint64_t            allocation_id,
+                                                        uint64_t            allocation_size)
 {
-    if ((GetCaptureMode() & kModeWrite) == kModeWrite)
+    if (IsCaptureModeWrite())
     {
         format::CreateHeapAllocationCommand allocation_cmd;
 
@@ -1102,7 +1177,7 @@ void CaptureManager::WriteCreateHeapAllocationCmd(uint64_t allocation_id, uint64
         allocation_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
         allocation_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(allocation_cmd);
         allocation_cmd.meta_header.meta_data_id =
-            format::MakeMetaDataId(api_family_, format::MetaDataType::kCreateHeapAllocationCommand);
+            format::MakeMetaDataId(api_family, format::MetaDataType::kCreateHeapAllocationCommand);
         allocation_cmd.thread_id       = thread_data->thread_id_;
         allocation_cmd.allocation_id   = allocation_id;
         allocation_cmd.allocation_size = allocation_size;
@@ -1111,7 +1186,7 @@ void CaptureManager::WriteCreateHeapAllocationCmd(uint64_t allocation_id, uint64
     }
 }
 
-void CaptureManager::WriteToFile(const void* data, size_t size)
+void CommonCaptureManager::WriteToFile(const void* data, size_t size)
 {
     if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUserfaultfd)
     {
@@ -1151,9 +1226,22 @@ void CaptureManager::WriteToFile(const void* data, size_t size)
     thread_data->block_index_ = block_index_.load();
 }
 
-void CaptureManager::WriteCaptureOptions(std::string& operation_annotation)
+void CommonCaptureManager::AtExit()
 {
-    CaptureSettings::TraceSettings default_settings = GetDefaultTraceSettings();
+    if (CommonCaptureManager::singleton_)
+    {
+        for (auto& api_capture_manager : singleton_->api_capture_managers_)
+        {
+            api_capture_manager.second.destroyer();
+        }
+        delete CommonCaptureManager::singleton_;
+        CommonCaptureManager::singleton_ = nullptr;
+    }
+}
+
+void CommonCaptureManager::WriteCaptureOptions(std::string& operation_annotation)
+{
+    CaptureSettings::TraceSettings default_settings = default_settings_.GetTraceSettings();
     std::string                    buffer;
 
     if (force_file_flush_ != default_settings.force_flush)
@@ -1249,12 +1337,6 @@ void CaptureManager::WriteCaptureOptions(std::string& operation_annotation)
     operation_annotation += "\": \n    {";
     operation_annotation += buffer;
     operation_annotation += "\n    }";
-}
-
-CaptureSettings::TraceSettings CaptureManager::GetDefaultTraceSettings()
-{
-    // Return default trace settings.
-    return CaptureSettings::TraceSettings();
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -49,7 +49,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-class CaptureManager
+class ApiCaptureManager;
+
+// The CommonCaptureManager provides common functionality referenced API specific capture managers
+class CommonCaptureManager
 {
   public:
     typedef std::shared_mutex ApiCallMutexT;
@@ -114,20 +117,20 @@ class CaptureManager
 
     void WriteFrameMarker(format::MarkerType marker_type);
 
-    void EndFrame();
+    void EndFrame(format::ApiFamilyId api_family);
 
     // Pre/PostQueueSubmit to be called immediately before and after work is submitted to the GPU by vkQueueSubmit for
     // Vulkan or by ID3D12CommandQueue::ExecuteCommandLists for DX12.
-    void PreQueueSubmit();
-    void PostQueueSubmit();
+    void PreQueueSubmit(format::ApiFamilyId api_family);
+    void PostQueueSubmit(format::ApiFamilyId api_family);
 
     bool ShouldTriggerScreenshot();
 
     util::ScreenshotFormat GetScreenshotFormat() { return screenshot_format_; }
 
-    void CheckContinueCaptureForWriteMode(uint32_t current_boundary_count);
+    void CheckContinueCaptureForWriteMode(format::ApiFamilyId api_family, uint32_t current_boundary_count);
 
-    void CheckStartCaptureForTrackMode(uint32_t current_boundary_count);
+    void CheckStartCaptureForTrackMode(format::ApiFamilyId api_family, uint32_t current_boundary_count);
 
     bool IsTrimHotkeyPressed();
 
@@ -137,9 +140,9 @@ class CaptureManager
 
     bool RuntimeTriggerDisabled();
 
-    void WriteDisplayMessageCmd(const char* message);
+    void WriteDisplayMessageCmd(format::ApiFamilyId api_family, const char* message);
 
-    void WriteExeFileInfo(const gfxrecon::util::filepath::FileInfo& info);
+    void WriteExeFileInfo(format::ApiFamilyId api_family, const gfxrecon::util::filepath::FileInfo& info);
 
     void ForcedWriteAnnotation(const format::AnnotationType type, const char* label, const char* data);
 
@@ -148,8 +151,6 @@ class CaptureManager
     /// @param label The key or name of the annotation.
     /// @param data The value or payload text of the annotation.
     void WriteAnnotation(const format::AnnotationType type, const char* label, const char* data);
-
-    virtual CaptureSettings::TraceSettings GetDefaultTraceSettings();
 
     bool GetIUnknownWrappingSetting() const { return iunknown_wrapping_; }
     auto GetForceCommandSerialization() const { return force_command_serialization_; }
@@ -167,7 +168,15 @@ class CaptureManager
         return thread_data->block_index_ == 0 ? 0 : thread_data->block_index_ - 1;
     }
 
-  protected:
+    static bool CreateInstance(ApiCaptureManager* api_instance_, const std::function<void()>& destroyer);
+    template <typename Derived>
+    static bool CreateInstance()
+    {
+        return CreateInstance(Derived::InitSingleton(), Derived::DestroySingleton);
+    }
+
+    CommonCaptureManager();
+
     enum CaptureModeFlags : uint32_t
     {
         kModeDisabled      = 0x0,
@@ -218,32 +227,22 @@ class CaptureManager
         std::vector<uint8_t> scratch_buffer_;
     };
 
+    ThreadData* GetThreadData();
+    bool        IsCaptureModeTrack() const;
+    bool        IsCaptureModeWrite() const;
+
+    void DestroyInstance(ApiCaptureManager* singleton);
+
   protected:
-    static bool CreateInstance(std::function<CaptureManager*()> GetInstanceFunc,
-                               std::function<void()>            NewInstanceFunc,
-                               std::function<void()>            DeleteInstanceFunc);
+    bool LockedCreateInstance(ApiCaptureManager* api_capture_singleton, const std::function<void()>& destroyer);
 
-    static void DestroyInstance(std::function<const CaptureManager*()> GetInstanceFunc);
+    virtual ~CommonCaptureManager();
 
-    CaptureManager(format::ApiFamilyId api_family);
+    bool Initialize(format::ApiFamilyId                   api_family,
+                    std::string                           base_filename,
+                    const CaptureSettings::TraceSettings& trace_settings);
 
-    virtual ~CaptureManager();
-
-    bool Initialize(std::string base_filename, const CaptureSettings::TraceSettings& trace_settings);
-
-    virtual void CreateStateTracker()                                                               = 0;
-    virtual void DestroyStateTracker()                                                              = 0;
-    virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) = 0;
-
-    ThreadData* GetThreadData()
-    {
-        if (!thread_data_)
-        {
-            thread_data_ = std::make_unique<ThreadData>();
-        }
-        return thread_data_.get();
-    }
-
+  public:
     bool                                GetForceFileFlush() const { return force_file_flush_; }
     CaptureSettings::MemoryTrackingMode GetMemoryTrackingMode() const { return memory_tracking_mode_; }
     bool                                GetPageGuardAlignBufferSizes() const { return page_guard_align_buffer_sizes_; }
@@ -258,8 +257,14 @@ class CaptureManager
     bool                                GetDisableDxrSetting() const { return disable_dxr_; }
     auto                                GetAccelStructPaddingSetting() const { return accel_struct_padding_; }
 
+    util::Compressor*      GetCompressor() { return compressor_.get(); }
+    std::mutex&            GetMappedMemoryLock() { return mapped_memory_lock_; }
+    util::Keyboard&        GetKeyboard() { return keyboard_; }
+    const std::string&     GetScreenshotPrefix() const { return screenshot_prefix_; }
+    util::ScreenshotFormat GetScreenShotFormat() const { return screenshot_format_; }
+
     std::string CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range);
-    bool        CreateCaptureFile(const std::string& base_filename);
+    bool        CreateCaptureFile(format::ApiFamilyId api_family, const std::string& base_filename);
     void        WriteCaptureOptions(std::string& operation_annotation);
     void        ActivateTrimming();
     void        DeactivateTrimming();
@@ -272,19 +277,13 @@ class CaptureManager
 
     ParameterEncoder* InitMethodCallCapture(format::ApiCallId call_id, format::HandleId object_id);
 
-    void WriteResizeWindowCmd(format::HandleId surface_id, uint32_t width, uint32_t height);
+    void
+    WriteResizeWindowCmd(format::ApiFamilyId api_family, format::HandleId surface_id, uint32_t width, uint32_t height);
 
-    void WriteFillMemoryCmd(format::HandleId memory_id, uint64_t offset, uint64_t size, const void* data);
+    void WriteFillMemoryCmd(
+        format::ApiFamilyId api_family, format::HandleId memory_id, uint64_t offset, uint64_t size, const void* data);
 
-    void WriteCreateHeapAllocationCmd(uint64_t allocation_id, uint64_t allocation_size);
-
-  protected:
-    std::unique_ptr<util::Compressor> compressor_;
-    std::mutex                        mapped_memory_lock_;
-    util::Keyboard                    keyboard_;
-    std::string                       screenshot_prefix_;
-    util::ScreenshotFormat            screenshot_format_;
-    std::atomic<uint64_t>             block_index_;
+    void WriteCreateHeapAllocationCmd(format::ApiFamilyId api_family, uint64_t allocation_id, uint64_t allocation_size);
 
     void WriteToFile(const void* data, size_t size);
 
@@ -306,24 +305,42 @@ class CaptureManager
         WriteToFile(scratch_buffer.data(), scratch_buffer.size());
     }
 
-  private:
-    static void AtExit()
+    void IncrementBlockIndex(uint64_t blocks)
     {
-        if (delete_instance_func_)
-        {
-            delete_instance_func_();
-            delete_instance_func_ = nullptr;
-        }
+        block_index_ += blocks;
+        GetThreadData()->block_index_ = block_index_;
     }
 
+  protected:
+    std::unique_ptr<util::Compressor> compressor_;
+    std::mutex                        mapped_memory_lock_;
+    util::Keyboard                    keyboard_;
+    std::string                       screenshot_prefix_;
+    util::ScreenshotFormat            screenshot_format_;
+    std::atomic<uint64_t>             block_index_;
+
   private:
-    static uint32_t                                 instance_count_;
+    static void AtExit();
+
+  private:
     static std::mutex                               instance_lock_;
+    static CommonCaptureManager*                    singleton_;
     static thread_local std::unique_ptr<ThreadData> thread_data_;
     static std::atomic<format::HandleId>            unique_id_counter_;
     static ApiCallMutexT                            api_call_mutex_;
 
-    const format::ApiFamilyId api_family_;
+    uint32_t instance_count_ = 0;
+    struct ApiInstanceRecord
+    {
+        size_t                count;
+        std::function<void()> destroyer;
+    };
+    using ApiCaptureManagerMap = std::unordered_map<ApiCaptureManager*, ApiInstanceRecord>;
+    ApiCaptureManagerMap api_capture_managers_;
+
+    CaptureSettings default_settings_; // Default settings from the initial api singleton
+    CaptureSettings
+        capture_settings_; // Settings from the settings file and environment at capture manager creation time.
 
     std::unique_ptr<util::FileOutputStream> file_stream_;
     format::EnabledOptions                  file_options_;
@@ -363,7 +380,6 @@ class CaptureManager
     bool                                    queue_zero_only_;
     bool                                    allow_pipeline_compile_required_;
     bool                                    quit_after_frame_ranges_;
-    static std::function<void()>            delete_instance_func_;
 
     struct
     {

--- a/framework/encode/custom_ags_wrappers.cpp
+++ b/framework/encode/custom_ags_wrappers.cpp
@@ -46,8 +46,8 @@ AMD_AGS_API AGSReturnCode agsInitialize(int                     agsVersion,
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -87,8 +87,8 @@ AMD_AGS_API AGSReturnCode agsDeInitialize(AGSContext* context)
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -129,8 +129,8 @@ AMD_AGS_API AGSReturnCode agsDriverExtensionsDX12_CreateDevice(AGSContext*      
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -214,8 +214,8 @@ AMD_AGS_API AGSReturnCode agsDriverExtensionsDX12_DestroyDevice(AGSContext*   co
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -260,8 +260,8 @@ AMD_AGS_API AGSDriverVersionResult agsCheckDriverVersion(const char*  radeonSoft
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -303,8 +303,8 @@ AMD_AGS_API int agsGetVersionNumber()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -345,8 +345,8 @@ AMD_AGS_API AGSReturnCode agsSetDisplayMode(AGSContext*               context,
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -388,8 +388,8 @@ AMD_AGS_API AGSReturnCode agsDriverExtensionsDX12_PushMarker(AGSContext*        
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -431,8 +431,8 @@ AMD_AGS_API AGSReturnCode agsDriverExtensionsDX12_PopMarker(AGSContext* context,
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -476,8 +476,8 @@ AMD_AGS_API AGSReturnCode agsDriverExtensionsDX12_SetMarker(AGSContext*         
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -384,8 +384,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice                 
     }
 
     auto force_command_serialization = VulkanCaptureManager::Get()->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -473,8 +473,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice                  
     }
 
     auto force_command_serialization = VulkanCaptureManager::Get()->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -563,8 +563,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice             
     }
 
     auto force_command_serialization = VulkanCaptureManager::Get()->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -655,8 +655,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice            
     }
 
     auto force_command_serialization = VulkanCaptureManager::Get()->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -35,44 +35,55 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 static constexpr char kDx12RuntimeName[] = "D3D12Core.dll";
 
-D3D12CaptureManager*  D3D12CaptureManager::instance_   = nullptr;
+D3D12CaptureManager*  D3D12CaptureManager::singleton_  = nullptr;
 thread_local uint32_t D3D12CaptureManager::call_scope_ = 0;
 
 D3D12CaptureManager::D3D12CaptureManager() :
-    CaptureManager(format::ApiFamilyId::ApiFamily_D3D12), dxgi_dispatch_table_{}, d3d12_dispatch_table_{},
+    ApiCaptureManager(format::ApiFamilyId::ApiFamily_D3D12), dxgi_dispatch_table_{}, d3d12_dispatch_table_{},
     debug_layer_enabled_(false), debug_device_lost_enabled_(false),
     track_enable_debug_layer_object_id_(format::kNullHandleId), frame_buffer_renderer_(nullptr)
 {}
 
 bool D3D12CaptureManager::CreateInstance()
 {
-    bool ret = CaptureManager::CreateInstance([]() -> CaptureManager* { return instance_; },
-                                              []() {
-                                                  assert(instance_ == nullptr);
-                                                  instance_ = new D3D12CaptureManager();
-                                              },
-                                              []() {
-                                                  if (instance_)
-                                                  {
-                                                      delete instance_;
-                                                      instance_ = nullptr;
-                                                  }
-                                              });
-    if (instance_->IsAnnotated() == true && instance_->resource_value_annotator_ == nullptr)
+    bool ret = CommonCaptureManager::CreateInstance<D3D12CaptureManager>();
+
+    GFXRECON_ASSERT(singleton_);
+
+    if (singleton_->IsAnnotated() == true && singleton_->resource_value_annotator_ == nullptr)
     {
-        instance_->resource_value_annotator_ = std::make_unique<Dx12ResourceValueAnnotator>();
+        singleton_->resource_value_annotator_ = std::make_unique<Dx12ResourceValueAnnotator>();
     }
     return ret;
 }
 
+D3D12CaptureManager* D3D12CaptureManager::InitSingleton()
+{
+    if (!singleton_)
+    {
+        singleton_ = new D3D12CaptureManager();
+    }
+    return singleton_;
+}
+
+void D3D12CaptureManager::DestroySingleton()
+{
+    if (singleton_)
+    {
+        delete singleton_;
+        singleton_ = nullptr;
+    }
+}
+
 void D3D12CaptureManager::DestroyInstance()
 {
-    CaptureManager::DestroyInstance([]() -> const CaptureManager* { return instance_; });
+    GFXRECON_ASSERT(singleton_ && singleton_->common_manager_);
+    singleton_->common_manager_->DestroyInstance(singleton_);
 }
 
 void D3D12CaptureManager::EndCreateApiCallCapture(HRESULT result, REFIID riid, void** handle)
 {
-    if (((GetCaptureMode() & kModeTrack) == kModeTrack) && SUCCEEDED(result))
+    if (IsCaptureModeTrack() && SUCCEEDED(result))
     {
         if ((handle != nullptr) && (*handle != nullptr))
         {
@@ -92,7 +103,7 @@ void D3D12CaptureManager::EndCreateApiCallCapture(HRESULT result, REFIID riid, v
 #ifdef GFXRECON_AGS_SUPPORT
 void D3D12CaptureManager::EndAgsApiCallCapture(HRESULT result, void* object_ptr)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         if (SUCCEEDED(result))
         {
@@ -110,7 +121,7 @@ void D3D12CaptureManager::EndAgsApiCallCapture(HRESULT result, void* object_ptr)
 
 void D3D12CaptureManager::EndAgsApiCallCapture(ID3D12GraphicsCommandList_Wrapper* list_wrapper)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         assert(state_tracker_ != nullptr);
 
@@ -129,7 +140,7 @@ void D3D12CaptureManager::EndAgsApiCallCapture(ID3D12GraphicsCommandList_Wrapper
 void D3D12CaptureManager::EndCreateDescriptorMethodCallCapture(D3D12_CPU_DESCRIPTOR_HANDLE dest_descriptor,
                                                                ID3D12Device_Wrapper*       create_object_wrapper)
 {
-    if (((GetCaptureMode() & kModeTrack) == kModeTrack) && (dest_descriptor.ptr != 0))
+    if (IsCaptureModeTrack() && (dest_descriptor.ptr != 0))
     {
         auto thread_data = GetThreadData();
         assert(thread_data != nullptr);
@@ -145,7 +156,7 @@ void D3D12CaptureManager::EndCreateDescriptorMethodCallCapture(D3D12_CPU_DESCRIP
 
 void D3D12CaptureManager::EndCommandListMethodCallCapture(ID3D12CommandList_Wrapper* list_wrapper)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         assert(state_tracker_ != nullptr);
 
@@ -160,7 +171,7 @@ void D3D12CaptureManager::EndCommandListMethodCallCapture(ID3D12CommandList_Wrap
 
 void D3D12CaptureManager::WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id)
 {
-    Dx12StateWriter state_writer(file_stream, compressor_.get(), thread_id);
+    Dx12StateWriter state_writer(file_stream, GetCompressor(), thread_id);
     state_tracker_->WriteState(&state_writer, GetCurrentFrame());
 }
 
@@ -195,7 +206,7 @@ void D3D12CaptureManager::PreAcquireSwapChainImages(IDXGISwapChain_Wrapper* wrap
             info->child_images.resize(image_count);
             info->swap_effect = swap_effect;
 
-            if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+            if (IsCaptureModeTrack())
             {
                 // TODO: In VK version, this thing is done in InitializeGroupObjectState,
                 //       This might need to be removed to InitializeGroupObjectState when it's ready.
@@ -277,7 +288,7 @@ void D3D12CaptureManager::ResizeSwapChainImages(IDXGISwapChain_Wrapper* wrapper,
 
         PreAcquireSwapChainImages(wrapper, nullptr, final_buffer_count, info->swap_effect);
 
-        if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+        if (IsCaptureModeTrack())
         {
             state_tracker_->TrackResizeBuffers(
                 wrapper, format::ApiCall_IDXGISwapChain_ResizeBuffers, GetThreadData()->parameter_buffer_.get());
@@ -363,7 +374,7 @@ void D3D12CaptureManager::InitializeID3D12ResourceInfo(ID3D12Device_Wrapper*    
                 layouts[i].Footprint.Depth;
         }
     }
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackResourceCreation(resource_wrapper, initial_state, false);
     }
@@ -383,7 +394,7 @@ void D3D12CaptureManager::InitializeSwapChainBufferResourceInfo(ID3D12Resource_W
     info->subresource_sizes    = std::make_unique<uint64_t[]>(info->num_subresources);
     info->subresource_sizes[0] = 0;
 
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackResourceCreation(resource_wrapper, initial_state, true);
     }
@@ -419,7 +430,7 @@ bool D3D12CaptureManager::IsAccelerationStructureResource(format::HandleId id)
 void D3D12CaptureManager::CheckWriteWatchIgnored(D3D12_HEAP_FLAGS flags, format::HandleId id)
 {
     // Report that write watch was ignored because the application enabled it.
-    if ((GetPageGuardMemoryMode() == kMemoryModeExternal) &&
+    if (IsPageGuardMemoryModeExternal() &&
         ((flags & D3D12_HEAP_FLAG_ALLOW_WRITE_WATCH) == D3D12_HEAP_FLAG_ALLOW_WRITE_WATCH))
     {
         GFXRECON_LOG_WARNING(
@@ -433,7 +444,7 @@ bool D3D12CaptureManager::UseWriteWatch(D3D12_HEAP_TYPE         type,
                                         D3D12_HEAP_FLAGS        flags,
                                         D3D12_CPU_PAGE_PROPERTY page_property)
 {
-    if ((GetPageGuardMemoryMode() == kMemoryModeExternal) &&
+    if (IsPageGuardMemoryModeExternal() &&
         ((flags & D3D12_HEAP_FLAG_ALLOW_WRITE_WATCH) != D3D12_HEAP_FLAG_ALLOW_WRITE_WATCH) &&
         IsUploadResource(type, page_property))
     {
@@ -585,8 +596,8 @@ void D3D12CaptureManager::PrePresent(IDXGISwapChain_Wrapper* swapchain_wrapper)
                                                      swapchain_info->command_queue,
                                                      swapchain,
                                                      GetCurrentFrame(),
-                                                     screenshot_prefix_,
-                                                     screenshot_format_);
+                                                     common_manager_->GetScreenshotPrefix(),
+                                                     common_manager_->GetScreenshotFormat());
         }
         else
         {
@@ -983,14 +994,15 @@ void D3D12CaptureManager::PreProcess_ID3D12Device3_OpenExistingHeapFromAddress(I
     GFXRECON_UNREFERENCED_PARAMETER(riid);
     GFXRECON_UNREFERENCED_PARAMETER(heap);
 
-    if ((GetCaptureMode() & kModeWrite) == kModeWrite)
+    if (IsCaptureModeWrite())
     {
         MEMORY_BASIC_INFORMATION info{};
 
         auto result = VirtualQuery(address, &info, sizeof(info));
         if (result > 0)
         {
-            WriteCreateHeapAllocationCmd(reinterpret_cast<uint64_t>(address), info.RegionSize);
+            common_manager_->WriteCreateHeapAllocationCmd(
+                api_family_, reinterpret_cast<uint64_t>(address), info.RegionSize);
         }
         else
         {
@@ -1007,7 +1019,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device3_OpenExistingHeapFromAddress(
     GFXRECON_UNREFERENCED_PARAMETER(wrapper);
     GFXRECON_UNREFERENCED_PARAMETER(riid);
 
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         if (SUCCEEDED(result) && (heap != nullptr) && ((*heap) != nullptr))
         {
@@ -1260,7 +1272,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Resource_Map(
             {
                 auto& mapped_subresource = info->mapped_subresources[subresource];
 
-                std::lock_guard<std::mutex> lock(mapped_memory_lock_);
+                std::lock_guard<std::mutex> lock(GetMappedMemoryLock());
                 if (++mapped_subresource.map_count == 1)
                 {
                     mapped_subresource.data = (*data);
@@ -1281,7 +1293,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Resource_Map(
                             use_shadow_memory = false;
                             use_write_watch   = true;
                         }
-                        else if ((GetPageGuardMemoryMode() == kMemoryModeShadowPersistent) &&
+                        else if (IsPageGuardMemoryModeShadowPersistent() &&
                                  (mapped_subresource.shadow_allocation == util::PageGuardManager::kNullShadowHandle))
                         {
                             mapped_subresource.shadow_allocation =
@@ -1349,7 +1361,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Resource_Map(
             {
                 auto& mapped_subresource = info->mapped_subresources[subresource];
 
-                std::lock_guard<std::mutex> lock(mapped_memory_lock_);
+                std::lock_guard<std::mutex> lock(GetMappedMemoryLock());
                 if (++mapped_subresource.map_count == 1)
                 {
                     if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUnassisted)
@@ -1381,7 +1393,7 @@ void D3D12CaptureManager::PreProcess_ID3D12Resource_Unmap(ID3D12Resource_Wrapper
             if (mapped_subresource.data != nullptr)
             {
                 // Handle first case, when mapped_subresource.data != null (like we've always done):
-                std::lock_guard<std::mutex> lock(mapped_memory_lock_);
+                std::lock_guard<std::mutex> lock(GetMappedMemoryLock());
                 if (mapped_subresource.map_count > 0)
                 {
                     if ((--mapped_subresource.map_count == 0) && (mapped_subresource.data != nullptr))
@@ -1467,7 +1479,7 @@ void D3D12CaptureManager::PreProcess_ID3D12Resource_Unmap(ID3D12Resource_Wrapper
                 // WriteToSubresource."
                 //
                 // Source: https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12resource-map
-                std::lock_guard<std::mutex> lock(mapped_memory_lock_);
+                std::lock_guard<std::mutex> lock(GetMappedMemoryLock());
                 if (mapped_subresource.map_count > 0)
                 {
                     if (--mapped_subresource.map_count == 0)
@@ -1514,7 +1526,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Resource_GetHeapProperties(ID3D12Res
     GFXRECON_UNREFERENCED_PARAMETER(wrapper);
     GFXRECON_UNREFERENCED_PARAMETER(heap_properties);
 
-    if (SUCCEEDED(result) && (heap_flags != nullptr) && (GetPageGuardMemoryMode() == kMemoryModeExternal))
+    if (SUCCEEDED(result) && (heap_flags != nullptr) && (IsPageGuardMemoryModeExternal()))
     {
         auto info = wrapper->GetObjectInfo();
         assert(info != nullptr);
@@ -1541,7 +1553,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Resource_GetHeapProperties(ID3D12Res
 void D3D12CaptureManager::PostProcess_ID3D12Resource_GetGPUVirtualAddress(ID3D12Resource_Wrapper*   wrapper,
                                                                           D3D12_GPU_VIRTUAL_ADDRESS result)
 {
-    if (((GetCaptureMode() & kModeTrack) == kModeTrack) && (result != 0))
+    if (IsCaptureModeTrack() && (result != 0))
     {
         state_tracker_->TrackResourceGpuVa(wrapper, result);
     }
@@ -1556,7 +1568,7 @@ bool D3D12CaptureManager::AddFillMemoryResourceValueCommand(
     const std::map<uint64_t, Dx12ResourceValueAnnotator::Dx12FillCommandResourceValue>& resource_values)
 {
     bool success = true;
-    if ((GetCaptureMode() & kModeWrite) == kModeWrite)
+    if (IsCaptureModeWrite())
     {
         std::vector<uint8_t>                         write_buffer;
         format::FillMemoryResourceValueCommandHeader rv_header;
@@ -1596,10 +1608,10 @@ bool D3D12CaptureManager::AddFillMemoryResourceValueCommand(
 
         std::vector<uint8_t> compressed_write_buffer;
 
-        if (compressor_ != nullptr)
+        if (GetCompressor() != nullptr)
         {
             size_t compressed_size =
-                compressor_->Compress(write_buffer.size(), write_buffer.data(), &compressed_write_buffer, 0);
+                GetCompressor()->Compress(write_buffer.size(), write_buffer.data(), &compressed_write_buffer, 0);
 
             if ((compressed_size > 0) && (compressed_size < uncompressed_size))
             {
@@ -1676,7 +1688,7 @@ void D3D12CaptureManager::Destroy_ID3D12Resource(ID3D12Resource_Wrapper* wrapper
             {
                 // If any subresources were mapped, the resource wrapper needs to be removed from the mapped resource
                 // table.
-                std::lock_guard<std::mutex> lock(mapped_memory_lock_);
+                std::lock_guard<std::mutex> lock(GetMappedMemoryLock());
                 mapped_resources_.erase(wrapper);
             }
         }
@@ -1687,7 +1699,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Heap_GetDesc(ID3D12Heap_Wrapper* wra
 {
     GFXRECON_UNREFERENCED_PARAMETER(wrapper);
 
-    if ((GetPageGuardMemoryMode() == kMemoryModeExternal))
+    if (IsPageGuardMemoryModeExternal())
     {
         auto info = wrapper->GetObjectInfo();
         assert(info != nullptr);
@@ -1729,7 +1741,7 @@ void D3D12CaptureManager::PreProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D
     }
     else if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kUnassisted)
     {
-        std::lock_guard<std::mutex> lock(mapped_memory_lock_);
+        std::lock_guard<std::mutex> lock(GetMappedMemoryLock());
         for (auto resource_wrapper : mapped_resources_)
         {
             auto info = resource_wrapper->GetObjectInfo();
@@ -1767,7 +1779,7 @@ void D3D12CaptureManager::PostProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3
 {
     PostQueueSubmit();
 
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackExecuteCommandLists(wrapper, num_lists, lists);
     }
@@ -1784,7 +1796,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE D3D12CaptureManager::OverrideID3D12DescriptorHeap_Ge
 
     result.ptr = reinterpret_cast<size_t>(info->descriptor_memory.get());
 
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         info->cpu_start = result.ptr;
     }
@@ -1801,7 +1813,7 @@ D3D12_GPU_DESCRIPTOR_HANDLE D3D12CaptureManager::OverrideID3D12DescriptorHeap_Ge
 
     auto result = heap->GetGPUDescriptorHandleForHeapStart();
 
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         info->gpu_start = result.ptr;
     }
@@ -2264,7 +2276,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Fence_SetEventOnCompletion(ID3D12Fen
 {
     assert(wrapper != nullptr);
 
-    if (((GetCaptureMode() & kModeTrack) == kModeTrack) && SUCCEEDED(result))
+    if (IsCaptureModeTrack() && SUCCEEDED(result))
     {
         state_tracker_->TrackFenceSetEventOnCompletion(wrapper, value, event);
     }
@@ -2274,7 +2286,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Fence_Signal(ID3D12Fence_Wrapper* wr
 {
     assert(wrapper != nullptr);
 
-    if (((GetCaptureMode() & kModeTrack) == kModeTrack) && SUCCEEDED(result))
+    if (IsCaptureModeTrack() && SUCCEEDED(result))
     {
         state_tracker_->TrackFenceSignal(wrapper, value);
     }
@@ -2289,7 +2301,7 @@ void D3D12CaptureManager::PostProcess_ID3D12CommandQueue_Signal(ID3D12CommandQue
 
     assert(fence != nullptr);
 
-    if (((GetCaptureMode() & kModeTrack) == kModeTrack) && SUCCEEDED(result))
+    if (IsCaptureModeTrack() && SUCCEEDED(result))
     {
         auto fence_wrapper = reinterpret_cast<ID3D12Fence_Wrapper*>(fence);
         state_tracker_->TrackFenceSignal(fence_wrapper, value);
@@ -2300,7 +2312,7 @@ void D3D12CaptureManager::PostProcess_ID3D12GraphicsCommandList_ResourceBarrier(
                                                                                 UINT                       num_barriers,
                                                                                 const D3D12_RESOURCE_BARRIER* barriers)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackResourceBarriers(list_wrapper, num_barriers, barriers);
     }
@@ -2315,7 +2327,7 @@ void D3D12CaptureManager::PostProcess_ID3D12GraphicsCommandList4_BuildRaytracing
     GFXRECON_UNREFERENCED_PARAMETER(num_postbuild_info_descs);
     GFXRECON_UNREFERENCED_PARAMETER(postbuild_info_descs);
 
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackBuildRaytracingAccelerationStructure(list_wrapper, desc);
     }
@@ -2327,7 +2339,7 @@ void D3D12CaptureManager::PostProcess_ID3D12GraphicsCommandList4_CopyRaytracingA
     D3D12_GPU_VIRTUAL_ADDRESS                         source_acceleration_structure_data,
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE mode)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackCopyRaytracingAccelerationStructure(
             list_wrapper, dest_acceleration_structure_data, source_acceleration_structure_data, mode);
@@ -2343,7 +2355,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateCommandList(ID3D12Devic
                                                                      REFIID                  riid,
                                                                      void**                  ppCommandList)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         auto list_wrapper = reinterpret_cast<ID3D12CommandList_Wrapper*>(*ppCommandList);
         state_tracker_->TrackCommandListCreation(list_wrapper, false, type);
@@ -2358,7 +2370,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device4_CreateCommandList1(ID3D12Dev
                                                                        REFIID                   riid,
                                                                        void**                   ppCommandList)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         auto list_wrapper = reinterpret_cast<ID3D12CommandList_Wrapper*>(*ppCommandList);
         state_tracker_->TrackCommandListCreation(list_wrapper, true, type);
@@ -2402,7 +2414,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CopyDescriptors(ID3D12Device_
                                                                    const UINT*                        src_range_sizes,
                                                                    D3D12_DESCRIPTOR_HEAP_TYPE         heap_type)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         UINT dest_range_i = 0;
         UINT src_range_i  = 0;
@@ -2447,7 +2459,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CopyDescriptorsSimple(ID3D12D
                                                                          D3D12_CPU_DESCRIPTOR_HANDLE src_start,
                                                                          D3D12_DESCRIPTOR_HEAP_TYPE  heap_type)
 {
-    if (((GetCaptureMode() & kModeTrack) == kModeTrack) && (num_descriptors > 0))
+    if (IsCaptureModeTrack() && (num_descriptors > 0))
     {
         auto dest_descriptor_info = GetDescriptorInfo(dest_start.ptr);
         auto src_descriptor_info  = GetDescriptorInfo(src_start.ptr);
@@ -2468,7 +2480,7 @@ void D3D12CaptureManager::PostProcess_ID3D12CommandQueue_UpdateTileMappings(
     const UINT*                            range_tile_counts,
     D3D12_TILE_MAPPING_FLAGS               flags)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         auto resource_wrapper = reinterpret_cast<ID3D12Resource_Wrapper*>(resource);
         auto heap_wrapper     = reinterpret_cast<ID3D12Heap_Wrapper*>(heap);
@@ -2490,7 +2502,7 @@ void D3D12CaptureManager::PostProcess_ID3D12CommandQueue_CopyTileMappings(
     D3D12_TILE_MAPPING_FLAGS               flags)
 {
     // TODO: Implement tracking for CopyTileMappings.
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         GFXRECON_LOG_ERROR("ID3D12CommandQueue::CopyTileMappings support is not implemented for trimmed capture.");
     }
@@ -2502,7 +2514,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateShaderResourceView(
     const D3D12_SHADER_RESOURCE_VIEW_DESC* pDesc,
     D3D12_CPU_DESCRIPTOR_HANDLE            DestDescriptor)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackDescriptorResources(DestDescriptor.ptr, pResource);
 
@@ -2520,7 +2532,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateUnorderedAccessView(
     const D3D12_UNORDERED_ACCESS_VIEW_DESC* pDesc,
     D3D12_CPU_DESCRIPTOR_HANDLE             DestDescriptor)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackDescriptorResources(DestDescriptor.ptr, pResource, pCounterResource);
     }
@@ -2531,7 +2543,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateRenderTargetView(ID3D12
                                                                           const D3D12_RENDER_TARGET_VIEW_DESC* pDesc,
                                                                           D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackDescriptorResources(DestDescriptor.ptr, pResource);
     }
@@ -2542,7 +2554,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateDepthStencilView(ID3D12
                                                                           const D3D12_DEPTH_STENCIL_VIEW_DESC* pDesc,
                                                                           D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackDescriptorResources(DestDescriptor.ptr, pResource);
     }
@@ -2553,7 +2565,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device_CreateConstantBufferView(
     const D3D12_CONSTANT_BUFFER_VIEW_DESC* pDesc,
     D3D12_CPU_DESCRIPTOR_HANDLE            DestDescriptor)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         D3D12_GPU_VIRTUAL_ADDRESS address = 0;
 
@@ -2572,7 +2584,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreateSamplerFeedbackUnorder
     ID3D12Resource*             pFeedbackResource,
     D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackDescriptorResources(DestDescriptor.ptr, pTargetedResource, pFeedbackResource);
     }
@@ -2580,7 +2592,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device8_CreateSamplerFeedbackUnorder
 
 void D3D12CaptureManager::PostProcess_ID3D12Debug_EnableDebugLayer(ID3D12Debug_Wrapper* debug_wrapper)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         // Track object id since ID3D12Debug could be released very soon.
         track_enable_debug_layer_object_id_ = debug_wrapper->GetCaptureId();
@@ -2589,7 +2601,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Debug_EnableDebugLayer(ID3D12Debug_W
 
 void D3D12CaptureManager::PostProcess_ID3D12Debug1_EnableDebugLayer(ID3D12Debug1_Wrapper* debug1_wrapper)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         // Track object id since ID3D12Debug1 could be released very soon.
         track_enable_debug_layer_object_id_ = debug1_wrapper->GetCaptureId();
@@ -2599,7 +2611,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Debug1_EnableDebugLayer(ID3D12Debug1
 void D3D12CaptureManager::PostProcess_ID3D12DeviceRemovedExtendedDataSettings_SetAutoBreadcrumbsEnablement(
     ID3D12DeviceRemovedExtendedDataSettings_Wrapper* dred_wrapper, D3D12_DRED_ENABLEMENT enablement)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         track_enable_dred_info_.dred_settings1_object_id         = dred_wrapper->GetCaptureId();
         track_enable_dred_info_.set_auto_breadcrumbs_enablement_ = enablement;
@@ -2609,7 +2621,7 @@ void D3D12CaptureManager::PostProcess_ID3D12DeviceRemovedExtendedDataSettings_Se
 void D3D12CaptureManager::PostProcess_ID3D12DeviceRemovedExtendedDataSettings1_SetBreadcrumbContextEnablement(
     ID3D12DeviceRemovedExtendedDataSettings1_Wrapper* dred1_wrapper, D3D12_DRED_ENABLEMENT enablement)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         track_enable_dred_info_.dred_settings1_object_id           = dred1_wrapper->GetCaptureId();
         track_enable_dred_info_.set_breadcrumb_context_enablement_ = enablement;
@@ -2619,7 +2631,7 @@ void D3D12CaptureManager::PostProcess_ID3D12DeviceRemovedExtendedDataSettings1_S
 void D3D12CaptureManager::PostProcess_ID3D12DeviceRemovedExtendedDataSettings_SetPageFaultEnablement(
     ID3D12DeviceRemovedExtendedDataSettings_Wrapper* dred_wrapper, D3D12_DRED_ENABLEMENT enablement)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         track_enable_dred_info_.dred_settings1_object_id   = dred_wrapper->GetCaptureId();
         track_enable_dred_info_.set_page_fault_enablement_ = enablement;
@@ -2629,7 +2641,7 @@ void D3D12CaptureManager::PostProcess_ID3D12DeviceRemovedExtendedDataSettings_Se
 void D3D12CaptureManager::PostProcess_SetPrivateData(
     IUnknown_Wrapper* wrapper, HRESULT result, REFGUID Name, UINT DataSize, const void* pData)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackPrivateData(wrapper, Name, DataSize, pData);
     }
@@ -2641,7 +2653,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device1_SetResidencyPriority(ID3D12D
                                                                          ID3D12Pageable* const*          ppObjects,
                                                                          const D3D12_RESIDENCY_PRIORITY* pPriorities)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackResidencyPriority(device_wrapper, NumObjects, ppObjects, pPriorities);
     }
@@ -2673,8 +2685,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device5_CreateStateObject(ID3D12Devi
                                                                       REFIID                         riid,
                                                                       void**                         state_object)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack && SUCCEEDED(result) && (state_object != nullptr) &&
-        (*state_object != nullptr))
+    if (IsCaptureModeTrack() && SUCCEEDED(result) && (state_object != nullptr) && (*state_object != nullptr))
     {
         state_tracker_->TrackCreateStateObject(device5_wrapper, desc, state_object);
     }
@@ -2687,8 +2698,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device7_AddToStateObject(ID3D12Devic
                                                                      REFIID             riid,
                                                                      void**             new_state_object)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack && SUCCEEDED(result) && (new_state_object != nullptr) &&
-        (*new_state_object != nullptr))
+    if (IsCaptureModeTrack() && SUCCEEDED(result) && (new_state_object != nullptr) && (*new_state_object != nullptr))
     {
         state_tracker_->TrackAddToStateObject(device7_wrapper, addition, state_object_to_grow_from, new_state_object);
     }
@@ -2697,7 +2707,7 @@ void D3D12CaptureManager::PostProcess_ID3D12Device7_AddToStateObject(ID3D12Devic
 void D3D12CaptureManager::PostProcess_ID3D12StateObjectProperties_GetShaderIdentifier(
     ID3D12StateObjectProperties_Wrapper* properties_wrapper, void* result, LPCWSTR export_name)
 {
-    if ((GetCaptureMode() & kModeTrack) == kModeTrack)
+    if (IsCaptureModeTrack())
     {
         state_tracker_->TrackGetShaderIdentifier(
             properties_wrapper, result, export_name, GetThreadData()->parameter_buffer_.get());
@@ -2711,7 +2721,7 @@ void D3D12CaptureManager::PostProcess_ID3D12StateObjectProperties_GetShaderIdent
 
 void D3D12CaptureManager::WriteDxgiAdapterInfoCommand(const format::DxgiAdapterDesc& adapter_desc)
 {
-    if (((GetCaptureMode() & kModeWrite) == kModeWrite))
+    if ((IsCaptureModeWrite()))
     {
         format::DxgiAdapterInfoCommandHeader adapter_info_header;
         memset(&adapter_info_header, 0, sizeof(adapter_info_header));
@@ -2765,7 +2775,7 @@ void D3D12CaptureManager::PostProcess_CreateDXGIFactory2(HRESULT result, UINT Fl
 
 void D3D12CaptureManager::WriteDx12DriverInfo()
 {
-    if ((GetCaptureMode() & kModeWrite) == kModeWrite)
+    if (IsCaptureModeWrite())
     {
         std::string       driverinfo = "";
         std::vector<LUID> adapter_luids;
@@ -2781,7 +2791,7 @@ void D3D12CaptureManager::WriteDx12DriverInfo()
 
 void D3D12CaptureManager::WriteDriverInfoCommand(const std::string& info)
 {
-    if (((GetCaptureMode() & kModeWrite) == kModeWrite))
+    if ((IsCaptureModeWrite()))
     {
         format::DriverInfoBlock driver_info_header = {};
 
@@ -2802,7 +2812,7 @@ void D3D12CaptureManager::WriteDriverInfoCommand(const std::string& info)
 
 void D3D12CaptureManager::WriteDx12RuntimeInfo()
 {
-    if ((GetCaptureMode() & kModeWrite) == kModeWrite)
+    if (IsCaptureModeWrite())
     {
         static bool wrote_dx12_runtime_info = false;
 
@@ -2850,7 +2860,7 @@ void D3D12CaptureManager::WriteDx12RuntimeInfo()
 
 void D3D12CaptureManager::WriteDx2RuntimeInfoCommand(const format::Dx12RuntimeInfo& runtime_info)
 {
-    if (((GetCaptureMode() & kModeWrite) == kModeWrite))
+    if ((IsCaptureModeWrite()))
     {
         format::Dx12RuntimeInfoCommandHeader dx12_runtime_info_header;
         memset(&dx12_runtime_info_header, 0, sizeof(dx12_runtime_info_header));

--- a/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
+++ b/framework/generated/dx12_generators/dx12_wrapper_body_generator.py
@@ -485,8 +485,8 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
         indent = self.increment_indent(indent)
 
         expr += indent + 'auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();\n'
-        expr += indent + 'std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
-        expr += indent + 'std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
+        expr += indent + 'std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
+        expr += indent + 'std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
         expr += indent + 'if (force_command_serialization)\n'
         expr += indent + '{\n'
         expr += indent + '    exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();\n'
@@ -690,8 +690,8 @@ class Dx12WrapperBodyGenerator(Dx12BaseGenerator):
                 expr += indent + 'auto api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();\n'
             else:
                 expr += indent + 'auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();\n'
-                expr += indent + 'std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
-                expr += indent + 'std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
+                expr += indent + 'std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
+                expr += indent + 'std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
                 expr += indent + 'if (force_command_serialization)\n'
                 expr += indent + '{\n'
                 expr += indent + '    exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();\n'

--- a/framework/generated/generated_dx12_wrappers.cpp
+++ b/framework/generated/generated_dx12_wrappers.cpp
@@ -193,8 +193,8 @@ HRESULT WINAPI CreateDXGIFactory(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -253,8 +253,8 @@ HRESULT WINAPI CreateDXGIFactory1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -318,8 +318,8 @@ HRESULT STDMETHODCALLTYPE IDXGIObject_Wrapper::SetPrivateData(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -381,8 +381,8 @@ HRESULT STDMETHODCALLTYPE IDXGIObject_Wrapper::SetPrivateDataInterface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -440,8 +440,8 @@ HRESULT STDMETHODCALLTYPE IDXGIObject_Wrapper::GetPrivateData(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -503,8 +503,8 @@ HRESULT STDMETHODCALLTYPE IDXGIObject_Wrapper::GetParent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -570,8 +570,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDeviceSubObject_Wrapper::GetDevice(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -652,8 +652,8 @@ HRESULT STDMETHODCALLTYPE IDXGIResource_Wrapper::GetSharedHandle(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -704,8 +704,8 @@ HRESULT STDMETHODCALLTYPE IDXGIResource_Wrapper::GetUsage(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -756,8 +756,8 @@ HRESULT STDMETHODCALLTYPE IDXGIResource_Wrapper::SetEvictionPriority(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -808,8 +808,8 @@ HRESULT STDMETHODCALLTYPE IDXGIResource_Wrapper::GetEvictionPriority(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -881,8 +881,8 @@ HRESULT STDMETHODCALLTYPE IDXGIKeyedMutex_Wrapper::AcquireSync(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -938,8 +938,8 @@ HRESULT STDMETHODCALLTYPE IDXGIKeyedMutex_Wrapper::ReleaseSync(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1010,8 +1010,8 @@ HRESULT STDMETHODCALLTYPE IDXGISurface_Wrapper::GetDesc(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1063,8 +1063,8 @@ HRESULT STDMETHODCALLTYPE IDXGISurface_Wrapper::Map(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1119,8 +1119,8 @@ HRESULT STDMETHODCALLTYPE IDXGISurface_Wrapper::Unmap()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1171,8 +1171,8 @@ HRESULT STDMETHODCALLTYPE IDXGISurface1_Wrapper::GetDC(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1228,8 +1228,8 @@ HRESULT STDMETHODCALLTYPE IDXGISurface1_Wrapper::ReleaseDC(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1301,8 +1301,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter_Wrapper::EnumOutputs(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1363,8 +1363,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter_Wrapper::GetDesc(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1416,8 +1416,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter_Wrapper::CheckInterfaceSupport(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1493,8 +1493,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::GetDesc(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1548,8 +1548,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::GetDisplayModeList(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1617,8 +1617,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::FindClosestMatchingMode(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1678,8 +1678,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::WaitForVBlank()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1726,8 +1726,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::TakeOwnership(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1780,8 +1780,8 @@ void STDMETHODCALLTYPE IDXGIOutput_Wrapper::ReleaseOwnership()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1823,8 +1823,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::GetGammaControlCapabilities(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1875,8 +1875,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::SetGammaControl(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1927,8 +1927,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::GetGammaControl(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -1979,8 +1979,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::SetDisplaySurface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2031,8 +2031,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::GetDisplaySurfaceData(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2083,8 +2083,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput_Wrapper::GetFrameStatistics(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2205,8 +2205,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::GetBuffer(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2273,8 +2273,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::SetFullscreenState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2331,8 +2331,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::GetFullscreenState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2393,8 +2393,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::GetDesc(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2449,8 +2449,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::ResizeBuffers(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2521,8 +2521,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::ResizeTarget(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2573,8 +2573,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::GetContainingOutput(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2630,8 +2630,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::GetFrameStatistics(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2682,8 +2682,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain_Wrapper::GetLastPresentCount(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2755,8 +2755,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory_Wrapper::EnumAdapters(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2818,8 +2818,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory_Wrapper::MakeWindowAssociation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2875,8 +2875,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory_Wrapper::GetWindowAssociation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2929,8 +2929,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory_Wrapper::CreateSwapChain(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -2997,8 +2997,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory_Wrapper::CreateSoftwareAdapter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3079,8 +3079,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice_Wrapper::GetAdapter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3140,8 +3140,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice_Wrapper::CreateSurface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3219,8 +3219,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice_Wrapper::QueryResourceResidency(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3283,8 +3283,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice_Wrapper::SetGPUThreadPriority(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3335,8 +3335,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice_Wrapper::GetGPUThreadPriority(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3392,8 +3392,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory1_Wrapper::EnumAdapters1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3453,8 +3453,8 @@ BOOL STDMETHODCALLTYPE IDXGIFactory1_Wrapper::IsCurrent()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3504,8 +3504,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter1_Wrapper::GetDesc1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3560,8 +3560,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice1_Wrapper::SetMaximumFrameLatency(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3612,8 +3612,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice1_Wrapper::GetMaximumFrameLatency(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3689,8 +3689,8 @@ BOOL STDMETHODCALLTYPE IDXGIDisplayControl_Wrapper::IsStereoEnabled()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3734,8 +3734,8 @@ void STDMETHODCALLTYPE IDXGIDisplayControl_Wrapper::SetStereoEnabled(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3800,8 +3800,8 @@ void STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::GetDesc(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3850,8 +3850,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::AcquireNextFrame(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3919,8 +3919,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::GetFrameDirtyRects(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -3983,8 +3983,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::GetFrameMoveRects(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4048,8 +4048,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::GetFramePointerShape(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4115,8 +4115,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::MapDesktopSurface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4166,8 +4166,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::UnMapDesktopSurface()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4212,8 +4212,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutputDuplication_Wrapper::ReleaseFrame()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4265,8 +4265,8 @@ HRESULT STDMETHODCALLTYPE IDXGISurface2_Wrapper::GetResource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4337,8 +4337,8 @@ HRESULT STDMETHODCALLTYPE IDXGIResource1_Wrapper::CreateSubresourceSurface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4402,8 +4402,8 @@ HRESULT STDMETHODCALLTYPE IDXGIResource1_Wrapper::CreateSharedHandle(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4475,8 +4475,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice2_Wrapper::OfferResources(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4541,8 +4541,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice2_Wrapper::ReclaimResources(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4605,8 +4605,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice2_Wrapper::EnqueueSetEvent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4661,8 +4661,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::GetDesc1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4713,8 +4713,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::GetFullscreenDesc(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4765,8 +4765,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::GetHwnd(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4818,8 +4818,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::GetCoreWindow(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4933,8 +4933,8 @@ BOOL STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::IsTemporaryMonoSupported()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -4980,8 +4980,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::GetRestrictToOutput(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5037,8 +5037,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::SetBackgroundColor(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5089,8 +5089,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::GetBackgroundColor(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5141,8 +5141,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::SetRotation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5193,8 +5193,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain1_Wrapper::GetRotation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5248,8 +5248,8 @@ BOOL STDMETHODCALLTYPE IDXGIFactory2_Wrapper::IsWindowedStereoEnabled()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5300,8 +5300,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::CreateSwapChainForHwnd(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5386,8 +5386,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::CreateSwapChainForCoreWindow(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5464,8 +5464,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::GetSharedResourceAdapterLuid(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5523,8 +5523,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::RegisterStereoStatusWindow(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5586,8 +5586,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::RegisterStereoStatusEvent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5641,8 +5641,8 @@ void STDMETHODCALLTYPE IDXGIFactory2_Wrapper::UnregisterStereoStatus(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5691,8 +5691,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::RegisterOcclusionStatusWindow(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5754,8 +5754,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::RegisterOcclusionStatusEvent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5809,8 +5809,8 @@ void STDMETHODCALLTYPE IDXGIFactory2_Wrapper::UnregisterOcclusionStatus(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5860,8 +5860,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory2_Wrapper::CreateSwapChainForComposition(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5936,8 +5936,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter2_Wrapper::GetDesc2(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -5995,8 +5995,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput1_Wrapper::GetDisplayModeList1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6064,8 +6064,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput1_Wrapper::FindClosestMatchingMode1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6126,8 +6126,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput1_Wrapper::GetDisplaySurfaceData1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6179,8 +6179,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput1_Wrapper::DuplicateOutput(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6249,8 +6249,8 @@ HRESULT WINAPI CreateDXGIFactory2(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6315,8 +6315,8 @@ HRESULT WINAPI DXGIGetDebugInterface1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6380,8 +6380,8 @@ void STDMETHODCALLTYPE IDXGIDevice3_Wrapper::Trim()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6428,8 +6428,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain2_Wrapper::SetSourceSize(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6486,8 +6486,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain2_Wrapper::GetSourceSize(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6543,8 +6543,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain2_Wrapper::SetMaximumFrameLatency(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6595,8 +6595,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain2_Wrapper::GetMaximumFrameLatency(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6646,8 +6646,8 @@ HANDLE STDMETHODCALLTYPE IDXGISwapChain2_Wrapper::GetFrameLatencyWaitableObject(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6693,8 +6693,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain2_Wrapper::SetMatrixTransform(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6745,8 +6745,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain2_Wrapper::GetMatrixTransform(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6800,8 +6800,8 @@ BOOL STDMETHODCALLTYPE IDXGIOutput2_Wrapper::SupportsOverlays()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6850,8 +6850,8 @@ UINT STDMETHODCALLTYPE IDXGIFactory3_Wrapper::GetCreationFlags()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6919,8 +6919,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::PresentBuffer(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -6981,8 +6981,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::SetSourceRect(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7033,8 +7033,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::SetTargetRect(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7086,8 +7086,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::SetDestSize(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7143,8 +7143,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::GetSourceRect(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7195,8 +7195,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::GetTargetRect(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7248,8 +7248,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::GetDestSize(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7305,8 +7305,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapper::SetColorSpace(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7356,8 +7356,8 @@ DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS STDMETHODCALLTYPE IDXGIDecodeSwapChain_Wrapp
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7427,8 +7427,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactoryMedia_Wrapper::CreateSwapChainForCompositi
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7509,8 +7509,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactoryMedia_Wrapper::CreateDecodeSwapChainForCom
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7611,8 +7611,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChainMedia_Wrapper::GetFrameStatisticsMedia(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7663,8 +7663,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChainMedia_Wrapper::SetPresentDuration(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7717,8 +7717,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChainMedia_Wrapper::CheckPresentDurationSuppo
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7785,8 +7785,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput3_Wrapper::CheckOverlaySupport(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7856,8 +7856,8 @@ UINT STDMETHODCALLTYPE IDXGISwapChain3_Wrapper::GetCurrentBackBufferIndex()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7904,8 +7904,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain3_Wrapper::CheckColorSpaceSupport(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -7961,8 +7961,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain3_Wrapper::SetColorSpace1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8019,8 +8019,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain3_Wrapper::ResizeBuffers1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8110,8 +8110,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput4_Wrapper::CheckOverlayColorSpaceSupport(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8183,8 +8183,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory4_Wrapper::EnumAdapterByLuid(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8251,8 +8251,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory4_Wrapper::EnumWarpAdapter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8318,8 +8318,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter3_Wrapper::RegisterHardwareContentProtecti
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8373,8 +8373,8 @@ void STDMETHODCALLTYPE IDXGIAdapter3_Wrapper::UnregisterHardwareContentProtectio
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8423,8 +8423,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter3_Wrapper::QueryVideoMemoryInfo(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8487,8 +8487,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter3_Wrapper::SetVideoMemoryReservation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8550,8 +8550,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter3_Wrapper::RegisterVideoMemoryBudgetChange
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8605,8 +8605,8 @@ void STDMETHODCALLTYPE IDXGIAdapter3_Wrapper::UnregisterVideoMemoryBudgetChangeN
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8667,8 +8667,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput5_Wrapper::DuplicateOutput1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8750,8 +8750,8 @@ HRESULT STDMETHODCALLTYPE IDXGISwapChain4_Wrapper::SetHDRMetaData(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8819,8 +8819,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice4_Wrapper::OfferResources1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8890,8 +8890,8 @@ HRESULT STDMETHODCALLTYPE IDXGIDevice4_Wrapper::ReclaimResources1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -8960,8 +8960,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory5_Wrapper::CheckFeatureSupport(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9027,8 +9027,8 @@ HRESULT WINAPI DXGIDeclareAdapterRemovalSupport()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9075,8 +9075,8 @@ HRESULT STDMETHODCALLTYPE IDXGIAdapter4_Wrapper::GetDesc3(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9131,8 +9131,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput6_Wrapper::GetDesc1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9183,8 +9183,8 @@ HRESULT STDMETHODCALLTYPE IDXGIOutput6_Wrapper::CheckHardwareCompositionSupport(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9242,8 +9242,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory6_Wrapper::EnumAdapterByGpuPreference(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9319,8 +9319,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory7_Wrapper::RegisterAdaptersChangedEvent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9376,8 +9376,8 @@ HRESULT STDMETHODCALLTYPE IDXGIFactory7_Wrapper::UnregisterAdaptersChangedEvent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9455,8 +9455,8 @@ HRESULT WINAPI D3D12SerializeRootSignature(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9528,8 +9528,8 @@ HRESULT WINAPI D3D12CreateRootSignatureDeserializer(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9599,8 +9599,8 @@ HRESULT WINAPI D3D12SerializeVersionedRootSignature(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9667,8 +9667,8 @@ HRESULT WINAPI D3D12CreateVersionedRootSignatureDeserializer(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9739,8 +9739,8 @@ HRESULT WINAPI D3D12CreateDevice(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9809,8 +9809,8 @@ HRESULT WINAPI D3D12GetDebugInterface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9871,8 +9871,8 @@ HRESULT WINAPI D3D12EnableExperimentalFeatures(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -9937,8 +9937,8 @@ HRESULT WINAPI D3D12GetInterface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10007,8 +10007,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Object_Wrapper::GetPrivateData(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10071,8 +10071,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Object_Wrapper::SetPrivateData(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10134,8 +10134,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Object_Wrapper::SetPrivateDataInterface(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10191,8 +10191,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Object_Wrapper::SetName(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10248,8 +10248,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceChild_Wrapper::GetDevice(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10349,8 +10349,8 @@ const D3D12_ROOT_SIGNATURE_DESC* STDMETHODCALLTYPE ID3D12RootSignatureDeserializ
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10417,8 +10417,8 @@ HRESULT STDMETHODCALLTYPE ID3D12VersionedRootSignatureDeserializer_Wrapper::GetR
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10473,8 +10473,8 @@ const D3D12_VERSIONED_ROOT_SIGNATURE_DESC* STDMETHODCALLTYPE ID3D12VersionedRoot
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10543,8 +10543,8 @@ D3D12_HEAP_DESC STDMETHODCALLTYPE ID3D12Heap_Wrapper::GetDesc()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10612,8 +10612,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Resource_Wrapper::Map(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10673,8 +10673,8 @@ void STDMETHODCALLTYPE ID3D12Resource_Wrapper::Unmap(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10725,8 +10725,8 @@ D3D12_RESOURCE_DESC STDMETHODCALLTYPE ID3D12Resource_Wrapper::GetDesc()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10771,8 +10771,8 @@ D3D12_GPU_VIRTUAL_ADDRESS STDMETHODCALLTYPE ID3D12Resource_Wrapper::GetGPUVirtua
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10824,8 +10824,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Resource_Wrapper::WriteToSubresource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10900,8 +10900,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Resource_Wrapper::ReadFromSubresource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -10973,8 +10973,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Resource_Wrapper::GetHeapProperties(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11049,8 +11049,8 @@ HRESULT STDMETHODCALLTYPE ID3D12CommandAllocator_Wrapper::Reset()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11115,8 +11115,8 @@ UINT64 STDMETHODCALLTYPE ID3D12Fence_Wrapper::GetCompletedValue()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11163,8 +11163,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Fence_Wrapper::SetEventOnCompletion(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11220,8 +11220,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Fence_Wrapper::Signal(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11275,8 +11275,8 @@ D3D12_FENCE_FLAGS STDMETHODCALLTYPE ID3D12Fence1_Wrapper::GetCreationFlags()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11342,8 +11342,8 @@ HRESULT STDMETHODCALLTYPE ID3D12PipelineState_Wrapper::GetCachedBlob(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11418,8 +11418,8 @@ D3D12_DESCRIPTOR_HEAP_DESC STDMETHODCALLTYPE ID3D12DescriptorHeap_Wrapper::GetDe
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11464,8 +11464,8 @@ D3D12_CPU_DESCRIPTOR_HANDLE STDMETHODCALLTYPE ID3D12DescriptorHeap_Wrapper::GetC
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11512,8 +11512,8 @@ D3D12_GPU_DESCRIPTOR_HANDLE STDMETHODCALLTYPE ID3D12DescriptorHeap_Wrapper::GetG
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11622,8 +11622,8 @@ D3D12_COMMAND_LIST_TYPE STDMETHODCALLTYPE ID3D12CommandList_Wrapper::GetType()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11672,8 +11672,8 @@ HRESULT STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::Close()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11720,8 +11720,8 @@ HRESULT STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::Reset(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11775,8 +11775,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11824,8 +11824,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::DrawInstanced(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11889,8 +11889,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::DrawIndexedInstanced(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -11957,8 +11957,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::Dispatch(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12017,8 +12017,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyBufferRegion(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12088,8 +12088,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyTextureRegion(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12162,8 +12162,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyResource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12218,8 +12218,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::CopyTiles(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12293,8 +12293,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ResolveSubresource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12359,8 +12359,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::IASetPrimitiveTopology
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12406,8 +12406,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::RSSetViewports(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12458,8 +12458,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::RSSetScissorRects(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12509,8 +12509,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::OMSetBlendFactor(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12555,8 +12555,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::OMSetStencilRef(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12601,8 +12601,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetPipelineState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12648,8 +12648,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ResourceBarrier(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12701,8 +12701,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ExecuteBundle(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12748,8 +12748,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetDescriptorHeaps(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12801,8 +12801,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootSignatur
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12847,8 +12847,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootSignatu
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12894,8 +12894,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootDescript
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -12948,8 +12948,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootDescrip
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13003,8 +13003,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRoot32BitCon
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13061,8 +13061,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRoot32BitCo
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13120,8 +13120,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRoot32BitCon
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13184,8 +13184,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRoot32BitCo
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13246,8 +13246,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootConstant
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13300,8 +13300,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootConstan
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13354,8 +13354,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootShaderRe
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13408,8 +13408,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootShaderR
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13462,8 +13462,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetComputeRootUnordere
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13516,8 +13516,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetGraphicsRootUnorder
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13569,8 +13569,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::IASetIndexBuffer(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13624,8 +13624,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::IASetVertexBuffers(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13689,8 +13689,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SOSetTargets(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13755,8 +13755,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::OMSetRenderTargets(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13823,8 +13823,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearDepthStencilView(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13899,8 +13899,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearRenderTargetView(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -13967,8 +13967,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearUnorderedAccessVi
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14047,8 +14047,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ClearUnorderedAccessVi
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14123,8 +14123,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::DiscardResource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14176,8 +14176,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::BeginQuery(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14234,8 +14234,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::EndQuery(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14295,8 +14295,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ResolveQueryData(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14368,8 +14368,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetPredication(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14426,8 +14426,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::SetMarker(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14484,8 +14484,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::BeginEvent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14539,8 +14539,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::EndEvent()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14585,8 +14585,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList_Wrapper::ExecuteIndirect(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14666,8 +14666,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::AtomicCopyBufferUINT(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14750,8 +14750,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::AtomicCopyBufferUINT6
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14829,8 +14829,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::OMSetDepthBounds(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14882,8 +14882,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::SetSamplePositions(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -14946,8 +14946,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::ResolveSubresourceReg
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15032,8 +15032,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList1_Wrapper::SetViewInstanceMask(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15084,8 +15084,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList2_Wrapper::WriteBufferImmediate(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15176,8 +15176,8 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::UpdateTileMappings(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15272,8 +15272,8 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::CopyTileMappings(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15344,8 +15344,8 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::ExecuteCommandLists(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15399,8 +15399,8 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::SetMarker(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15457,8 +15457,8 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::BeginEvent(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15512,8 +15512,8 @@ void STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::EndEvent()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15556,8 +15556,8 @@ HRESULT STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::Signal(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15614,8 +15614,8 @@ HRESULT STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::Wait(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15671,8 +15671,8 @@ HRESULT STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::GetTimestampFrequency(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15724,8 +15724,8 @@ HRESULT STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::GetClockCalibration(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15780,8 +15780,8 @@ D3D12_COMMAND_QUEUE_DESC STDMETHODCALLTYPE ID3D12CommandQueue_Wrapper::GetDesc()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15846,8 +15846,8 @@ UINT STDMETHODCALLTYPE ID3D12Device_Wrapper::GetNodeCount()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15895,8 +15895,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateCommandQueue(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -15964,8 +15964,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateCommandAllocator(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16033,8 +16033,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateGraphicsPipelineState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16104,8 +16104,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateComputePipelineState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16178,8 +16178,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateCommandList(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16262,8 +16262,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CheckFeatureSupport(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16327,8 +16327,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateDescriptorHeap(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16394,8 +16394,8 @@ UINT STDMETHODCALLTYPE ID3D12Device_Wrapper::GetDescriptorHandleIncrementSize(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16450,8 +16450,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateRootSignature(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16526,8 +16526,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateConstantBufferView(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16588,8 +16588,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateShaderResourceView(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16656,8 +16656,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateUnorderedAccessView(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16721,8 +16721,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateRenderTargetView(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16781,8 +16781,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateDepthStencilView(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16840,8 +16840,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateSampler(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16899,8 +16899,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CopyDescriptors(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -16980,8 +16980,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::CopyDescriptorsSimple(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17047,8 +17047,8 @@ D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE ID3D12Device_Wrapper::GetResour
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17110,8 +17110,8 @@ D3D12_HEAP_PROPERTIES STDMETHODCALLTYPE ID3D12Device_Wrapper::GetCustomHeapPrope
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17173,8 +17173,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateCommittedResource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17263,8 +17263,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateHeap(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17337,8 +17337,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreatePlacedResource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17428,8 +17428,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateReservedResource(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17509,8 +17509,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateSharedHandle(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17583,8 +17583,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::OpenSharedHandle(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17652,8 +17652,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::OpenSharedHandleByName(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17715,8 +17715,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::MakeResident(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17775,8 +17775,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::Evict(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17837,8 +17837,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateFence(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17908,8 +17908,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::GetDeviceRemovedReason()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -17960,8 +17960,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::GetCopyableFootprints(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18045,8 +18045,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateQueryHeap(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18112,8 +18112,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::SetStablePowerState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18167,8 +18167,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device_Wrapper::CreateCommandSignature(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18243,8 +18243,8 @@ void STDMETHODCALLTYPE ID3D12Device_Wrapper::GetResourceTiling(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18320,8 +18320,8 @@ LUID STDMETHODCALLTYPE ID3D12Device_Wrapper::GetAdapterLuid()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18388,8 +18388,8 @@ HRESULT STDMETHODCALLTYPE ID3D12PipelineLibrary_Wrapper::StorePipeline(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18448,8 +18448,8 @@ HRESULT STDMETHODCALLTYPE ID3D12PipelineLibrary_Wrapper::LoadGraphicsPipeline(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18526,8 +18526,8 @@ HRESULT STDMETHODCALLTYPE ID3D12PipelineLibrary_Wrapper::LoadComputePipeline(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18600,8 +18600,8 @@ SIZE_T STDMETHODCALLTYPE ID3D12PipelineLibrary_Wrapper::GetSerializedSize()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18648,8 +18648,8 @@ HRESULT STDMETHODCALLTYPE ID3D12PipelineLibrary_Wrapper::Serialize(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18712,8 +18712,8 @@ HRESULT STDMETHODCALLTYPE ID3D12PipelineLibrary1_Wrapper::LoadPipeline(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18794,8 +18794,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device1_Wrapper::CreatePipelineLibrary(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18871,8 +18871,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device1_Wrapper::SetEventOnMultipleFenceCompleti
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -18947,8 +18947,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device1_Wrapper::SetResidencyPriority(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19017,8 +19017,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device2_Wrapper::CreatePipelineState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19092,8 +19092,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device3_Wrapper::OpenExistingHeapFromAddress(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19161,8 +19161,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device3_Wrapper::OpenExistingHeapFromFileMapping
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19232,8 +19232,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device3_Wrapper::EnqueueMakeResident(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19311,8 +19311,8 @@ HRESULT STDMETHODCALLTYPE ID3D12ProtectedSession_Wrapper::GetStatusFence(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19372,8 +19372,8 @@ D3D12_PROTECTED_SESSION_STATUS STDMETHODCALLTYPE ID3D12ProtectedSession_Wrapper:
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19438,8 +19438,8 @@ D3D12_PROTECTED_RESOURCE_SESSION_DESC STDMETHODCALLTYPE ID3D12ProtectedResourceS
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19493,8 +19493,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device4_Wrapper::CreateCommandList1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19572,8 +19572,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device4_Wrapper::CreateProtectedResourceSession(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19646,8 +19646,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device4_Wrapper::CreateCommittedResource1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19742,8 +19742,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device4_Wrapper::CreateHeap1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19820,8 +19820,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device4_Wrapper::CreateReservedResource1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19905,8 +19905,8 @@ D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE ID3D12Device4_Wrapper::GetResou
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -19990,8 +19990,8 @@ void STDMETHODCALLTYPE ID3D12LifetimeOwner_Wrapper::LifetimeStateUpdated(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20057,8 +20057,8 @@ LUID STDMETHODCALLTYPE ID3D12SwapChainAssistant_Wrapper::GetLUID()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20105,8 +20105,8 @@ HRESULT STDMETHODCALLTYPE ID3D12SwapChainAssistant_Wrapper::GetSwapChainObject(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20170,8 +20170,8 @@ HRESULT STDMETHODCALLTYPE ID3D12SwapChainAssistant_Wrapper::GetCurrentResourceAn
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20242,8 +20242,8 @@ HRESULT STDMETHODCALLTYPE ID3D12SwapChainAssistant_Wrapper::InsertImplicitSync()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20309,8 +20309,8 @@ HRESULT STDMETHODCALLTYPE ID3D12LifetimeTracker_Wrapper::DestroyOwnedObject(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20401,8 +20401,8 @@ void* STDMETHODCALLTYPE ID3D12StateObjectProperties_Wrapper::GetShaderIdentifier
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20455,8 +20455,8 @@ UINT64 STDMETHODCALLTYPE ID3D12StateObjectProperties_Wrapper::GetShaderStackSize
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20506,8 +20506,8 @@ UINT64 STDMETHODCALLTYPE ID3D12StateObjectProperties_Wrapper::GetPipelineStackSi
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20551,8 +20551,8 @@ void STDMETHODCALLTYPE ID3D12StateObjectProperties_Wrapper::SetPipelineStackSize
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20605,8 +20605,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device5_Wrapper::CreateLifetimeTracker(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20669,8 +20669,8 @@ void STDMETHODCALLTYPE ID3D12Device5_Wrapper::RemoveDevice()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20713,8 +20713,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device5_Wrapper::EnumerateMetaCommands(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20774,8 +20774,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device5_Wrapper::EnumerateMetaCommandParameters(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20851,8 +20851,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device5_Wrapper::CreateMetaCommand(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -20935,8 +20935,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device5_Wrapper::CreateStateObject(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21003,8 +21003,8 @@ void STDMETHODCALLTYPE ID3D12Device5_Wrapper::GetRaytracingAccelerationStructure
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21066,8 +21066,8 @@ D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS STDMETHODCALLTYPE ID3D12Device5_Wrapper:
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21141,8 +21141,8 @@ void STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedDataSettings_Wrapper::SetAutoB
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21187,8 +21187,8 @@ void STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedDataSettings_Wrapper::SetPageF
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21233,8 +21233,8 @@ void STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedDataSettings_Wrapper::SetWatso
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21283,8 +21283,8 @@ void STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedDataSettings1_Wrapper::SetBrea
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21333,8 +21333,8 @@ void STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedDataSettings2_Wrapper::UseMark
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21401,8 +21401,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedData_Wrapper::GetAutoBreadc
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21458,8 +21458,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedData_Wrapper::GetPageFaultA
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21514,8 +21514,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedData1_Wrapper::GetAutoBread
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21571,8 +21571,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedData1_Wrapper::GetPageFault
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21632,8 +21632,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedData2_Wrapper::GetPageFault
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21688,8 +21688,8 @@ D3D12_DRED_DEVICE_STATE STDMETHODCALLTYPE ID3D12DeviceRemovedExtendedData2_Wrapp
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21742,8 +21742,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device6_Wrapper::SetBackgroundProcessingMode(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21812,8 +21812,8 @@ D3D12_PROTECTED_RESOURCE_SESSION_DESC1 STDMETHODCALLTYPE ID3D12ProtectedResource
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21866,8 +21866,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device7_Wrapper::AddToStateObject(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -21942,8 +21942,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device7_Wrapper::CreateProtectedResourceSession1
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22016,8 +22016,8 @@ D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE ID3D12Device8_Wrapper::GetResou
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22090,8 +22090,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device8_Wrapper::CreateCommittedResource2(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22189,8 +22189,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device8_Wrapper::CreatePlacedResource1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22276,8 +22276,8 @@ void STDMETHODCALLTYPE ID3D12Device8_Wrapper::CreateSamplerFeedbackUnorderedAcce
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22341,8 +22341,8 @@ void STDMETHODCALLTYPE ID3D12Device8_Wrapper::GetCopyableFootprints1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22429,8 +22429,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Resource1_Wrapper::GetProtectedResourceSession(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22494,8 +22494,8 @@ D3D12_RESOURCE_DESC1 STDMETHODCALLTYPE ID3D12Resource2_Wrapper::GetDesc1()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22546,8 +22546,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Heap1_Wrapper::GetProtectedResourceSession(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22610,8 +22610,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList3_Wrapper::SetProtectedResourceS
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22679,8 +22679,8 @@ UINT64 STDMETHODCALLTYPE ID3D12MetaCommand_Wrapper::GetRequiredParameterResource
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22741,8 +22741,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::BeginRenderPass(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22803,8 +22803,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::EndRenderPass()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22846,8 +22846,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::InitializeMetaCommand
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22904,8 +22904,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::ExecuteMetaCommand(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -22962,8 +22962,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::BuildRaytracingAccele
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23035,8 +23035,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::EmitRaytracingAcceler
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23107,8 +23107,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::CopyRaytracingAcceler
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23167,8 +23167,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::SetPipelineState1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23213,8 +23213,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList4_Wrapper::DispatchRays(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23291,8 +23291,8 @@ HRESULT STDMETHODCALLTYPE ID3D12ShaderCacheSession_Wrapper::FindValue(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23361,8 +23361,8 @@ HRESULT STDMETHODCALLTYPE ID3D12ShaderCacheSession_Wrapper::StoreValue(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23425,8 +23425,8 @@ void STDMETHODCALLTYPE ID3D12ShaderCacheSession_Wrapper::SetDeleteOnDestroy()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23467,8 +23467,8 @@ D3D12_SHADER_CACHE_SESSION_DESC STDMETHODCALLTYPE ID3D12ShaderCacheSession_Wrapp
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23520,8 +23520,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device9_Wrapper::CreateShaderCacheSession(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23588,8 +23588,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device9_Wrapper::ShaderCacheControl(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23648,8 +23648,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device9_Wrapper::CreateCommandQueue1(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23733,8 +23733,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device10_Wrapper::CreateCommittedResource3(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23844,8 +23844,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device10_Wrapper::CreatePlacedResource2(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -23948,8 +23948,8 @@ HRESULT STDMETHODCALLTYPE ID3D12Device10_Wrapper::CreateReservedResource2(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24043,8 +24043,8 @@ void STDMETHODCALLTYPE ID3D12Device11_Wrapper::CreateSampler2(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24107,8 +24107,8 @@ D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE ID3D12Device12_Wrapper::GetReso
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24205,8 +24205,8 @@ HRESULT STDMETHODCALLTYPE ID3D12VirtualizationGuestDevice_Wrapper::ShareWithHost
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24264,8 +24264,8 @@ HRESULT STDMETHODCALLTYPE ID3D12VirtualizationGuestDevice_Wrapper::CreateFenceFd
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24344,8 +24344,8 @@ void STDMETHODCALLTYPE ID3D12Tools_Wrapper::EnableShaderInstrumentation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24391,8 +24391,8 @@ BOOL STDMETHODCALLTYPE ID3D12Tools_Wrapper::ShaderInstrumentationEnabled()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24459,8 +24459,8 @@ HRESULT STDMETHODCALLTYPE ID3D12SDKConfiguration_Wrapper::SetSDKVersion(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24523,8 +24523,8 @@ HRESULT STDMETHODCALLTYPE ID3D12SDKConfiguration1_Wrapper::CreateDeviceFactory(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24592,8 +24592,8 @@ void STDMETHODCALLTYPE ID3D12SDKConfiguration1_Wrapper::FreeUnusedSDKs()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24654,8 +24654,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceFactory_Wrapper::InitializeFromGlobalState
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24700,8 +24700,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceFactory_Wrapper::ApplyToGlobalState()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24747,8 +24747,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceFactory_Wrapper::SetFlags(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24798,8 +24798,8 @@ D3D12_DEVICE_FACTORY_FLAGS STDMETHODCALLTYPE ID3D12DeviceFactory_Wrapper::GetFla
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24847,8 +24847,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceFactory_Wrapper::GetConfigurationInterface
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24917,8 +24917,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceFactory_Wrapper::EnableExperimentalFeature
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -24987,8 +24987,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceFactory_Wrapper::CreateDevice(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25078,8 +25078,8 @@ D3D12_DEVICE_CONFIGURATION_DESC STDMETHODCALLTYPE ID3D12DeviceConfiguration_Wrap
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25126,8 +25126,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceConfiguration_Wrapper::GetEnabledExperimen
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25185,8 +25185,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceConfiguration_Wrapper::SerializeVersionedR
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25256,8 +25256,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DeviceConfiguration_Wrapper::CreateVersionedRoot
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25331,8 +25331,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList5_Wrapper::RSSetShadingRate(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25382,8 +25382,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList5_Wrapper::RSSetShadingRateImage
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25434,8 +25434,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList6_Wrapper::DispatchMesh(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25495,8 +25495,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList7_Wrapper::Barrier(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25553,8 +25553,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList8_Wrapper::OMSetFrontAndBackSten
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25610,8 +25610,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList9_Wrapper::RSSetDepthBias(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25666,8 +25666,8 @@ void STDMETHODCALLTYPE ID3D12GraphicsCommandList9_Wrapper::IASetIndexBufferStrip
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25737,8 +25737,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DSRDeviceFactory_Wrapper::CreateDSRDevice(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25834,8 +25834,8 @@ LPVOID STDMETHODCALLTYPE ID3D10Blob_Wrapper::GetBufferPointer()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25880,8 +25880,8 @@ SIZE_T STDMETHODCALLTYPE ID3D10Blob_Wrapper::GetBufferSize()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -25949,8 +25949,8 @@ HRESULT STDMETHODCALLTYPE ID3DDestructionNotifier_Wrapper::RegisterDestructionCa
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26011,8 +26011,8 @@ HRESULT STDMETHODCALLTYPE ID3DDestructionNotifier_Wrapper::UnregisterDestruction
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26086,8 +26086,8 @@ void STDMETHODCALLTYPE ID3D12Debug_Wrapper::EnableDebugLayer()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26146,8 +26146,8 @@ void STDMETHODCALLTYPE ID3D12Debug1_Wrapper::EnableDebugLayer()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26187,8 +26187,8 @@ void STDMETHODCALLTYPE ID3D12Debug1_Wrapper::SetEnableGPUBasedValidation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26233,8 +26233,8 @@ void STDMETHODCALLTYPE ID3D12Debug1_Wrapper::SetEnableSynchronizedCommandQueueVa
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26299,8 +26299,8 @@ void STDMETHODCALLTYPE ID3D12Debug2_Wrapper::SetGPUBasedValidationFlags(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26349,8 +26349,8 @@ void STDMETHODCALLTYPE ID3D12Debug3_Wrapper::SetEnableGPUBasedValidation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26395,8 +26395,8 @@ void STDMETHODCALLTYPE ID3D12Debug3_Wrapper::SetEnableSynchronizedCommandQueueVa
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26441,8 +26441,8 @@ void STDMETHODCALLTYPE ID3D12Debug3_Wrapper::SetGPUBasedValidationFlags(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26490,8 +26490,8 @@ void STDMETHODCALLTYPE ID3D12Debug4_Wrapper::DisableDebugLayer()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26535,8 +26535,8 @@ void STDMETHODCALLTYPE ID3D12Debug5_Wrapper::SetEnableAutoName(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26585,8 +26585,8 @@ void STDMETHODCALLTYPE ID3D12Debug6_Wrapper::SetForceLegacyBarrierValidation(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26655,8 +26655,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugDevice1_Wrapper::SetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26719,8 +26719,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugDevice1_Wrapper::GetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26781,8 +26781,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugDevice1_Wrapper::ReportLiveDeviceObjects(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26853,8 +26853,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugDevice_Wrapper::SetFeatureMask(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26904,8 +26904,8 @@ D3D12_DEBUG_FEATURE STDMETHODCALLTYPE ID3D12DebugDevice_Wrapper::GetFeatureMask(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -26951,8 +26951,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugDevice_Wrapper::ReportLiveDeviceObjects(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27009,8 +27009,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugDevice2_Wrapper::SetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27073,8 +27073,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugDevice2_Wrapper::GetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27157,8 +27157,8 @@ BOOL STDMETHODCALLTYPE ID3D12DebugCommandQueue_Wrapper::AssertResourceState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27223,8 +27223,8 @@ void STDMETHODCALLTYPE ID3D12DebugCommandQueue1_Wrapper::AssertResourceAccess(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27281,8 +27281,8 @@ void STDMETHODCALLTYPE ID3D12DebugCommandQueue1_Wrapper::AssertTextureLayout(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27361,8 +27361,8 @@ BOOL STDMETHODCALLTYPE ID3D12DebugCommandList1_Wrapper::AssertResourceState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27425,8 +27425,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugCommandList1_Wrapper::SetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27489,8 +27489,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugCommandList1_Wrapper::GetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27573,8 +27573,8 @@ BOOL STDMETHODCALLTYPE ID3D12DebugCommandList_Wrapper::AssertResourceState(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27635,8 +27635,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugCommandList_Wrapper::SetFeatureMask(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27686,8 +27686,8 @@ D3D12_DEBUG_FEATURE STDMETHODCALLTYPE ID3D12DebugCommandList_Wrapper::GetFeature
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27739,8 +27739,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugCommandList2_Wrapper::SetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27803,8 +27803,8 @@ HRESULT STDMETHODCALLTYPE ID3D12DebugCommandList2_Wrapper::GetDebugParameter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27869,8 +27869,8 @@ void STDMETHODCALLTYPE ID3D12DebugCommandList3_Wrapper::AssertResourceAccess(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -27927,8 +27927,8 @@ void STDMETHODCALLTYPE ID3D12DebugCommandList3_Wrapper::AssertTextureLayout(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28005,8 +28005,8 @@ void STDMETHODCALLTYPE ID3D12SharingContract_Wrapper::Present(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28062,8 +28062,8 @@ void STDMETHODCALLTYPE ID3D12SharingContract_Wrapper::SharedFenceSignal(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28113,8 +28113,8 @@ void STDMETHODCALLTYPE ID3D12SharingContract_Wrapper::BeginCapturableWork(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28159,8 +28159,8 @@ void STDMETHODCALLTYPE ID3D12SharingContract_Wrapper::EndCapturableWork(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28226,8 +28226,8 @@ void STDMETHODCALLTYPE ID3D12ManualWriteTrackingResource_Wrapper::TrackWrite(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28299,8 +28299,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::SetMessageCountLimit(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28348,8 +28348,8 @@ void STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::ClearStoredMessages()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28393,8 +28393,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetMessage(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28454,8 +28454,8 @@ UINT64 STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetNumMessagesAllowedByStorage
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28500,8 +28500,8 @@ UINT64 STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetNumMessagesDeniedByStorageF
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28546,8 +28546,8 @@ UINT64 STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetNumStoredMessages()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28592,8 +28592,8 @@ UINT64 STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetNumStoredMessagesAllowedByR
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28638,8 +28638,8 @@ UINT64 STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetNumMessagesDiscardedByMessa
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28684,8 +28684,8 @@ UINT64 STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetMessageCountLimit()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28731,8 +28731,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::AddStorageFilterEntries(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28784,8 +28784,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetStorageFilter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28838,8 +28838,8 @@ void STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::ClearStorageFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28880,8 +28880,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PushEmptyStorageFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28926,8 +28926,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PushCopyOfStorageFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -28973,8 +28973,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PushStorageFilter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29022,8 +29022,8 @@ void STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PopStorageFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29064,8 +29064,8 @@ UINT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetStorageFilterStackSize()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29111,8 +29111,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::AddRetrievalFilterEntries(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29164,8 +29164,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetRetrievalFilter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29218,8 +29218,8 @@ void STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::ClearRetrievalFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29260,8 +29260,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PushEmptyRetrievalFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29306,8 +29306,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PushCopyOfRetrievalFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29353,8 +29353,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PushRetrievalFilter(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29402,8 +29402,8 @@ void STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::PopRetrievalFilter()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29444,8 +29444,8 @@ UINT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetRetrievalFilterStackSize()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29494,8 +29494,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::AddMessage(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29562,8 +29562,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::AddApplicationMessage(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29620,8 +29620,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::SetBreakOnCategory(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29678,8 +29678,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::SetBreakOnSeverity(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29736,8 +29736,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::SetBreakOnID(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29793,8 +29793,8 @@ BOOL STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetBreakOnCategory(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29845,8 +29845,8 @@ BOOL STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetBreakOnSeverity(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29897,8 +29897,8 @@ BOOL STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetBreakOnID(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29947,8 +29947,8 @@ void STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::SetMuteDebugOutput(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -29994,8 +29994,8 @@ BOOL STDMETHODCALLTYPE ID3D12InfoQueue_Wrapper::GetMuteDebugOutput()
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -30048,8 +30048,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue1_Wrapper::RegisterMessageCallback(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();
@@ -30115,8 +30115,8 @@ HRESULT STDMETHODCALLTYPE ID3D12InfoQueue1_Wrapper::UnregisterMessageCallback(
     if (call_scope == 1)
     {
         auto force_command_serialization = D3D12CaptureManager::Get()->GetForceCommandSerialization();
-        std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-        std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+        std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+        std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
         if (force_command_serialization)
         {
             exclusive_api_call_lock = D3D12CaptureManager::AcquireExclusiveApiCallLock();

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -92,8 +92,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -129,8 +129,8 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -177,8 +177,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -211,8 +211,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -250,8 +250,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -297,8 +297,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -331,8 +331,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -365,8 +365,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -400,8 +400,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -444,8 +444,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -482,8 +482,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -521,8 +521,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -561,8 +561,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueWaitIdle(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -595,8 +595,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DeviceWaitIdle(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -632,8 +632,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -677,8 +677,8 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -718,8 +718,8 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -764,8 +764,8 @@ VKAPI_ATTR void VKAPI_CALL UnmapMemory(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -798,8 +798,8 @@ VKAPI_ATTR VkResult VKAPI_CALL FlushMappedMemoryRanges(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -839,8 +839,8 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -880,8 +880,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMemoryCommitment(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -916,8 +916,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -956,8 +956,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -995,8 +995,8 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1030,8 +1030,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1066,8 +1066,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1107,8 +1107,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1148,8 +1148,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1191,8 +1191,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1241,8 +1241,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1279,8 +1279,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetFences(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1316,8 +1316,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceStatus(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1355,8 +1355,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForFences(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1396,8 +1396,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1446,8 +1446,8 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1485,8 +1485,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1535,8 +1535,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1572,8 +1572,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1608,8 +1608,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetEvent(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1644,8 +1644,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetEvent(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1682,8 +1682,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1732,8 +1732,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1775,8 +1775,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1825,8 +1825,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1870,8 +1870,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1909,8 +1909,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -1962,8 +1962,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2001,8 +2001,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2046,8 +2046,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2085,8 +2085,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2122,8 +2122,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2175,8 +2175,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2214,8 +2214,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2267,8 +2267,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2306,8 +2306,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2356,8 +2356,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2395,8 +2395,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2441,8 +2441,8 @@ VKAPI_ATTR VkResult VKAPI_CALL MergePipelineCaches(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2480,8 +2480,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2519,8 +2519,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2572,8 +2572,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2611,8 +2611,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2664,8 +2664,8 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2703,8 +2703,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2756,8 +2756,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2795,8 +2795,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2845,8 +2845,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2883,8 +2883,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2922,8 +2922,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -2975,8 +2975,8 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3019,8 +3019,8 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3061,8 +3061,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3114,8 +3114,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3153,8 +3153,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3203,8 +3203,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3241,8 +3241,8 @@ VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3277,8 +3277,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3327,8 +3327,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3365,8 +3365,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3403,8 +3403,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3456,8 +3456,8 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3494,8 +3494,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3532,8 +3532,8 @@ VKAPI_ATTR VkResult VKAPI_CALL EndCommandBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3567,8 +3567,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3604,8 +3604,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3640,8 +3640,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewport(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3677,8 +3677,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissor(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3712,8 +3712,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineWidth(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3747,8 +3747,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3782,8 +3782,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetBlendConstants(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3816,8 +3816,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBounds(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3851,8 +3851,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilCompareMask(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3886,8 +3886,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilWriteMask(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3921,8 +3921,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilReference(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -3961,8 +3961,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4002,8 +4002,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4040,8 +4040,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4079,8 +4079,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDraw(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4119,8 +4119,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexed(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4159,8 +4159,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4198,8 +4198,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4236,8 +4236,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatch(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4272,8 +4272,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4309,8 +4309,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4350,8 +4350,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4394,8 +4394,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4437,8 +4437,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4478,8 +4478,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4518,8 +4518,8 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4557,8 +4557,8 @@ VKAPI_ATTR void VKAPI_CALL CmdFillBuffer(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4597,8 +4597,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4638,8 +4638,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4678,8 +4678,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearAttachments(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4719,8 +4719,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4758,8 +4758,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4793,8 +4793,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4836,8 +4836,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4890,8 +4890,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4937,8 +4937,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQuery(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -4973,8 +4973,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQuery(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5009,8 +5009,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetQueryPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5046,8 +5046,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5087,8 +5087,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyQueryPoolResults(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5130,8 +5130,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5168,8 +5168,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5205,8 +5205,8 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5237,8 +5237,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5270,8 +5270,8 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5305,8 +5305,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5346,8 +5346,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5389,8 +5389,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeatures(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5425,8 +5425,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMask(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5463,8 +5463,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBase(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5502,8 +5502,8 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5551,8 +5551,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5589,8 +5589,8 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5628,8 +5628,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5666,8 +5666,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5699,8 +5699,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5733,8 +5733,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5768,8 +5768,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5812,8 +5812,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5846,8 +5846,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5881,8 +5881,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5917,8 +5917,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5952,8 +5952,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -5990,8 +5990,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6040,8 +6040,8 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6079,8 +6079,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6132,8 +6132,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6170,8 +6170,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6205,8 +6205,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFenceProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6240,8 +6240,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphoreProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6275,8 +6275,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupport(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6317,8 +6317,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCount(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6360,8 +6360,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCount(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6400,8 +6400,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6450,8 +6450,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6488,8 +6488,8 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6522,8 +6522,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6557,8 +6557,8 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPool(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6593,8 +6593,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValue(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6637,8 +6637,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphores(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6677,8 +6677,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphore(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6716,8 +6716,8 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddress(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6755,8 +6755,8 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddress(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6794,8 +6794,8 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddress(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6834,8 +6834,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolProperties(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6879,8 +6879,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlot(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6929,8 +6929,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlot(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -6969,8 +6969,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7011,8 +7011,8 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateData(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7048,8 +7048,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7086,8 +7086,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7122,8 +7122,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7160,8 +7160,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7198,8 +7198,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7235,8 +7235,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7276,8 +7276,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7312,8 +7312,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7348,8 +7348,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7384,8 +7384,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7420,8 +7420,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7456,8 +7456,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7492,8 +7492,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRendering(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7527,8 +7527,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRendering(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7559,8 +7559,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullMode(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7592,8 +7592,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFace(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7625,8 +7625,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopology(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7659,8 +7659,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCount(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7694,8 +7694,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCount(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7733,8 +7733,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7771,8 +7771,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnable(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7804,8 +7804,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnable(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7837,8 +7837,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOp(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7870,8 +7870,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnable(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7903,8 +7903,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnable(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7940,8 +7940,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOp(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -7977,8 +7977,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnable(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8010,8 +8010,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnable(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8043,8 +8043,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnable(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8077,8 +8077,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirements(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8112,8 +8112,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirements(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8151,8 +8151,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirements(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8190,8 +8190,8 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8229,8 +8229,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8274,8 +8274,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilitiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8319,8 +8319,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormatsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8365,8 +8365,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8411,8 +8411,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8464,8 +8464,8 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8503,8 +8503,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8556,8 +8556,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8631,8 +8631,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupPresentCapabilitiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8674,8 +8674,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8719,8 +8719,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDevicePresentRectanglesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8764,8 +8764,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8811,8 +8811,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8860,8 +8860,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8910,8 +8910,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -8961,8 +8961,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9013,8 +9013,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9065,8 +9065,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilitiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9111,8 +9111,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9166,8 +9166,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9221,8 +9221,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9272,8 +9272,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXlibPresentationSupportKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9312,8 +9312,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9363,8 +9363,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXcbPresentationSupportKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9403,8 +9403,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9453,8 +9453,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWaylandPresentationSupportKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9492,8 +9492,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9543,8 +9543,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9592,8 +9592,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWin32PresentationSupportKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9629,8 +9629,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoCapabilitiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9674,8 +9674,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoFormatPropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9720,8 +9720,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9770,8 +9770,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9809,8 +9809,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9855,8 +9855,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindVideoSessionMemoryKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9898,8 +9898,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9951,8 +9951,8 @@ VKAPI_ATTR VkResult VKAPI_CALL UpdateVideoSessionParametersKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -9989,8 +9989,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10026,8 +10026,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10062,8 +10062,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndVideoCodingKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10095,8 +10095,8 @@ VKAPI_ATTR void VKAPI_CALL CmdControlVideoCodingKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10128,8 +10128,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDecodeVideoKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10164,8 +10164,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderingKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10199,8 +10199,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderingKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10231,8 +10231,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10264,8 +10264,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10298,8 +10298,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10333,8 +10333,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10377,8 +10377,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10411,8 +10411,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10446,8 +10446,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10484,8 +10484,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeaturesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10520,8 +10520,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10558,8 +10558,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10597,8 +10597,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10632,8 +10632,8 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10681,8 +10681,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10716,8 +10716,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10764,8 +10764,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10809,8 +10809,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10857,8 +10857,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10902,8 +10902,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphorePropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10936,8 +10936,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -10976,8 +10976,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11022,8 +11022,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11062,8 +11062,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11112,8 +11112,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11154,8 +11154,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11207,8 +11207,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11246,8 +11246,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11296,8 +11296,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11334,8 +11334,8 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11368,8 +11368,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11401,8 +11401,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainStatusKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11438,8 +11438,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFencePropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11472,8 +11472,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11512,8 +11512,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11558,8 +11558,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11598,8 +11598,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceFdKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11647,8 +11647,8 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceQueueFamilyPerformanceQuer
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11693,8 +11693,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11727,8 +11727,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireProfilingLockKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11762,8 +11762,8 @@ VKAPI_ATTR void VKAPI_CALL ReleaseProfilingLockKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11795,8 +11795,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11843,8 +11843,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11891,8 +11891,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11940,8 +11940,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -11990,8 +11990,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12040,8 +12040,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilities2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12087,8 +12087,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12125,8 +12125,8 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12164,8 +12164,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12204,8 +12204,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12254,8 +12254,8 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12292,8 +12292,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12333,8 +12333,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12374,8 +12374,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12416,8 +12416,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12459,8 +12459,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12498,8 +12498,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12542,8 +12542,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12582,8 +12582,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphoreKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12622,8 +12622,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceFragmentShadingRatesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12666,8 +12666,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12700,8 +12700,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingAttachmentLocationsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12733,8 +12733,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRenderingInputAttachmentIndicesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12768,8 +12768,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForPresentKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12806,8 +12806,8 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12845,8 +12845,8 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddressKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12884,8 +12884,8 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddressKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12924,8 +12924,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -12973,8 +12973,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13010,8 +13010,8 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13046,8 +13046,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13082,8 +13082,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13120,8 +13120,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13169,8 +13169,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableStatisticsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13218,8 +13218,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableInternalRepresentationsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13266,8 +13266,8 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13312,8 +13312,8 @@ VKAPI_ATTR VkResult VKAPI_CALL UnmapMemory2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13352,8 +13352,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoEncodeQualityLevelPropertie
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13398,8 +13398,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEncodedVideoSessionParametersKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13446,8 +13446,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEncodeVideoKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13483,8 +13483,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13521,8 +13521,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13557,8 +13557,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13595,8 +13595,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13633,8 +13633,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13670,8 +13670,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13714,8 +13714,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarker2AMD(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13751,8 +13751,8 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointData2NV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13785,8 +13785,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13821,8 +13821,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13857,8 +13857,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13893,8 +13893,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13929,8 +13929,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -13965,8 +13965,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14001,8 +14001,8 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirect2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14035,8 +14035,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirementsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14070,8 +14070,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirementsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14109,8 +14109,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirementsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14150,8 +14150,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14187,8 +14187,8 @@ VKAPI_ATTR void VKAPI_CALL GetRenderingAreaGranularityKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14222,8 +14222,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSubresourceLayoutKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14261,8 +14261,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14297,8 +14297,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14341,8 +14341,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14376,8 +14376,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14422,8 +14422,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14467,8 +14467,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14503,8 +14503,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14539,8 +14539,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSet2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14575,8 +14575,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14611,8 +14611,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDescriptorBufferOffsets2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14647,8 +14647,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorBufferEmbeddedSamplers2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14684,8 +14684,8 @@ VKAPI_ATTR void VKAPI_CALL FrameBoundaryANDROID(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14720,8 +14720,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14770,8 +14770,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14813,8 +14813,8 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14852,8 +14852,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14891,8 +14891,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14930,8 +14930,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14962,8 +14962,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -14994,8 +14994,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15031,8 +15031,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindTransformFeedbackBuffersEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15071,8 +15071,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15110,8 +15110,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15149,8 +15149,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15187,8 +15187,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15227,8 +15227,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15265,8 +15265,8 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15305,8 +15305,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageViewAddressNVX(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15353,8 +15353,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15396,8 +15396,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15438,8 +15438,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderInfoAMD(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15486,8 +15486,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateStreamDescriptorSurfaceGGP(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15541,8 +15541,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15591,8 +15591,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15637,8 +15637,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15686,8 +15686,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15721,8 +15721,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndConditionalRenderingEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15755,8 +15755,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15790,8 +15790,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15827,8 +15827,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15866,8 +15866,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15916,8 +15916,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15960,8 +15960,8 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -15999,8 +15999,8 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16051,8 +16051,8 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16103,8 +16103,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainCounterEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16148,8 +16148,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16193,8 +16193,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16239,8 +16239,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16274,8 +16274,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16307,8 +16307,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16342,8 +16342,8 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16379,8 +16379,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16430,8 +16430,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16479,8 +16479,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16520,8 +16520,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16561,8 +16561,8 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16593,8 +16593,8 @@ VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16625,8 +16625,8 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16658,8 +16658,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16690,8 +16690,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16722,8 +16722,8 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16757,8 +16757,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16807,8 +16807,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16846,8 +16846,8 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16882,8 +16882,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16926,8 +16926,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -16972,8 +16972,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17006,8 +17006,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17041,8 +17041,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageDrmFormatModifierPropertiesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17086,8 +17086,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17136,8 +17136,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17175,8 +17175,8 @@ VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17215,8 +17215,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17260,8 +17260,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17296,8 +17296,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17333,8 +17333,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17370,8 +17370,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17423,8 +17423,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17461,8 +17461,8 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17499,8 +17499,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindAccelerationStructureMemoryNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17546,8 +17546,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17591,8 +17591,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17639,8 +17639,8 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17689,8 +17689,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17739,8 +17739,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17787,8 +17787,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAccelerationStructureHandleNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17835,8 +17835,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17873,8 +17873,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CompileDeferredNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17912,8 +17912,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17959,8 +17959,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -17996,8 +17996,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18042,8 +18042,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18088,8 +18088,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18125,8 +18125,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18166,8 +18166,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18206,8 +18206,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorEnableNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18243,8 +18243,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18278,8 +18278,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18312,8 +18312,8 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18346,8 +18346,8 @@ VKAPI_ATTR VkResult VKAPI_CALL InitializePerformanceApiINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18381,8 +18381,8 @@ VKAPI_ATTR void VKAPI_CALL UninitializePerformanceApiINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18413,8 +18413,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceMarkerINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18449,8 +18449,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceStreamMarkerINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18485,8 +18485,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceOverrideINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18522,8 +18522,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18570,8 +18570,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18609,8 +18609,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSetPerformanceConfigurationINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18646,8 +18646,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPerformanceParameterINTEL(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18690,8 +18690,8 @@ VKAPI_ATTR void VKAPI_CALL SetLocalDimmingAMD(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18726,8 +18726,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18777,8 +18777,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18826,8 +18826,8 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18866,8 +18866,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18910,8 +18910,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18954,8 +18954,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSupportedFramebufferMixedSamples
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -18999,8 +18999,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModes2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19046,8 +19046,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireFullScreenExclusiveModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19082,8 +19082,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseFullScreenExclusiveModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19119,8 +19119,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19167,8 +19167,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateHeadlessSurfaceEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19217,8 +19217,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19253,8 +19253,8 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPoolEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19288,8 +19288,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19321,8 +19321,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFaceEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19354,8 +19354,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopologyEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19388,8 +19388,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCountEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19423,8 +19423,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCountEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19462,8 +19462,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19500,8 +19500,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19533,8 +19533,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19566,8 +19566,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOpEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19599,8 +19599,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19632,8 +19632,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19669,8 +19669,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOpEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19706,8 +19706,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToImageEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19745,8 +19745,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToMemoryEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19784,8 +19784,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyImageToImageEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19824,8 +19824,8 @@ VKAPI_ATTR VkResult VKAPI_CALL TransitionImageLayoutEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19866,8 +19866,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19901,8 +19901,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseSwapchainImagesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19941,8 +19941,8 @@ VKAPI_ATTR void VKAPI_CALL GetGeneratedCommandsMemoryRequirementsNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -19978,8 +19978,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPreprocessGeneratedCommandsNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20015,8 +20015,8 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteGeneratedCommandsNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20054,8 +20054,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipelineShaderGroupNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20091,8 +20091,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20144,8 +20144,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20181,8 +20181,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias2EXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20215,8 +20215,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireDrmDisplayEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20254,8 +20254,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20305,8 +20305,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20355,8 +20355,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20395,8 +20395,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20437,8 +20437,8 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateDataEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20474,8 +20474,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateEnumNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20509,8 +20509,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceFaultInfoEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20552,8 +20552,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireWinrtDisplayNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20589,8 +20589,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20639,8 +20639,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDirectFBSurfaceEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20689,8 +20689,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceDirectFBPresentationSupportEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20729,8 +20729,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetVertexInputEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20766,8 +20766,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandleFUCHSIA(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20814,8 +20814,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandlePropertiesFUCHSIA(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20858,8 +20858,8 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreZirconHandleFUCHSIA(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20898,8 +20898,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreZirconHandleFUCHSIA(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20945,8 +20945,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindInvocationMaskHUAWEI(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -20980,8 +20980,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryRemoteAddressNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21026,8 +21026,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPatchControlPointsEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21059,8 +21059,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21092,8 +21092,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21125,8 +21125,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21158,8 +21158,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21193,8 +21193,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateScreenSurfaceQNX(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21243,8 +21243,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceScreenPresentationSupportQNX(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21281,8 +21281,8 @@ VKAPI_ATTR void                                    VKAPI_CALL CmdSetColorWriteEn
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21319,8 +21319,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21361,8 +21361,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiIndexedEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21401,8 +21401,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMicromapEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21454,8 +21454,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyMicromapEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21492,8 +21492,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildMicromapsEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21531,8 +21531,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BuildMicromapsEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21573,8 +21573,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21614,8 +21614,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMicromapToMemoryEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21655,8 +21655,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToMicromapEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21700,8 +21700,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteMicromapsPropertiesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21747,8 +21747,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21783,8 +21783,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMicromapToMemoryEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21819,8 +21819,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToMicromapEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21859,8 +21859,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteMicromapsPropertiesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21897,8 +21897,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceMicromapCompatibilityEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21933,8 +21933,8 @@ VKAPI_ATTR void VKAPI_CALL GetMicromapBuildSizesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -21973,8 +21973,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterHUAWEI(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22009,8 +22009,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawClusterIndirectHUAWEI(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22044,8 +22044,8 @@ VKAPI_ATTR void VKAPI_CALL SetDeviceMemoryPriorityEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22079,8 +22079,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutHostMappingInfoVALVE(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22117,8 +22117,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetHostMappingVALVE(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22152,8 +22152,8 @@ VKAPI_ATTR void VKAPI_CALL GetPipelineIndirectMemoryRequirementsNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22190,8 +22190,8 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdatePipelineIndirectBufferNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22224,8 +22224,8 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetPipelineIndirectDeviceAddressNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22263,8 +22263,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClampEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22296,8 +22296,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPolygonModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22329,8 +22329,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationSamplesEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22363,8 +22363,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleMaskEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22397,8 +22397,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToCoverageEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22430,8 +22430,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAlphaToOneEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22463,8 +22463,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22498,8 +22498,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22535,8 +22535,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendEquationEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22572,8 +22572,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorWriteMaskEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22607,8 +22607,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetTessellationDomainOriginEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22640,8 +22640,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizationStreamEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22673,8 +22673,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetConservativeRasterizationModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22706,8 +22706,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExtraPrimitiveOverestimationSizeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22739,8 +22739,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22772,8 +22772,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22807,8 +22807,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetColorBlendAdvancedEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22842,8 +22842,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetProvokingVertexModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22875,8 +22875,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineRasterizationModeEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22908,8 +22908,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22941,8 +22941,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthClipNegativeOneToOneEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -22974,8 +22974,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingEnableNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23009,8 +23009,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportSwizzleNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23044,8 +23044,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorEnableNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23077,8 +23077,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageToColorLocationNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23110,8 +23110,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationModeNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23143,8 +23143,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableEnableNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23177,8 +23177,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageModulationTableNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23211,8 +23211,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetShadingRateImageEnableNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23244,8 +23244,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRepresentativeFragmentTestEnableNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23277,8 +23277,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoverageReductionModeNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23311,8 +23311,8 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleIdentifierEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23346,8 +23346,8 @@ VKAPI_ATTR void VKAPI_CALL GetShaderModuleCreateInfoIdentifierEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23385,8 +23385,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceOpticalFlowImageFormatsNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23431,8 +23431,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateOpticalFlowSessionNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23481,8 +23481,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyOpticalFlowSessionNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23521,8 +23521,8 @@ VKAPI_ATTR VkResult VKAPI_CALL BindOpticalFlowSessionImageNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23561,8 +23561,8 @@ VKAPI_ATTR void VKAPI_CALL CmdOpticalFlowExecuteNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23598,8 +23598,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23652,8 +23652,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23691,8 +23691,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23737,8 +23737,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadersEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23774,8 +23774,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFramebufferTilePropertiesQCOM(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23819,8 +23819,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDynamicRenderingTilePropertiesQCOM(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23866,8 +23866,8 @@ VKAPI_ATTR VkResult VKAPI_CALL SetLatencySleepModeNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23904,8 +23904,8 @@ VKAPI_ATTR VkResult VKAPI_CALL LatencySleepNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23945,8 +23945,8 @@ VKAPI_ATTR void VKAPI_CALL SetLatencyMarkerNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -23980,8 +23980,8 @@ VKAPI_ATTR void VKAPI_CALL GetLatencyTimingsNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24014,8 +24014,8 @@ VKAPI_ATTR void VKAPI_CALL QueueNotifyOutOfBandNV(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24047,8 +24047,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetAttachmentFeedbackLoopEnableEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24082,8 +24082,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24127,8 +24127,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24166,8 +24166,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24205,8 +24205,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24246,8 +24246,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24287,8 +24287,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToAccelerationStructureKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24332,8 +24332,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteAccelerationStructuresPropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24379,8 +24379,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24415,8 +24415,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureToMemoryKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24451,8 +24451,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToAccelerationStructureKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24487,8 +24487,8 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetAccelerationStructureDeviceAddressKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24530,8 +24530,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24568,8 +24568,8 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceAccelerationStructureCompatibilityKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24605,8 +24605,8 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureBuildSizesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24650,8 +24650,8 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24693,8 +24693,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingCaptureReplayShaderGroupHandlesKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24743,8 +24743,8 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirectKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24782,8 +24782,8 @@ VKAPI_ATTR VkDeviceSize VKAPI_CALL GetRayTracingShaderGroupStackSizeKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24820,8 +24820,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRayTracingPipelineStackSizeKHR(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24855,8 +24855,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24893,8 +24893,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
@@ -24934,8 +24934,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountEXT(
     VulkanCaptureManager* manager = VulkanCaptureManager::Get();
     GFXRECON_ASSERT(manager != nullptr);
     auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;
+    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
+    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
     if (force_command_serialization)
     {
         exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -241,8 +241,8 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
             body += indent + 'auto api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();\n'
         else:
             body += indent + 'auto force_command_serialization = manager->GetForceCommandSerialization();\n'
-            body += indent + 'std::shared_lock<CaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
-            body += indent + 'std::unique_lock<CaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
+            body += indent + 'std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;\n'
+            body += indent + 'std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;\n'
             body += indent + 'if (force_command_serialization)\n'
             body += indent + '{\n'
             body += indent + '    exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();\n'


### PR DESCRIPTION
Split common and api specific options from isA to refsA relationship.

For single API sessions should be exactly equivalent.

This is a first piece of multiple API support needed for pending feature development.

Issues to be resolved:
Settings Arbitration: different API invocations of the layer may have different settings.  Determining where are complete set of options are (without having to repeat them in every JSON) is one challenge.  Resolving which setting "wins" (first, last, some priority heuristic). Settings side effects (like whether an StateTracker is create) need to be address if later invocations can change settings.

A number of interfaces became "public" to support this.  The other choice is friendship between the various CaptureManagers, thoughts?

Also, concerns about performance or maintainability.

