### PR TITLE
Insert dummy annotations in place of optimized out resources

### DIFF
--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -65,8 +65,9 @@ const size_t   kAdapterDescriptionSize    = 128;
 
 /// Label for operation annotation, which captures parameters used by tools
 /// operating on a capture file.
-const char* const kAnnotationLabelOperation     = "operation";
-const char* const kAnnotationLabelReplayOptions = "replayopts";
+const char* const kAnnotationLabelOperation       = "operation";
+const char* const kAnnotationLabelReplayOptions   = "replayopts";
+const char* const kAnnotationLabelRemovedResource = "removed-resource";
 
 const char* const kOperationAnnotationGfxreconstructVersion = "gfxrecon-version";
 const char* const kOperationAnnotationVulkanVersion         = "vulkan-version";


### PR DESCRIPTION
FileOptimizer now should insert empty annotation meta commands in place of the resources that are removed as not referenced in a trimmed capture range. This should keep the block index when replaying an optimized trimmed capture in alignment with the block index calculated at capture time.