### PR TITLE
options for print block information

### DIFF
--- a/USAGE_desktop_D3D12.md
+++ b/USAGE_desktop_D3D12.md
@@ -211,7 +211,8 @@ Usage:
                         [--fwo <x,y> | --force-windowed-origin <x,y>]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
                         [--batching-memory-usage <pct>]
-                        [--dump-resources <submit-index,command-index,drawcall-index> <file>
+                        [--dump-resources <submit-index,command-index,drawcall-index>] <file>
+                        [--pbi-all] [--pbis <index1,index2>]
 
 Required arguments:
   <file>                Path to the capture file to replay.
@@ -270,6 +271,8 @@ Optional arguments:
                         returned by vkEnumeratePhysicalDevices or IDXGIFactory1::EnumAdapters1.
                         Replay may fail if the specified device is not compatible with the
                         original capture devices.
+  --pbi-all             Print all block information.
+  --pbis <index1,index2>Print block information between block index1 and block index2.
 
 Windows-only:
   --fwo <x,y>           Force windowed mode if not already, and allow setting of a custom window location.

--- a/USAGE_desktop_Vulkan.md
+++ b/USAGE_desktop_Vulkan.md
@@ -543,6 +543,8 @@ gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
                         [--dump-resources-json-output-per-command]
                         [--dump-resources-dump-immutable-resources]
                         [--dump-resources-dump-all-image-subresources] <file>
+                        [--pbi-all] [--pbis <index1,index2>]
+
 
 Required arguments:
   <file>                Path to the capture file to replay.
@@ -755,6 +757,8 @@ Optional arguments:
               Enables dumping of resources that are used as inputs in the commands requested for dumping.
   --dump-resources-dump-all-image-subresources
               Enables dumping of all image sub resources (mip map levels and array layers).
+  --pbi-all             Print all block information.
+  --pbis <index1,index2>Print block information between block index1 and block index2.
 ```
 
 ### Key Controls

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -111,6 +111,8 @@ def CreateReplayParser():
     parser.add_argument('--dump-resources-json-output-per-command', action='store_true', default=False, help= 'Enables storing a json output file for each dumped command. Default is disabled.')
     parser.add_argument('--dump-resources-dump-immutable-resources', action='store_true', default=False, help= 'Dump immutable immutable shader resources.')
     parser.add_argument('--dump-resources-dump-all-image-subresources', action='store_true', default=False, help= 'Dump all available mip levels and layers when dumping images.')
+    parser.add_argument('--pbi-all', action='store_true', default=False, help='Print all block information.')
+    parser.add_argument('--pbis', metavar='RANGES', default=False, help='Print block information between block index1 and block index2')
     return parser
 
 def MakeExtrasString(args):
@@ -267,6 +269,13 @@ def MakeExtrasString(args):
 
     if args.dump_resources_dump_all_image_subresources:
         arg_list.append('--dump-resources-dump-all-image-subresources')
+
+    if args.pbi_all:
+        arg_list.append('--pbi-all')
+
+    if args.pbis:
+        arg_list.append('--pbis')
+        arg_list.append('{}'.format(args.pbis))
 
     if args.file:
         arg_list.append(args.file)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -243,6 +243,12 @@ bool FileProcessor::ProcessBlocks()
 
     while (success)
     {
+        if (enable_print_block_info_ && ((block_index_from_ < 0 || block_index_to_ < 0) ||
+                                         (block_index_from_ <= block_index_ && block_index_to_ >= block_index_)))
+        {
+            GFXRECON_LOG_INFO(
+                "block info: index: %" PRIu64 ", current frame: %" PRIu64 "", block_index_, current_frame_number_);
+        }
         success = ContinueDecoding();
 
         if (success)

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -99,6 +99,13 @@ class FileProcessor
 
     bool UsesFrameMarkers() const { return capture_uses_frame_markers_; }
 
+    void SetPrintBlockInfoFlag(bool enable_print_block_info, int64_t block_index_from, int64_t block_index_to)
+    {
+        enable_print_block_info_ = enable_print_block_info;
+        block_index_from_        = block_index_from;
+        block_index_to_          = block_index_to;
+    }
+
   protected:
     bool ContinueDecoding();
 
@@ -128,7 +135,7 @@ class FileProcessor
 
   protected:
     FILE*                    file_descriptor_;
-    uint32_t                 current_frame_number_;
+    uint64_t                 current_frame_number_;
     std::vector<ApiDecoder*> decoders_;
     AnnotationHandler*       annotation_handler_;
     Error                    error_state_;
@@ -164,6 +171,9 @@ class FileProcessor
     uint64_t                            block_limit_;
     bool                                capture_uses_frame_markers_;
     uint64_t                            first_frame_;
+    bool                                enable_print_block_info_{ false };
+    int64_t                             block_index_from_{ 0 };
+    int64_t                             block_index_to_{ 0 };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -57,6 +57,9 @@ struct ReplayOptions
     int32_t     window_topleft_y{ 0 };
     int32_t     override_gpu_index{ -1 };
     std::string capture_filename;
+    bool        enable_print_block_info{ false };
+    int64_t     block_index_from{ -1 };
+    int64_t     block_index_to{ -1 };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -214,6 +214,9 @@ int main(int argc, const char** argv)
                 vulkan_decoder.AddConsumer(&vulkan_replay_consumer);
                 file_processor.AddDecoder(&vulkan_decoder);
             }
+            file_processor.SetPrintBlockInfoFlag(vulkan_replay_options.enable_print_block_info,
+                                                 vulkan_replay_options.block_index_from,
+                                                 vulkan_replay_options.block_index_to);
 
 #if defined(D3D12_SUPPORT)
             gfxrecon::decode::DxReplayOptions    dx_replay_options = GetDxReplayOptions(arg_parser, filename);

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -35,7 +35,7 @@ const char kOptions[] =
     "offscreen-swapchain-frame-boundary,--wait-before-present,--dump-resources-before-draw,"
     "--dump-resources-dump-depth-attachment,--dump-"
     "resources-dump-vertex-index-buffers,--dump-resources-json-output-per-command,--dump-resources-dump-immutable-"
-    "resources,--dump-resources-dump-all-image-subresources";
+    "resources,--dump-resources-dump-all-image-subresources,--pbi-all";
 const char kArguments[] =
     "--log-level,--log-file,--gpu,--gpu-group,--pause-frame,--wsi,--surface-index,-m|--memory-translation,"
     "--replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
@@ -43,7 +43,7 @@ const char kArguments[] =
     "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
     "get-fence-status,--sgfr|--"
     "skip-get-fence-ranges,--dump-resources,--dump-resources-scale,--dump-resources-image-format,--dump-resources-dir,"
-    "--dump-resources-dump-color-attachment-index";
+    "--dump-resources-dump-color-attachment-index,--pbis";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -80,6 +80,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fw <width,height> | --force-windowed <width,height>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfs <status> | --skip-get-fence-status <status>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sgfr <frame-ranges> | --skip-get-fence-ranges <frame-ranges>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--pbi-all] [--pbis <index1,index2>]");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources <submit-index,command-index,drawcall-index>]");
 #endif
@@ -161,6 +162,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDevices or IDXGIFactory1::EnumAdapters1.");
     GFXRECON_WRITE_CONSOLE("          \t\tReplay may fail if the specified device is not compatible with the");
     GFXRECON_WRITE_CONSOLE("          \t\toriginal capture devices.");
+    GFXRECON_WRITE_CONSOLE("  --pbi-all\t\tPrint all block information.");
+    GFXRECON_WRITE_CONSOLE(
+        "  --pbis <index1,index2>\t\tPrint block information between block index1 and block index2.");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")
     GFXRECON_WRITE_CONSOLE("Windows only:")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -120,6 +120,8 @@ const char kFilePerFrameOption[]                  = "--file-per-frame";
 const char kSkipGetFenceStatus[]                  = "--skip-get-fence-status";
 const char kSkipGetFenceRanges[]                  = "--skip-get-fence-ranges";
 const char kWaitBeforePresent[]                   = "--wait-before-present";
+const char kPrintBlockInfoAllOption[]             = "--pbi-all";
+const char kPrintBlockInfosArgument[]             = "--pbis";
 #if defined(WIN32)
 const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
 const char kDxOverrideObjectNames[]       = "--dx12-override-object-names";
@@ -894,6 +896,24 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions&      options,
     if (arg_parser.IsOptionSet(kFlushInsideMeasurementRangeOption))
     {
         options.flush_inside_measurement_range = true;
+    }
+
+    if (arg_parser.IsOptionSet(kPrintBlockInfoAllOption))
+    {
+        options.enable_print_block_info = true;
+    }
+    else if (arg_parser.IsArgumentSet(kPrintBlockInfosArgument))
+    {
+        options.enable_print_block_info = true;
+        const auto& value               = arg_parser.GetArgumentValue(kPrintBlockInfosArgument);
+
+        if (!value.empty())
+        {
+            std::vector<gfxrecon::util::UintRange> block_ranges =
+                gfxrecon::util::GetUintRanges(value.c_str(), "Print block information");
+            options.block_index_from = block_ranges[0].first;
+            options.block_index_to   = block_ranges[1].first;
+        }
     }
 
     const auto& override_gpu = arg_parser.GetArgumentValue(kOverrideGpuArgument);


### PR DESCRIPTION
Added two options: 
  ```
--pbi-all             Print all block information.
--pbi <index1,index2> Print block information between block index1 and block index2.
```
closed: https://github.com/LunarG/gfxreconstruct/issues/748
closed: https://github.com/LunarG/gfxreconstruct/issues/752
Print block information in every beginning of block is easier and more useful than adding block index and frame in every log. Also, it could also help to figure out which block to print validation layers log.

Now, it prints block index and frame. It could add more in the future,