### PR TITLE
Fix for 32/64-bit portability when encoding inline-uniform-blocks

### DIFF
--- a/framework/decode/descriptor_update_template_decoder.cpp
+++ b/framework/decode/descriptor_update_template_decoder.cpp
@@ -47,9 +47,6 @@ DescriptorUpdateTemplateDecoder::~DescriptorUpdateTemplateDecoder() {}
 
 size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buffer_size)
 {
-    // account for an encoded array's metadata (inline-uniform-block encoded using ParameterEncoder::EncodeUInt8Array)
-    constexpr size_t array_meta_size = sizeof(format::PointerAttributes) + sizeof(size_t) + sizeof(void*);
-
     size_t bytes_read = DecodeAttributes(buffer, buffer_size);
 
     // The update template should identify as a struct pointer.
@@ -137,7 +134,7 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
                     case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
                     {
                         cur_type.offset    = total_size;
-                        uint32_t num_bytes = cur_type.count + array_meta_size;
+                        uint32_t num_bytes = cur_type.count;
 
                         // We will read/write raw bytes in the allocated memory block, they should be the same
                         required_read_memory_size  = num_bytes;
@@ -254,7 +251,6 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
                     inline_uniform_block_count_ = cur_type.count;
                     inline_uniform_block_       = template_memory_ + cur_type.offset;
 
-                    bytes_read += array_meta_size;
                     bytes_read += ValueDecoder::DecodeUInt8Array((buffer + bytes_read),
                                                                  (buffer_size - bytes_read),
                                                                  inline_uniform_block_,

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -199,7 +199,7 @@ static void EncodeDescriptorUpdateTemplateInfo(VulkanCaptureManager*     manager
 
             for (const auto& entry_info : info->inline_uniform_block)
             {
-                encoder->EncodeUInt8Array(bytes + entry_info.offset, entry_info.count);
+                encoder->EncodeRawBytes(bytes + entry_info.offset, entry_info.count);
             }
         }
     }

--- a/framework/encode/parameter_encoder.h
+++ b/framework/encode/parameter_encoder.h
@@ -292,6 +292,11 @@ class ParameterEncoder
     }
 #endif
 
+    void EncodeRawBytes(const void* bytes, size_t num_bytes)
+    {
+        output_stream_->Write(bytes, num_bytes);
+    }
+
   private:
     uint32_t GetPointerAttributeMask(const void* ptr, bool omit_data, bool omit_addr)
     {


### PR DESCRIPTION
- Do not use `ParameterEncoder::EncodeUInt8Array`,  avoid usage of non-portable `sizeof(size_t)`.
- Add '`ParameterEncoder::EncodeRawBytes`' to write raw-byte-arrays without meta-data (and avoid looping over the bytes with 'EncodeUInt8Value')