### PR TITLE
Don't display warning message for `VK_SUCCESS` over `VK_SUBOPTIMAL_KHR`

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1161,7 +1161,8 @@ void VulkanReplayConsumerBase::CheckResult(const char*                func_name,
             RaiseFatalError(enumutil::GetResultDescription(replay));
         }
         else if (!((replay == VK_SUCCESS) &&
-                   ((original == VK_TIMEOUT) || (original == VK_NOT_READY) || (original == VK_ERROR_OUT_OF_DATE_KHR))))
+                   ((original == VK_TIMEOUT) || (original == VK_NOT_READY) || (original == VK_ERROR_OUT_OF_DATE_KHR) ||
+                    (original == VK_SUBOPTIMAL_KHR))))
         {
             // Report differences between replay result and capture result, unless the replay results indicates
             // that a wait operation completed before the original or a WSI function succeeded when the original failed.


### PR DESCRIPTION
When the capture result was `VK_SUBOPTIMAL_KHR` and that the replay result is `VK_SUCCESS`, no warning message should be displayed.