### PR TITLE
Fixing ppBuildRanges for gfxrecon-convert

### DIFF
--- a/framework/decode/decode_json_util.h
+++ b/framework/decode/decode_json_util.h
@@ -160,6 +160,18 @@ void FieldToJson(nlohmann::ordered_json&                   jdata,
                 FieldToJson(jdata[i], meta_struct[i], options);
             }
         }
+        else if (data->IsArray2D())
+        {
+            for (size_t i = 0; i < length; ++i)
+            {
+                size_t inner_length = data->GetInnerLength(i);
+                auto&  jdata_arr    = jdata.emplace_back(nlohmann::ordered_json::array_t(inner_length));
+                for (size_t j = 0; j < inner_length; ++j)
+                {
+                    FieldToJson(jdata_arr[j], &meta_struct[i][j], options);
+                }
+            }
+        }
         else if (length == 1)
         {
             FieldToJson(jdata, *meta_struct, options);

--- a/framework/decode/pointer_decoder_base.h
+++ b/framework/decode/pointer_decoder_base.h
@@ -59,6 +59,12 @@ class PointerDecoderBase
         return ((attrib_ & format::PointerAttributes::kIsArray) == format::PointerAttributes::kIsArray) ? true : false;
     }
 
+    bool IsArray2D() const
+    {
+        return ((attrib_ & format::PointerAttributes::kIsArray2D) == format::PointerAttributes::kIsArray2D) ? true
+                                                                                                            : false;
+    }
+
     uint32_t GetAttributeMask() const { return attrib_; }
 
     uint64_t GetAddress() const { return address_; }


### PR DESCRIPTION
When converting `vkCmdBuildAccelerationStructuresKHR`, there was incorrect information in the resulting file, namely missing build ranges.

`ppBuildRanges` is a an array of pointers of `infoCount` pointers to arrays of `geometryCount` of a particular build geometry info. Previously, convert was failing to extract this information if the `infoCount` or `geometryCount` was `> 1`.

This commit enables convert to extract the info correctly.