### PR TITLE
Fix bug in which no .bin files are created when doing a dx12 dump resources

### DIFF
--- a/framework/decode/dx12_dump_resources.cpp
+++ b/framework/decode/dx12_dump_resources.cpp
@@ -75,7 +75,7 @@ void Dx12DumpResources::StartDump(ID3D12Device* device, const std::string& captu
     {
         json_filename_ = json_filename_.substr(0, ext_pos);
     }
-    json_options_.data_sub_dir = json_filename_;
+    json_options_.data_sub_dir = util::filepath::GetFilenameStem(json_filename_);
     json_options_.root_dir     = util::filepath::GetBasedir(json_filename_);
     json_filename_ += "_dr." + util::get_json_format(json_options_.format);
 

--- a/framework/decode/dx12_dump_resources.h
+++ b/framework/decode/dx12_dump_resources.h
@@ -140,7 +140,8 @@ class Dx12DumpResources
 {
   public:
     Dx12DumpResources(std::function<DxObjectInfo*(format::HandleId id)> get_object_info_func,
-                      const graphics::Dx12GpuVaMap&                     gpu_va_map);
+                      const graphics::Dx12GpuVaMap&                     gpu_va_map,
+                      DxReplayOptions&                                  options);
 
     std::vector<CommandSet> GetCommandListsForDumpResources(DxObjectInfo*     command_list_object_info,
                                                             uint64_t          block_index,
@@ -274,6 +275,7 @@ class Dx12DumpResources
 
     std::function<DxObjectInfo*(format::HandleId id)> get_object_info_func_;
     const graphics::Dx12GpuVaMap&                     gpu_va_map_;
+    const DxReplayOptions&                            options_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -638,7 +638,7 @@ void Dx12ReplayConsumerBase::SetDumpTarget(TrackDumpDrawcall& track_dump_target)
     if (!dump_resources_)
     {
         auto get_object_func = std::bind(&Dx12ReplayConsumerBase::GetObjectInfo, this, std::placeholders::_1);
-        dump_resources_      = std::make_unique<Dx12DumpResources>(get_object_func, gpu_va_map_);
+        dump_resources_      = std::make_unique<Dx12DumpResources>(get_object_func, gpu_va_map_, options_);
     }
     dump_resources_->SetDumpTarget(track_dump_target);
 }

--- a/framework/decode/vulkan_replay_dump_resources_json.cpp
+++ b/framework/decode/vulkan_replay_dump_resources_json.cpp
@@ -86,7 +86,7 @@ bool VulkanReplayDumpResourcesJson::Open(const std::string& infile, const std::s
     {
         outfile = outfile.substr(0, outfile.size() - 5);
     }
-    outfile = outfile + "_rd.json";
+    outfile = outfile + "_dr.json";
 
     if (!InitializeFile(outfile))
     {


### PR DESCRIPTION
Files would not be created when the full path was specified for the capture file on the command line.
