### PR TITLE
Add ID3D12DeviceFactory replay override

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -367,6 +367,13 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                       Decoded_GUID                 riid,
                                       HandlePointerDecoder<void*>* device);
 
+    HRESULT OverrideD3D12DeviceFactoryCreateDevice(DxObjectInfo*                replay_object_info,
+                                                   HRESULT                      original_result,
+                                                   DxObjectInfo*                adapter_info,
+                                                   D3D_FEATURE_LEVEL            minimum_feature_level,
+                                                   Decoded_GUID                 riid,
+                                                   HandlePointerDecoder<void*>* device);
+
     void ProcessDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header);
 
     void InitCommandQueueExtraInfo(ID3D12Device* device, HandlePointerDecoder<void*>* command_queue_decoder);
@@ -924,6 +931,10 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
             offsets.clear();
         }
     };
+
+    IUnknown* GetCreateDeviceAdapter(DxObjectInfo* adapter_info);
+
+    void InitializeD3D12Device(HandlePointerDecoder<void*>* device);
 
     void DetectAdapters();
 

--- a/framework/generated/dx12_generators/replay_overrides.json
+++ b/framework/generated/dx12_generators/replay_overrides.json
@@ -18,6 +18,9 @@
     "ID3D12DeviceRemovedExtendedDataSettings1": {
       "SetBreadcrumbContextEnablement": "OverrideSetBreadcrumbContextEnablement"
     },
+    "ID3D12DeviceFactory": {
+      "CreateDevice": "OverrideD3D12DeviceFactoryCreateDevice"
+    },
     "ID3D12Device": {
       "CreateCommandQueue": "OverrideCreateCommandQueue",
       "CreateDescriptorHeap": "OverrideCreateDescriptorHeap",


### PR DESCRIPTION
Add a replay override for ID3D12DeviceFactory::CreateDevice to perform the same device initialization as the D3D12CreateDevice replay override.