### PR TITLE
Allocator support VideoSession

### DIFF
--- a/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
+++ b/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
@@ -6144,6 +6144,7 @@ private:
     VmaPool m_hParentPool; // VK_NULL_HANDLE if not belongs to custom pool.
     uint32_t m_MemoryTypeIndex;
     uint32_t m_Id;
+public:
     VkDeviceMemory m_hMemory;
 
     /*
@@ -6151,7 +6152,9 @@ private:
     Also protects m_MapCount, m_pMappedData.
     Allocations, deallocations, any change in m_pMetadata is protected by parent's VmaBlockVector::m_Mutex.
     */
+public:
     VMA_MUTEX m_MapAndBindMutex;
+private:
     VmaMappingHysteresis m_MappingHysteresis;
     uint32_t m_MapCount;
     void* m_pMappedData;

--- a/framework/decode/vulkan_default_allocator.h
+++ b/framework/decode/vulkan_default_allocator.h
@@ -72,6 +72,16 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                               const VkAllocationCallbacks* allocation_callbacks,
                               ResourceData                 allocator_data) override;
 
+    virtual VkResult CreateVideoSession(const VkVideoSessionCreateInfoKHR* create_info,
+                                        const VkAllocationCallbacks*       allocation_callbacks,
+                                        format::HandleId                   capture_id,
+                                        VkVideoSessionKHR*                 session,
+                                        std::vector<ResourceData>*         allocator_datas) override;
+
+    virtual void DestroyVideoSession(VkVideoSessionKHR            session,
+                                     const VkAllocationCallbacks* allocation_callbacks,
+                                     std::vector<ResourceData>    allocator_datas) override;
+
     virtual void GetImageSubresourceLayout(VkImage                    image,
                                            const VkImageSubresource*  subresource,
                                            VkSubresourceLayout*       layout,
@@ -118,6 +128,13 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                                       const MemoryData*            allocator_memory_datas,
                                       VkMemoryPropertyFlags*       bind_memory_properties) override;
 
+    virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
+                                            uint32_t                               bind_info_count,
+                                            const VkBindVideoSessionMemoryInfoKHR* bind_infos,
+                                            const ResourceData*                    allocator_session_datas,
+                                            const MemoryData*                      allocator_memory_datas,
+                                            VkMemoryPropertyFlags*                 bind_memory_properties) override;
+
     virtual VkResult MapMemory(VkDeviceMemory   memory,
                                VkDeviceSize     offset,
                                VkDeviceSize     size,
@@ -157,6 +174,12 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                                                  const VkBindImageMemoryInfo* bind_infos,
                                                  const ResourceData*          allocator_resource_datas,
                                                  const MemoryData*            allocator_memory_datas) override;
+
+    virtual void ReportBindVideoSessionIncompatibility(VkVideoSessionKHR                      video_session,
+                                                       uint32_t                               bind_info_count,
+                                                       const VkBindVideoSessionMemoryInfoKHR* bind_infos,
+                                                       const ResourceData*                    allocator_resource_datas,
+                                                       const MemoryData* allocator_memory_datas) override;
 
     // Direct allocation methods that perform memory allocation and resource creation without performing memory
     // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so

--- a/framework/decode/vulkan_default_allocator.h
+++ b/framework/decode/vulkan_default_allocator.h
@@ -274,6 +274,8 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
 
     virtual bool SupportsOpaqueDeviceAddresses() override { return true; }
 
+    virtual bool SupportBindVideoSessionMemory() override { return false; }
+
   protected:
     struct ResourceAllocInfo
     {

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -537,6 +537,14 @@ struct DeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR
 struct VideoSessionKHRInfo : VulkanObjectInfo<VkVideoSessionKHR>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
+
+    // The following values are only used for memory portability.
+    std::vector<VulkanResourceAllocator::ResourceData> allocator_datas;
+
+    // This is only used when loading the initial state for trimmed files.
+    std::vector<VkMemoryPropertyFlags> memory_property_flags;
+
+    uint32_t queue_family_index{ 0 };
 };
 
 struct ShaderEXTInfo : VulkanObjectInfo<VkShaderEXT>

--- a/framework/decode/vulkan_realign_allocator.h
+++ b/framework/decode/vulkan_realign_allocator.h
@@ -75,6 +75,13 @@ class VulkanRealignAllocator : public VulkanDefaultAllocator
                                       const MemoryData*            allocator_memory_datas,
                                       VkMemoryPropertyFlags*       bind_memory_properties) override;
 
