### PR TITLE
Fix DX12 Render Pass Union Encode/Decode

### DIFF
--- a/framework/decode/custom_dx12_struct_decoders.cpp
+++ b/framework/decode/custom_dx12_struct_decoders.cpp
@@ -606,9 +606,30 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->Type));
 
-    wrapper->Clear = DecodeAllocator::Allocate<Decoded_D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS>();
-    wrapper->Clear->decoded_value = &(value->Clear);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->Clear);
+    switch (value->Type)
+    {
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR:
+            wrapper->Clear = DecodeAllocator::Allocate<Decoded_D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS>();
+            wrapper->Clear->decoded_value = &(value->Clear);
+            bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->Clear);
+            break;
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE_LOCAL_RENDER:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE_LOCAL_SRV:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE_LOCAL_UAV:
+            wrapper->PreserveLocal =
+                DecodeAllocator::Allocate<Decoded_D3D12_RENDER_PASS_BEGINNING_ACCESS_PRESERVE_LOCAL_PARAMETERS>();
+            wrapper->PreserveLocal->decoded_value = &(value->PreserveLocal);
+            bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->PreserveLocal);
+            break;
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS:
+            // These cases have no additional values to decode.
+            break;
+        default:
+            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
+            break;
+    }
 
     return bytes_read;
 }
@@ -622,9 +643,30 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_D3D12_REN
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->Type));
 
-    wrapper->Resolve = DecodeAllocator::Allocate<Decoded_D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS>();
-    wrapper->Resolve->decoded_value = &(value->Resolve);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->Resolve);
+    switch (value->Type)
+    {
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_RESOLVE:
+            wrapper->Resolve = DecodeAllocator::Allocate<Decoded_D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS>();
+            wrapper->Resolve->decoded_value = &(value->Resolve);
+            bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->Resolve);
+            break;
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE_LOCAL_RENDER:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE_LOCAL_SRV:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE_LOCAL_UAV:
+            wrapper->PreserveLocal =
+                DecodeAllocator::Allocate<Decoded_D3D12_RENDER_PASS_ENDING_ACCESS_PRESERVE_LOCAL_PARAMETERS>();
+            wrapper->PreserveLocal->decoded_value = &(value->PreserveLocal);
+            bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->PreserveLocal);
+            break;
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS:
+            // These cases have no additional values to decode.
+            break;
+        default:
+            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value->Type);
+            break;
+    }
 
     return bytes_read;
 }

--- a/framework/decode/custom_dx12_struct_decoders.h
+++ b/framework/decode/custom_dx12_struct_decoders.h
@@ -189,15 +189,17 @@ struct Decoded_D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA
 struct Decoded_D3D12_RENDER_PASS_BEGINNING_ACCESS
 {
     using struct_type = D3D12_RENDER_PASS_BEGINNING_ACCESS;
-    D3D12_RENDER_PASS_BEGINNING_ACCESS*                          decoded_value{ nullptr };
-    Decoded_D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS* Clear{ nullptr };
+    D3D12_RENDER_PASS_BEGINNING_ACCESS*                                   decoded_value{ nullptr };
+    Decoded_D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS*          Clear{ nullptr };
+    Decoded_D3D12_RENDER_PASS_BEGINNING_ACCESS_PRESERVE_LOCAL_PARAMETERS* PreserveLocal{ nullptr };
 };
 
 struct Decoded_D3D12_RENDER_PASS_ENDING_ACCESS
 {
     using struct_type = D3D12_RENDER_PASS_ENDING_ACCESS;
-    D3D12_RENDER_PASS_ENDING_ACCESS*                            decoded_value{ nullptr };
-    Decoded_D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS* Resolve{ nullptr };
+    D3D12_RENDER_PASS_ENDING_ACCESS*                                   decoded_value{ nullptr };
+    Decoded_D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS*        Resolve{ nullptr };
+    Decoded_D3D12_RENDER_PASS_ENDING_ACCESS_PRESERVE_LOCAL_PARAMETERS* PreserveLocal{ nullptr };
 };
 
 // Platform types.

--- a/framework/encode/custom_dx12_struct_encoders.cpp
+++ b/framework/encode/custom_dx12_struct_encoders.cpp
@@ -399,13 +399,51 @@ void EncodeStruct(ParameterEncoder* encoder, const D3D12_VERSIONED_DEVICE_REMOVE
 void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_BEGINNING_ACCESS& value)
 {
     encoder->EncodeEnumValue(value.Type);
-    EncodeStruct(encoder, value.Clear);
+
+    switch (value.Type)
+    {
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR:
+            EncodeStruct(encoder, value.Clear);
+            break;
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE_LOCAL_RENDER:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE_LOCAL_SRV:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE_LOCAL_UAV:
+            EncodeStruct(encoder, value.PreserveLocal);
+            break;
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE:
+        case D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS:
+            // These cases have no additional values to encode.
+            break;
+        default:
+            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_BEGINNING_ACCESS union type %u", value.Type);
+            break;
+    }
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const D3D12_RENDER_PASS_ENDING_ACCESS& value)
 {
     encoder->EncodeEnumValue(value.Type);
-    EncodeStruct(encoder, value.Resolve);
+
+    switch (value.Type)
+    {
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_RESOLVE:
+            EncodeStruct(encoder, value.Resolve);
+            break;
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE_LOCAL_RENDER:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE_LOCAL_SRV:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE_LOCAL_UAV:
+            EncodeStruct(encoder, value.PreserveLocal);
+            break;
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE:
+        case D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS:
+            // These cases have no additional values to encode.
+            break;
+        default:
+            GFXRECON_LOG_FATAL_ONCE("Unrecognized D3D12_RENDER_PASS_ENDING_ACCESS union type %u", value.Type);
+            break;
+    }
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const LARGE_INTEGER& value)


### PR DESCRIPTION
Fix encoding/decoding for the D3D12_RENDER_PASS_BEGINNING_ACCESS and D3D12_RENDER_PASS_ENDING_ACCESS union members:
- The Clear/Resolve union members were always encoded/decoded, regardless of render pass access type, resulting in uninitialized pointers being dereferenced when the type was not clear or resolve.
- A new union member, PreserveLocal, added by the Agility SDK, was not being processed for encoding/decoding.