### PR TITLE
Fix `vkSetDebugUtilsObjectNameEXT` and `vkSetDebugUtilsObjectTagEXT` for `VkDeviceMemory` objects when using rebind allocator.

### DIFF
--- a/framework/decode/vulkan_default_allocator.cpp
+++ b/framework/decode/vulkan_default_allocator.cpp
@@ -488,6 +488,22 @@ VkResult VulkanDefaultAllocator::InvalidateMappedMemoryRanges(uint32_t          
     return functions_.invalidate_memory_ranges(device_, memory_range_count, memory_ranges);
 }
 
+VkResult VulkanDefaultAllocator::SetDebugUtilsObjectNameEXT(VkDevice                       device,
+                                                            VkDebugUtilsObjectNameInfoEXT* name_info,
+                                                            uintptr_t                      allocator_data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(allocator_data);
+    return functions_.set_debug_utils_object_name(device, name_info);
+}
+
+VkResult VulkanDefaultAllocator::SetDebugUtilsObjectTagEXT(VkDevice                      device,
+                                                           VkDebugUtilsObjectTagInfoEXT* tag_info,
+                                                           uintptr_t                     allocator_data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(allocator_data);
+    return functions_.set_debug_utils_object_tag(device, tag_info);
+}
+
 VkResult VulkanDefaultAllocator::WriteMappedMemoryRange(MemoryData     allocator_data,
                                                         uint64_t       offset,
                                                         uint64_t       size,

--- a/framework/decode/vulkan_default_allocator.h
+++ b/framework/decode/vulkan_default_allocator.h
@@ -152,6 +152,14 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                                                   const VkMappedMemoryRange* memory_ranges,
                                                   const MemoryData*          allocator_datas) override;
 
+    virtual VkResult SetDebugUtilsObjectNameEXT(VkDevice                       device,
+                                                VkDebugUtilsObjectNameInfoEXT* name_info,
+                                                uintptr_t                      allocator_data) override;
+
+    virtual VkResult SetDebugUtilsObjectTagEXT(VkDevice                      device,
+                                               VkDebugUtilsObjectTagInfoEXT* tag_info,
+                                               uintptr_t                     allocator_data) override;
+
     virtual VkResult
     WriteMappedMemoryRange(MemoryData allocator_data, uint64_t offset, uint64_t size, const uint8_t* data) override;
 

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -632,7 +632,7 @@ VkResult VulkanRebindAllocator::BindBufferMemory(VkBuffer                       
                                                resource_alloc_info,
                                                allocation_info.deviceMemory,
                                                VK_OBJECT_TYPE_BUFFER,
-                                               reinterpret_cast<uint64_t>(buffer));
+                                               VK_HANDLE_TO_UINT64(buffer));
             }
         }
     }
@@ -724,7 +724,7 @@ VkResult VulkanRebindAllocator::BindBufferMemory2(uint32_t                      
                                                        resource_alloc_info,
                                                        allocation_info.deviceMemory,
                                                        VK_OBJECT_TYPE_BUFFER,
-                                                       reinterpret_cast<uint64_t>(buffer));
+                                                       VK_HANDLE_TO_UINT64(buffer));
                     }
                 }
             }
@@ -858,7 +858,7 @@ VkResult VulkanRebindAllocator::BindImageMemory(VkImage                         
                                                    resource_alloc_info,
                                                    allocation_info.deviceMemory,
                                                    VK_OBJECT_TYPE_IMAGE,
-                                                   reinterpret_cast<uint64_t>(image));
+                                                   VK_HANDLE_TO_UINT64(image));
                 }
             }
         }
@@ -971,7 +971,7 @@ VkResult VulkanRebindAllocator::BindImageMemory2(uint32_t                     bi
                                                            resource_alloc_info,
                                                            allocation_info.deviceMemory,
                                                            VK_OBJECT_TYPE_IMAGE,
-                                                           reinterpret_cast<uint64_t>(image));
+                                                           VK_HANDLE_TO_UINT64(image));
                         }
                     }
                 }

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -65,6 +65,12 @@
 #include <algorithm>
 #include <cassert>
 
+#if VK_USE_64_BIT_PTR_DEFINES == 1
+#define VK_HANDLE_TO_UINT64(value) reinterpret_cast<uint64_t>(value)
+#else
+#define VK_HANDLE_TO_UINT64(value) (value)
+#endif
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
@@ -621,6 +627,12 @@ VkResult VulkanRebindAllocator::BindBufferMemory(VkBuffer                       
                 }
 
                 (*bind_memory_properties) = property_flags;
