### PR TITLE
Fix handle mapping/unwrapping for acceleration structure building

### DIFF
--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -113,5 +113,60 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
     }
 }
 
+void MapStructHandles(Decoded_VkAccelerationStructureGeometryKHR* wrapper,
+                      const VulkanObjectInfoTable&                object_info_table)
+{
+    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
+    {
+        VkAccelerationStructureGeometryKHR* value = wrapper->decoded_value;
+
+        switch (value->geometryType)
+        {
+            case VK_GEOMETRY_TYPE_TRIANGLES_KHR:
+                MapStructHandles(wrapper->geometry->triangles, object_info_table);
+                break;
+            case VK_GEOMETRY_TYPE_AABBS_KHR:
+                // No handle there so the map func doesn't exist
+                break;
+            case VK_GEOMETRY_TYPE_INSTANCES_KHR:
+                // No handle there so the map func doesn't exist
+                break;
+            default:
+                GFXRECON_LOG_WARNING("Attempting to map unknown acceleration structure geometry type");
+                break;
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapper,
+                      const VulkanObjectInfoTable&                         object_info_table)
+{
+    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
+    {
+        VkAccelerationStructureBuildGeometryInfoKHR* value = wrapper->decoded_value;
+
+        value->srcAccelerationStructure = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(
+            wrapper->srcAccelerationStructure,
+            object_info_table,
+            &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+
+        value->dstAccelerationStructure = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(
+            wrapper->dstAccelerationStructure,
+            object_info_table,
+            &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
+
+        MapStructArrayHandles<Decoded_VkAccelerationStructureGeometryKHR>(
+            wrapper->pGeometries->GetMetaStructPointer(), wrapper->pGeometries->GetLength(), object_info_table);
+
+        if (wrapper->ppGeometries->GetMetaStructPointer() != nullptr)
+        {
+            for (size_t i = 0; i < wrapper->ppGeometries->GetLength(); ++i)
+            {
+                MapStructHandles(wrapper->ppGeometries->GetMetaStructPointer()[i], object_info_table);
+            }
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/custom_vulkan_struct_handle_mappers.h
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.h
@@ -39,6 +39,12 @@ void MapStructHandles(VkDescriptorType               type,
 
 void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectInfoTable& object_info_table);
 
+void MapStructHandles(Decoded_VkAccelerationStructureGeometryKHR* wrapper,
+                      const VulkanObjectInfoTable&                object_info_table);
+
+void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapper,
+                      const VulkanObjectInfoTable&                         object_info_table);
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -147,6 +147,9 @@ uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObject
         case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
             return format::ToHandleId(MapHandle<IndirectCommandsLayoutNVInfo>(
                 object, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutNVInfo));
+        case VK_OBJECT_TYPE_MICROMAP_EXT:
+            return format::ToHandleId(
+                MapHandle<MicromapEXTInfo>(object, object_info_table, &VulkanObjectInfoTable::GetMicromapEXTInfo));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
             return format::ToHandleId(MapHandle<PrivateDataSlotEXTInfo>(
                 object, object_info_table, &VulkanObjectInfoTable::GetPrivateDataSlotInfo));

--- a/framework/encode/custom_vulkan_struct_handle_wrappers.h
+++ b/framework/encode/custom_vulkan_struct_handle_wrappers.h
@@ -38,6 +38,10 @@ void UnwrapStructHandles(VkDescriptorType type, VkDescriptorImageInfo* value, Ha
 
 void UnwrapStructHandles(VkWriteDescriptorSet* value, HandleUnwrapMemory* unwrap_memory);
 
+void UnwrapStructHandles(VkAccelerationStructureGeometryKHR* value, HandleUnwrapMemory* unwrap_memory);
+
+void UnwrapStructHandles(VkAccelerationStructureBuildGeometryInfoKHR* value, HandleUnwrapMemory* unwrap_memory);
+
 GFXRECON_END_NAMESPACE(vulkan_wrappers)
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -112,6 +112,8 @@ uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
         case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
             return GetWrappedId<IndirectCommandsLayoutNVWrapper>(
                 format::FromHandleId<VkIndirectCommandsLayoutNV>(object));
+        case VK_OBJECT_TYPE_MICROMAP_EXT:
+            return GetWrappedId<MicromapEXTWrapper>(format::FromHandleId<VkMicromapEXT>(object));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
             return GetWrappedId<PrivateDataSlotEXTWrapper>(format::FromHandleId<VkPrivateDataSlotEXT>(object));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:

--- a/framework/generated/base_generators/base_struct_handle_mappers_body_generator.py
+++ b/framework/generated/base_generators/base_struct_handle_mappers_body_generator.py
@@ -110,7 +110,7 @@ class BaseStructHandleMappersBodyGenerator():
                 (struct in self.structs_with_handles)
                 or (struct in self.GENERIC_HANDLE_STRUCTS)
                 or (struct in self.structs_with_map_data)
-            ):
+            ) and (struct not in self.STRUCT_MAPPERS_BLACKLIST):
                 handle_members = list()
                 generic_handle_members = dict()
 

--- a/framework/generated/base_generators/base_struct_handle_mappers_header_generator.py
+++ b/framework/generated/base_generators/base_struct_handle_mappers_header_generator.py
@@ -159,7 +159,7 @@ class BaseStructHandleMappersHeaderGenerator():
                 (struct in self.structs_with_handles)
                 or (struct in self.GENERIC_HANDLE_STRUCTS)
                 or (struct in self.structs_with_map_data)
-            ):
+            ) and (struct not in self.STRUCT_MAPPERS_BLACKLIST):
                 body = '\n'
                 body += 'void MapStruct{}(Decoded_{}* wrapper, const {}ObjectInfoTable& object_info_table{});'.format(
                     map_type, struct, platform_type, map_table

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -1840,18 +1840,6 @@ void MapStructHandles(Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* w
     }
 }
 
-void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
-{
-    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
-    {
-        VkAccelerationStructureBuildGeometryInfoKHR* value = wrapper->decoded_value;
-
-        value->srcAccelerationStructure = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(wrapper->srcAccelerationStructure, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
-
-        value->dstAccelerationStructure = handle_mapping::MapHandle<AccelerationStructureKHRInfo>(wrapper->dstAccelerationStructure, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo);
-    }
-}
-
 void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -369,8 +369,6 @@ void MapStructHandles(Decoded_VkLatencySleepInfoNV* wrapper, const VulkanObjectI
 
 void MapStructHandles(Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkAccelerationStructureBuildGeometryInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
-
 void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
 
 void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureKHR* wrapper, const VulkanObjectInfoTable& object_info_table);

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
@@ -1294,13 +1294,6 @@ void UnwrapStructHandles(VkAccelerationStructureGeometryTrianglesDataKHR* value,
     }
 }
 
-void UnwrapStructHandles(VkAccelerationStructureBuildGeometryInfoKHR* value, HandleUnwrapMemory* unwrap_memory)
-{
-    if (value != nullptr)
-    {
-    }
-}
-
 void UnwrapStructHandles(VkAccelerationStructureCreateInfoKHR* value, HandleUnwrapMemory* unwrap_memory)
 {
     if (value != nullptr)

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -369,8 +369,6 @@ void UnwrapStructHandles(VkLatencySleepInfoNV* value, HandleUnwrapMemory* unwrap
 
 void UnwrapStructHandles(VkAccelerationStructureGeometryTrianglesDataKHR* value, HandleUnwrapMemory* unwrap_memory);
 
-void UnwrapStructHandles(VkAccelerationStructureBuildGeometryInfoKHR* value, HandleUnwrapMemory* unwrap_memory);
-
 void UnwrapStructHandles(VkAccelerationStructureCreateInfoKHR* value, HandleUnwrapMemory* unwrap_memory);
 
 void UnwrapStructHandles(VkWriteDescriptorSetAccelerationStructureKHR* value, HandleUnwrapMemory* unwrap_memory);

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -306,6 +306,9 @@ class BaseGenerator(OutputGenerator):
         # These structures should not be processed by the code generator.  They require special implementations.
         self.STRUCT_BLACKLIST = []
 
+        # These structures should be ignored for handle mapping/unwrapping. They require special implementations.
+        self.STRUCT_MAPPERS_BLACKLIST = ['VkAccelerationStructureBuildGeometryInfoKHR']
+
         # Platform specific basic types that have been defined extarnally to the Vulkan header.
         self.PLATFORM_TYPES = {}
 

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_body_generator.py
@@ -242,7 +242,7 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
             if (
                 (struct in self.structs_with_handles)
                 or (struct in self.GENERIC_HANDLE_STRUCTS)
-            ):
+            ) and (struct not in self.STRUCT_MAPPERS_BLACKLIST):
                 handle_members = dict()
                 generic_handle_members = dict()
 

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
@@ -257,7 +257,7 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
             if (
                 (struct in self.structs_with_handles)
                 or (struct in self.GENERIC_HANDLE_STRUCTS)
-            ):
+            ) and (struct not in self.STRUCT_MAPPERS_BLACKLIST):
                 body = '\n'
                 body += 'void UnwrapStructHandles({}* value, HandleUnwrapMemory* unwrap_memory);'.format(
                     struct


### PR DESCRIPTION
The mapping/unwrapping of handles contained in `VkAccelerationStructureBuildGeometryInfoKHR` was not done correctly for multiple reasons:
- The field `VkAccelerationStructureBuildGeometryInfoKHR::ppGeometries` was not correctly handled because of the double pointer
- The type `VkAccelerationStructureGeometryDataKHR` was ignored because it is a union, even though one of the fields of the union can contains handles to map/unwrap in the pNext chain
- VkMicromapEXT was not entirely handled

I tried to fix this in the most clean way to be able to map/unwrap correctly opacity micromaps