### PR TITLE
Add missing state-write for ShaderEXTWrapper

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -156,6 +156,7 @@ uint64_t VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint
     WriteAccelerationStructureKHRState(state_table);
     WriteTlasToBlasDependenciesMetadata(state_table);
     StandardCreateWrite<vulkan_wrappers::AccelerationStructureNVWrapper>(state_table);
+    StandardCreateWrite<vulkan_wrappers::ShaderEXTWrapper>(state_table);
 
     // Descriptor creation.
     StandardCreateWrite<vulkan_wrappers::DescriptorPoolWrapper>(state_table);


### PR DESCRIPTION
- fixes trimmed captures for VK_EXT_shader_object