+
+                SetBindingDebugUtilsNameAndTag(memory_alloc_info,
+                                               resource_alloc_info,
+                                               allocation_info.deviceMemory,
+                                               VK_OBJECT_TYPE_BUFFER,
+                                               reinterpret_cast<uint64_t>(buffer));
             }
         }
     }
@@ -1213,7 +1225,7 @@ VkResult VulkanRebindAllocator::SetDebugUtilsObjectNameEXT(VkDevice             
                         vmaGetAllocationInfo(allocator_, it->second->allocation, &allocation_info);
                     }
 
-                    name_info->objectHandle = reinterpret_cast<uint64_t>(allocation_info.deviceMemory);
+                    name_info->objectHandle = VK_HANDLE_TO_UINT64(allocation_info.deviceMemory);
                 }
                 break;
             }
@@ -1274,7 +1286,7 @@ VkResult VulkanRebindAllocator::SetDebugUtilsObjectTagEXT(VkDevice              
                         vmaGetAllocationInfo(allocator_, it->second->allocation, &allocation_info);
                     }
 
-                    tag_info->objectHandle = reinterpret_cast<uint64_t>(allocation_info.deviceMemory);
+                    tag_info->objectHandle = VK_HANDLE_TO_UINT64(allocation_info.deviceMemory);
                 }
                 break;
             }
@@ -2105,7 +2117,7 @@ void VulkanRebindAllocator::SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo
     if (!memory_alloc_info->debug_utils_name.empty())
     {
         name_info.objectType   = VK_OBJECT_TYPE_DEVICE_MEMORY;
-        name_info.objectHandle = reinterpret_cast<uint64_t>(device_memory);
+        name_info.objectHandle = VK_HANDLE_TO_UINT64(device_memory);
         name_info.pObjectName  = memory_alloc_info->debug_utils_name.c_str();
 
         functions_.set_debug_utils_object_name(device_, &name_info);
@@ -2114,7 +2126,7 @@ void VulkanRebindAllocator::SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo
     if (!memory_alloc_info->debug_utils_tag.empty())
     {
         tag_info.objectType   = VK_OBJECT_TYPE_DEVICE_MEMORY;
-        tag_info.objectHandle = reinterpret_cast<uint64_t>(device_memory);
+        tag_info.objectHandle = VK_HANDLE_TO_UINT64(device_memory);
         tag_info.tagName      = memory_alloc_info->debug_utils_tag_name;
         tag_info.tagSize      = memory_alloc_info->debug_utils_tag.size();
         tag_info.pTag         = memory_alloc_info->debug_utils_tag.data();

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -174,6 +174,14 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                                   const VkMappedMemoryRange* memory_ranges,
                                                   const MemoryData*          allocator_datas) override;
 
+    virtual VkResult SetDebugUtilsObjectNameEXT(VkDevice                       device,
+                                                VkDebugUtilsObjectNameInfoEXT* name_info,
+                                                uintptr_t                      allocator_data) override;
+
+    virtual VkResult SetDebugUtilsObjectTagEXT(VkDevice                      device,
+                                               VkDebugUtilsObjectTagInfoEXT* tag_info,
+                                               uintptr_t                     allocator_data) override;
+
     virtual VkResult
     WriteMappedMemoryRange(MemoryData allocator_data, uint64_t offset, uint64_t size, const uint8_t* data) override;
 
@@ -340,6 +348,10 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         uint32_t         height{ 0 };
         bool             uses_extensions{ false };
 
+        std::string          debug_utils_name;
+        std::vector<uint8_t> debug_utils_tag;
+        uint64_t             debug_utils_tag_name;
+
         // Image layouts for performing mapped memory writes to linear images with different capture/replay memory
         // alignments.
         std::vector<SubresourceLayouts> layouts;
@@ -357,6 +369,10 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         std::unordered_map<VkBuffer, ResourceAllocInfo*> original_buffers;
         std::unordered_map<VkImage, ResourceAllocInfo*>  original_images;
         std::unordered_map<VkVideoSessionKHR, ResourceAllocInfo*> original_sessions;
+
+        std::string          debug_utils_name;
+        std::vector<uint8_t> debug_utils_tag;
+        uint64_t             debug_utils_tag_name;
     };
 
   private:
@@ -437,6 +453,12 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                              MemoryData                              allocator_memory_data,
                              VkMemoryPropertyFlags*                  bind_memory_properties,
                              const VkPhysicalDeviceMemoryProperties& device_memory_properties);
+
+    void SetBindingDebugUtilsNameAndTag(const MemoryAllocInfo*   memory_alloc_info,
+                                        const ResourceAllocInfo* resource_alloc_info,
+                                        VkDeviceMemory           device_memory,
+                                        VkObjectType             resource_type,
+                                        uint64_t                 resource_handle);
 
   private:
     VkDevice                         device_ = VK_NULL_HANDLE;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -6240,11 +6240,11 @@ uintptr_t VulkanReplayConsumerBase::GetObjectAllocatorData(VkObjectType object_t
     switch (object_type)
     {
         case VK_OBJECT_TYPE_DEVICE_MEMORY:
-            return GetObjectInfoTable().GetDeviceMemoryInfo(handle_id)->allocator_data;
+            return GetObjectInfoTable().GetVkDeviceMemoryInfo(handle_id)->allocator_data;
         case VK_OBJECT_TYPE_BUFFER:
-            return GetObjectInfoTable().GetBufferInfo(handle_id)->allocator_data;
+            return GetObjectInfoTable().GetVkBufferInfo(handle_id)->allocator_data;
         case VK_OBJECT_TYPE_IMAGE:
-            return GetObjectInfoTable().GetImageInfo(handle_id)->allocator_data;
+            return GetObjectInfoTable().GetVkImageInfo(handle_id)->allocator_data;
         default:
             return 0;
     }
@@ -6253,7 +6253,7 @@ uintptr_t VulkanReplayConsumerBase::GetObjectAllocatorData(VkObjectType object_t
 VkResult VulkanReplayConsumerBase::OverrideSetDebugUtilsObjectNameEXT(
     PFN_vkSetDebugUtilsObjectNameEXT                             func,
     const VkResult                                               original_result,
-    const DeviceInfo*                                            device_info,
+    const VulkanDeviceInfo*                                      device_info,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* name_info)
 {
     GFXRECON_ASSERT(device_info != nullptr);
@@ -6275,7 +6275,7 @@ VkResult VulkanReplayConsumerBase::OverrideSetDebugUtilsObjectNameEXT(
 VkResult VulkanReplayConsumerBase::OverrideSetDebugUtilsObjectTagEXT(
     PFN_vkSetDebugUtilsObjectTagEXT                             func,
     const VkResult                                              original_result,
-    const DeviceInfo*                                           device_info,
+    const VulkanDeviceInfo*                                     device_info,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* tag_info)
 {
     GFXRECON_ASSERT(device_info != nullptr);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -6268,8 +6268,14 @@ VkResult VulkanReplayConsumerBase::OverrideSetDebugUtilsObjectNameEXT(
     VkDebugUtilsObjectNameInfoEXT* info = meta_info->decoded_value;
     GFXRECON_ASSERT(info != nullptr);
 
-    return allocator->SetDebugUtilsObjectNameEXT(
-        device_info->handle, info, GetObjectAllocatorData(info->objectType, meta_info->objectHandle));
+    uintptr_t allocator_data = GetObjectAllocatorData(info->objectType, meta_info->objectHandle);
+
+    if (allocator_data != 0)
+    {
+        // depending on which allocator is used, the call might get deferred until resources are actually bound
+        return allocator->SetDebugUtilsObjectNameEXT(device_info->handle, info, allocator_data);
+    }
+    return func(device_info->handle, info);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideSetDebugUtilsObjectTagEXT(
@@ -6290,8 +6296,14 @@ VkResult VulkanReplayConsumerBase::OverrideSetDebugUtilsObjectTagEXT(
     VkDebugUtilsObjectTagInfoEXT* info = meta_info->decoded_value;
     GFXRECON_ASSERT(info != nullptr);
 
-    return allocator->SetDebugUtilsObjectTagEXT(
-        device_info->handle, info, GetObjectAllocatorData(info->objectType, meta_info->objectHandle));
+    uintptr_t allocator_data = GetObjectAllocatorData(info->objectType, meta_info->objectHandle);
+
+    if (allocator_data != 0)
+    {
+        // depending on which allocator is used, the call might get deferred until resources are actually bound
+        return allocator->SetDebugUtilsObjectTagEXT(device_info->handle, info, allocator_data);
+    }
+    return func(device_info->handle, info);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateSwapchainKHR(

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -978,6 +978,18 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>*                         pMessenger);
 
+    uintptr_t GetObjectAllocatorData(VkObjectType object_type, format::HandleId handle_id);
+
+    VkResult OverrideSetDebugUtilsObjectNameEXT(PFN_vkSetDebugUtilsObjectNameEXT func,
+                                                const VkResult                   original_result,
+                                                const DeviceInfo*                device_info,
+                                                StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* name_info);
+
+    VkResult OverrideSetDebugUtilsObjectTagEXT(PFN_vkSetDebugUtilsObjectTagEXT func,
+                                               const VkResult                  original_result,
+                                               const DeviceInfo*               device_info,
+                                               StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* tag_info);
+
     VkResult OverrideCreateSwapchainKHR(PFN_vkCreateSwapchainKHR                                      func,
                                         VkResult                                                      original_result,
                                         VulkanDeviceInfo*                                             device_info,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -981,13 +981,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     uintptr_t GetObjectAllocatorData(VkObjectType object_type, format::HandleId handle_id);
 
     VkResult OverrideSetDebugUtilsObjectNameEXT(PFN_vkSetDebugUtilsObjectNameEXT func,
-                                                const VkResult                   original_result,
-                                                const DeviceInfo*                device_info,
+                                                VkResult                         original_result,
+                                                const VulkanDeviceInfo*          device_info,
                                                 StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* name_info);
 
     VkResult OverrideSetDebugUtilsObjectTagEXT(PFN_vkSetDebugUtilsObjectTagEXT func,
-                                               const VkResult                  original_result,
-                                               const DeviceInfo*               device_info,
+                                               VkResult                        original_result,
+                                               const VulkanDeviceInfo*         device_info,
                                                StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* tag_info);
 
     VkResult OverrideCreateSwapchainKHR(PFN_vkCreateSwapchainKHR                                      func,

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -91,6 +91,8 @@ class VulkanResourceAllocator
         PFN_vkFreeCommandBuffers                     free_command_buffers{ nullptr };
         PFN_vkDestroyCommandPool                     destroy_command_pool{ nullptr };
         PFN_vkGetPhysicalDeviceQueueFamilyProperties get_physical_device_queue_family_properties{ nullptr };
+        PFN_vkSetDebugUtilsObjectNameEXT             set_debug_utils_object_name{ nullptr };
+        PFN_vkSetDebugUtilsObjectTagEXT              set_debug_utils_object_tag{ nullptr };
     };
 
   public:
@@ -204,6 +206,13 @@ class VulkanResourceAllocator
     virtual VkResult InvalidateMappedMemoryRanges(uint32_t                   memory_range_count,
                                                   const VkMappedMemoryRange* memory_ranges,
                                                   const MemoryData*          allocator_datas) = 0;
+
+    // allocator_data can be either MemoryData or ResourceData depending on name_info->objectType
+    virtual VkResult
+    SetDebugUtilsObjectNameEXT(VkDevice device, VkDebugUtilsObjectNameInfoEXT* name_info, uintptr_t allocator_data) = 0;
+
+    virtual VkResult
+    SetDebugUtilsObjectTagEXT(VkDevice device, VkDebugUtilsObjectTagInfoEXT* tag_info, uintptr_t allocator_data) = 0;
 
     // Offset is relative to the start of the pointer returned by vkMapMemory.
     virtual VkResult

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -7298,13 +7298,13 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    const VkDebugUtilsObjectNameInfoEXT* in_pNameInfo = pNameInfo->GetPointer();
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
+
     MapStructHandles(pNameInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VulkanDeviceInfo* device_info     = GetObjectInfoTable().GetVkDeviceInfo(device);
     VkPhysicalDevice  physical_device = device_info->parent;
 
-    VkResult replay_result = GetInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT(in_device, in_pNameInfo);
+    VkResult replay_result = OverrideSetDebugUtilsObjectNameEXT(GetInstanceTable(physical_device)->SetDebugUtilsObjectNameEXT, returnValue, in_device, pNameInfo);
     CheckResult("vkSetDebugUtilsObjectNameEXT", returnValue, replay_result, call_info);
 }
 
@@ -7314,13 +7314,13 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo)
 {
-    VkDevice in_device = MapHandle<VulkanDeviceInfo>(device, &CommonObjectInfoTable::GetVkDeviceInfo);
-    const VkDebugUtilsObjectTagInfoEXT* in_pTagInfo = pTagInfo->GetPointer();
+    auto in_device = GetObjectInfoTable().GetVkDeviceInfo(device);
+
     MapStructHandles(pTagInfo->GetMetaStructPointer(), GetObjectInfoTable());
     VulkanDeviceInfo* device_info     = GetObjectInfoTable().GetVkDeviceInfo(device);
     VkPhysicalDevice  physical_device = device_info->parent;
 
-    VkResult replay_result = GetInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT(in_device, in_pTagInfo);
+    VkResult replay_result = OverrideSetDebugUtilsObjectTagEXT(GetInstanceTable(physical_device)->SetDebugUtilsObjectTagEXT, returnValue, in_device, pTagInfo);
     CheckResult("vkSetDebugUtilsObjectTagEXT", returnValue, replay_result, call_info);
 }
 

--- a/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
+++ b/framework/generated/khronos_generators/vulkan_generators/replay_overrides.json
@@ -112,6 +112,8 @@
     "vkAcquireProfilingLockKHR": "OverrideAcquireProfilingLockKHR",
     "vkWaitForPresentKHR": "OverrideWaitForPresentKHR",
     "vkWaitSemaphores": "OverrideWaitSemaphores",
+    "vkSetDebugUtilsObjectNameEXT": "OverrideSetDebugUtilsObjectNameEXT",
+    "vkSetDebugUtilsObjectTagEXT": "OverrideSetDebugUtilsObjectTagEXT",
     "vkFrameBoundaryANDROID": "OverrideFrameBoundaryANDROID",
     "vkCmdInsertDebugUtilsLabelEXT": "OverrideCmdInsertDebugUtilsLabelEXT",
     "vkUpdateDescriptorSets": "OverrideUpdateDescriptorSets",

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -288,7 +288,7 @@ class VulkanReplayConsumerBodyGenerator(
         )
         arglist = ', '.join(args)
 
-        dispatchfunc = ''
+        dispatchfunc = 'GetDeviceTable'
         if name not in ['vkCreateInstance', 'vkCreateDevice']:
             object_name = args[0]
             dispatch_func_is_set = False
@@ -298,8 +298,8 @@ class VulkanReplayConsumerBodyGenerator(
                     object_name = 'physical_device'
                     preexpr.append("VulkanDeviceInfo* device_info     = GetObjectInfoTable().GetVkDeviceInfo(device);")
                     preexpr.append("VkPhysicalDevice  physical_device = device_info->parent;")
-            else:
-                dispatchfunc = 'GetDeviceTable'
+                    dispatchfunc += '({})->{}'.format(object_name, name[2:])
+                    dispatch_func_is_set = True
 
             if not dispatch_func_is_set:
                 if is_override:

--- a/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/khronos_generators/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -291,6 +291,7 @@ class VulkanReplayConsumerBodyGenerator(
         dispatchfunc = ''
         if name not in ['vkCreateInstance', 'vkCreateDevice']:
             object_name = args[0]
+            dispatch_func_is_set = False
             if self.use_instance_table(name, values[0].base_type):
                 dispatchfunc = 'GetInstanceTable'
                 if values[0].base_type == 'VkDevice':
@@ -300,10 +301,11 @@ class VulkanReplayConsumerBodyGenerator(
             else:
                 dispatchfunc = 'GetDeviceTable'
 
-            if is_override:
-                dispatchfunc += '({}->handle)->{}'.format(object_name, name[2:])
-            else:
-                dispatchfunc += '({})->{}'.format(object_name, name[2:])
+            if not dispatch_func_is_set:
+                if is_override:
+                    dispatchfunc += '({}->handle)->{}'.format(object_name, name[2:])
+                else:
+                    dispatchfunc += '({})->{}'.format(object_name, name[2:])
 
         call_expr = ''
         if is_override:


### PR DESCRIPTION
When using rebind allocator, lazy allocation make it impossible to have a valid Vulkan handle before binding memory. However, it remains possible to set name and tag of the memory before binding it.

These informations should thus be stored in the allocator, and the appropriate call emitted once the memory is actually allocated.

In addition, even without this lazy allocation issue, only a "fake" handle is stored in `DeviceMemoryInfo`, making it impossible to use even after binding time.

This is what this commit aims to fix.