### PR TITLE
openxr: Move xrFrameEnd to manually generated encode

### DIFF
--- a/framework/encode/custom_openxr_api_call_encoders.h
+++ b/framework/encode/custom_openxr_api_call_encoders.h
@@ -37,6 +37,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
+XRAPI_ATTR XrResult XRAPI_CALL xrEndFrame(XrSession session, const XrFrameEndInfo* frameEndInfo);
 XRAPI_ATTR XrResult XRAPI_CALL xrCreateTriangleMeshFB(XrSession                         session,
                                                       const XrTriangleMeshCreateInfoFB* createInfo,
                                                       XrTriangleMeshFB*                 outTriangleMesh);

--- a/framework/generated/generated_openxr_api_call_encoders.cpp
+++ b/framework/generated/generated_openxr_api_call_encoders.cpp
@@ -1383,45 +1383,6 @@ XRAPI_ATTR XrResult XRAPI_CALL xrBeginFrame(
     return result;
 }
 
-XRAPI_ATTR XrResult XRAPI_CALL xrEndFrame(
-    XrSession                                   session,
-    const XrFrameEndInfo*                       frameEndInfo)
-{
-    OpenXrCaptureManager* manager = OpenXrCaptureManager::Get();
-    GFXRECON_ASSERT(manager != nullptr);
-    auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
-    if (force_command_serialization)
-    {
-        exclusive_api_call_lock = OpenXrCaptureManager::AcquireExclusiveApiCallLock();
-    }
-    else
-    {
-        shared_api_call_lock = OpenXrCaptureManager::AcquireSharedApiCallLock();
-    }
-
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_xrEndFrame>::Dispatch(manager, session, frameEndInfo);
-
-    auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
-    const XrFrameEndInfo* frameEndInfo_unwrapped = openxr_wrappers::UnwrapStructPtrHandles(frameEndInfo, handle_unwrap_memory);
-
-    XrResult result = openxr_wrappers::GetInstanceTable(session)->EndFrame(session, frameEndInfo_unwrapped);
-
-    auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_xrEndFrame);
-    if (encoder)
-    {
-        encoder->EncodeOpenXrHandleValue<openxr_wrappers::SessionWrapper>(session);
-        EncodeStructPtr(encoder, frameEndInfo);
-        encoder->EncodeEnumValue(result);
-        manager->EndApiCallCapture();
-    }
-
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_xrEndFrame>::Dispatch(manager, result, session, frameEndInfo);
-
-    return result;
-}
-
 XRAPI_ATTR XrResult XRAPI_CALL xrLocateViews(
     XrSession                                   session,
     const XrViewLocateInfo*                     viewLocateInfo,

--- a/framework/generated/generated_openxr_api_call_encoders.h
+++ b/framework/generated/generated_openxr_api_call_encoders.h
@@ -195,10 +195,6 @@ XRAPI_ATTR XrResult XRAPI_CALL xrBeginFrame(
     XrSession                                   session,
     const XrFrameBeginInfo*                     frameBeginInfo);
 
-XRAPI_ATTR XrResult XRAPI_CALL xrEndFrame(
-    XrSession                                   session,
-    const XrFrameEndInfo*                       frameEndInfo);
-
 XRAPI_ATTR XrResult XRAPI_CALL xrLocateViews(
     XrSession                                   session,
     const XrViewLocateInfo*                     viewLocateInfo,

--- a/framework/generated/openxr_generators/blacklists.json
+++ b/framework/generated/openxr_generators/blacklists.json
@@ -13,6 +13,7 @@
     "xrTriangleMeshGetIndexBufferFB"
   ],
   "functions-encoder": [
+    "xrEndFrame"
   ],
   "functions-decoder": [
   ],


### PR DESCRIPTION
Move the xrFrameEnd function to be manually defined so that we can trigger a capture manager EndFrame() call after all is done.