### PR TITLE
openxr: Remove invalid function name

### DIFF
--- a/layer/json/XrLayer_gfxreconstruct.json.in
+++ b/layer/json/XrLayer_gfxreconstruct.json.in
@@ -5,10 +5,6 @@
         "library_path": "@RELATIVE_LAYER_BINARY@",
         "api_version" : "@XR_VERSION@",
         "implementation_version" : "@GFXRECONSTRUCT_VERSION@",
-        "description": "GFXReconstruct Capture Layer Version @GFXRECONSTRUCT_VERSION_STRING@",
-        "functions": {
-            "xrNegotiateLoaderApiLayerInterface":
-                "GFXR_xrNegotiateLoaderApiLayerInterface"
-        }
+        "description": "GFXReconstruct Capture Layer Version @GFXRECONSTRUCT_VERSION_STRING@"
     }
 }


### PR DESCRIPTION
Remove invalid function name for xrNegotiateLoaderApiLayerInterface in JSON file.