### PR TITLE
Add support for `VK_EXT_device_fault` for better crash reporting.

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4165,9 +4165,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
             VkMemoryAllocateInfo                     modified_allocate_info = (*replay_allocate_info);
             VkMemoryOpaqueCaptureAddressAllocateInfo address_info           = {
-                VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
-                modified_allocate_info.pNext,
-                opaque_address
+                          VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
+                          modified_allocate_info.pNext,
+                          opaque_address
             };
             modified_allocate_info.pNext = &address_info;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -162,8 +162,7 @@ VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::
     loader_handle_(nullptr),
     get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr), application_(application), options_(options),
     loading_trim_state_(false), replaying_trimmed_capture_(false), have_imported_semaphores_(false), fps_info_(nullptr),
-    omitted_pipeline_cache_data_(false),
-    device_fault_supported_(false), device_fault_vendor_data_supported_(false),
+    omitted_pipeline_cache_data_(false), device_fault_supported_(false), device_fault_vendor_data_supported_(false),
     device_fault_vendor_binary_dump_v1_header_size_(56)
 {
     assert(application_ != nullptr);
@@ -4166,9 +4165,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
             VkMemoryAllocateInfo                     modified_allocate_info = (*replay_allocate_info);
             VkMemoryOpaqueCaptureAddressAllocateInfo address_info           = {
-                          VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
-                          modified_allocate_info.pNext,
-                          opaque_address
+                VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
+                modified_allocate_info.pNext,
+                opaque_address
             };
             modified_allocate_info.pNext = &address_info;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -221,6 +221,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void CheckResult(const char* func_name, VkResult original, VkResult replay, const decode::ApiCallInfo& call_info);
 
+    void CheckResult(const char*                 func_name,
+                     VkResult                    original,
+                     VkResult                    replay,
+                     const decode::ApiCallInfo&  call_info,
+                     VkDevice                    lost_device,
+                     PFN_vkGetDeviceFaultInfoEXT func);
+
     template <typename T>
     typename T::HandleType MapHandle(format::HandleId id,
                                      const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const) const
@@ -1158,6 +1165,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     bool CheckCommandBufferInfoForFrameBoundary(const CommandBufferInfo* command_buffer_info);
     bool CheckPNextChainForFrameBoundary(const DeviceInfo* device_info, const PNextNode* pnext);
 
+    void ConsumeVendorBinaryDataHeader(const uint8_t*                                vendor_binary_data,
+                                       VkDeviceFaultVendorBinaryHeaderVersionOneEXT& header);
+
   private:
     struct HardwareBufferInfo
     {
@@ -1249,6 +1259,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void*                capture_pipeline_cache_data_;
     bool                 matched_replay_cache_data_exist_ = false;
     std::vector<uint8_t> matched_replay_cache_data_;
+
+    bool           device_fault_supported_;
+    bool           device_fault_vendor_data_supported_;
+    const uint32_t device_fault_vendor_binary_dump_v1_header_size_;
 };
 
 GFXRECON_END_NAMESPACE(decode)


### PR DESCRIPTION
This commit adds some additional error reporting on failed `CheckResult` call, in case the replay device supports the `VK_EXT_device_fault`.