### PR TITLE
Do second round API detect for optimizer if needed

### DIFF
--- a/framework/decode/decode_api_detection.cpp
+++ b/framework/decode/decode_api_detection.cpp
@@ -29,7 +29,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-bool DetectAPIs(const std::string& input_filename, bool& dx12_detected, bool& vulkan_detected)
+bool DetectAPIs(const std::string& input_filename, bool& dx12_detected, bool& vulkan_detected, bool no_block_limit)
 {
     dx12_detected   = false;
     vulkan_detected = false;
@@ -37,12 +37,16 @@ bool DetectAPIs(const std::string& input_filename, bool& dx12_detected, bool& vu
     gfxrecon::decode::FileProcessor file_processor;
     if (file_processor.Initialize(input_filename))
     {
-        gfxrecon::decode::VulkanDetectionConsumer vulkan_detection_consumer;
+        uint64_t vulkan_block_limit = no_block_limit ? gfxrecon::decode::VulkanDetectionConsumer::kNoBlockLimit
+                                                     : gfxrecon::decode::VulkanDetectionConsumer::kDefaultBlockLimit;
+        gfxrecon::decode::VulkanDetectionConsumer vulkan_detection_consumer(vulkan_block_limit);
         gfxrecon::decode::VulkanDecoder           vulkan_decoder;
         vulkan_decoder.AddConsumer(&vulkan_detection_consumer);
         file_processor.AddDecoder(&vulkan_decoder);
 #if defined(D3D12_SUPPORT)
-        gfxrecon::decode::Dx12DetectionConsumer dx12_detection_consumer;
+        uint64_t dx12_block_limit = no_block_limit ? gfxrecon::decode::Dx12DetectionConsumer::kNoBlockLimit
+                                                   : gfxrecon::decode::Dx12DetectionConsumer::kDefaultBlockLimit;
+        gfxrecon::decode::Dx12DetectionConsumer dx12_detection_consumer(dx12_block_limit);
         gfxrecon::decode::Dx12Decoder           dx12_decoder;
         dx12_decoder.AddConsumer(&dx12_detection_consumer);
         file_processor.AddDecoder(&dx12_decoder);

--- a/framework/decode/decode_api_detection.h
+++ b/framework/decode/decode_api_detection.h
@@ -37,7 +37,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-bool DetectAPIs(const std::string& input_filename, bool& dx12_detected, bool& vulkan_detected);
+bool DetectAPIs(const std::string& input_filename, bool& dx12_detected, bool& vulkan_detected, bool no_block_limit = false);
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/decode_api_detection.h
+++ b/framework/decode/decode_api_detection.h
@@ -37,7 +37,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-bool DetectAPIs(const std::string& input_filename, bool& dx12_detected, bool& vulkan_detected, bool no_block_limit = false);
+bool DetectAPIs(const std::string& input_filename,
+                bool&              dx12_detected,
+                bool&              vulkan_detected,
+                bool               no_block_limit = false);
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -274,6 +274,12 @@ int main(int argc, const char** argv)
             bool detected_vulkan = false;
             gfxrecon::decode::DetectAPIs(input_filename, detected_d3d12, detected_vulkan);
 
+            if ((!detected_d3d12) && (!detected_vulkan))
+            {
+                //Detect with no block limit
+                gfxrecon::decode::DetectAPIs(input_filename, detected_d3d12, detected_vulkan, true);
+            }
+
             if (detected_d3d12)
             {
                 dx12_options.optimize_resource_values = true;

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, const char** argv)
 
             if ((!detected_d3d12) && (!detected_vulkan))
             {
-                //Detect with no block limit
+                // Detect with no block limit
                 gfxrecon::decode::DetectAPIs(input_filename, detected_d3d12, detected_vulkan, true);
             }
 


### PR DESCRIPTION
**Problem**
For some cases, 1000 blocks is not enough for API detection.

**Solution**
If the first round detection with 1000 blocks doesn't return any detection result, we will do a second round API detection with no-block-limit parameter. The detection will be done with no block limit, till one of targeted API calls is found. A message will show in the console if the second round is needed.

**Result**
It looks for most cases, 1000 blocks should be enough for the API detection. The second round detection should always give us the result and it will be performed only the first round detection (short) doesn't provide any result.