### PR TITLE
Support CmdPushDescriptorSetWithTemplate2KHR

### DIFF
--- a/framework/decode/custom_vulkan_struct_decoders.cpp
+++ b/framework/decode/custom_vulkan_struct_decoders.cpp
@@ -272,6 +272,27 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     return bytes_read;
 }
 
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPushDescriptorSetWithTemplateInfoKHR* wrapper)
+{
+    GFXRECON_ASSERT((wrapper != nullptr) && (wrapper->decoded_value != nullptr));
+
+    size_t                                  bytes_read = 0;
+    VkPushDescriptorSetWithTemplateInfoKHR* value      = wrapper->decoded_value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &value->sType);
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &wrapper->pNext);
+    bytes_read += ValueDecoder::DecodeHandleIdValue(
+        (buffer + bytes_read), (buffer_size - bytes_read), &wrapper->descriptorUpdateTemplate);
+    bytes_read +=
+        ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &wrapper->layout);
+    bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &value->set);
+
+    if (wrapper->pNext != nullptr)
+        value->pNext = wrapper->pNext->GetPointer();
+
+    return bytes_read;
+}
+
 // The WIN32 SID structure has a variable size, so was encoded as an array of bytes instead of a struct.
 static uint8_t* unpack_sid_struct(const PointerDecoder<uint8_t>& packed_value)
 {

--- a/framework/decode/custom_vulkan_struct_decoders.h
+++ b/framework/decode/custom_vulkan_struct_decoders.h
@@ -26,6 +26,7 @@
 
 #include "format/platform_types.h"
 #include "decode/custom_vulkan_struct_decoders_forward.h"
+#include "decode/descriptor_update_template_decoder.h"
 #include "decode/handle_pointer_decoder.h"
 #include "decode/pointer_decoder.h"
 #include "decode/string_decoder.h"
@@ -150,6 +151,18 @@ struct Decoded_VkAccelerationStructureGeometryKHR
 
     PNextNode*                                      pNext{ nullptr };
     Decoded_VkAccelerationStructureGeometryDataKHR* geometry{ nullptr };
+};
+
+struct Decoded_VkPushDescriptorSetWithTemplateInfoKHR
+{
+    using struct_type = VkPushDescriptorSetWithTemplateInfoKHR;
+
+    struct_type* decoded_value{ nullptr };
+
+    PNextNode*                      pNext{ nullptr };
+    format::HandleId                descriptorUpdateTemplate{ format::kNullHandleId };
+    format::HandleId                layout{ format::kNullHandleId };
+    DescriptorUpdateTemplateDecoder pData;
 };
 
 // Decoded struct wrappers for SECURITY_ATTRIBUTES and related WIN32 structures.

--- a/framework/decode/custom_vulkan_struct_decoders_forward.h
+++ b/framework/decode/custom_vulkan_struct_decoders_forward.h
@@ -54,11 +54,13 @@ struct Decoded_VkDescriptorImageInfo;
 struct Decoded_VkWriteDescriptorSet;
 struct Decoded_VkPerformanceValueINTEL;
 struct Decoded_VkAccelerationStructureGeometryKHR;
+struct Decoded_VkPushDescriptorSetWithTemplateInfoKHR;
 
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorImageInfo* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSet* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPerformanceValueINTEL* wrapper);
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccelerationStructureGeometryKHR* wrapper);
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPushDescriptorSetWithTemplateInfoKHR* wrapper);
 
 // Decoded struct wrappers for SECURITY_ATTRIBUTES and related WIN32 structures.
 struct Decoded_ACL;

--- a/framework/decode/custom_vulkan_struct_to_json.cpp
+++ b/framework/decode/custom_vulkan_struct_to_json.cpp
@@ -408,5 +408,15 @@ void FieldToJson(nlohmann::ordered_json&                      jdata,
     }
 }
 
+void FieldToJson(nlohmann::ordered_json&                                     jdata,
+                 const Decoded_VkPushDescriptorSetWithTemplateInfoKHR* const pData,
+                 const util::JsonOptions&                                    options)
+{
+    HandleToJson(jdata["descriptorUpdateTemplate"], pData->descriptorUpdateTemplate, options);
+    HandleToJson(jdata["layout"], pData->layout, options);
+    FieldToJson(jdata["set"], pData->decoded_value->set, options);
+    FieldToJson(jdata["pData"], &pData->pData, options);
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/custom_vulkan_struct_to_json.h
+++ b/framework/decode/custom_vulkan_struct_to_json.h
@@ -111,6 +111,10 @@ void FieldToJson(nlohmann::ordered_json&                      jdata,
                  const DescriptorUpdateTemplateDecoder* const pData,
                  const util::JsonOptions&                     options = util::JsonOptions());
 
+void FieldToJson(nlohmann::ordered_json&                                     jdata,
+                 const Decoded_VkPushDescriptorSetWithTemplateInfoKHR* const pData,
+                 const util::JsonOptions&                                    options = util::JsonOptions());
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -73,6 +73,12 @@ class VulkanConsumerBase : public CommonConsumerBase
                                                               DescriptorUpdateTemplateDecoder* pData)
     {}
 
+    virtual void Process_vkCmdPushDescriptorSetWithTemplate2KHR(
+        const ApiCallInfo&                                                    call_info,
+        format::HandleId                                                      commandBuffer,
+        StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
+    {}
+
     virtual void Process_vkCreateRayTracingPipelinesKHR(
         const ApiCallInfo&                                               call_info,
         VkResult                                                         returnValue,

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -2724,8 +2724,7 @@ std::string VulkanCppConsumerBase::BuildValue(const VkClearColorValue color)
     }
 
     std::stringstream output;
-    output << "{{" << values[0] << ", " << values[1] << ", " << values[2] << ", " << values[3] << ""
-           << "}}";
+    output << "{{" << values[0] << ", " << values[1] << ", " << values[2] << ", " << values[3] << "" << "}}";
     return output.str();
 }
 