+    virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
+                                            uint32_t                               bind_info_count,
+                                            const VkBindVideoSessionMemoryInfoKHR* bind_infos,
+                                            const ResourceData*                    allocator_session_datas,
+                                            const MemoryData*                      allocator_memory_datas,
+                                            VkMemoryPropertyFlags*                 bind_memory_properties) override;
+
     virtual VkResult MapMemory(VkDeviceMemory   memory,
                                VkDeviceSize     offset,
                                VkDeviceSize     size,

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -305,6 +305,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     }
 
     virtual bool SupportsOpaqueDeviceAddresses() override { return false; }
+    virtual bool SupportBindVideoSessionMemory() override { return true; }
 
   private:
     struct MemoryAllocInfo;

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -76,6 +76,16 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                               const VkAllocationCallbacks* allocation_callbacks,
                               ResourceData                 allocator_data) override;
 
+    virtual VkResult CreateVideoSession(const VkVideoSessionCreateInfoKHR* create_info,
+                                        const VkAllocationCallbacks*       allocation_callbacks,
+                                        format::HandleId                   capture_id,
+                                        VkVideoSessionKHR*                 session,
+                                        std::vector<ResourceData>*         allocator_datas) override;
+
+    virtual void DestroyVideoSession(VkVideoSessionKHR            session,
+                                     const VkAllocationCallbacks* allocation_callbacks,
+                                     std::vector<ResourceData>    allocator_datas) override;
+
     virtual void GetImageSubresourceLayout(VkImage                    image,
                                            const VkImageSubresource*  subresource,
                                            VkSubresourceLayout*       layout,
@@ -140,6 +150,13 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                       const MemoryData*            allocator_memory_datas,
                                       VkMemoryPropertyFlags*       bind_memory_properties) override;
 
+    virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
+                                            uint32_t                               bind_info_count,
+                                            const VkBindVideoSessionMemoryInfoKHR* bind_infos,
+                                            const ResourceData*                    allocator_session_datas,
+                                            const MemoryData*                      allocator_memory_datas,
+                                            VkMemoryPropertyFlags*                 bind_memory_properties) override;
+
     virtual VkResult MapMemory(VkDeviceMemory   memory,
                                VkDeviceSize     offset,
                                VkDeviceSize     size,
@@ -179,6 +196,12 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                                  const VkBindImageMemoryInfo* bind_infos,
                                                  const ResourceData*          allocator_resource_datas,
                                                  const MemoryData*            allocator_memory_datas) override;
+
+    virtual void ReportBindVideoSessionIncompatibility(VkVideoSessionKHR                      video_session,
+                                                       uint32_t                               bind_info_count,
+                                                       const VkBindVideoSessionMemoryInfoKHR* bind_infos,
+                                                       const ResourceData*                    allocator_resource_datas,
+                                                       const MemoryData* allocator_memory_datas) override;
 
     // Direct allocation methods that perform memory allocation and resource creation without performing memory
     // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so
@@ -293,6 +316,14 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         VkSubresourceLayout rebind{};
     };
 
+    enum ObjectType
+    {
+        none          = 0,
+        buffer        = 1,
+        image         = 2,
+        video_session = 3,
+    };
+
     struct ResourceAllocInfo
     {
         MemoryAllocInfo* memory_info{ nullptr };
@@ -302,7 +333,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         VkDeviceSize     original_offset{ 0 };
         VkDeviceSize     rebind_offset{ 0 };
         VkDeviceSize     size{ 0 };
-        bool             is_image{ false };
+        ObjectType       object_type{ none };
         VkFlags          usage{ 0 };
         VkImageTiling    tiling{};
         uint32_t         height{ 0 };
@@ -322,6 +353,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         std::unique_ptr<uint8_t[]>                       original_content;
         std::unordered_map<VkBuffer, ResourceAllocInfo*> original_buffers;
         std::unordered_map<VkImage, ResourceAllocInfo*>  original_images;
+        std::unordered_map<VkVideoSessionKHR, ResourceAllocInfo*> original_sessions;
     };
 
   private:
@@ -377,6 +409,9 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                        VkImageTiling               tiling,
                                        VkMemoryPropertyFlags       capture_properties,
                                        const VkMemoryRequirements& replay_requirements);
+
+    VmaMemoryUsage GetVideoSeesionMemoryUsage(VkMemoryPropertyFlags       capture_properties,
+                                              const VkMemoryRequirements& replay_requirements);
 
     VmaMemoryUsage AdjustMemoryUsage(VmaMemoryUsage desired_usage, const VkMemoryRequirements& replay_requirements);
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -676,6 +676,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                       uint32_t                                                   bindInfoCount,
                                       const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos);
 
