### PR TITLE
Fix crash when window cannot be opened with same resolution

### DIFF
--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -117,6 +117,11 @@ std::string AndroidWindow::GetWsiExtension() const
     return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
 }
 
+VkExtent2D AndroidWindow::GetSize() const
+{
+    return { width_, height_ };
+}
+
 VkResult AndroidWindow::CreateSurface(const encode::VulkanInstanceTable* table,
                                       VkInstance                         instance,
                                       VkFlags                            flags,

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -71,6 +71,8 @@ class AndroidWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
+    virtual VkExtent2D GetSize() const override;
+
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,

--- a/framework/application/display_window.cpp
+++ b/framework/application/display_window.cpp
@@ -30,7 +30,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-DisplayWindow::DisplayWindow(DisplayContext* display_context) : display_context_(display_context)
+DisplayWindow::DisplayWindow(DisplayContext* display_context) : display_context_(display_context), width_(0), height_(0)
 {
     assert(display_context_ != nullptr);
 }
@@ -195,9 +195,20 @@ VkResult DisplayWindow::SelectPlane(const encode::VulkanInstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
+void DisplayWindow::SetSize(const uint32_t width, const uint32_t height)
+{
+    width_  = width;
+    height_ = height;
+}
+
 std::string DisplayWindow::GetWsiExtension() const
 {
     return VK_KHR_DISPLAY_EXTENSION_NAME;
+}
+
+VkExtent2D DisplayWindow::GetSize() const
+{
+    return { width_, height_ };
 }
 
 VkResult DisplayWindow::CreateSurface(const encode::VulkanInstanceTable* table,
@@ -240,6 +251,9 @@ VkResult DisplayWindow::CreateSurface(const encode::VulkanInstanceTable* table,
             GFXRECON_LOG_ERROR("Failed to select display plane");
             return error;
         }
+
+        width_  = mode_props.parameters.visibleRegion.width;
+        height_ = mode_props.parameters.visibleRegion.height;
 
         VkExtent2D image_extent;
         image_extent.width  = mode_props.parameters.visibleRegion.width;

--- a/framework/application/display_window.h
+++ b/framework/application/display_window.h
@@ -55,9 +55,9 @@ class DisplayWindow : public decode::Window
 
     virtual void SetPosition(const int32_t, const int32_t) override {}
 
-    virtual void SetSize(const uint32_t, const uint32_t) override{};
+    virtual void SetSize(const uint32_t width, const uint32_t height) override;
 
-    virtual void SetSizePreTransform(const uint32_t, const uint32_t, const uint32_t) override{};
+    virtual void SetSizePreTransform(const uint32_t, const uint32_t, const uint32_t) override {}
 
     virtual void SetVisibility(bool) override {}
 
@@ -66,6 +66,8 @@ class DisplayWindow : public decode::Window
     virtual bool GetNativeHandle(HandleType, void**) override { return false; }
 
     virtual std::string GetWsiExtension() const override;
+
+    virtual VkExtent2D GetSize() const override;
 
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
@@ -94,6 +96,9 @@ class DisplayWindow : public decode::Window
 
   private:
     DisplayContext* display_context_;
+
+    uint32_t width_;
+    uint32_t height_;
 };
 
 class DisplayWindowFactory : public decode::WindowFactory

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -47,9 +47,10 @@ bool HeadlessWindow::Create(const std::string& title,
     GFXRECON_UNREFERENCED_PARAMETER(title);
     GFXRECON_UNREFERENCED_PARAMETER(xpos);
     GFXRECON_UNREFERENCED_PARAMETER(ypos);
-    GFXRECON_UNREFERENCED_PARAMETER(width);
-    GFXRECON_UNREFERENCED_PARAMETER(height);
     GFXRECON_UNREFERENCED_PARAMETER(force_windowed);
+
+    width_  = width;
+    height_ = height;
 
     return true;
 }
@@ -72,14 +73,14 @@ void HeadlessWindow::SetPosition(const int32_t x, const int32_t y)
 
 void HeadlessWindow::SetSize(const uint32_t width, const uint32_t height)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(width);
-    GFXRECON_UNREFERENCED_PARAMETER(height);
+    width_  = width;
+    height_ = height;
 }
 
 void HeadlessWindow::SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(width);
-    GFXRECON_UNREFERENCED_PARAMETER(height);
+    width_  = width;
+    height_ = height;
     GFXRECON_UNREFERENCED_PARAMETER(pre_transform);
 }
 
