### PR TITLE
Fix recapture trim failure caused by adding usage flag in trim capturing

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1,7 +1,7 @@
 /*
  ** Copyright (c) 2018-2021 Valve Corporation
  ** Copyright (c) 2018-2023 LunarG, Inc.
- ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ ** Copyright (c) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  **
  ** Permission is hereby granted, free of charge, to any person obtaining a
  ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -801,11 +801,6 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
 
     VkBufferCreateInfo modified_create_info = (*pCreateInfo);
 
-    if (IsTrimEnabled())
-    {
-        modified_create_info.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-    }
-
     bool                uses_address         = false;
     VkBufferCreateFlags address_create_flags = 0;
     VkBufferUsageFlags  address_usage_flags  = 0;
@@ -879,35 +874,6 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
         }
     }
 
-    return result;
-}
-
-VkResult VulkanCaptureManager::OverrideCreateImage(VkDevice                     device,
-                                                   const VkImageCreateInfo*     pCreateInfo,
-                                                   const VkAllocationCallbacks* pAllocator,
-                                                   VkImage*                     pImage)
-{
-    auto                     handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
-    const VkImageCreateInfo* pCreateInfo_unwrapped =
-        vulkan_wrappers::UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
-
-    VkImageCreateInfo modified_create_info = (*pCreateInfo_unwrapped);
-
-    if (IsTrimEnabled())
-    {
-        modified_create_info.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    }
-
-    VkResult result =
-        vulkan_wrappers::GetDeviceTable(device)->CreateImage(device, &modified_create_info, pAllocator, pImage);
-
-    if (result >= 0)
-    {
-        vulkan_wrappers::CreateWrappedHandle<vulkan_wrappers::DeviceWrapper,
-                                             vulkan_wrappers::NoParentWrapper,
-                                             vulkan_wrappers::ImageWrapper>(
-            device, vulkan_wrappers::NoParentWrapper::kHandleValue, pImage, VulkanCaptureManager::GetUniqueId);
-    }
     return result;
 }
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -281,11 +281,6 @@ class VulkanCaptureManager : public ApiCaptureManager
                                   const VkAllocationCallbacks* pAllocator,
                                   VkBuffer*                    pBuffer);
 
-    VkResult OverrideCreateImage(VkDevice                     device,
-                                 const VkImageCreateInfo*     pCreateInfo,
-                                 const VkAllocationCallbacks* pAllocator,
-                                 VkImage*                     pImage);
-
     VkResult OverrideCreateAccelerationStructureKHR(VkDevice                                    device,
                                                     const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
                                                     const VkAllocationCallbacks*                pAllocator,

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -1,7 +1,7 @@
 /*
  ** Copyright (c) 2018-2021 Valve Corporation
  ** Copyright (c) 2018-2023 LunarG, Inc.
- ** Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ ** Copyright (c) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  **
  ** Permission is hereby granted, free of charge, to any person obtaining a
  ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -3,7 +3,6 @@
         "vkCreateInstance": "VulkanCaptureManager::OverrideCreateInstance",
         "vkCreateDevice": "manager->OverrideCreateDevice",
         "vkCreateBuffer": "manager->OverrideCreateBuffer",
-        "vkCreateImage": "manager->OverrideCreateImage",
         "vkAllocateMemory": "manager->OverrideAllocateMemory",
         "vkGetPhysicalDeviceToolPropertiesEXT": "manager->OverrideGetPhysicalDeviceToolPropertiesEXT",
         "vkCreateAccelerationStructureKHR": "manager->OverrideCreateAccelerationStructureKHR",

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2018-2019 Valve Corporation
 # Copyright (c) 2018-2019 LunarG, Inc.
-# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -221,6 +221,28 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
 
         return [call_setup_expr, '{}({})->{}({})'.format(dispatchfunc, object_name, name[2:], arg_list)]
 
+    def change_usage_flag_for_image_and_buffer(self, name, arg_list_string, indent):
+        arg_list = arg_list_string.split(',')
+        comment = indent + '// While attempting to recapture trim for a particular title\'s trace file, an issue related to binding\n'\
+                 + indent + '// resources to memory arose, leading to playback failure. Further investigation uncovered that the root cause\n'\
+                 + indent + '// was the addition of VK_BUFFER_USAGE_TRANSFER_SRC_BIT or VK_IMAGE_USAGE_TRANSFER_SRC_BIT flags in the\n'\
+                 + indent + '// image/buffer create info during trim capture handling. This resulted in a change in memory requirements for\n'\
+                 + indent + '// some resources compared to the original capturing process, which caused memory binding errors and playback\n'\
+                 + indent + '// failure. To resolve this, here we add the flags into the capturing process and captured trace file, ensuring\n'\
+                 + indent + '// consistent memory usage across all scenarios (including target title running with capturing, full trace or\n'\
+                 + indent + '// trim trace playback, and recapturing trace files with or without trim). This solution fixed the issues\n'\
+                 + indent + '// described above.\n'
+        if name == 'vkCreateBuffer':
+            change_usage_flag = '\n' + comment + '\n' + indent + 'VkBufferCreateInfo modified_create_info = (*{});\n' \
+                 + indent + 'modified_create_info.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;\n' \
+                 + indent + '{} = const_cast<const VkBufferCreateInfo*>(&modified_create_info);\n'
+            return change_usage_flag.format(arg_list[1].strip(), arg_list[1].strip())
+        else: # name is vkCreateImage
+            change_usage_flag = '\n' + comment + '\n' + indent + 'VkImageCreateInfo modified_create_info = (*{});\n' \
+                 + indent + 'modified_create_info.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;\n' \
+                 + indent + '{} = const_cast<const VkImageCreateInfo*>(&modified_create_info);\n'
+            return change_usage_flag.format(arg_list[1].strip(), arg_list[1].strip())
+
     def make_cmd_body(self, return_type, name, values):
         """Command definition."""
         indent = ' ' * self.INDENT_SIZE
@@ -265,6 +287,10 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
         body += indent + 'CustomEncoderPreCall<format::ApiCallId::ApiCall_{}>::Dispatch({}, {});\n'.format(
             name, capture_manager, arg_list
         )
+
+        # Change usage flag of create info for vkCreateBuffer and vkCreateImage
+        if name in ['vkCreateBuffer', 'vkCreateImage']:
+            body += self.change_usage_flag_for_image_and_buffer(name, arg_list, indent)
 
         if not encode_after:
             body += self.make_parameter_encoding(


### PR DESCRIPTION
**The problem**
   
While attempting to recapture trim for a particular title's full trace file on the same machine where the full trace was captured, an error related to binding resources to memory arose, leading to playback failure. The root cause was the addition of VK_BUFFER_USAGE_TRANSFER_SRC_BIT/VK_IMAGE_USAGE_TRANSFER_SRC_BIT flags in the trim capture handling. This resulted in a change in memory requirements for some resources, which caused memory binding errors and playback failure. 

**The solution**

The commit fixes the issue through adding the flags into the capturing process and captured trace file to ensuring consistent memory usage across all scenarios (including target title running with capturing, full trace or trim trace playback, and recapturing trace files with or without trim).

**Result**

Tested the target title with the build of the pull request, the pull request fixed the capture trim issue.