### PR TITLE
Remove empty command buffer from frame boundary submission

### DIFF
--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -47,8 +47,7 @@ VkResult VulkanOffscreenSwapchain::CreateSurface(VkResult                       
 
     // For multi-surface captures, when replay is restricted to a specific surface, only create a surface for
     // the specified index.
-    if ((swapchain_options_.select_surface_index == -1) ||
-        (swapchain_options_.select_surface_index == create_surface_count_))
+    if ((swapchain_options_.surface_index == -1) || (swapchain_options_.surface_index == create_surface_count_))
     {
 
         const format::HandleId* id             = surface->GetPointer();
@@ -108,7 +107,7 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
     // `vkQueuePresentKHR` should have been called by the offscreen swapchain. So a maximum of work must be done at
     // swapchain creation: Allocation and recording of an empty command buffer, initialization of a `VkFrameBoundaryEXT`
     // structure... (Don't forget to free everything at swapchain destruction)
-    if (insert_frame_boundary_)
+    if (swapchain_options_.offscreen_swapchain_frame_boundary)
     {
         frame_boundary_.sType       = VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT;
         frame_boundary_.pNext       = nullptr;
@@ -246,7 +245,7 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
                                                    const QueueInfo*                      queue_info,
                                                    const VkPresentInfoKHR*               present_info)
 {
-    if (insert_frame_boundary_)
+    if (swapchain_options_.offscreen_swapchain_frame_boundary)
     {
         std::vector<VkImage> images(present_info->swapchainCount);
         for (uint32_t i = 0; i < images.size(); ++i)

--- a/framework/decode/vulkan_offscreen_swapchain.cpp
+++ b/framework/decode/vulkan_offscreen_swapchain.cpp
@@ -110,50 +110,6 @@ VkResult VulkanOffscreenSwapchain::CreateSwapchainKHR(VkResult                  
     // structure... (Don't forget to free everything at swapchain destruction)
     if (insert_frame_boundary_)
     {
-        VkResult result;
-        command_pools_.resize(device_info->queue_family_index_enabled.size());
-        command_buffers_.resize(device_info->queue_family_index_enabled.size());
-
-        for (uint32_t family_index = 0; family_index < device_info->queue_family_index_enabled.size(); family_index++)
-        {
-            if (!device_info->queue_family_index_enabled.at(family_index))
-            {
-                continue;
-            }
-
-            VkCommandPoolCreateInfo commandPoolCreateInfo;
-            commandPoolCreateInfo.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-            commandPoolCreateInfo.pNext            = nullptr;
-            commandPoolCreateInfo.queueFamilyIndex = family_index;
-            commandPoolCreateInfo.flags            = 0;
-
-            result = device_table_->CreateCommandPool(
-                device, &commandPoolCreateInfo, nullptr, &command_pools_.at(family_index));
-            GFXRECON_ASSERT(result == VK_SUCCESS);
-
-            VkCommandBufferAllocateInfo commandBufferAllocateInfo;
-            commandBufferAllocateInfo.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-            commandBufferAllocateInfo.pNext              = nullptr;
-            commandBufferAllocateInfo.commandPool        = command_pools_.at(family_index);
-            commandBufferAllocateInfo.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-            commandBufferAllocateInfo.commandBufferCount = 1;
-
-            result = device_table_->AllocateCommandBuffers(
-                device, &commandBufferAllocateInfo, &command_buffers_.at(family_index));
-            GFXRECON_ASSERT(result == VK_SUCCESS);
-
-            VkCommandBufferBeginInfo commandBufferBeginInfo;
-            commandBufferBeginInfo.sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-            commandBufferBeginInfo.pNext            = nullptr;
-            commandBufferBeginInfo.flags            = 0;
-            commandBufferBeginInfo.pInheritanceInfo = nullptr;
-
-            result = device_table_->BeginCommandBuffer(command_buffers_.at(family_index), &commandBufferBeginInfo);
-            GFXRECON_ASSERT(result == VK_SUCCESS);
-
-            result = device_table_->EndCommandBuffer(command_buffers_.at(family_index));
-            GFXRECON_ASSERT(result == VK_SUCCESS);
-        }
         frame_boundary_.sType       = VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT;
         frame_boundary_.pNext       = nullptr;
         frame_boundary_.flags       = VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT;
@@ -178,14 +134,6 @@ void VulkanOffscreenSwapchain::DestroySwapchainKHR(PFN_vkDestroySwapchainKHR    
     if ((device_info != nullptr) && (swapchain_info != nullptr))
     {
         CleanSwapchainResourceData(device_info, swapchain_info);
-    }
-
-    if (insert_frame_boundary_ && command_pools_.size() > 0)
-    {
-        for (const auto& command_pool : command_pools_)
-        {
-            device_table_->DestroyCommandPool(device_info->handle, command_pool, nullptr);
-        }
     }
 }
 
@@ -298,7 +246,7 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
                                                    const QueueInfo*                      queue_info,
                                                    const VkPresentInfoKHR*               present_info)
 {
-    if (insert_frame_boundary_ && command_buffers_.size() > 0)
+    if (insert_frame_boundary_)
     {
         std::vector<VkImage> images(present_info->swapchainCount);
         for (uint32_t i = 0; i < images.size(); ++i)
@@ -320,8 +268,8 @@ VkResult VulkanOffscreenSwapchain::QueuePresentKHR(VkResult                     
         submitInfo.waitSemaphoreCount   = present_info->waitSemaphoreCount;
         submitInfo.pWaitSemaphores      = present_info->pWaitSemaphores;
         submitInfo.pWaitDstStageMask    = dstStageFlags.data();
-        submitInfo.commandBufferCount   = 1;
-        submitInfo.pCommandBuffers      = &command_buffers_.at(queue_info->family_index);
+        submitInfo.commandBufferCount   = 0;
+        submitInfo.pCommandBuffers      = nullptr;
         submitInfo.signalSemaphoreCount = 0;
         submitInfo.pSignalSemaphores    = nullptr;
 

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -110,10 +110,8 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    const VkSemaphore* signal_semaphores,
                                    VkFence            fence);
 
-    bool                         insert_frame_boundary_{ false };
-    std::vector<VkCommandPool>   command_pools_{ VK_NULL_HANDLE };
-    std::vector<VkCommandBuffer> command_buffers_{ VK_NULL_HANDLE };
-    VkFrameBoundaryEXT           frame_boundary_;
+    bool               insert_frame_boundary_{ false };
+    VkFrameBoundaryEXT frame_boundary_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_offscreen_swapchain.h
+++ b/framework/decode/vulkan_offscreen_swapchain.h
@@ -110,7 +110,6 @@ class VulkanOffscreenSwapchain : public VulkanVirtualSwapchain
                                    const VkSemaphore* signal_semaphores,
                                    VkFence            fence);
 
-    bool               insert_frame_boundary_{ false };
     VkFrameBoundaryEXT frame_boundary_;
 };
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -195,8 +195,9 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
     }
 
     VulkanSwapchainOptions swapchain_options;
-    swapchain_options.skip_additional_present_blts = options.virtual_swapchain_skip_blit;
-    swapchain_options.select_surface_index         = options_.surface_index;
+    swapchain_options.virtual_swapchain_skip_blit        = options_.virtual_swapchain_skip_blit;
+    swapchain_options.surface_index                      = options_.surface_index;
+    swapchain_options.offscreen_swapchain_frame_boundary = options_.offscreen_swapchain_frame_boundary;
     swapchain_->SetOptions(swapchain_options);
 
     if (options_.enable_debug_device_lost)

--- a/framework/decode/vulkan_swapchain.cpp
+++ b/framework/decode/vulkan_swapchain.cpp
@@ -28,11 +28,11 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 void VulkanSwapchain::Clean()
 {
-    if (swapchain_options_.select_surface_index >= create_surface_count_)
+    if (swapchain_options_.surface_index >= create_surface_count_)
     {
         GFXRECON_LOG_WARNING("Rendering was restricted to surface index %u, but a surface was never created for that "
                              "index; replay created %d surface(s)",
-                             swapchain_options_.select_surface_index,
+                             swapchain_options_.surface_index,
                              create_surface_count_);
     }
 
@@ -75,8 +75,7 @@ VkResult VulkanSwapchain::CreateSurface(VkResult                            orig
 
     // For multi-surface captures, when replay is restricted to a specific surface, only create a surface for
     // the specified index.
-    if ((swapchain_options_.select_surface_index == -1) ||
-        (swapchain_options_.select_surface_index == create_surface_count_))
+    if ((swapchain_options_.surface_index == -1) || (swapchain_options_.surface_index == create_surface_count_))
     {
         // Create a window for our surface.
         assert(application_);

--- a/framework/decode/vulkan_swapchain.h
+++ b/framework/decode/vulkan_swapchain.h
@@ -48,8 +48,9 @@ class ScreenshotHandler;
 
 struct VulkanSwapchainOptions
 {
-    bool    skip_additional_present_blts{ false };
-    int32_t select_surface_index{ -1 };
+    bool    virtual_swapchain_skip_blit{ false };
+    int32_t surface_index{ -1 };
+    bool    offscreen_swapchain_frame_boundary{ false };
 };
 
 class VulkanSwapchain
@@ -59,7 +60,7 @@ class VulkanSwapchain
 
     virtual void Clean();
 
-    void SetOptions(VulkanSwapchainOptions& options) { swapchain_options_ = options; }
+    void SetOptions(const VulkanSwapchainOptions& options) { swapchain_options_ = options; }
 
     virtual VkResult CreateSurface(VkResult                            original_result,
                                    InstanceInfo*                       instance_info,

--- a/framework/decode/vulkan_virtual_swapchain.cpp
+++ b/framework/decode/vulkan_virtual_swapchain.cpp
@@ -665,7 +665,7 @@ VkResult VulkanVirtualSwapchain::QueuePresentKHR(VkResult                       
     {
         return VK_ERROR_FEATURE_NOT_PRESENT;
     }
-    else if (swapchain_options_.skip_additional_present_blts)
+    else if (swapchain_options_.virtual_swapchain_skip_blit)
     {
         // If we're to skip the BLT, just go ahead and perform the present even thought it won't
         // produce the valid image to the screen.  The intent for this path is mostly for performance


### PR DESCRIPTION
To submit VkFrameBoundaryEXT, a queue submission is necessary but not having a command buffer inside the queue submission. Empty command buffers are badly handled by some drivers and the management of this buffer uselessly requires some resources and can cause bugs when the replayer terminates unexpectedly.

I propose to simply remove this empty command buffer entirely.