@@ -100,6 +101,11 @@ bool HeadlessWindow::GetNativeHandle(HandleType type, void** handle)
 std::string HeadlessWindow::GetWsiExtension() const
 {
     return VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME;
+}
+
+VkExtent2D HeadlessWindow::GetSize() const
+{
+    return { width_, height_ };
 }
 
 VkResult HeadlessWindow::CreateSurface(const encode::VulkanInstanceTable* table,

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -65,6 +65,8 @@ class HeadlessWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
+    virtual VkExtent2D GetSize() const override;
+
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,
@@ -75,6 +77,9 @@ class HeadlessWindow : public decode::Window
 
   private:
     HeadlessContext* headless_context_;
+
+    uint32_t width_;
+    uint32_t height_;
 };
 
 class HeadlessWindowFactory : public decode::WindowFactory

--- a/framework/application/metal_window.h
+++ b/framework/application/metal_window.h
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class MetalContext;
 class MetalWindow : public decode::Window
 {
-public:
+  public:
     MetalWindow(MetalContext* metal_context);
 
     ~MetalWindow() override;
@@ -66,6 +66,8 @@ public:
 
     std::string GetWsiExtension() const override;
 
+    VkExtent2D GetSize() const override;
+
     VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                            VkInstance                         instance,
                            VkFlags                            flags,
@@ -75,21 +77,25 @@ public:
 
   private:
     GFXReconWindowDelegate* window_delegate_;
-    MetalContext* metal_context_;
-    NSWindow*     window_;
-    CAMetalLayer* layer_;
-    uint32_t      width_;
-    uint32_t      height_;
+    MetalContext*           metal_context_;
+    NSWindow*               window_;
+    CAMetalLayer*           layer_;
+    uint32_t                width_;
+    uint32_t                height_;
 };
 
 class MetalWindowFactory : public decode::WindowFactory
 {
-public:
+  public:
     MetalWindowFactory(MetalContext* metal_context);
 
     const char* GetSurfaceExtensionName() const override { return VK_EXT_METAL_SURFACE_EXTENSION_NAME; }
 
-    decode::Window* Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed = false) override;
+    decode::Window* Create(const int32_t  x,
+                           const int32_t  y,
+                           const uint32_t width,
+                           const uint32_t height,
+                           bool           force_windowed = false) override;
 
     void Destroy(decode::Window* window) override;
 

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -216,8 +216,10 @@ void MetalWindow::SetSize(const uint32_t width, const uint32_t height)
             NSRect window_frame      = [screen convertRectToBacking:[window_ contentRectForFrameRect:[window_ frame]]];
             window_frame.size.width  = std::min<CGFloat>(screen_frame.size.width, width);
             window_frame.size.height = std::min<CGFloat>(screen_frame.size.height, height);
-            window_frame.origin.x = std::max<CGFloat>(0, std::min<CGFloat>(window_frame.origin.x, screen_frame.size.width - window_frame.size.width));
-            window_frame.origin.y = std::max<CGFloat>(0, std::min<CGFloat>(window_frame.origin.y, screen_frame.size.height - window_frame.size.height));
+            window_frame.origin.x    = std::max<CGFloat>(
+                0, std::min<CGFloat>(window_frame.origin.x, screen_frame.size.width - window_frame.size.width));
+            window_frame.origin.y = std::max<CGFloat>(
+                0, std::min<CGFloat>(window_frame.origin.y, screen_frame.size.height - window_frame.size.height));
             [window_ setFrame:[window_ frameRectForContentRect: window_frame] display:YES];
 
             NSSize content_size;

--- a/framework/application/metal_window.mm
+++ b/framework/application/metal_window.mm
@@ -29,41 +29,46 @@
 #include <QuartzCore/QuartzCore.h>
 
 #if !__has_feature(objc_arc)
-    #error "Compile this with -fobjc-arc"
+#error "Compile this with -fobjc-arc"
 #endif
 
-typedef void(^GFXReconKeyCallback)(gfxrecon::application::Application*);
+typedef void (^GFXReconKeyCallback)(gfxrecon::application::Application*);
 
-@interface GFXReconWindowDelegate : NSObject<NSWindowDelegate>
+@interface GFXReconWindowDelegate : NSObject <NSWindowDelegate>
 - (void)windowWillClose:(NSNotification*)notification;
 @end
 
 @implementation GFXReconWindowDelegate