@@ -3678,6 +3677,47 @@ void VulkanCppConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(const A
 {
     Generate_vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
     Post_APICall(format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplateKHR);
+}
+
+void VulkanCppConsumerBase::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
+    const ApiCallInfo&                                                    call_info,
+    format::HandleId                                                      commandBuffer,
+    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
+{
+    FILE*       file = GetFrameFile();
+    std::string var_name;
+
+    Decoded_VkPushDescriptorSetWithTemplateInfoKHR* decoded_info =
+        pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
+
+    fprintf(file, "\t{\n");
+
+    pfn_loader_.AddMethodName("vkCmdPushDescriptorSetWithTemplate2KHR");
+
+    DescriptorUpdateTemplateDecoder pData;
+    const uint8_t*                  ptr = static_cast<const uint8_t*>(decoded_info->pNext->GetPointer());
+    pData.Decode(ptr, pData.GetLength());
+    GenerateDescriptorUpdateTemplateData(&pData, decoded_info->descriptorUpdateTemplate, file, var_name);
+
+    fprintf(file,
+            "\t\tVkPushDescriptorSetWithTemplateInfoKHR info;\n\
+		             \t\tinfo.sType = VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_WITH_TEMPLATE_INFO_KHR;\n\
+		             \t\tinfo.pNext = nullptr;\n\
+		             \t\tinfo.descriptorUpdateTemplate = %s;\n\
+		             \t\tinfo.layout = %s\n\
+		             \t\tinfo.set = %u\n\
+		             \t\tinfo.pData = %s\n",
+            this->GetHandle(decoded_info->descriptorUpdateTemplate).c_str(),
+            this->GetHandle(decoded_info->layout).c_str(),
+            decoded_info->decoded_value->set,
+            var_name.c_str());
+
+    fprintf(file,
+            "\t\tloaded_vkCmdPushDescriptorSetWithTemplate2KHR(%s, &info);\n",
+            this->GetHandle(commandBuffer).c_str());
+    fprintf(file, "\t}\n");
+
+    Post_APICall(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
 }
 
 void VulkanCppConsumerBase::Process_vkCreateRayTracingPipelinesKHR(

--- a/framework/decode/vulkan_cpp_consumer_base.cpp
+++ b/framework/decode/vulkan_cpp_consumer_base.cpp
@@ -2724,7 +2724,8 @@ std::string VulkanCppConsumerBase::BuildValue(const VkClearColorValue color)
     }
 
     std::stringstream output;
-    output << "{{" << values[0] << ", " << values[1] << ", " << values[2] << ", " << values[3] << "" << "}}";
+    output << "{{" << values[0] << ", " << values[1] << ", " << values[2] << ", " << values[3] << ""
+           << "}}";
     return output.str();
 }
 

--- a/framework/decode/vulkan_cpp_consumer_base.h
+++ b/framework/decode/vulkan_cpp_consumer_base.h
@@ -574,6 +574,12 @@ class VulkanCppConsumerBase : public VulkanConsumer
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData) override;
 
+    virtual void
+    Process_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info,
+                                                   format::HandleId   commandBuffer,
+                                                   StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>*
+                                                       pPushDescriptorSetWithTemplateInfo) override;
+
     // String utilities
     static std::string ToEscape(const char* value);
     static std::string EscapeStringArray(const char* const* layerNames, const uint32_t stringArrayLength);

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -372,6 +372,31 @@ size_t VulkanDecoderBase::Decode_vkCmdPushDescriptorSetWithTemplateKHR(const Api
     return bytes_read;
 }
 
+size_t VulkanDecoderBase::Decode_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info,
+                                                                        const uint8_t*     parameter_buffer,
+                                                                        size_t             buffer_size)
+{
+    size_t bytes_read = 0;
+
+    format::HandleId                                                     commandBuffer;
+    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR> pPushDescriptorSetWithTemplateInfo;
+
+    bytes_read +=
+        ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &commandBuffer);
+    bytes_read +=
+        pPushDescriptorSetWithTemplateInfo.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += pPushDescriptorSetWithTemplateInfo.GetMetaStructPointer()->pData.Decode(
+        (parameter_buffer + bytes_read), (buffer_size - bytes_read));
+
+    for (auto consumer : consumers_)
+    {
+        consumer->Process_vkCmdPushDescriptorSetWithTemplate2KHR(
+            call_info, commandBuffer, &pPushDescriptorSetWithTemplateInfo);
+    }
+
+    return bytes_read;
+}
+
 size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
                                                                       const uint8_t*     parameter_buffer,
                                                                       size_t             buffer_size)
@@ -505,6 +530,9 @@ void VulkanDecoderBase::DecodeFunctionCall(format::ApiCallId  call_id,
             break;
         case format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR:
             Decode_vkCreateRayTracingPipelinesKHR(call_info, parameter_buffer, buffer_size);
+            break;
+        case format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR:
+            Decode_vkCmdPushDescriptorSetWithTemplate2KHR(call_info, parameter_buffer, buffer_size);
             break;
         case format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR:
             Decode_vkDeferredOperationJoinKHR(call_info, parameter_buffer, buffer_size);

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -209,6 +209,10 @@ class VulkanDecoderBase : public ApiDecoder
                                                         const uint8_t*     parameter_buffer,
                                                         size_t             buffer_size);
 
+    size_t Decode_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info,
+                                                         const uint8_t*     parameter_buffer,
+                                                         size_t             buffer_size);
+
     size_t Decode_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
                                                        const uint8_t*     parameter_buffer,
                                                        size_t             buffer_size);

--- a/framework/decode/vulkan_json_consumer_base.cpp
+++ b/framework/decode/vulkan_json_consumer_base.cpp
@@ -227,5 +227,45 @@ void VulkanExportJsonConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(con
     WriteBlockEnd();
 }
 
