### PR TITLE
Fix broken trimming for vkCmdPushDescriptorSetWithTemplate[2]KHR commands

### DIFF
--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -667,9 +667,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTem
     Decoded_VkPushDescriptorSetWithTemplateInfoKHR* info = pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
     format::HandleId                                descriptorUpdateTemplate = info->descriptorUpdateTemplate;
 
-    DescriptorUpdateTemplateDecoder pData;
-    const uint8_t*                  ptr = static_cast<const uint8_t*>(info->pNext->GetPointer());
-    pData.Decode(ptr, pData.GetLength());
+    DescriptorUpdateTemplateDecoder pData = info->pData;
 
     PushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, &pData);
 }

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -664,8 +664,8 @@ void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTem
     format::HandleId                                                      commandBuffer,
     StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
 {
-    Decoded_VkPushDescriptorSetWithTemplateInfoKHR* info                 = pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
-    format::HandleId descriptorUpdateTemplate =                 info->descriptorUpdateTemplate;
+    Decoded_VkPushDescriptorSetWithTemplateInfoKHR* info = pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
+    format::HandleId                                descriptorUpdateTemplate = info->descriptorUpdateTemplate;
     DescriptorUpdateTemplateDecoder                 pData                    = info->pData;
 
     PushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, &pData);

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -664,10 +664,9 @@ void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTem
     format::HandleId                                                      commandBuffer,
     StructPointerDecoder<Decoded_VkPushDescriptorSetWithTemplateInfoKHR>* pPushDescriptorSetWithTemplateInfo)
 {
-    Decoded_VkPushDescriptorSetWithTemplateInfoKHR* info = pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
-    format::HandleId                                descriptorUpdateTemplate = info->descriptorUpdateTemplate;
-
-    DescriptorUpdateTemplateDecoder pData = info->pData;
+    Decoded_VkPushDescriptorSetWithTemplateInfoKHR* info                 = pPushDescriptorSetWithTemplateInfo->GetMetaStructPointer();
+    format::HandleId descriptorUpdateTemplate =                 info->descriptorUpdateTemplate;
+    DescriptorUpdateTemplateDecoder                 pData                    = info->pData;
 
     PushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, &pData);
 }

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -270,7 +270,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer  
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR>::Dispatch(
         manager, commandBuffer, descriptorUpdateTemplate, layout, set, pData);
 
-    auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR);
+    auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR);
     if (encoder)
     {
         encoder->EncodeVulkanHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
@@ -280,7 +280,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer  
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pData);
 
-        manager->EndApiCallCapture();
+        manager->EndCommandApiCallCapture(commandBuffer);
     }
 
     auto handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
@@ -310,7 +310,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR>::Dispatch(
         manager, commandBuffer, pPushDescriptorSetWithTemplateInfo);
 
-    auto encoder = manager->BeginApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
+    auto encoder = manager->BeginTrackedApiCallCapture(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplate2KHR);
     if (encoder)
     {
         encoder->EncodeVulkanHandleValue<vulkan_wrappers::CommandBufferWrapper>(commandBuffer);
@@ -318,7 +318,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplate2KHR(
 
         EncodeDescriptorUpdateTemplateInfo(manager, encoder, info, pPushDescriptorSetWithTemplateInfo->pData);
 
-        manager->EndApiCallCapture();
+        manager->EndCommandApiCallCapture(commandBuffer);
     }
 
     auto handle_unwrap_memory = manager->GetHandleUnwrapMemory();


### PR DESCRIPTION
This PR fixes #1596

For the vkCmdPushDescriptorSetWithTemplate[2]KHR commands, we change `manager->BeginApiCallCapture()` and `manager->EndApiCallCapture()` to `manager->BeginTrackedApiCallCapture()` and `manager->EndCommandApiCallCapture()` respectively. Along with fixing a mistake in VulkanReferencedResourceConsumerBase, this allows the two functions to replay, trim-replay, and optimize-replay correctly.