-- (void)windowWillClose:(NSNotification*)notification {
+- (void)windowWillClose:(NSNotification*)notification
+{
     GFXRECON_LOG_DEBUG_ONCE("User closed window");
     [NSApp terminate:self];
 }
 @end
 
-@interface GFXReconView : NSView
-@property (nonatomic) gfxrecon::application::Application* app;
+@interface                                               GFXReconView : NSView
+@property(nonatomic) gfxrecon::application::Application* app;
 - (instancetype)initWithFrame:(NSRect)frame app:(gfxrecon::application::Application*)app;
 @end
 
 @implementation GFXReconView
 
-- (instancetype)initWithFrame:(NSRect)frame app:(gfxrecon::application::Application *)app {
+- (instancetype)initWithFrame:(NSRect)frame app:(gfxrecon::application::Application*)app
+{
     self = [super initWithFrame:frame];
-    if (self) {
+    if (self)
+    {
         _app = app;
     }
     return self;
 }
 
-- (void)keyDown:(NSEvent *)event {
+- (void)keyDown:(NSEvent*)event
+{
     if (!_app)
         return;
-    switch ([event keyCode]) {
+    switch ([event keyCode])
+    {
         case kVK_Space:
         case kVK_ANSI_P:
             _app->SetPaused(!_app->GetPaused());
@@ -81,7 +86,8 @@ typedef void(^GFXReconKeyCallback)(gfxrecon::application::Application*);
     }
 }
 
-- (BOOL)acceptsFirstResponder {
+- (BOOL)acceptsFirstResponder
+{
     return YES;
 }
 
@@ -95,21 +101,26 @@ static NSString* NSStringFromStdString(const std::string& std_string)
     return [[NSString alloc] initWithBytes:std_string.data() length:std_string.size() encoding:NSUTF8StringEncoding];
 }
 
-MetalWindow::MetalWindow(MetalContext* metal_context)
-    : metal_context_(metal_context), window_(nil), window_delegate_(nil), layer_(nil), width_(0), height_(0)
-{
-}
+MetalWindow::MetalWindow(MetalContext* metal_context) :
+    metal_context_(metal_context), window_(nil), window_delegate_(nil), layer_(nil), width_(0), height_(0)
+{}
 
 MetalWindow::~MetalWindow() = default;
 
-bool MetalWindow::Create(const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height, bool force_windowed)
+bool MetalWindow::Create(const std::string& title,
+                         const int32_t      xpos,
+                         const int32_t      ypos,
+                         const uint32_t     width,
+                         const uint32_t     height,
+                         bool               force_windowed)
 {
     @autoreleasepool
     {
-        window_delegate_ = [GFXReconWindowDelegate new];
-        NSScreen* screen = [NSScreen mainScreen];
-        NSRect screen_frame = [screen convertRectToBacking:[screen frame]];
-        NSWindowStyleMask style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+        window_delegate_               = [GFXReconWindowDelegate new];
+        NSScreen*         screen       = [NSScreen mainScreen];
+        NSRect            screen_frame = [screen convertRectToBacking:[screen frame]];
+        NSWindowStyleMask style        = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
+                                  NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
         if (width >= screen_frame.size.width && height >= screen_frame.size.height)
             style |= NSWindowStyleMaskFullScreen;
 
@@ -151,7 +162,7 @@ bool MetalWindow::Destroy()
         [window_ close];
         metal_context_->UnregisterWindow(this);
     }
-    layer_ = nil;
+    layer_  = nil;
     window_ = nil;
     return true;
 }
@@ -170,11 +181,13 @@ void MetalWindow::SetPosition(const int32_t x, const int32_t y)
     {
         if ([window_ styleMask] & NSWindowStyleMaskFullScreen)
             return;
-        NSScreen* screen = [window_ screen];
-        NSRect screen_frame = [screen convertRectToBacking:[window_ contentRectForFrameRect:[screen frame]]];
-        NSRect window_frame = [screen convertRectToBacking:[window_ contentRectForFrameRect:[window_ frame]]];
-        window_frame.origin.x = std::max<CGFloat>(0, std::min<CGFloat>(x, screen_frame.size.width - window_frame.size.width));
-        window_frame.origin.y = std::max<CGFloat>(0, std::min<CGFloat>(y, screen_frame.size.height - window_frame.size.height));
+        NSScreen* screen       = [window_ screen];
+        NSRect    screen_frame = [screen convertRectToBacking:[window_ contentRectForFrameRect:[screen frame]]];
+        NSRect    window_frame = [screen convertRectToBacking:[window_ contentRectForFrameRect:[window_ frame]]];
+        window_frame.origin.x =
+            std::max<CGFloat>(0, std::min<CGFloat>(x, screen_frame.size.width - window_frame.size.width));
+        window_frame.origin.y =
+            std::max<CGFloat>(0, std::min<CGFloat>(y, screen_frame.size.height - window_frame.size.height));
         [window_ setFrameOrigin:[window_ frameRectForContentRect:[screen convertRectFromBacking:window_frame]].origin];
     }
 }
@@ -185,12 +198,12 @@ void MetalWindow::SetSize(const uint32_t width, const uint32_t height)
         return;
     @autoreleasepool
     {
-        width_ = width;
-        height_ = height;
-        NSScreen* screen = [window_ screen];
-        NSRect screen_frame = [screen convertRectToBacking:[window_ contentRectForFrameRect:[screen frame]]];
-        bool fullscreen = width >= screen_frame.size.width && height >= screen_frame.size.height;
-        NSWindowStyleMask style = [window_ styleMask];
+        width_                         = width;
+        height_                        = height;
+        NSScreen*         screen       = [window_ screen];
+        NSRect            screen_frame = [screen convertRectToBacking:[window_ contentRectForFrameRect:[screen frame]]];
+        bool              fullscreen   = width >= screen_frame.size.width && height >= screen_frame.size.height;
+        NSWindowStyleMask style        = [window_ styleMask];
         if (fullscreen)
         {
             if (!(style & NSWindowStyleMaskFullScreen))
@@ -200,8 +213,8 @@ void MetalWindow::SetSize(const uint32_t width, const uint32_t height)
         {
             if (style & NSWindowStyleMaskFullScreen)
                 [window_ toggleFullScreen:nil];
-            NSRect window_frame = [screen convertRectToBacking:[window_ contentRectForFrameRect:[window_ frame]]];
-            window_frame.size.width = std::min<CGFloat>(screen_frame.size.width, width);
+            NSRect window_frame      = [screen convertRectToBacking:[window_ contentRectForFrameRect:[window_ frame]]];
+            window_frame.size.width  = std::min<CGFloat>(screen_frame.size.width, width);
             window_frame.size.height = std::min<CGFloat>(screen_frame.size.height, height);
             window_frame.origin.x = std::max<CGFloat>(0, std::min<CGFloat>(window_frame.origin.x, screen_frame.size.width - window_frame.size.width));
             window_frame.origin.y = std::max<CGFloat>(0, std::min<CGFloat>(window_frame.origin.y, screen_frame.size.height - window_frame.size.height));
@@ -248,6 +261,11 @@ std::string MetalWindow::GetWsiExtension() const
     return VK_EXT_METAL_SURFACE_EXTENSION_NAME;
 }
 
+VkExtent2D MetalWindow::GetSize() const
+{
+    return { width_, height_ };
+}
+
 VkResult MetalWindow::CreateSurface(const encode::VulkanInstanceTable* table,
                                     VkInstance                         instance,
                                     VkFlags                            flags,
@@ -256,7 +274,7 @@ VkResult MetalWindow::CreateSurface(const encode::VulkanInstanceTable* table,
     if (table)
     {
         VkMetalSurfaceCreateInfoEXT create_info = { VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT };
-        create_info.pLayer = layer_;
+        create_info.pLayer                      = layer_;
 
         return table->CreateMetalSurfaceEXT(instance, &create_info, nullptr, pSurface);
     }
@@ -275,11 +293,12 @@ MetalWindowFactory::MetalWindowFactory(MetalContext* metal_context) : metal_cont
     assert(metal_context_);
 }
 
-decode::Window* MetalWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
+decode::Window* MetalWindowFactory::Create(
+    const int32_t x, const int32_t y, const uint32_t width, const uint32_t height, bool force_windowed)
 {
     assert(metal_context_);
-    decode::Window* window = new MetalWindow(metal_context_);
-    Application* application = metal_context_->GetApplication();
+    decode::Window* window      = new MetalWindow(metal_context_);
+    Application*    application = metal_context_->GetApplication();
     window->Create(application->GetName(), x, y, width, height, force_windowed);
     return window;
 }

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -254,6 +254,11 @@ std::string WaylandWindow::GetWsiExtension() const
     return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
 }
 
+VkExtent2D WaylandWindow::GetSize() const
+{
+    return { width_, height_ };
+}
+
 VkResult WaylandWindow::CreateSurface(const encode::VulkanInstanceTable* table,
                                       VkInstance                         instance,
                                       VkFlags                            flags,

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -73,6 +73,8 @@ class WaylandWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
+    virtual VkExtent2D GetSize() const override;
+
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -286,6 +286,11 @@ std::string Win32Window::GetWsiExtension() const
     return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
 }
 
+VkExtent2D Win32Window::GetSize() const
+{
+    return { width_, height_ };
+}
+
 VkResult Win32Window::CreateSurface(const encode::VulkanInstanceTable* table,
                                     VkInstance                         instance,
                                     VkFlags                            flags,

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -68,6 +68,8 @@ class Win32Window : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
+    virtual VkExtent2D GetSize() const override;
+
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -409,6 +409,11 @@ std::string XcbWindow::GetWsiExtension() const
     return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
 }
 
+VkExtent2D XcbWindow::GetSize() const
+{
+    return { width_, height_ };
+}
+
 VkResult XcbWindow::CreateSurface(const encode::VulkanInstanceTable* table,
                                   VkInstance                         instance,
                                   VkFlags                            flags,

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -86,6 +86,8 @@ class XcbWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
+    virtual VkExtent2D GetSize() const override;
+
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -300,6 +300,11 @@ std::string XlibWindow::GetWsiExtension() const
     return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
 }
 
+VkExtent2D XlibWindow::GetSize() const
+{
+    return { width_, height_ };
+}
+
 VkResult XlibWindow::CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,

--- a/framework/application/xlib_window.h
+++ b/framework/application/xlib_window.h
@@ -64,6 +64,8 @@ class XlibWindow : public decode::Window
 
     virtual std::string GetWsiExtension() const override;
 
+    virtual VkExtent2D GetSize() const override;
+
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -86,6 +86,8 @@ VkResult VulkanVirtualSwapchain::CreateSwapchainKHR(VkResult                    
         {
             return VK_ERROR_OUT_OF_HOST_MEMORY;
         }
+
+        swapchain_resources_[*replay_swapchain]->actual_extent = modified_create_info.imageExtent;
     }
     return result;
 }
@@ -900,7 +902,9 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
                                           &initial_barrier_swapchain_image);
 
         subresource.layerCount   = swapchain_info->image_array_layers;
-        VkExtent3D  image_extent = { swapchain_info->width, swapchain_info->height, 1 };
+        VkExtent3D  image_extent = { std::min(swapchain_resources->actual_extent.width, swapchain_info->width),
+                                     std::min(swapchain_resources->actual_extent.height, swapchain_info->height),
+                                     1 };
         VkImageCopy image_copy   = { subresource, offset, subresource, offset, image_extent };
 
         // NOTE: vkCmdCopyImage works on Queues of types including Graphics, Compute

--- a/framework/decode/vulkan_virtual_swapchain.h
+++ b/framework/decode/vulkan_virtual_swapchain.h
@@ -149,6 +149,8 @@ class VulkanVirtualSwapchain : public VulkanSwapchain
         // as a vector of the actual hardware ones used during replay.
         std::vector<VirtualImage> virtual_swapchain_images;
         std::vector<VkImage>      replay_swapchain_images;
+
+        VkExtent2D actual_extent;
     };
 
     bool AddSwapchainResourceData(VkSwapchainKHR swapchain);

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -82,6 +82,8 @@ class Window
 
     virtual std::string GetWsiExtension() const = 0;
 
+    virtual VkExtent2D GetSize() const = 0;
+
     virtual VkResult CreateSurface(const encode::VulkanInstanceTable* table,
                                    VkInstance                         instance,
                                    VkFlags                            flags,


### PR DESCRIPTION
This commit partially fix issue #759 

Fix a crash on `VK_ERROR_OUT_OF_DATE_KHR` when the window of the replayer cannot be resized to the size of the swapchain at capture time and that the replayer uses virtual swapchain.

The idea is to store the actual size of the window that could be opened at replay time in the virtual swapchain so that the virtual swapchain has the same size as at capture time, and the actual swapchain is the size of the window. When the image is copied from the virtual image to the actual image, only a sub-part of the image is copied.
