### PR TITLE
Enable marking of api calls injected by the replayer

### DIFF
--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -99,6 +99,7 @@ def CreateReplayParser():
     parser.add_argument('--swapchain', metavar='MODE', choices=['virtual', 'captured', 'offscreen'], help='Choose a swapchain mode to replay. Available modes are: virtual, captured, offscreen (forwarded to replay tool)')
     parser.add_argument('--vssb', '--virtual-swapchain-skip-blit', action='store_true', default=False, help='Skip blit to real swapchain to gain performance during replay.')
     parser.add_argument('--use-captured-swapchain-indices', action='store_true', default=False, help='Same as "--swapchain captured". Ignored if the "--swapchain" option is used.')
+    parser.add_argument('--marking-layers', metavar='names', help='Specifies the layers that are used to mark API calls injected by replayer')
     parser.add_argument('file', nargs='?', help='File on device to play (forwarded to replay tool)')
     parser.add_argument('--dump-resources', metavar='DUMP_RESOURCES', help='--dump-resources <filename> Extract --dump-resources args from the specified file.')
     parser.add_argument('--dump-resources-before-draw', action='store_true', default=False, help= 'In addition to dumping gpu resources after the Vulkan draw calls specified by the --dump-resources argument, also dump resources before the draw calls.')
@@ -276,6 +277,11 @@ def MakeExtrasString(args):
     if args.pbis:
         arg_list.append('--pbis')
         arg_list.append('{}'.format(args.pbis))