+void VulkanExportJsonConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
+    const ApiCallInfo&               call_info,
+    format::HandleId                 commandBuffer,
+    format::HandleId                 descriptorUpdateTemplate,
+    format::HandleId                 layout,
+    uint32_t                         set,
+    DescriptorUpdateTemplateDecoder* pData)
+{
+    const JsonOptions& json_options = GetJsonOptions();
+
+    auto& function = WriteApiCallStart(call_info, "vkCmdPushDescriptorSetWithTemplateKHR");
+    auto& args     = function[NameArgs()];
+
+    HandleToJson(args["commandBuffer"], commandBuffer, json_options);
+    HandleToJson(args["descriptorUpdateTemplate"], descriptorUpdateTemplate, json_options);
+    HandleToJson(args["layout"], layout, json_options);
+    FieldToJson(args["set"], set, json_options);
+    FieldToJson(args["pData"], pData, json_options);
+
+    WriteBlockEnd();
+}
+
+void VulkanExportJsonConsumerBase::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
+    const ApiCallInfo&                                                    call_info,
+    format::HandleId                                                      commandBuffer,
+    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
+{
+    const JsonOptions& json_options = GetJsonOptions();
+
+    auto& function = WriteApiCallStart(call_info, "vkCmdPushDescriptorSetWithTemplate2KHR");
+    auto& args     = function[NameArgs()];
+    const StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* info =
+        pPushDescriptorSetWithTemplateInfo;
+
+    HandleToJson(args["commandBuffer"], commandBuffer, json_options);
+    FieldToJson(args["pPushDescriptorSetWithTemplateInfo"], info, json_options);
+
+    WriteBlockEnd();
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_json_consumer_base.h
+++ b/framework/decode/vulkan_json_consumer_base.h
@@ -119,6 +119,19 @@ class VulkanExportJsonConsumerBase : public VulkanConsumer
                                                    DescriptorUpdateTemplateDecoder* pData,
                                                    bool                             use_KHR_suffix);
 
+    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                               format::HandleId   commandBuffer,
+                                                               format::HandleId   descriptorUpdateTemplate,
+                                                               format::HandleId   layout,
+                                                               uint32_t           set,
+                                                               DescriptorUpdateTemplateDecoder* pData) override;
+
+    virtual void
+    Process_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info,
+                                                   format::HandleId   commandBuffer,
+                                                   StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>*
+                                                       pPushDescriptorSetWithTemplateInfo) override;
+
     const util::JsonOptions& GetJsonOptions() const { return writer_->GetOptions(); }
 
     nlohmann::ordered_json& WriteBlockStart() { return writer_->WriteBlockStart(); }

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -659,6 +659,21 @@ void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTem
     PushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, pData);
 }
 
+void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
+    const ApiCallInfo&                                                    call_info,
+    format::HandleId                                                      commandBuffer,
+    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
+{
+    Decoded_VkPushDescriptorSetWithTemplateInfoKHR* info = pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
+    format::HandleId                                descriptorUpdateTemplate = info->descriptorUpdateTemplate;
+
+    DescriptorUpdateTemplateDecoder pData;
+    const uint8_t*                  ptr = static_cast<const uint8_t*>(info->pNext->GetPointer());
+    pData.Decode(ptr, pData.GetLength());
+
+    PushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, &pData);
+}
+
 void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
     const ApiCallInfo&               call_info,
     format::HandleId                 device,

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -184,6 +184,12 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
                                                                uint32_t           set,
                                                                DescriptorUpdateTemplateDecoder* pData) override;
 
+    virtual void
+    Process_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info,
+                                                   format::HandleId   commandBuffer,
+                                                   StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>*
+                                                       pPushDescriptorSetWithTemplateInfo) override;
+
     virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo&               call_info,
                                                               format::HandleId                 device,
                                                               format::HandleId                 descriptorSet,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -158,9 +158,10 @@ static uint32_t GetHardwareBufferFormatBpp(uint32_t format)
 
 VulkanReplayConsumerBase::VulkanReplayConsumerBase(std::shared_ptr<application::Application> application,
                                                    const VulkanReplayOptions&                options) :
-    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr),
-    application_(application), options_(options), loading_trim_state_(false), replaying_trimmed_capture_(false),
-    have_imported_semaphores_(false), fps_info_(nullptr), omitted_pipeline_cache_data_(false)
+    loader_handle_(nullptr),
+    get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr), application_(application), options_(options),
+    loading_trim_state_(false), replaying_trimmed_capture_(false), have_imported_semaphores_(false), fps_info_(nullptr),
+    omitted_pipeline_cache_data_(false)
 {
     assert(application_ != nullptr);
     assert(options.create_resource_allocator != nullptr);
@@ -4037,9 +4038,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
             VkMemoryAllocateInfo                     modified_allocate_info = (*replay_allocate_info);
             VkMemoryOpaqueCaptureAddressAllocateInfo address_info           = {
-                VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
-                modified_allocate_info.pNext,
-                opaque_address
+                          VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
+                          modified_allocate_info.pNext,
+                          opaque_address
             };
             modified_allocate_info.pNext = &address_info;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -178,6 +178,12 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                               format::HandleId                 descriptorSet,
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData) override;
+
+    virtual void
+                 Process_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info,
+                                                                format::HandleId   commandBuffer,
+                                                                StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>*
+                                                                    pPushDescriptorSetWithTemplateInfo) override;
     virtual void Process_vkCreateRayTracingPipelinesKHR(
         const ApiCallInfo&                                               call_info,
         VkResult                                                         returnValue,

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -293,6 +293,45 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer  
         manager, commandBuffer, descriptorUpdateTemplate, layout, set, pData);
 }
 
+VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo)
+{
+    VulkanCaptureManager* manager = VulkanCaptureManager::Get();
+    GFXRECON_ASSERT(manager != nullptr);
+
+    auto api_call_lock = VulkanCaptureManager::AcquireSharedApiCallLock();
+
+    const UpdateTemplateInfo* info = nullptr;
+    if (!manager->GetDescriptorUpdateTemplateInfo(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate, &info))
+    {
+        GFXRECON_LOG_DEBUG("Descriptor update template info not found");
+    }
+
+    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR>::Dispatch(
+        manager, commandBuffer, pPushDescriptorSetWithTemplateInfo);
+
+    auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
+    if (encoder)
+    {
+        encoder->EncodeVulkanHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
+        EncodeStructPtr(encoder, pPushDescriptorSetWithTemplateInfo);
+
+        EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pPushDescriptorSetWithTemplateInfo->pData);
+
+        manager->EndApiCallCapture();
+    }
+
+    auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
+    auto pData_unwrapped      = UnwrapDescriptorUpdateTemplateInfoHandles(
+        info, pPushDescriptorSetWithTemplateInfo->pData, handle_unwrap_memory);
+
+    vulkan_wrappers::GetDeviceTable(commandBuffer)
+        ->CmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo);
+
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR>::Dispatch(
+        manager, commandBuffer, pPushDescriptorSetWithTemplateInfo);
+}
+
 VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice                   device,
                                                               VkDescriptorSet            descriptorSet,
                                                               VkDescriptorUpdateTemplate descriptorUpdateTemplate,