+    VkResult OverrideBindVideoSessionMemoryKHR(
+        PFN_vkBindVideoSessionMemoryKHR                                func,
+        VkResult                                                       original_result,
+        const DeviceInfo*                                              device_info,
+        VideoSessionKHRInfo*                                           video_session_info,
+        uint32_t                                                       bindSessionMemoryInfoCount,
+        StructPointerDecoder<Decoded_VkBindVideoSessionMemoryInfoKHR>* pBindSessionMemoryInfos);
+
     VkResult OverrideCreateBuffer(PFN_vkCreateBuffer                                         func,
                                   VkResult                                                   original_result,
                                   const DeviceInfo*                                          device_info,
@@ -699,6 +707,18 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                               const DeviceInfo*                                          device_info,
                               ImageInfo*                                                 image_info,
                               const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
+
+    VkResult OverrideCreateVideoSessionKHR(PFN_vkCreateVideoSessionKHR func,
+                                           VkResult                    original_result,
+                                           const DeviceInfo*           device_info,
+                                           const StructPointerDecoder<Decoded_VkVideoSessionCreateInfoKHR>* pCreateInfo,
+                                           const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
+                                           HandlePointerDecoder<VkVideoSessionKHR>* pVideoSession);
+
+    void OverrideDestroyVideoSessionKHR(PFN_vkDestroyVideoSessionKHR                               func,
+                                        const DeviceInfo*                                          device_info,
+                                        VideoSessionKHRInfo*                                       video_session_info,
+                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideGetImageSubresourceLayout(PFN_vkGetImageSubresourceLayout                         func,
                                            const DeviceInfo*                                       device_info,

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -295,6 +295,7 @@ class VulkanResourceAllocator
                                                         const MemoryData*          allocator_datas) = 0;
 
     virtual bool SupportsOpaqueDeviceAddresses() = 0;
+    virtual bool SupportBindVideoSessionMemory() = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -68,11 +68,15 @@ class VulkanResourceAllocator
         PFN_vkCmdCopyBuffer                          cmd_copy_buffer{ nullptr };
         PFN_vkCreateImage                            create_image{ nullptr };
         PFN_vkDestroyImage                           destroy_image{ nullptr };
+        PFN_vkCreateVideoSessionKHR                  create_video_session{ nullptr };
+        PFN_vkDestroyVideoSessionKHR                 destroy_video_session{ nullptr };
         PFN_vkGetImageMemoryRequirements             get_image_memory_requirements{ nullptr };
         PFN_vkGetImageMemoryRequirements2            get_image_memory_requirements2{ nullptr };
+        PFN_vkGetVideoSessionMemoryRequirementsKHR   get_video_session_memory_requirements{ nullptr };
         PFN_vkGetImageSubresourceLayout              get_image_subresource_layout{ nullptr };
         PFN_vkBindImageMemory                        bind_image_memory{ nullptr };
         PFN_vkBindImageMemory2                       bind_image_memory2{ nullptr };
+        PFN_vkBindVideoSessionMemoryKHR              bind_video_session_memory{ nullptr };
         PFN_vkGetInstanceProcAddr                    get_instance_proc_addr{ nullptr };
         PFN_vkGetDeviceProcAddr                      get_device_proc_addr{ nullptr };
         PFN_vkGetDeviceQueue                         get_device_queue{ nullptr };
@@ -122,6 +126,16 @@ class VulkanResourceAllocator
     virtual void
     DestroyImage(VkImage image, const VkAllocationCallbacks* allocation_callbacks, ResourceData allocator_data) = 0;
 
+    virtual VkResult CreateVideoSession(const VkVideoSessionCreateInfoKHR* create_info,
+                                        const VkAllocationCallbacks*       allocation_callbacks,
+                                        format::HandleId                   capture_id,
+                                        VkVideoSessionKHR*                 session,
+                                        std::vector<ResourceData>*         allocator_datas) = 0;
+
+    virtual void DestroyVideoSession(VkVideoSessionKHR            session,
+                                     const VkAllocationCallbacks* allocation_callbacks,
+                                     std::vector<ResourceData>    allocator_datas) = 0;
+
     virtual void GetImageSubresourceLayout(VkImage                    image,
                                            const VkImageSubresource*  subresource,
                                            VkSubresourceLayout*       layout,
@@ -167,6 +181,13 @@ class VulkanResourceAllocator
                                       const MemoryData*            allocator_memory_datas,
                                       VkMemoryPropertyFlags*       bind_memory_properties) = 0;
 
+    virtual VkResult BindVideoSessionMemory(VkVideoSessionKHR                      video_session,
+                                            uint32_t                               bind_info_count,
+                                            const VkBindVideoSessionMemoryInfoKHR* bind_infos,
+                                            const ResourceData*                    allocator_session_datas,
+                                            const MemoryData*                      allocator_memory_datas,
+                                            VkMemoryPropertyFlags*                 bind_memory_properties) = 0;
+
     virtual VkResult MapMemory(VkDeviceMemory   memory,
                                VkDeviceSize     offset,
                                VkDeviceSize     size,
@@ -207,6 +228,12 @@ class VulkanResourceAllocator
                                                  const VkBindImageMemoryInfo* bind_infos,
                                                  const ResourceData*          allocator_resource_datas,
                                                  const MemoryData*            allocator_memory_datas) = 0;
+
+    virtual void ReportBindVideoSessionIncompatibility(VkVideoSessionKHR                      video_session,
+                                                       uint32_t                               bind_info_count,
+                                                       const VkBindVideoSessionMemoryInfoKHR* bind_infos,
+                                                       const ResourceData*                    allocator_resource_datas,
+                                                       const MemoryData* allocator_memory_datas) = 0;
 
     // Direct allocation methods that perform memory allocation and resource creation without performing memory
     // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -4126,16 +4126,15 @@ void VulkanReplayConsumer::Process_vkCreateVideoSessionKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkVideoSessionKHR>*    pVideoSession)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkVideoSessionCreateInfoKHR* in_pCreateInfo = pCreateInfo->GetPointer();
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
     if (!pVideoSession->IsNull()) { pVideoSession->SetHandleLength(1); }
-    VkVideoSessionKHR* out_pVideoSession = pVideoSession->GetHandlePointer();
+    VideoSessionKHRInfo handle_info;
+    pVideoSession->SetConsumerData(0, &handle_info);
 
-    VkResult replay_result = GetDeviceTable(in_device)->CreateVideoSessionKHR(in_device, in_pCreateInfo, in_pAllocator, out_pVideoSession);
+    VkResult replay_result = OverrideCreateVideoSessionKHR(GetDeviceTable(in_device->handle)->CreateVideoSessionKHR, returnValue, in_device, pCreateInfo, pAllocator, pVideoSession);
     CheckResult("vkCreateVideoSessionKHR", returnValue, replay_result, call_info);
 
-    AddHandle<VideoSessionKHRInfo>(device, pVideoSession->GetPointer(), out_pVideoSession, &VulkanObjectInfoTable::AddVideoSessionKHRInfo);
+    AddHandle<VideoSessionKHRInfo>(device, pVideoSession->GetPointer(), pVideoSession->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddVideoSessionKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyVideoSessionKHR(
@@ -4144,11 +4143,10 @@ void VulkanReplayConsumer::Process_vkDestroyVideoSessionKHR(
     format::HandleId                            videoSession,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkVideoSessionKHR in_videoSession = MapHandle<VideoSessionKHRInfo>(videoSession, &VulkanObjectInfoTable::GetVideoSessionKHRInfo);
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_videoSession = GetObjectInfoTable().GetVideoSessionKHRInfo(videoSession);
 
-    GetDeviceTable(in_device)->DestroyVideoSessionKHR(in_device, in_videoSession, in_pAllocator);
+    OverrideDestroyVideoSessionKHR(GetDeviceTable(in_device->handle)->DestroyVideoSessionKHR, in_device, in_videoSession, pAllocator);
     RemoveHandle(videoSession, &VulkanObjectInfoTable::RemoveVideoSessionKHRInfo);
 }
 
@@ -4179,12 +4177,12 @@ void VulkanReplayConsumer::Process_vkBindVideoSessionMemoryKHR(
     uint32_t                                    bindSessionMemoryInfoCount,
     StructPointerDecoder<Decoded_VkBindVideoSessionMemoryInfoKHR>* pBindSessionMemoryInfos)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkVideoSessionKHR in_videoSession = MapHandle<VideoSessionKHRInfo>(videoSession, &VulkanObjectInfoTable::GetVideoSessionKHRInfo);
-    const VkBindVideoSessionMemoryInfoKHR* in_pBindSessionMemoryInfos = pBindSessionMemoryInfos->GetPointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_videoSession = GetObjectInfoTable().GetVideoSessionKHRInfo(videoSession);
+
     MapStructArrayHandles(pBindSessionMemoryInfos->GetMetaStructPointer(), pBindSessionMemoryInfos->GetLength(), GetObjectInfoTable());
 
-    VkResult replay_result = GetDeviceTable(in_device)->BindVideoSessionMemoryKHR(in_device, in_videoSession, bindSessionMemoryInfoCount, in_pBindSessionMemoryInfos);
+    VkResult replay_result = OverrideBindVideoSessionMemoryKHR(GetDeviceTable(in_device->handle)->BindVideoSessionMemoryKHR, returnValue, in_device, in_videoSession, bindSessionMemoryInfoCount, pBindSessionMemoryInfos);
     CheckResult("vkBindVideoSessionMemoryKHR", returnValue, replay_result, call_info);
 }
 

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -114,6 +114,9 @@
     "vkCmdInsertDebugUtilsLabelEXT": "OverrideCmdInsertDebugUtilsLabelEXT",
     "vkUpdateDescriptorSets": "OverrideUpdateDescriptorSets",
     "vkCreateGraphicsPipelines": "OverrideCreateGraphicsPipelines",
-    "vkCreateComputePipelines": "OverrideCreateComputePipelines"
+    "vkCreateComputePipelines": "OverrideCreateComputePipelines",
+    "vkCreateVideoSessionKHR": "OverrideCreateVideoSessionKHR",
+    "vkDestroyVideoSessionKHR": "OverrideDestroyVideoSessionKHR",
+    "vkBindVideoSessionMemoryKHR": "OverrideBindVideoSessionMemoryKHR"
   }
 }


### PR DESCRIPTION
Closed: https://github.com/LunarG/gfxreconstruct/issues/1593

1. Allocator does something for `VideoSession`, that is similar with Buffer and Image. The different is that a VideoSeesion could bind plural memories. See `GetVideoSessionMemoryRequirements` and `BindVideoSessionMemory`.

2. VMA doesn't support `VideoSession`
See https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/issues/307
We need to do the unsupported part ourselves.

3. replay MemoryRequirements could have different count and size. Depend on device, driver, and queue. Some have one big
MemoryRequirements. Some have plural small. Use replay MemoryRequirements to AllocateMemory and Bind on RebindAllocator.

Capture files from sample code: https://github.com/nvpro-samples/vk_video_samples
Nvidia 2070 v555.99
[gfxr_vk-video-enc-test-n2070.zip](https://github.com/user-attachments/files/16183520/gfxr_vk-video-enc-test-n2070.zip)
[gfxr_vk-video-dec-test-n2070.zip](https://github.com/user-attachments/files/16183521/gfxr_vk-video-dec-test-n2070.zip)
Nvidia 3070 v556.12
[gfxr_vk-video-enc-test-n3070.zip](https://github.com/user-attachments/files/16170969/gfxr_vk-video-enc-test-n3070.zip)
[gfxr_vk-video-dec-test-n3070.zip](https://github.com/user-attachments/files/16170970/gfxr_vk-video-dec-test-n3070.zip)

Those capture files could replay on the same device with and without `-m rebind`. 

**BUT** it could fail when it replays on different devices because of **the incompatible Queue** that doesn't support `VK_QUEUE_VIDEO_ENCODE_BIT_KHR` or `VK_QUEUE_VIDEO_DECODE_BIT_KHR`. ~~Capturing with `GFXRECON_QUEUE_ZERO_ONLY` could avoid this issue.~~  Refer to  `Implement queue portability` https://github.com/LunarG/gfxreconstruct/issues/856. 

Update: `GFXRECON_QUEUE_ZERO_ONLY` might not able to fix incompatible Queue issue. `VK_QUEUE_VIDEO_ENCODE_BIT_KHR` and `VK_QUEUE_VIDEO_DECODE_BIT_KHR` might not is in Queue Family 0. 

My RTX 2070: VK_QUEUE_VIDEO_ENCODE_BIT_KHR is in Queue Family 4.  VK_QUEUE_VIDEO_DECODE_BIT_KHR is in Queue Family 3.  Queue Family 0 doesn't have them.

My RX 6800: VK_QUEUE_VIDEO_DECODE_BIT_KHR  in Queue Family 4. No VK_QUEUE_VIDEO_ENCODE_BIT_KHR.

Add an issue for adjust queue family https://github.com/LunarG/gfxreconstruct/issues/1626

Validation Layers could cause crash during replay https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8267