+
+    if args.marking_layers:
+        arg_list.append('--marking-layers')
+        arg_list.append('{}'.format(args.marking_layers))
+
 
     if args.file:
         arg_list.append(args.file)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4275,9 +4275,9 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(
 
             VkMemoryAllocateInfo                     modified_allocate_info = (*replay_allocate_info);
             VkMemoryOpaqueCaptureAddressAllocateInfo address_info           = {
-                VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
-                modified_allocate_info.pNext,
-                opaque_address
+                          VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
+                          modified_allocate_info.pNext,
+                          opaque_address
             };
             modified_allocate_info.pNext = &address_info;
 

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -100,7 +100,8 @@ struct VulkanReplayOptions : public ReplayOptions
     bool  dump_resources_dump_immutable_resources{ false };
     bool  dump_resources_dump_all_image_subresources{ false };
 
-    bool preload_measurement_range{ false };
+    bool                     preload_measurement_range{ false };
+    std::vector<std::string> marking_layers_names;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -115,6 +115,7 @@ target_sources(gfxrecon_util
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_loader.h>
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_loader.cpp>
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_wayland_xdg_shell.h>
+                    ${CMAKE_CURRENT_LIST_DIR}/marking_layers.h
 )
 
 

--- a/framework/util/marking_layers.h
+++ b/framework/util/marking_layers.h
@@ -62,7 +62,7 @@ class MarkingLayersUtil
         {
             if (!scope_closed_)
             {
-                GFXRECON_LOG_FATAL("Marking was not closed, previous begin call at %s, %s", file_.c_str(), line_);
+                GFXRECON_LOG_FATAL("Marking was not closed, previous begin call at %s, %d", file_.c_str(), line_);
                 GFXRECON_ASSERT(false);
             }
             file_         = file;

--- a/framework/util/marking_layers.h
+++ b/framework/util/marking_layers.h
@@ -1,0 +1,166 @@
+/*
+** Copyright (c) 2024 Valve Corporation
+** Copyright (c) 2024 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_UTIL_MARKING_LAYER_H
+#define GFXRECON_UTIL_MARKING_LAYER_H
+
+#include "vulkan/vulkan.h"
+#include "util/defines.h"
+#include "format/format.h"
+
+#include "decode/vulkan_object_info.h"
+#include "decode/vulkan_object_info_table.h"
+
+#include <string>
+#include <set>
+#include <unordered_map>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+typedef void MarkInjectedCallback(void*);
+struct MarkInjectedCallbacks
+{
+    void*                 user_data;
+    MarkInjectedCallback* begin_injected = nullptr;
+    MarkInjectedCallback* end_injected   = nullptr;
+};
+
+class MarkingLayersUtil
+{
+  public:
+    static MarkingLayersUtil& instance()
+    {
+        static MarkingLayersUtil instance;
+        return instance;
+    }
+
+    template <typename T>
+    void BeginInjected(const decode::VulkanObjectInfo<T>* info, const std::string& file = "", int line = 0)
+    {
+        if constexpr (is_debug_)
+        {
+            if (!scope_closed_)
+            {
+                GFXRECON_LOG_FATAL("Marking was not closed, previous begin call at %s, %s", file_.c_str(), line_);
+                GFXRECON_ASSERT(false);
+            }
+            file_         = file;
+            line_         = line;
+            scope_closed_ = false;
+        }
+
+        callbacks_it_t entries = Callbacks(info);
+        if (entries == callbacks_.end())
+        {
+            return;
+        }
+
+        for (const MarkInjectedCallbacks& callback : entries->second)
+        {
+            callback.begin_injected(callback.user_data);
+        }
+    }
+
+    template <typename T>
+    void EndInjected(const decode::VulkanObjectInfo<T>* info)
+    {
+        if constexpr (is_debug_)
+        {
+            scope_closed_ = true;
+        }
+
+        MarkingLayersUtil::callbacks_it_t entries = Callbacks(info);
+        if (entries == callbacks_.end())
+        {
+            return;
+        }
+
+        for (const MarkInjectedCallbacks& callback : entries->second)
+        {
+            callback.end_injected(callback.user_data);
+        }
+    }
+
+    void AddCallbacks(format::HandleId physical_device_id, const VkPhysicalDeviceToolProperties& tool_properties)
+    {
+        // Do not add callbacks for the layers that were not enabled by the respective argument
+        if (layer_names_.count(tool_properties.layer) == 0)
+        {
+            return;
+        }
+        GFXRECON_LOG_DEBUG(
+            "Adding a %s layer callbacks from physical device %" PRIu64, tool_properties.layer, physical_device_id);
+        callbacks_[physical_device_id].emplace_back(*reinterpret_cast<MarkInjectedCallbacks*>(tool_properties.pNext));
+    }
+
+    void SetInfoTable(const decode::VulkanObjectInfoTable* object_info_table)
+    {
+        object_info_table_ = object_info_table;
+    }
+
+    void AddLayerName(std::string_view name) { layer_names_.insert(name); }
+
+  private:
+    using callbacks_it_t = std::unordered_map<format::HandleId, std::vector<MarkInjectedCallbacks>>::iterator;
+
+  private:
+    MarkingLayersUtil() = default;
+
+    callbacks_it_t Callbacks(format::HandleId physical_device_id) { return callbacks_.find(physical_device_id); }
+
+    template <typename T>
+    callbacks_it_t Callbacks(const decode::VulkanObjectInfo<T>* info)
+    {
+        const decode::DeviceInfo* device_info = object_info_table_->GetDeviceInfo(info->parent_id);
+        return Callbacks(device_info->parent_id);
+    }
+    MarkingLayersUtil::callbacks_it_t Callbacks(const decode::VulkanObjectInfo<VkDevice>* info)
+    {
+        return Callbacks(info->parent_id);
+    }
+
+    MarkingLayersUtil::callbacks_it_t Callbacks(const decode::VulkanObjectInfo<VkPhysicalDevice>* info)
+    {
+        return Callbacks(info->capture_id);
+    }
+
+  private:
+    std::set<std::string_view>                                               layer_names_;
+    std::unordered_map<format::HandleId, std::vector<MarkInjectedCallbacks>> callbacks_;
+    const decode::VulkanObjectInfoTable*                                     object_info_table_{ nullptr };
+
+    bool        scope_closed_{ true };
+    std::string file_;
+    int         line_;
+
+#ifdef NDEBUG
+    static const bool is_debug_ = false;
+#else
+    static const bool is_debug_ = true;
+#endif
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+#endif

--- a/framework/util/marking_layers.h
+++ b/framework/util/marking_layers.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2024 Valve Corporation
 ** Copyright (c) 2024 LunarG, Inc.
+** Copyright (c) 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -43,7 +43,7 @@ const char kArguments[] =
     "force-windowed,--fwo|--force-windowed-origin,--batching-memory-usage,--measurement-file,--swapchain,--sgfs|--skip-"
     "get-fence-status,--sgfr|--"
     "skip-get-fence-ranges,--dump-resources,--dump-resources-scale,--dump-resources-image-format,--dump-resources-dir,"
-    "--dump-resources-dump-color-attachment-index,--pbis";
+    "--dump-resources-dump-color-attachment-index,--pbis,--marking-layers";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -93,6 +93,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-json-output-per-command]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-dump-immutable-resources]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dump-resources-dump-all-image-subresources]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--marking-layers <N1,...>]");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--fwo <x,y> | --force-windowed-origin <x,y>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--log-level <level>] [--log-file <file>] [--log-debugview]");
@@ -325,6 +326,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\tDump immutable shader resources.");
     GFXRECON_WRITE_CONSOLE("  --dump-resources-dump-all-image-subresources");
     GFXRECON_WRITE_CONSOLE("          \t\tDump all available mip levels and layers when dumping images.");
+    GFXRECON_WRITE_CONSOLE("  --marking-layers <N1[,...]>");
+    GFXRECON_WRITE_CONSOLE("          \t\t Specifies the layers that are used to mark API calls injected by replayer");
 
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("")

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -123,6 +123,7 @@ const char kWaitBeforePresent[]                   = "--wait-before-present";
 const char kPrintBlockInfoAllOption[]             = "--pbi-all";
 const char kPrintBlockInfosArgument[]             = "--pbis";
 const char kPreloadMeasurementRangeOption[]       = "--preload-measurement-range";
+const char kMarkingLayersArgument[]               = "--marking-layers";
 #if defined(WIN32)
 const char kDxTwoPassReplay[]             = "--dx12-two-pass-replay";
 const char kDxOverrideObjectNames[]       = "--dx12-override-object-names";
@@ -927,6 +928,16 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions&      options,
     SetWindowOrigin(options, arg_parser);
 }
 
+static std::vector<std::string> GetMarkingLayersNames(const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    const std::string& value = arg_parser.GetArgumentValue(kMarkingLayersArgument);
+    if (value.empty())
+    {
+        return {};
+    }
+    return gfxrecon::util::strings::SplitString(value, ',');
+}
+
 static gfxrecon::decode::VulkanReplayOptions
 GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parser,
                        const std::string&                              filename,
@@ -1093,6 +1104,8 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
         replay_options.dump_resources_color_attachment_index = std::stoi(dr_color_att_idx);
     }
 
+    replay_options.marking_layers_names = GetMarkingLayersNames(arg_parser);
+
     return replay_options;
 }
 
@@ -1204,5 +1217,4 @@ static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::Ar
 
     return false;
 }
-
 #endif // GFXRECON_PLATFORM_SETTINGS_H


### PR DESCRIPTION
For different reasons, it is useful to be able to mark the calls injected during the replay, as "injected". 

In this change, it is done by calling functions that can mark the beginning of injected calls section and the ending of such section. This functions are loaded from a layer, and therefore this change is versatile in regards to what do you do with the calls that are marked as injected.

This change enables this, by adding a new replay option, that can be used to specify the names of the layers (that should be present on `VK_LAYER_PATH`) as a comma separated list. This layers are then loaded when the instance is created, and are setup when the relevant device is created. The callbacks are stored inside a utility class, that is easy to use as a singleton in any file where you need your calls marked. To mark the calls, you should provide `VulkanObjectInfo<T>`, or a handle id of a physical device directly. 