--- a/framework/encode/custom_vulkan_api_call_encoders.h
+++ b/framework/encode/custom_vulkan_api_call_encoders.h
@@ -43,6 +43,9 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer  
                                                                uint32_t                   set,
                                                                const void*                pData);
 
+VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
+
 VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice                   device,
                                                               VkDescriptorSet            descriptorSet,
                                                               VkDescriptorUpdateTemplate descriptorUpdateTemplate,

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -791,6 +791,16 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWi
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdPushDescriptorSetWithTemplate2KHR(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>
 {
     template <typename... Args>

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -279,5 +279,14 @@ void EncodeStruct(ParameterEncoder* encoder, const SECURITY_ATTRIBUTES& value)
     encoder->EncodeInt32Value(value.bInheritHandle);
 }
 
+void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetWithTemplateInfoKHR& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeVulkanHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(value.descriptorUpdateTemplate);
+    encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
+    encoder->EncodeUInt32Value(value.set);
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/custom_vulkan_struct_encoders.h
+++ b/framework/encode/custom_vulkan_struct_encoders.h
@@ -46,6 +46,7 @@ void EncodeStruct(ParameterEncoder* encoder, VkDescriptorType type, const VkDesc
 void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPerformanceValueINTEL& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureGeometryKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetWithTemplateInfoKHR& value);
 
 // Platform defined structures that are external to Vulkan.
 void EncodeStruct(ParameterEncoder* encoder, const ACL& value);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1256,7 +1256,10 @@ class VulkanCaptureManager : public ApiCaptureManager
     void PostProcess_vkCmdDebugMarkerInsertEXT(VkCommandBuffer                   commandBuffer,
                                                const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
 
-    void PostProcess_vkFrameBoundaryANDROID(VkDevice device, VkSemaphore semaphore, VkImage image) { EndFrame(); }
+    void PostProcess_vkFrameBoundaryANDROID(VkDevice device, VkSemaphore semaphore, VkImage image)
+    {
+        EndFrame();
+    }
 
 #if defined(__ANDROID__)
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
@@ -1267,9 +1270,15 @@ class VulkanCaptureManager : public ApiCaptureManager
 
     virtual ~VulkanCaptureManager() {}
 
-    virtual void CreateStateTracker() override { state_tracker_ = std::make_unique<VulkanStateTracker>(); }
+    virtual void CreateStateTracker() override
+    {
+        state_tracker_ = std::make_unique<VulkanStateTracker>();
+    }
 
-    virtual void DestroyStateTracker() override { state_tracker_ = nullptr; }
+    virtual void DestroyStateTracker() override
+    {
+        state_tracker_ = nullptr;
+    }
 
     virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1050,6 +1050,13 @@ class VulkanCaptureManager : public ApiCaptureManager
         // TODO: Need to be able to map layout + set to a VkDescriptorSet handle.
     }
 
+    void PostProcess_vkCmdPushDescriptorSetWithTemplate2KHR(VkCommandBuffer,
+                                                            const VkPushDescriptorSetWithTemplateInfoKHR* info)
+    {
+        GFXRECON_UNREFERENCED_PARAMETER(info);
+        // TODO: Need to be able to map layout + set to a VkDescriptorSet handle.
+    }
+
     void PostProcess_vkResetDescriptorPool(VkResult result,
                                            VkDevice,
                                            VkDescriptorPool descriptorPool,
@@ -1249,10 +1256,7 @@ class VulkanCaptureManager : public ApiCaptureManager
     void PostProcess_vkCmdDebugMarkerInsertEXT(VkCommandBuffer                   commandBuffer,
                                                const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
 
-    void PostProcess_vkFrameBoundaryANDROID(VkDevice device, VkSemaphore semaphore, VkImage image)
-    {
-        EndFrame();
-    }
+    void PostProcess_vkFrameBoundaryANDROID(VkDevice device, VkSemaphore semaphore, VkImage image) { EndFrame(); }
 
 #if defined(__ANDROID__)
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
@@ -1263,15 +1267,9 @@ class VulkanCaptureManager : public ApiCaptureManager
 
     virtual ~VulkanCaptureManager() {}
 
-    virtual void CreateStateTracker() override
-    {
-        state_tracker_ = std::make_unique<VulkanStateTracker>();
-    }
+    virtual void CreateStateTracker() override { state_tracker_ = std::make_unique<VulkanStateTracker>(); }
 
-    virtual void DestroyStateTracker() override
-    {
-        state_tracker_ = nullptr;
-    }
+    virtual void DestroyStateTracker() override { state_tracker_ = nullptr; }
 
     virtual void WriteTrackedState(util::FileOutputStream* file_stream, format::ThreadId thread_id) override;
 

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -14568,42 +14568,6 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSet2KHR(
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSet2KHR>::Dispatch(manager, commandBuffer, pPushDescriptorSetInfo);
 }
 
-VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
-    VkCommandBuffer                             commandBuffer,
-    const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo)
-{
-    VulkanCaptureManager* manager = VulkanCaptureManager::Get();
-    GFXRECON_ASSERT(manager != nullptr);
-    auto force_command_serialization = manager->GetForceCommandSerialization();
-    std::shared_lock<CommonCaptureManager::ApiCallMutexT> shared_api_call_lock;
-    std::unique_lock<CommonCaptureManager::ApiCallMutexT> exclusive_api_call_lock;
-    if (force_command_serialization)
-    {
-        exclusive_api_call_lock = VulkanCaptureManager::AcquireExclusiveApiCallLock();
-    }
-    else
-    {
-        shared_api_call_lock = VulkanCaptureManager::AcquireSharedApiCallLock();
-    }
-
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR>::Dispatch(manager, commandBuffer, pPushDescriptorSetWithTemplateInfo);
-
-    auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
-    if (encoder)
-    {
-        encoder->EncodeVulkanHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
-        EncodeStructPtr(encoder, pPushDescriptorSetWithTemplateInfo);
-        manager->EndCommandApiCallCapture(commandBuffer, TrackCmdPushDescriptorSetWithTemplate2KHRHandles, pPushDescriptorSetWithTemplateInfo);
-    }
-
-    auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();
-    const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo_unwrapped = vulkan_wrappers::UnwrapStructPtrHandles(pPushDescriptorSetWithTemplateInfo, handle_unwrap_memory);
-
-    vulkan_wrappers::GetDeviceTable(commandBuffer)->CmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo_unwrapped);
-
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR>::Dispatch(manager, commandBuffer, pPushDescriptorSetWithTemplateInfo);
-}
-
 VKAPI_ATTR void VKAPI_CALL CmdSetDescriptorBufferOffsets2EXT(
     VkCommandBuffer                             commandBuffer,
     const VkSetDescriptorBufferOffsetsInfoEXT*  pSetDescriptorBufferOffsetsInfo)

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -1983,10 +1983,6 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSet2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkPushDescriptorSetInfoKHR*           pPushDescriptorSetInfo);
 
-VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
-    VkCommandBuffer                             commandBuffer,
-    const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
-
 VKAPI_ATTR void VKAPI_CALL CmdSetDescriptorBufferOffsets2EXT(
     VkCommandBuffer                             commandBuffer,
     const VkSetDescriptorBufferOffsetsInfoEXT*  pSetDescriptorBufferOffsetsInfo);

--- a/framework/generated/generated_vulkan_command_buffer_util.cpp
+++ b/framework/generated/generated_vulkan_command_buffer_util.cpp
@@ -1185,39 +1185,6 @@ void TrackCmdPushDescriptorSet2KHRHandles(vulkan_wrappers::CommandBufferWrapper*
     }
 }
 
-void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo)
-{
-    assert(wrapper != nullptr);
-
-    if (pPushDescriptorSetWithTemplateInfo != nullptr)
-    {
-        auto pnext_header = reinterpret_cast<const VkBaseInStructure*>(pPushDescriptorSetWithTemplateInfo->pNext);
-        while (pnext_header)
-        {
-            switch (pnext_header->sType)
-            {
-                default:
-                    break;
-                case VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO:
-                {
-                    auto pnext_value = reinterpret_cast<const VkPipelineLayoutCreateInfo*>(pnext_header);
-                    if (pnext_value->pSetLayouts != nullptr)
-                    {
-                        for (uint32_t pSetLayouts_index = 0; pSetLayouts_index < pnext_value->setLayoutCount; ++pSetLayouts_index)
-                        {
-                            if(pnext_value->pSetLayouts[pSetLayouts_index] != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorSetLayoutHandle].insert(vulkan_wrappers::GetWrappedId<vulkan_wrappers::DescriptorSetLayoutWrapper>(pnext_value->pSetLayouts[pSetLayouts_index]));
-                        }
-                    }
-                    break;
-                }
-            }
-            pnext_header = pnext_header->pNext;
-        }
-        if(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::DescriptorUpdateTemplateHandle].insert(vulkan_wrappers::GetWrappedId<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate));
-        if(pPushDescriptorSetWithTemplateInfo->layout != VK_NULL_HANDLE) wrapper->command_handles[vulkan_state_info::CommandHandleType::PipelineLayoutHandle].insert(vulkan_wrappers::GetWrappedId<vulkan_wrappers::PipelineLayoutWrapper>(pPushDescriptorSetWithTemplateInfo->layout));
-    }
-}
-
 void TrackCmdSetDescriptorBufferOffsets2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo)
 {
     assert(wrapper != nullptr);

--- a/framework/generated/generated_vulkan_command_buffer_util.h
+++ b/framework/generated/generated_vulkan_command_buffer_util.h
@@ -185,8 +185,6 @@ void TrackCmdPushConstants2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wra
 
 void TrackCmdPushDescriptorSet2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo);
 
