### PR TITLE
vulkan dump resources fixes

### DIFF
--- a/framework/graphics/vulkan_resources_util.cpp
+++ b/framework/graphics/vulkan_resources_util.cpp
@@ -24,6 +24,7 @@
 #include "Vulkan-Utility-Libraries/vk_format_utils.h"
 #include "generated/generated_vulkan_enum_to_string.h"
 #include "util/logging.h"
+#include "vulkan/vulkan_core.h"
 
 #include <cinttypes>
 #include <cstdint>
@@ -455,7 +456,7 @@ VkResult VulkanResourcesUtil::CreateStagingBuffer(VkDeviceSize size)
     create_info.pNext                 = nullptr;
     create_info.flags                 = 0;
     create_info.size                  = size;
-    create_info.usage                 = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    create_info.usage                 = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     create_info.sharingMode           = VK_SHARING_MODE_EXCLUSIVE;
     create_info.queueFamilyIndexCount = 0;
     create_info.pQueueFamilyIndices   = nullptr;


### PR DESCRIPTION
The calculations for the size of indirect draw calls param buffer was off.