### PR TITLE
Avoid writing redundant QueueSubmit

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -871,7 +871,9 @@ void CommonCaptureManager::PostQueueSubmit(format::ApiFamilyId api_family)
         if ((capture_mode_ & kModeWrite) == kModeWrite)
         {
             // Currently capturing a queue submit range, check for end of range.
-            CheckContinueCaptureForWriteMode(api_family, queue_submit_count_);
+            // It checks the boundary count with +1. That is for trim frames.
+            // It will write one more QueueSubmit for trim QueueSubmits, so +1.
+            CheckContinueCaptureForWriteMode(api_family, queue_submit_count_ + 1);
         }
     }
 }


### PR DESCRIPTION
That is for capture option: `GFXRECON_CAPTURE_QUEUE_SUBMITS`. It trims one or a range queue submits. But the original code will write one more queue submit. For example, if I want to trim queue submit 1, it will write queue submit 1 and 2. The reason is that `CheckContinueCaptureForWriteMode` use `if (current_boundary_count == (trim_ranges_[trim_current_range_].last + 1))` to check if it should stop writing. That `+1` causes this error. But I couldn't just remove that `+1` because that's necessary for trimming frames. In this case, I just added `+1` there to fix it.

More detail:
For trimming frames, in `CommonCaptureManager::EndFrame`, it check if it should stop writing or start to write. When the current frame is the target frame, it starts to write. When the current frame is the following target frame, it stops writing. In this case, it needs `+1` to check if it should stop writing.

For trimming queue submits, it checks if it should start to write in `CommonCaptureManager::PreQueueSubmit`. It checks if it should stop writing in `CommonCaptureManager::PostQueueSubmit`.  It writes one queue submit between `Pre` and `Post`. In this case, if it starts to write in `Pre`, and then write one queue submit, and then stop writing in the following queue submit's `Post`, it will write one more queue submit. The correct way is to stop writing in the current queue submit's `Post`, not the following queue submit's `Post`.