-void TrackCmdPushDescriptorSetWithTemplate2KHRHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
-
 void TrackCmdSetDescriptorBufferOffsets2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo);
 
 void TrackCmdBindDescriptorBufferEmbeddedSamplers2EXTHandles(vulkan_wrappers::CommandBufferWrapper* wrapper, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo);

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -2521,11 +2521,6 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPushDescriptorSetInfoKHR>* pPushDescriptorSetInfo) {}
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-        const ApiCallInfo&                          call_info,
-        format::HandleId                            commandBuffer,
-        StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo) {}
-
     virtual void Process_vkCmdSetDescriptorBufferOffsets2EXT(
         const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_cpp_consumer.cpp
+++ b/framework/generated/generated_vulkan_cpp_consumer.cpp
@@ -8685,28 +8685,6 @@ void VulkanCppConsumer::Process_vkCmdPushDescriptorSet2KHR(
     Post_APICall(format::ApiCallId::ApiCall_vkCmdPushDescriptorSet2KHR);
 }
 
-void VulkanCppConsumer::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-    const ApiCallInfo&                          call_info,
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
-{
-    FILE* file = GetFrameFile();
-    fprintf(file, "\t{\n");
-    std::stringstream stream_ppush_descriptor_set_with_template_info;
-    std::string ppush_descriptor_set_with_template_info_struct = GenerateStruct_VkPushDescriptorSetWithTemplateInfoKHR(stream_ppush_descriptor_set_with_template_info,
-                                                                                                                       pPushDescriptorSetWithTemplateInfo->GetPointer(),
-                                                                                                                       pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer(),
-                                                                                                                       *this);
-    fprintf(file, "%s", stream_ppush_descriptor_set_with_template_info.str().c_str());
-    pfn_loader_.AddMethodName("vkCmdPushDescriptorSetWithTemplate2KHR");
-    fprintf(file,
-            "\t\tloaded_vkCmdPushDescriptorSetWithTemplate2KHR(%s, &%s);\n",
-            this->GetHandle(commandBuffer).c_str(),
-            ppush_descriptor_set_with_template_info_struct.c_str());
-    fprintf(file, "\t}\n");
-    Post_APICall(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
-}
-
 void VulkanCppConsumer::Process_vkCmdSetDescriptorBufferOffsets2EXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_cpp_consumer.h
+++ b/framework/generated/generated_vulkan_cpp_consumer.h
@@ -2467,11 +2467,6 @@ class VulkanCppConsumer : public VulkanCppConsumerBase
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPushDescriptorSetInfoKHR>* pPushDescriptorSetInfo) override;
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-        const ApiCallInfo&                          call_info,
-        format::HandleId                            commandBuffer,
-        StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo) override;
-
     virtual void Process_vkCmdSetDescriptorBufferOffsets2EXT(
         const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_cpp_structs.cpp
+++ b/framework/generated/generated_vulkan_cpp_structs.cpp
@@ -12404,23 +12404,6 @@ std::string GenerateStruct_VkPushDescriptorSetInfoKHR(std::ostream &out, const V
 }
 
 
-std::string GenerateStruct_VkPushDescriptorSetWithTemplateInfoKHR(std::ostream &out, const VkPushDescriptorSetWithTemplateInfoKHR* structInfo, Decoded_VkPushDescriptorSetWithTemplateInfoKHR* metaInfo, VulkanCppConsumerBase &consumer){
-    std::stringstream struct_body;
-    std::string pnext_name = GenerateExtension(out, structInfo->pNext, metaInfo->pNext, consumer);
-    struct_body << "\t" << "VkStructureType(" << structInfo->sType << ")" << "," << std::endl;
-    struct_body << "\t\t\t" << pnext_name << "," << std::endl;
-    struct_body << "\t\t\t" << consumer.GetHandle(metaInfo->descriptorUpdateTemplate) << "," << std::endl;
-    struct_body << "\t\t\t" << consumer.GetHandle(metaInfo->layout) << "," << std::endl;
-    struct_body << "\t\t\t" << structInfo->set << "," << std::endl;
-    struct_body << "\t\t\t" << structInfo->pData << ",";
-    std::string variable_name = consumer.AddStruct(struct_body, "pushDescriptorSetWithTemplateInfoKHR");
-    out << "\t\t" << "VkPushDescriptorSetWithTemplateInfoKHR " << variable_name << " {" << std::endl;
-    out << "\t\t" << struct_body.str() << std::endl;
-    out << "\t\t" << "};" << std::endl;
-    return variable_name;
-}
-
-
 std::string GenerateStruct_VkSetDescriptorBufferOffsetsInfoEXT(std::ostream &out, const VkSetDescriptorBufferOffsetsInfoEXT* structInfo, Decoded_VkSetDescriptorBufferOffsetsInfoEXT* metaInfo, VulkanCppConsumerBase &consumer){
     std::stringstream struct_body;
     std::string pnext_name = GenerateExtension(out, structInfo->pNext, metaInfo->pNext, consumer);

--- a/framework/generated/generated_vulkan_cpp_structs.h
+++ b/framework/generated/generated_vulkan_cpp_structs.h
@@ -1169,8 +1169,6 @@ std::string GenerateStruct_VkPushConstantsInfoKHR(std::ostream &out, const VkPus
 
 std::string GenerateStruct_VkPushDescriptorSetInfoKHR(std::ostream &out, const VkPushDescriptorSetInfoKHR* structInfo, Decoded_VkPushDescriptorSetInfoKHR* metaInfo, VulkanCppConsumerBase &consumer);
 
-std::string GenerateStruct_VkPushDescriptorSetWithTemplateInfoKHR(std::ostream &out, const VkPushDescriptorSetWithTemplateInfoKHR* structInfo, Decoded_VkPushDescriptorSetWithTemplateInfoKHR* metaInfo, VulkanCppConsumerBase &consumer);
-
 std::string GenerateStruct_VkSetDescriptorBufferOffsetsInfoEXT(std::ostream &out, const VkSetDescriptorBufferOffsetsInfoEXT* structInfo, Decoded_VkSetDescriptorBufferOffsetsInfoEXT* metaInfo, VulkanCppConsumerBase &consumer);
 
 std::string GenerateStruct_VkDebugReportCallbackCreateInfoEXT(std::ostream &out, const VkDebugReportCallbackCreateInfoEXT* structInfo, Decoded_VkDebugReportCallbackCreateInfoEXT* metaInfo, VulkanCppConsumerBase &consumer);

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -7858,24 +7858,6 @@ size_t VulkanDecoder::Decode_vkCmdPushDescriptorSet2KHR(const ApiCallInfo& call_
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
-{
-    size_t bytes_read = 0;
-
-    format::HandleId commandBuffer;
-    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR> pPushDescriptorSetWithTemplateInfo;
-
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &commandBuffer);
-    bytes_read += pPushDescriptorSetWithTemplateInfo.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
-
-    for (auto consumer : GetConsumers())
-    {
-        consumer->Process_vkCmdPushDescriptorSetWithTemplate2KHR(call_info, commandBuffer, &pPushDescriptorSetWithTemplateInfo);
-    }
-
-    return bytes_read;
-}
-
 size_t VulkanDecoder::Decode_vkCmdSetDescriptorBufferOffsets2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
@@ -14636,9 +14618,6 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,
         break;
     case format::ApiCallId::ApiCall_vkCmdPushDescriptorSet2KHR:
         Decode_vkCmdPushDescriptorSet2KHR(call_info, parameter_buffer, buffer_size);
-        break;
-    case format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR:
-        Decode_vkCmdPushDescriptorSetWithTemplate2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDescriptorBufferOffsets2EXT:
         Decode_vkCmdSetDescriptorBufferOffsets2EXT(call_info, parameter_buffer, buffer_size);

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -778,8 +778,6 @@ class VulkanDecoder : public VulkanDecoderBase
 
     size_t Decode_vkCmdPushDescriptorSet2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdPushDescriptorSetWithTemplate2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
-
     size_t Decode_vkCmdSetDescriptorBufferOffsets2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
     size_t Decode_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);

--- a/framework/generated/generated_vulkan_json_consumer.cpp
+++ b/framework/generated/generated_vulkan_json_consumer.cpp
@@ -6105,20 +6105,6 @@ void VulkanExportJsonConsumer::Process_vkCmdPushDescriptorSet2KHR(
     WriteBlockEnd();
 }
 
-void VulkanExportJsonConsumer::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-    const ApiCallInfo&                          call_info,
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
-{
-    nlohmann::ordered_json& jdata = WriteApiCallStart(call_info, "vkCmdPushDescriptorSetWithTemplate2KHR");
-    const JsonOptions& json_options = GetJsonOptions();
-    FieldToJson(jdata[NameCommandIndex()], GetCommandBufferRecordIndex(commandBuffer), json_options);
-    auto& args = jdata[NameArgs()];
-        HandleToJson(args["commandBuffer"], commandBuffer, json_options);
-        FieldToJson(args["pPushDescriptorSetWithTemplateInfo"], pPushDescriptorSetWithTemplateInfo, json_options);
-    WriteBlockEnd();
-}
-
 void VulkanExportJsonConsumer::Process_vkCmdSetDescriptorBufferOffsets2EXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_json_consumer.h
+++ b/framework/generated/generated_vulkan_json_consumer.h
@@ -2488,11 +2488,6 @@ class VulkanExportJsonConsumer : public VulkanExportJsonConsumerBase
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPushDescriptorSetInfoKHR>* pPushDescriptorSetInfo) override;
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-        const ApiCallInfo&                          call_info,
-        format::HandleId                            commandBuffer,
-        StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo) override;
-
     virtual void Process_vkCmdSetDescriptorBufferOffsets2EXT(
         const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -1571,19 +1571,6 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSet2KHR(
     }
 }
 
