### PR TITLE
Fix of infinite loop when looping over pNext chain

### DIFF
--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -59,6 +59,7 @@ static T* GetPNextStruct(const Parent_T* parent, VkStructureType struct_type)
         {
             return reinterpret_cast<T*>(current_struct);
         }
+        current_struct = current_struct->pNext;
     }
     return nullptr;
 }


### PR DESCRIPTION
In case when searching for a struct on `pNext` chain, if the relevant struct is not the first in the list, we would have an infinite loop. 

This commit fixes that.