-void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-    const ApiCallInfo&                          call_info,
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
-{
-    assert(pPushDescriptorSetWithTemplateInfo != nullptr);
-
-    if (!pPushDescriptorSetWithTemplateInfo->IsNull() && (pPushDescriptorSetWithTemplateInfo->HasData()))
-    {
-        auto pPushDescriptorSetWithTemplateInfo_ptr = pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
-    }
-}
-
 void VulkanReferencedResourceConsumer::Process_vkCmdSetDescriptorBufferOffsets2EXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -470,11 +470,6 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPushDescriptorSetInfoKHR>* pPushDescriptorSetInfo) override;
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-        const ApiCallInfo&                          call_info,
-        format::HandleId                            commandBuffer,
-        StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo) override;
-
     virtual void Process_vkCmdSetDescriptorBufferOffsets2EXT(
         const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -5547,18 +5547,6 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSet2KHR(
     GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSet2KHR(in_commandBuffer, in_pPushDescriptorSetInfo);
 }
 
-void VulkanReplayConsumer::Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-    const ApiCallInfo&                          call_info,
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
-{
-    VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
-    const VkPushDescriptorSetWithTemplateInfoKHR* in_pPushDescriptorSetWithTemplateInfo = pPushDescriptorSetWithTemplateInfo->GetPointer();
-    MapStructHandles(pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer(), GetObjectInfoTable());
-
-    GetDeviceTable(in_commandBuffer)->CmdPushDescriptorSetWithTemplate2KHR(in_commandBuffer, in_pPushDescriptorSetWithTemplateInfo);
-}
-
 void VulkanReplayConsumer::Process_vkCmdSetDescriptorBufferOffsets2EXT(
     const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -2521,11 +2521,6 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPushDescriptorSetInfoKHR>* pPushDescriptorSetInfo) override;
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplate2KHR(
-        const ApiCallInfo&                          call_info,
-        format::HandleId                            commandBuffer,
-        StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo) override;
-
     virtual void Process_vkCmdSetDescriptorBufferOffsets2EXT(
         const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -11893,27 +11893,6 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPushDes
     return bytes_read;
 }
 
-size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPushDescriptorSetWithTemplateInfoKHR* wrapper)
-{
-    assert((wrapper != nullptr) && (wrapper->decoded_value != nullptr));
-
-    size_t bytes_read = 0;
-    VkPushDescriptorSetWithTemplateInfoKHR* value = wrapper->decoded_value;
-
-    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
-    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->descriptorUpdateTemplate));
-    value->descriptorUpdateTemplate = VK_NULL_HANDLE;
-    bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->layout));
-    value->layout = VK_NULL_HANDLE;
-    bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->set));
-    bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pData));
-    value->pData = nullptr;
-
-    return bytes_read;
-}
-
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->decoded_value != nullptr));

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -5902,18 +5902,6 @@ struct Decoded_VkPushDescriptorSetInfoKHR
     StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites{ nullptr };
 };
 
-struct Decoded_VkPushDescriptorSetWithTemplateInfoKHR
-{
-    using struct_type = VkPushDescriptorSetWithTemplateInfoKHR;
-
-    VkPushDescriptorSetWithTemplateInfoKHR* decoded_value{ nullptr };
-
-    PNextNode* pNext{ nullptr };
-    format::HandleId descriptorUpdateTemplate{ format::kNullHandleId };
-    format::HandleId layout{ format::kNullHandleId };
-    uint64_t pData{ 0 };
-};
-
 struct Decoded_VkSetDescriptorBufferOffsetsInfoEXT
 {
     using struct_type = VkSetDescriptorBufferOffsetsInfoEXT;

--- a/framework/generated/generated_vulkan_struct_decoders_forward.h
+++ b/framework/generated/generated_vulkan_struct_decoders_forward.h
@@ -1310,7 +1310,6 @@ struct Decoded_VkBindMemoryStatusKHR;
 struct Decoded_VkBindDescriptorSetsInfoKHR;
 struct Decoded_VkPushConstantsInfoKHR;
 struct Decoded_VkPushDescriptorSetInfoKHR;
-struct Decoded_VkPushDescriptorSetWithTemplateInfoKHR;
 struct Decoded_VkSetDescriptorBufferOffsetsInfoEXT;
 struct Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT;
 
@@ -1320,7 +1319,6 @@ size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindDescriptorSetsInfoKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPushConstantsInfoKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPushDescriptorSetInfoKHR* wrapper);
-size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPushDescriptorSetWithTemplateInfoKHR* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wrapper);
 

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -5966,16 +5966,6 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetInfoKHR& v
     EncodeStructArray(encoder, value.pDescriptorWrites, value.descriptorWriteCount);
 }
 
-void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetWithTemplateInfoKHR& value)
-{
-    encoder->EncodeEnumValue(value.sType);
-    EncodePNextStruct(encoder, value.pNext);
-    encoder->EncodeVulkanHandleValue<vulkan_wrappers::DescriptorUpdateTemplateWrapper>(value.descriptorUpdateTemplate);
-    encoder->EncodeVulkanHandleValue<vulkan_wrappers::PipelineLayoutWrapper>(value.layout);
-    encoder->EncodeUInt32Value(value.set);
-    encoder->EncodeVoidPtr(value.pData);
-}
-
 void EncodeStruct(ParameterEncoder* encoder, const VkSetDescriptorBufferOffsetsInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -685,7 +685,6 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBindMemoryStatusKHR& value)
 void EncodeStruct(ParameterEncoder* encoder, const VkBindDescriptorSetsInfoKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPushConstantsInfoKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetInfoKHR& value);
-void EncodeStruct(ParameterEncoder* encoder, const VkPushDescriptorSetWithTemplateInfoKHR& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkSetDescriptorBufferOffsetsInfoEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT& value);
 

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -1258,23 +1258,6 @@ void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const VulkanO
     }
 }
 
-void MapStructHandles(Decoded_VkPushDescriptorSetWithTemplateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table)
-{
-    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
-    {
-        VkPushDescriptorSetWithTemplateInfoKHR* value = wrapper->decoded_value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_info_table);
-        }
-
-        value->descriptorUpdateTemplate = handle_mapping::MapHandle<DescriptorUpdateTemplateInfo>(wrapper->descriptorUpdateTemplate, object_info_table, &VulkanObjectInfoTable::GetDescriptorUpdateTemplateInfo);
-
-        value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
-    }
-}
-
 void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -261,8 +261,6 @@ void MapStructHandles(Decoded_VkPushConstantsInfoKHR* wrapper, const VulkanObjec
 
 void MapStructHandles(Decoded_VkPushDescriptorSetInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
 
-void MapStructHandles(Decoded_VkPushDescriptorSetWithTemplateInfoKHR* wrapper, const VulkanObjectInfoTable& object_info_table);
-
 void MapStructHandles(Decoded_VkSetDescriptorBufferOffsetsInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
 
 void MapStructHandles(Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
@@ -889,17 +889,6 @@ void UnwrapStructHandles(VkPushDescriptorSetInfoKHR* value, HandleUnwrapMemory* 
     }
 }
 
-void UnwrapStructHandles(VkPushDescriptorSetWithTemplateInfoKHR* value, HandleUnwrapMemory* unwrap_memory)
-{
-    if (value != nullptr)
-    {
-        if (value->pNext != nullptr)
-        {
-            value->pNext = UnwrapPNextStructHandles(value->pNext, unwrap_memory);
-        }
-    }
-}
-
 void UnwrapStructHandles(VkSetDescriptorBufferOffsetsInfoEXT* value, HandleUnwrapMemory* unwrap_memory)
 {
     if (value != nullptr)

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -261,8 +261,6 @@ void UnwrapStructHandles(VkPushConstantsInfoKHR* value, HandleUnwrapMemory* unwr
 
 void UnwrapStructHandles(VkPushDescriptorSetInfoKHR* value, HandleUnwrapMemory* unwrap_memory);
 
-void UnwrapStructHandles(VkPushDescriptorSetWithTemplateInfoKHR* value, HandleUnwrapMemory* unwrap_memory);
-
 void UnwrapStructHandles(VkSetDescriptorBufferOffsetsInfoEXT* value, HandleUnwrapMemory* unwrap_memory);
 
 void UnwrapStructHandles(VkBindDescriptorBufferEmbeddedSamplersInfoEXT* value, HandleUnwrapMemory* unwrap_memory);

--- a/framework/generated/generated_vulkan_struct_to_json.cpp
+++ b/framework/generated/generated_vulkan_struct_to_json.cpp
@@ -9338,22 +9338,6 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPushDescriptorSe
     }
 }
 
-void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPushDescriptorSetWithTemplateInfoKHR* data, const JsonOptions& options)
-{
-    if (data && data->decoded_value)
-    {
-        const VkPushDescriptorSetWithTemplateInfoKHR& decoded_value = *data->decoded_value;
-        const Decoded_VkPushDescriptorSetWithTemplateInfoKHR& meta_struct = *data;
-
-        FieldToJson(jdata["sType"], decoded_value.sType, options);
-        HandleToJson(jdata["descriptorUpdateTemplate"], meta_struct.descriptorUpdateTemplate, options);
-        HandleToJson(jdata["layout"], meta_struct.layout, options);
-        FieldToJson(jdata["set"], decoded_value.set, options);
-        FieldToJson(jdata["pData"], meta_struct.pData, options);
-        FieldToJson(jdata["pNext"], meta_struct.pNext, options);
-    }
-}
-
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSetDescriptorBufferOffsetsInfoEXT* data, const JsonOptions& options)
 {
     if (data && data->decoded_value)

--- a/framework/generated/generated_vulkan_struct_to_json.h
+++ b/framework/generated/generated_vulkan_struct_to_json.h
@@ -603,7 +603,6 @@ void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindMemoryStatus
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindDescriptorSetsInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPushConstantsInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPushDescriptorSetInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());
-void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkPushDescriptorSetWithTemplateInfoKHR* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkSetDescriptorBufferOffsetsInfoEXT* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkBindDescriptorBufferEmbeddedSamplersInfoEXT* data, const util::JsonOptions& options = util::JsonOptions());
 void FieldToJson(nlohmann::ordered_json& jdata, const Decoded_VkDebugReportCallbackCreateInfoEXT* data, const util::JsonOptions& options = util::JsonOptions());

--- a/framework/generated/vulkan_generators/blacklists.json
+++ b/framework/generated/vulkan_generators/blacklists.json
@@ -10,6 +10,7 @@
     "vkUpdateDescriptorSetWithTemplate",
     "vkUpdateDescriptorSetWithTemplateKHR",
     "vkCmdPushDescriptorSetWithTemplateKHR",
+    "vkCmdPushDescriptorSetWithTemplate2KHR",
     "vkBuildAccelerationStructuresKHR",
     "vkCopyAccelerationStructureKHR",
     "vkCreateRayTracingPipelinesKHR"
@@ -29,6 +30,7 @@
     "VkDescriptorImageInfo",
     "VkWriteDescriptorSet",
     "VkPerformanceValueINTEL",
+    "VkPushDescriptorSetWithTemplateInfoKHR",
     "VkAccelerationStructureGeometryKHR",
     "VkAccelerationStructureMotionInstanceNV"
   ]


### PR DESCRIPTION
Fixes #1400 

Adds support for vkCmdPushDescriptorSetWithTemplate2KHR() such that the functionality is at parity with the original vkCmdPushDescriptorSetWithTemplateKHR(). That is to say, everything works except trimmed replay.